### PR TITLE
Add metatag defaults and pathauto patterns for content types; update sitemap, pathauto and redirect settings

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -34,6 +34,8 @@ module:
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  metatag_open_graph: 0
+  metatag_twitter_cards: 0
   mysql: 0
   node: 0
   options: 0

--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -7,5 +7,14 @@ _core:
 id: front
 label: 'Front page'
 tags:
+  title: 'Agence Drupal & IA | [site:name]'
+  description: 'Agence Drupal 11 : services, solutions IA et cas clients.'
   canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  og_title: 'Agence Drupal & IA | [site:name]'
+  og_description: 'Agence Drupal 11 : services, solutions IA et cas clients.'
+  og_url: '[site:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: 'Agence Drupal & IA | [site:name]'
+  twitter_cards_description: 'Agence Drupal 11 : services, solutions IA et cas clients.'

--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -9,3 +9,11 @@ label: Global
 tags:
   canonical_url: '[current-page:url]'
   title: '[current-page:title] | [site:name]'
+  description: 'Agence Drupal 11 : services web, IA & cas clients.'
+  og_title: '[current-page:title] | [site:name]'
+  og_description: 'Agence Drupal 11 : services web, IA & cas clients.'
+  og_url: '[current-page:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: 'Agence Drupal 11 : services web, IA & cas clients.'

--- a/config/sync/metatag.metatag_defaults.node__ai_feature.yml
+++ b/config/sync/metatag.metatag_defaults.node__ai_feature.yml
@@ -10,3 +10,10 @@ tags:
   title: '[node:title] | [site:name]'
   description: '[node:field_short_description:value]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | [site:name]'
+  og_description: '[node:field_short_description:value]'
+  og_url: '[node:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: '[node:field_short_description:value]'

--- a/config/sync/metatag.metatag_defaults.node__ai_feature.yml
+++ b/config/sync/metatag.metatag_defaults.node__ai_feature.yml
@@ -1,0 +1,12 @@
+uuid: 3dec4bcf-45c9-4ddb-a54c-7c2aee536f65
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node__ai_feature
+label: 'Content: Fonctionnalité IA'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:field_short_description:value]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -1,0 +1,12 @@
+uuid: b221ca12-be61-4678-9343-8a7285fb20da
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node__article
+label: 'Content: Article'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:field_short_description:value]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -10,3 +10,10 @@ tags:
   title: '[node:title] | [site:name]'
   description: '[node:field_short_description:value]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | [site:name]'
+  og_description: '[node:field_short_description:value]'
+  og_url: '[node:url]'
+  og_type: article
+  twitter_cards_type: summary
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: '[node:field_short_description:value]'

--- a/config/sync/metatag.metatag_defaults.node__case_client.yml
+++ b/config/sync/metatag.metatag_defaults.node__case_client.yml
@@ -1,0 +1,12 @@
+uuid: a8224e19-286d-45d5-92ee-39c1ac6beb18
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node__case_client
+label: 'Content: Cas client'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:field_short_description:value]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.node__case_client.yml
+++ b/config/sync/metatag.metatag_defaults.node__case_client.yml
@@ -10,3 +10,10 @@ tags:
   title: '[node:title] | [site:name]'
   description: '[node:field_short_description:value]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | [site:name]'
+  og_description: '[node:field_short_description:value]'
+  og_url: '[node:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: '[node:field_short_description:value]'

--- a/config/sync/metatag.metatag_defaults.node__page.yml
+++ b/config/sync/metatag.metatag_defaults.node__page.yml
@@ -8,5 +8,12 @@ id: node__page
 label: 'Content: Page'
 tags:
   title: '[node:title] | [site:name]'
-  description: '[node:title] - [site:name]'
+  description: 'Page institutionnelle de [site:name].'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | [site:name]'
+  og_description: 'Page institutionnelle de [site:name].'
+  og_url: '[node:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: 'Page institutionnelle de [site:name].'

