### PR TITLE
Add Drupal settings scaffold and dev config split; update .gitignore and CI PHP setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup PHP
+      - name: Setup PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.3.0'
           tools: composer:v2
           coverage: none
+
+      - name: Verify PHP version
+        run: |
+          php -v
+          php -r "exit(version_compare(PHP_VERSION, '8.3.0', '>=') ? 0 : 1);"
 
       - name: Validate composer.json
         run: composer validate --strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-```gitignore
 # --- OS ---
 .DS_Store
 Thumbs.db
@@ -23,12 +22,13 @@ composer.phar
 
 # Settings (do not commit secrets)
 /web/sites/*/settings.php
+!/web/sites/default/settings.php
 /web/sites/*/settings.local.php
 /web/sites/*/services.yml
 /web/sites/*/services.local.yml
 
-# Config sync (will be enabled later)
-/config/sync/
+# Private files
+/private/
 
 # --- Tests ---
 /web/sites/simpletest/

--- a/config/sync/config_split.config_split.dev.yml
+++ b/config/sync/config_split.config_split.dev.yml
@@ -1,0 +1,19 @@
+uuid: 0f4d9b95-3f3f-4d02-9a5c-7ef2ec0f9f2d
+langcode: en
+status: false
+dependencies: {  }
+id: dev
+label: Dev
+description: 'Local development split.'
+weight: 0
+stackable: false
+no_patching: false
+storage: folder
+folder: '../config/dev'
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+complete_list: {  }

--- a/web/sites/default/settings.local.php.example
+++ b/web/sites/default/settings.local.php.example
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Example local development settings.
+ *
+ * Copy this file to settings.local.php for local-only overrides.
+ */
+
+$settings['rebuild_access'] = TRUE;
+
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['page'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Activate the development split only on local environments.
+$config['config_split.config_split.dev']['status'] = TRUE;

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Base Drupal settings scaffold.
+ *
+ * Keep this include first to preserve Drupal defaults and documentation.
+ */
+require __DIR__ . '/default.settings.php';
+
+/**
+ * Shared project configuration paths.
+ */
+$settings['config_sync_directory'] = '../config/sync';
+$settings['file_private_path'] = '../private';
+
+/**
+ * Load local development override configuration, if available.
+ */
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  require __DIR__ . '/settings.local.php';
+}


### PR DESCRIPTION
### Motivation
- Provide a baseline Drupal `settings.php` scaffold and an example local override to simplify local development and enable a dev-only config split.
- Ensure repository ignores private runtime files while allowing the committed `web/sites/default/settings.php` and keep sensitive local settings out of VCS.
- Make the CI workflow explicit about the PHP runtime by pinning to `8.3.0` and verifying the PHP version during CI runs.

### Description
- Update the GitHub Actions workflow to use `php-version: '8.3.0'` and add a `Verify PHP version` step that runs `php -v` and `php -r "exit(version_compare(PHP_VERSION, '8.3.0', '>=') ? 0 : 1);"`.
- Clean up `.gitignore` formatting, whitelist `!/web/sites/default/settings.php`, and add `/private/` to the ignored paths to protect private files.
- Add `config/sync/config_split.config_split.dev.yml` to define a `dev` config split with storage in `../config/dev`.
- Add `web/sites/default/settings.php` scaffold that requires `default.settings.php`, sets `config_sync_directory` and `file_private_path`, and conditionally loads `settings.local.php` if present.
- Add `web/sites/default/settings.local.php.example` containing local development overrides (disabled cache/preprocessing, `rebuild_access`, and enabling the dev config split).

### Testing
- No automated tests were executed as part of this PR; the CI workflow was updated and will run on `push`/`pull_request` and includes `composer validate` and `composer ci` steps to run checks in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da52c802748321a5da0f0e6517c01b)