### PR TITLE
Add Twig templates, Paragraph bundles and homepage scaffolding (Ticket 4.1)

### DIFF
--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -1,0 +1,49 @@
+uuid: d690f758-f32f-4b24-a7fa-62e77bd7940c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.page.field_home_components
+    - node.type.page
+  module:
+    - paragraphs
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  field_home_components:
+    type: paragraphs
+    weight: 20
+    region: content
+    settings:
+      title: Paragraphe
+      title_plural: Paragraphes
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: hero
+      features:
+        add_above: false
+        collapse_edit_all: false
+        convert: false
+        duplicate: false
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_form_display.paragraph.ai_features.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.ai_features.default.yml
@@ -1,0 +1,32 @@
+uuid: 19772705-5268-4636-b0f2-b2139da3fa57
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.ai_features.field_heading
+    - field.field.paragraph.ai_features.field_text
+    - paragraphs.paragraphs_type.ai_features
+id: paragraph.ai_features.default
+targetEntityType: paragraph
+bundle: ai_features
+mode: default
+content:
+  field_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.case_clients.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.case_clients.default.yml
@@ -1,0 +1,32 @@
+uuid: dc839b03-d398-42e3-aa1d-bd5d464b616f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.case_clients.field_heading
+    - field.field.paragraph.case_clients.field_text
+    - paragraphs.paragraphs_type.case_clients
+id: paragraph.case_clients.default
+targetEntityType: paragraph
+bundle: case_clients
+mode: default
+content:
+  field_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.cta.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.cta.default.yml
@@ -1,0 +1,43 @@
+uuid: f81fd9ce-60b1-4095-8bfa-e849e24583a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta.field_heading
+    - field.field.paragraph.cta.field_text
+    - field.field.paragraph.cta.field_link
+    - paragraphs.paragraphs_type.cta
+  module:
+    - link
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content:
+  field_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 2
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.hero.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.hero.default.yml
@@ -1,0 +1,43 @@
+uuid: bd3b7106-4d8e-4a5f-b432-12702bcf3c1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_heading
+    - field.field.paragraph.hero.field_text
+    - field.field.paragraph.hero.field_link
+    - paragraphs.paragraphs_type.hero
+  module:
+    - link
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  field_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 2
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.services.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.services.default.yml
@@ -1,0 +1,32 @@
+uuid: 60f3111c-67cd-4dd5-ad64-b5343574c1a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.services.field_heading
+    - field.field.paragraph.services.field_text
+    - paragraphs.paragraphs_type.services
+id: paragraph.services.default
+targetEntityType: paragraph
+bundle: services
+mode: default
+content:
+  field_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -1,0 +1,31 @@
+uuid: 802e33bd-0795-4077-8e2f-7091d21432c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.page.field_home_components
+    - node.type.page
+  module:
+    - entity_reference_revisions
+    - user
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  field_home_components:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/config/sync/core.entity_view_display.paragraph.ai_features.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.ai_features.default.yml
@@ -1,0 +1,32 @@
+uuid: 350473f9-f85f-418f-a769-997f64b0a8a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.ai_features.field_heading
+    - field.field.paragraph.ai_features.field_text
+    - paragraphs.paragraphs_type.ai_features
+  module:
+    - text
+id: paragraph.ai_features.default
+targetEntityType: paragraph
+bundle: ai_features
+mode: default
+content:
+  field_heading:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.case_clients.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.case_clients.default.yml
@@ -1,0 +1,32 @@
+uuid: a7328d72-a35d-4181-ba03-1e04c0df1a06
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.case_clients.field_heading
+    - field.field.paragraph.case_clients.field_text
+    - paragraphs.paragraphs_type.case_clients
+  module:
+    - text
+id: paragraph.case_clients.default
+targetEntityType: paragraph
+bundle: case_clients
+mode: default
+content:
+  field_heading:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.cta.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.cta.default.yml
@@ -1,0 +1,46 @@
+uuid: 9673a576-e0c4-461d-a8de-e98aee0c375f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta.field_heading
+    - field.field.paragraph.cta.field_text
+    - field.field.paragraph.cta.field_link
+    - paragraphs.paragraphs_type.cta
+  module:
+    - text
+    - link
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content:
+  field_heading:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.hero.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.hero.default.yml
@@ -1,0 +1,46 @@
+uuid: ccb70d2f-fe90-4ec3-ada3-bc604b63586b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_heading
+    - field.field.paragraph.hero.field_text
+    - field.field.paragraph.hero.field_link
+    - paragraphs.paragraphs_type.hero
+  module:
+    - text
+    - link
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  field_heading:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.services.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.services.default.yml
@@ -1,0 +1,32 @@
+uuid: 1060b724-93b3-4e37-a1b1-2df185365455
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.services.field_heading
+    - field.field.paragraph.services.field_text
+    - paragraphs.paragraphs_type.services
+  module:
+    - text
+id: paragraph.services.default
+targetEntityType: paragraph
+bundle: services
+mode: default
+content:
+  field_heading:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/field.field.node.page.field_home_components.yml
+++ b/config/sync/field.field.node.page.field_home_components.yml
@@ -1,0 +1,51 @@
+uuid: be115f8f-dbb2-4dde-acdd-f82579cd634d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_home_components
+    - node.type.page
+    - paragraphs.paragraphs_type.ai_features
+    - paragraphs.paragraphs_type.case_clients
+    - paragraphs.paragraphs_type.cta
+    - paragraphs.paragraphs_type.hero
+    - paragraphs.paragraphs_type.services
+  module:
+    - entity_reference_revisions
+id: node.page.field_home_components
+field_name: field_home_components
+entity_type: node
+bundle: page
+label: 'Composants d''accueil'
+description: 'Ordre recommandé : Hero → Services → IA → Cas clients → CTA.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      hero: hero
+      services: services
+      ai_features: ai_features
+      case_clients: case_clients
+      cta: cta
+    negate: 0
+    target_bundles_drag_drop:
+      ai_features:
+        weight: 3
+        enabled: true
+      case_clients:
+        weight: 4
+        enabled: true
+      cta:
+        weight: 5
+        enabled: true
+      hero:
+        weight: 1
+        enabled: true
+      services:
+        weight: 2
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/sync/field.field.paragraph.ai_features.field_heading.yml
+++ b/config/sync/field.field.paragraph.ai_features.field_heading.yml
@@ -1,0 +1,19 @@
+uuid: 3abf9f22-eabd-449b-8a35-206ef1a86b11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.ai_features
+id: paragraph.ai_features.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: ai_features
+label: Titre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.ai_features.field_text.yml
+++ b/config/sync/field.field.paragraph.ai_features.field_text.yml
@@ -1,0 +1,22 @@
+uuid: 8236bd0f-7799-45d2-bbfc-9a0c40aeb430
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.ai_features
+  module:
+    - text
+id: paragraph.ai_features.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: ai_features
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.case_clients.field_heading.yml
+++ b/config/sync/field.field.paragraph.case_clients.field_heading.yml
@@ -1,0 +1,19 @@
+uuid: 53be7a05-d554-4aef-a82a-f6bb1183a5e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.case_clients
+id: paragraph.case_clients.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: case_clients
+label: Titre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.case_clients.field_text.yml
+++ b/config/sync/field.field.paragraph.case_clients.field_text.yml
@@ -1,0 +1,22 @@
+uuid: da50e4dc-a66f-4ce7-82dc-710a5c0d149d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.case_clients
+  module:
+    - text
+id: paragraph.case_clients.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: case_clients
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.cta.field_heading.yml
+++ b/config/sync/field.field.paragraph.cta.field_heading.yml
@@ -1,0 +1,19 @@
+uuid: b7f1134a-6384-44ce-aecb-a8cdb3e439bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.cta
+id: paragraph.cta.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: cta
+label: Titre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.cta.field_link.yml
+++ b/config/sync/field.field.paragraph.cta.field_link.yml
@@ -1,0 +1,23 @@
+uuid: aaf8e75c-dcc0-49c1-8209-75e213d4be93
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.cta
+  module:
+    - link
+id: paragraph.cta.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: cta
+label: Lien
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/sync/field.field.paragraph.cta.field_text.yml
+++ b/config/sync/field.field.paragraph.cta.field_text.yml
@@ -1,0 +1,22 @@
+uuid: 19a6e0e6-b35b-4efc-91d8-c2840f7b0c2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.cta
+  module:
+    - text
+id: paragraph.cta.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: cta
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.hero.field_heading.yml
+++ b/config/sync/field.field.paragraph.hero.field_heading.yml
@@ -1,0 +1,19 @@
+uuid: 7bfa4fa3-c1b5-4102-b076-c4a69d045853
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: hero
+label: Titre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.hero.field_link.yml
+++ b/config/sync/field.field.paragraph.hero.field_link.yml
@@ -1,0 +1,23 @@
+uuid: c8f15cb2-fe0e-4503-99e8-a0de0cbb1561
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.hero
+  module:
+    - link
+id: paragraph.hero.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: hero
+label: Lien
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/sync/field.field.paragraph.hero.field_text.yml
+++ b/config/sync/field.field.paragraph.hero.field_text.yml
@@ -1,0 +1,22 @@
+uuid: b9476f5e-c743-41a3-b91d-ca9b17514879
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.hero
+  module:
+    - text
+id: paragraph.hero.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: hero
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.services.field_heading.yml
+++ b/config/sync/field.field.paragraph.services.field_heading.yml
@@ -1,0 +1,19 @@
+uuid: a2cb8cc8-9ca8-4be7-b210-8bbbff76db6b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_heading
+    - paragraphs.paragraphs_type.services
+id: paragraph.services.field_heading
+field_name: field_heading
+entity_type: paragraph
+bundle: services
+label: Titre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.services.field_text.yml
+++ b/config/sync/field.field.paragraph.services.field_text.yml
@@ -1,0 +1,22 @@
+uuid: c56bc6b1-2782-4c0f-9b2b-91dd0d584101
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.services
+  module:
+    - text
+id: paragraph.services.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: services
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.storage.node.field_home_components.yml
+++ b/config/sync/field.storage.node.field_home_components.yml
@@ -1,0 +1,20 @@
+uuid: 339107e0-7388-4bf9-980b-45814a51d4bc
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+id: node.field_home_components
+field_name: field_home_components
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_heading.yml
+++ b/config/sync/field.storage.paragraph.field_heading.yml
@@ -1,0 +1,21 @@
+uuid: cc17ed6d-c1b5-4cb9-8d66-056976adf3d5
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_heading
+field_name: field_heading
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_link.yml
+++ b/config/sync/field.storage.paragraph.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 0b7a352d-d23a-452d-b1d4-a05fd5368f08
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_text.yml
+++ b/config/sync/field.storage.paragraph.field_text.yml
@@ -1,0 +1,19 @@
+uuid: 69702976-ead1-407c-9b3e-236026d406ec
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_text
+field_name: field_text
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/paragraphs.paragraphs_type.ai_features.yml
+++ b/config/sync/paragraphs.paragraphs_type.ai_features.yml
@@ -1,0 +1,8 @@
+uuid: b8ae3d26-43e9-4e75-b20c-3daae1c4117b
+langcode: en
+status: true
+dependencies: {  }
+id: ai_features
+label: 'Fonctionnalités IA'
+description: 'Section de mise en avant IA.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.case_clients.yml
+++ b/config/sync/paragraphs.paragraphs_type.case_clients.yml
@@ -1,0 +1,8 @@
+uuid: def9858b-542d-4d45-9483-54b7281db29f
+langcode: en
+status: true
+dependencies: {  }
+id: case_clients
+label: 'Cas clients'
+description: 'Section de preuves clients.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.cta.yml
+++ b/config/sync/paragraphs.paragraphs_type.cta.yml
@@ -1,0 +1,8 @@
+uuid: 62f7766d-8cf4-4f21-bfca-418115a7fd9d
+langcode: en
+status: true
+dependencies: {  }
+id: cta
+label: CTA
+description: 'Bloc d''appel à action.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.hero.yml
+++ b/config/sync/paragraphs.paragraphs_type.hero.yml
@@ -1,0 +1,8 @@
+uuid: 94901a6b-6977-4b14-acfd-4b7ab2da23ec
+langcode: en
+status: true
+dependencies: {  }
+id: hero
+label: Hero
+description: 'Bloc Hero pour la page d''accueil.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.services.yml
+++ b/config/sync/paragraphs.paragraphs_type.services.yml
@@ -1,0 +1,8 @@
+uuid: f48eb8e0-96a0-4ec6-a0a7-6faa1eff2c9a
+langcode: en
+status: true
+dependencies: {  }
+id: services
+label: Services
+description: 'Section des services principaux.'
+behavior_plugins: {  }

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -35,3 +35,66 @@ button:focus-visible {
   background: transparent;
   color: var(--color-text);
 }