--- a/config/sync/metatag.metatag_defaults.node__page.yml
+++ b/config/sync/metatag.metatag_defaults.node__page.yml
@@ -1,0 +1,12 @@
+uuid: a5bf0e5b-0c01-4c25-886e-343851eae18f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node__page
+label: 'Content: Page'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:title] - [site:name]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.node__service.yml
+++ b/config/sync/metatag.metatag_defaults.node__service.yml
@@ -1,0 +1,12 @@
+uuid: 06f680a1-ea01-4396-8b93-f818b69e51bd
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node__service
+label: 'Content: Service'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:field_short_description:value]'
+  canonical_url: '[node:url]'

--- a/config/sync/metatag.metatag_defaults.node__service.yml
+++ b/config/sync/metatag.metatag_defaults.node__service.yml
@@ -10,3 +10,10 @@ tags:
   title: '[node:title] | [site:name]'
   description: '[node:field_short_description:value]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | [site:name]'
+  og_description: '[node:field_short_description:value]'
+  og_url: '[node:url]'
+  og_type: website
+  twitter_cards_type: summary
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: '[node:field_short_description:value]'

--- a/config/sync/pathauto.pattern.node_ai_feature.yml
+++ b/config/sync/pathauto.pattern.node_ai_feature.yml
@@ -1,0 +1,22 @@
+uuid: 2fd977f2-104b-4129-9675-8f66e6488d6a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_ai_feature
+label: 'Content path pattern (Fonctionnalité IA)'
+type: 'canonical_entities:node'
+pattern: 'ia/[node:title]'
+selection_criteria:
+  8d7f8da3-6ec4-44ed-85e5-00296c84173b:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 8d7f8da3-6ec4-44ed-85e5-00296c84173b
+    context_mapping:
+      node: node
+    bundles:
+      ai_feature: ai_feature
+selection_logic: and
+weight: -6
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_article.yml
+++ b/config/sync/pathauto.pattern.node_article.yml
@@ -1,0 +1,22 @@
+uuid: 10315169-eb0f-42be-9776-7f80047a3843
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_article
+label: 'Content path pattern (Article)'
+type: 'canonical_entities:node'
+pattern: 'actualites/[node:title]'
+selection_criteria:
+  dc548961-b1bc-41a1-b140-62ca0fd8f9fe:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: dc548961-b1bc-41a1-b140-62ca0fd8f9fe
+    context_mapping:
+      node: node
+    bundles:
+      article: article
+selection_logic: and
+weight: -8
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_case_client.yml
+++ b/config/sync/pathauto.pattern.node_case_client.yml
@@ -1,0 +1,22 @@
+uuid: cb90a0fe-df18-4584-9cdf-404b80018582
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_case_client
+label: 'Content path pattern (Cas client)'
+type: 'canonical_entities:node'
+pattern: 'cas-clients/[node:title]'
+selection_criteria:
+  ca74dee3-e177-4818-91b6-83009a5b3f75:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: ca74dee3-e177-4818-91b6-83009a5b3f75
+    context_mapping:
+      node: node
+    bundles:
+      case_client: case_client
+selection_logic: and
+weight: -7
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_page.yml
+++ b/config/sync/pathauto.pattern.node_page.yml
@@ -1,0 +1,22 @@
+uuid: 5a0ab78f-3494-4b7c-bbd6-18d91cf71b11
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_page
+label: 'Content path pattern (Page)'
+type: 'canonical_entities:node'
+pattern: '[node:title]'
+selection_criteria:
+  2d5dcbce-aad6-4424-bca0-4b9d1a9ad2b0:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 2d5dcbce-aad6-4424-bca0-4b9d1a9ad2b0
+    context_mapping:
+      node: node
+    bundles:
+      page: page
+selection_logic: and
+weight: -10
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_service.yml
+++ b/config/sync/pathauto.pattern.node_service.yml
@@ -1,0 +1,22 @@
+uuid: 8d039650-6bbd-4f03-8671-53ae777331dc
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node_service
+label: 'Content path pattern (Service)'
+type: 'canonical_entities:node'
+pattern: 'services/[node:title]'
+selection_criteria:
+  5d6066ce-be42-4d75-ae05-c4044020944c:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 5d6066ce-be42-4d75-ae05-c4044020944c
+    context_mapping:
+      node: node
+    bundles:
+      service: service
+selection_logic: and
+weight: -9
+relationships: {  }

--- a/config/sync/pathauto.settings.yml
+++ b/config/sync/pathauto.settings.yml
@@ -1,6 +1,8 @@
 _core:
   default_config_hash: SwvLp8snyPEExF41CaJJYdPUVomofLqtXvwciHc4cPg
 enabled_entity_types:
+  - node
+  - taxonomy_term
   - user
 punctuation:
   hyphen: 1

--- a/config/sync/redirect.settings.yml
+++ b/config/sync/redirect.settings.yml
@@ -4,6 +4,6 @@ auto_redirect: true
 default_status_code: 301
 passthrough_querystring: true
 warning: false
-ignore_admin_path: false
+ignore_admin_path: true
 access_check: false
 route_normalizer_enabled: true

--- a/config/sync/simple_sitemap.settings.yml
+++ b/config/sync/simple_sitemap.settings.yml
@@ -9,12 +9,10 @@ remove_duplicates: true
 skip_untranslated: true
 xsl: true
 base_url: ''
-default_variant: default
+default_variant: index
 custom_links_include_images: false
 disable_language_hreflang: false
 hide_branding: false
 excluded_languages: {  }
 enabled_entity_types:
   - node
-  - taxonomy_term
-  - menu_link_content

--- a/config/sync/simple_sitemap.sitemap.index.yml
+++ b/config/sync/simple_sitemap.sitemap.index.yml
@@ -1,6 +1,6 @@
 uuid: e7fc78cc-2594-4f2a-bfa4-058db2a3193c
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - simple_sitemap.type.index

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * @file
  * Post-update hooks for Emerging Digital Content.
  */
+
+declare(strict_types=1);
 
 /**
  * Imports packaged default content for already-installed environments.

--- a/web/modules/custom/emerging_digital_content/scripts/import_default_content.php
+++ b/web/modules/custom/emerging_digital_content/scripts/import_default_content.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Imports packaged default content for local/bootstrap workflows.
+ */
+
 declare(strict_types=1);
 
 require_once DRUPAL_ROOT . '/modules/custom/emerging_digital_content/emerging_digital_content.install';
@@ -13,6 +18,6 @@ $importer->importContent('emerging_digital_content');
   ->set('page.front', '/accueil')
   ->save(TRUE);
 
-  \Drupal::state()->set('system.maintenance_mode', 0);
+\Drupal::state()->set('system.maintenance_mode', 0);
 
 print "Default content imported and front page set to /accueil.\n";


### PR DESCRIPTION
### Motivation
- Provide consistent SEO metadata and canonical URLs for several content types by adding metatag defaults. 
- Ensure human-friendly URLs for the new content bundles using `pathauto` patterns. 
- Adjust site generation and routing behavior for sitemaps, redirects, and path generation to match the new content configuration.

### Description
- Enabled metatag submodules `metatag_open_graph` and `metatag_twitter_cards` in `config/sync/core.extension.yml`.
- Added metatag default configs `metatag.metatag_defaults.node__ai_feature.yml`, `node__article.yml`, `node__case_client.yml`, `node__page.yml`, and `node__service.yml` setting `title`, `description`, and `canonical_url` tags.
- Added `pathauto` patterns for the new bundles with files `pathauto.pattern.node_ai_feature.yml`, `node_article.yml`, `node_case_client.yml`, `node_page.yml`, and `node_service.yml` defining the URL patterns and selection criteria.
- Updated `pathauto.settings.yml` to include `node` (and `taxonomy_term`) in `enabled_entity_types` for alias generation.
- Tweaked `redirect.settings.yml` to set `ignore_admin_path: true`.
- Modified `simple_sitemap.settings.yml` to change `default_variant` to `index` and adjust `enabled_entity_types` and related sitemap options, and enabled the sitemap index by setting `simple_sitemap.sitemap.index.yml` `status: true`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21412014c8321a0a1bb1a862dbf3f)