+
+.node {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.node__header {
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--space-3);
+}
+
+.node__title {
+  margin: 0;
+}
+
+.node__related,
+.node__references {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.node__related {
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.component {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.component__inner {
+  width: min(100%, 52rem);
+}
+
+.component__title {
+  margin-bottom: var(--space-3);
+}
+
+.component__text {
+  color: var(--color-muted);
+}
+
+.component__actions {
+  margin-top: var(--space-4);
+}
+
+.component--hero {
+  padding-block: var(--space-7);
+}
+
+.component--hero .component__inner {
+  width: min(100%, 44rem);
+}
+
+.component--cta {
+  border-bottom: 0;
+  background: var(--color-surface);
+  padding-inline: var(--space-4);
+  border-radius: var(--radius-md);
+}

--- a/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for article nodes.
+ */
+#}
+<article{{ attributes.addClass('node', 'node--article') }}>
+  <header class="node__header">
+    {{ title_prefix }}
+    <h1{{ title_attributes.addClass('node__title') }}>{{ label }}</h1>
+    {{ title_suffix }}
+  </header>
+
+  <div class="node__content">
+    {{ content }}
+  </div>
+</article>

--- a/web/themes/custom/emerging_digital/templates/content/node--case-client.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--case-client.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override for case client nodes.
+ */
+#}
+<article{{ attributes.addClass('node', 'node--case-client') }}>
+  <header class="node__header">
+    {{ title_prefix }}
+    <h1{{ title_attributes.addClass('node__title') }}>{{ label }}</h1>
+    {{ title_suffix }}
+  </header>
+
+  <div class="node__content">
+    {{ content|without('field_related_services', 'field_related_ai_features') }}
+  </div>
+
+  <div class="node__references">
+    {% if content.field_related_services %}
+      <section class="node__related">
+        <h2 class="node__related-title">Services associés</h2>
+        {{ content.field_related_services }}
+      </section>
+    {% endif %}
+
+    {% if content.field_related_ai_features %}
+      <section class="node__related">
+        <h2 class="node__related-title">Fonctionnalités IA mobilisées</h2>
+        {{ content.field_related_ai_features }}
+      </section>
+    {% endif %}
+  </div>
+</article>

--- a/web/themes/custom/emerging_digital/templates/content/node--service.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--service.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override for service nodes.
+ */
+#}
+<article{{ attributes.addClass('node', 'node--service') }}>
+  <header class="node__header">
+    {{ title_prefix }}
+    <h1{{ title_attributes.addClass('node__title') }}>{{ label }}</h1>
+    {{ title_suffix }}
+  </header>
+
+  <div class="node__content">
+    {{ content|without('field_related_ai_features') }}
+  </div>
+
+  {% if content.field_related_ai_features %}
+    <aside class="node__related">
+      <h2 class="node__related-title">Fonctionnalités IA liées</h2>
+      {{ content.field_related_ai_features }}
+    </aside>
+  {% endif %}
+</article>

--- a/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Theme override for the front page.
+ */
+#}
+<div class="site-shell site-shell--front">
+  <header class="page-header" role="banner">
+    <div class="page-container">
+      {{ page.header }}
+    </div>
+  </header>
+
+  <main role="main" class="page-main page-main--front">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="page-container">
+      {{ page.content }}
+    </div>
+  </main>
+
+  <footer class="page-footer" role="contentinfo">
+    <div class="page-container">
+      {{ page.footer }}
+    </div>
+  </footer>
+</div>

--- a/web/themes/custom/emerging_digital/templates/layout/page.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a page.
+ */
+#}
+<div class="site-shell">
+  <header class="page-header" role="banner">
+    <div class="page-container">
+      {{ page.header }}
+    </div>
+  </header>
+
+  {% if page.highlighted %}
+    <section class="page-highlighted" aria-label="Highlighted">
+      <div class="page-container">
+        {{ page.highlighted }}
+      </div>
+    </section>
+  {% endif %}
+
+  <main role="main" class="page-main">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="page-container layout-grid {% if page.sidebar %}layout-grid--with-sidebar{% endif %}">
+      <section class="layout-grid__content">
+        {{ page.content }}
+      </section>
+      {% if page.sidebar %}
+        <aside class="layout-grid__sidebar">
+          {{ page.sidebar }}
+        </aside>
+      {% endif %}
+    </div>
+  </main>
+
+  <footer class="page-footer" role="contentinfo">
+    <div class="page-container">
+      {{ page.footer }}
+    </div>
+  </footer>
+</div>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--ai-features.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--ai-features.html.twig
@@ -1,0 +1,10 @@
+<section{{ attributes.addClass('component', 'component--ai-features') }}>
+  <div class="component__inner">
+    {% if content.field_heading %}
+      <h2 class="component__title">{{ content.field_heading }}</h2>
+    {% endif %}
+    {% if content.field_text %}
+      <div class="component__text">{{ content.field_text }}</div>
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--case-clients.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--case-clients.html.twig
@@ -1,0 +1,10 @@
+<section{{ attributes.addClass('component', 'component--case-clients') }}>
+  <div class="component__inner">
+    {% if content.field_heading %}
+      <h2 class="component__title">{{ content.field_heading }}</h2>
+    {% endif %}
+    {% if content.field_text %}
+      <div class="component__text">{{ content.field_text }}</div>
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
@@ -1,0 +1,13 @@
+<section{{ attributes.addClass('component', 'component--cta') }}>
+  <div class="component__inner">
+    {% if content.field_heading %}
+      <h2 class="component__title">{{ content.field_heading }}</h2>
+    {% endif %}
+    {% if content.field_text %}
+      <div class="component__text">{{ content.field_text }}</div>
+    {% endif %}
+    {% if content.field_link %}
+      <div class="component__actions">{{ content.field_link }}</div>
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
@@ -1,0 +1,13 @@
+<section{{ attributes.addClass('component', 'component--hero') }}>
+  <div class="component__inner">
+    {% if content.field_heading %}
+      <h2 class="component__title">{{ content.field_heading }}</h2>
+    {% endif %}
+    {% if content.field_text %}
+      <div class="component__text">{{ content.field_text }}</div>
+    {% endif %}
+    {% if content.field_link %}
+      <div class="component__actions">{{ content.field_link }}</div>
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--services.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--services.html.twig
@@ -1,0 +1,10 @@
+<section{{ attributes.addClass('component', 'component--services') }}>
+  <div class="component__inner">
+    {% if content.field_heading %}
+      <h2 class="component__title">{{ content.field_heading }}</h2>
+    {% endif %}
+    {% if content.field_text %}
+      <div class="component__text">{{ content.field_text }}</div>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a maintainable scaffold for the homepage and main content types using Paragraphs as the building blocks.
- Prepare a clean, reusable set of Twig templates and minimal styles so content editors can compose the front page without finalizing design.
- Ensure the `page` content type can host ordered Paragraph components: Hero → Services → IA → Case clients → CTA.

### Description
- Added base layout templates `web/themes/custom/emerging_digital/templates/layout/page.html.twig` and `page--front.html.twig` and node templates `node--service.html.twig`, `node--article.html.twig`, `node--case-client.html.twig` to standardize page/node structure.
- Created 5 Paragraph bundles via config in `config/sync`: `hero`, `services`, `ai_features`, `case_clients`, `cta` and corresponding field storages/instances and displays, and added `field_home_components` on `page` to reference them.
- Added Paragraph Twig templates in `web/themes/custom/emerging_digital/templates/paragraphs/` with consistent classes (`component`, `component--*`) and a small component stylesheet in `web/themes/custom/emerging_digital/css/components.css` for a minimal design system.
- Exported the configuration files to `config/sync/` so the new bundles, fields and displays are deliverable and importable; templates and CSS committed in the theme.
- Work implemented on branch `feature/ticket-4-1` and this PR closes the ticket with `Closes #4.1`.

### Testing
- Ran repository checks: `git status --short --branch` to verify changes staged and branch context (succeeded). 
- Attempted configuration export/import with `drush cex -y` and `drush cim -y`, but `drush` is not available in the execution environment so these commands could not run here. 
- Attempted YAML validation via a small Python check, but the `yaml` module was not available in the environment so automated YAML parsing could not be completed. 
- All created files were committed and added to `config/sync` so CI or a local environment with `drush` can run `drush cim -y` to import and validate the configuration (recommended as next step).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb86c2674832199cd4e95dd59771e)