### PR TITLE
Fix main navigation content and responsive header menu styling

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -1,11 +1,12 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * @file
  * Install hooks for Emerging Digital Content module.
  */
+
+declare(strict_types=1);
+use Drupal\emerging_digital_content\MainNavigationManager;
 
 /**
  * Sets front page and purges stale packaged UUIDs before auto-import runs.
@@ -18,6 +19,8 @@ function emerging_digital_content_install(): void {
     ->save(TRUE);
 
   \Drupal::state()->set('system.maintenance_mode', 0);
+
+  MainNavigationManager::ensureMainNavigationLinks();
 }
 
 /**

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\emerging_digital_content\MainNavigationManager;
 
 /**
  * Imports packaged default content for already-installed environments.
@@ -40,45 +40,7 @@ function emerging_digital_content_post_update_import_default_content(array &$san
  * Creates missing main navigation links for the public website pages.
  */
 function emerging_digital_content_post_update_main_navigation_links(array &$sandbox): string {
-  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+  $updated = MainNavigationManager::ensureMainNavigationLinks();
 
-  $links = [
-    ['title' => 'Accueil', 'uri' => 'internal:/accueil', 'weight' => 0],
-    ['title' => 'Services', 'uri' => 'internal:/services', 'weight' => 1],
-    ['title' => 'IA & Drupal', 'uri' => 'internal:/ia-drupal', 'weight' => 2],
-    ['title' => 'Cas clients', 'uri' => 'internal:/cas-clients', 'weight' => 3],
-    ['title' => 'Contact', 'uri' => 'internal:/contact', 'weight' => 4],
-  ];
-
-  $created = 0;
-  foreach ($links as $link) {
-    $candidate_ids = \Drupal::entityQuery('menu_link_content')
-      ->accessCheck(FALSE)
-      ->condition('menu_name', 'main')
-      ->condition('title', $link['title'])
-      ->execute();
-
-    if ($candidate_ids) {
-      $candidates = $storage->loadMultiple($candidate_ids);
-      foreach ($candidates as $candidate) {
-        $link_item = $candidate->get('link')->first();
-        if ($link_item && ($link_item->getValue()['uri'] ?? '') === $link['uri']) {
-          continue 2;
-        }
-      }
-    }
-
-    MenuLinkContent::create([
-      'title' => $link['title'],
-      'menu_name' => 'main',
-      'link' => ['uri' => $link['uri']],
-      'expanded' => FALSE,
-      'enabled' => TRUE,
-      'weight' => $link['weight'],
-    ])->save();
-
-    $created++;
-  }
-
-  return sprintf('%d main navigation links were created.', $created);
+  return sprintf('%d main navigation links were created or updated.', $updated);
 }

--- a/web/modules/custom/emerging_digital_content/src/MainNavigationManager.php
+++ b/web/modules/custom/emerging_digital_content/src/MainNavigationManager.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\emerging_digital_content;
+
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+
+/**
+ * Ensures the expected links exist in the Main navigation menu.
+ */
+final class MainNavigationManager {
+
+  /**
+   * Creates or updates the expected public navigation links.
+   */
+  public static function ensureMainNavigationLinks(): int {
+    $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+
+    $links = [
+      ['title' => 'Accueil', 'uri' => 'internal:/accueil', 'weight' => 0],
+      ['title' => 'Services', 'uri' => 'internal:/services', 'weight' => 1],
+      ['title' => 'IA & Drupal', 'uri' => 'internal:/ia-drupal', 'weight' => 2],
+      ['title' => 'Cas clients', 'uri' => 'internal:/cas-clients', 'weight' => 3],
+      ['title' => 'Contact', 'uri' => 'internal:/contact', 'weight' => 4],
+    ];
+
+    $created_or_updated = 0;
+
+    foreach ($links as $link) {
+      $candidate_ids = \Drupal::entityQuery('menu_link_content')
+        ->accessCheck(FALSE)
+        ->condition('menu_name', 'main')
+        ->condition('title', $link['title'])
+        ->execute();
+
+      if ($candidate_ids) {
+        $candidates = $storage->loadMultiple($candidate_ids);
+        foreach ($candidates as $candidate) {
+          $link_item = $candidate->get('link')->first();
+          if ($link_item && ($link_item->getValue()['uri'] ?? '') === $link['uri']) {
+            if ((int) $candidate->get('weight')->value !== $link['weight']) {
+              $candidate->set('weight', $link['weight']);
+              $candidate->save();
+              $created_or_updated++;
+            }
+
+            continue 2;
+          }
+
+          $candidate->set('link', ['uri' => $link['uri']]);
+          $candidate->set('enabled', TRUE);
+          $candidate->set('weight', $link['weight']);
+          $candidate->save();
+          $created_or_updated++;
+          continue 2;
+        }
+      }
+
+      MenuLinkContent::create([
+        'title' => $link['title'],
+        'menu_name' => 'main',
+        'link' => ['uri' => $link['uri']],
+        'expanded' => FALSE,
+        'enabled' => TRUE,
+        'weight' => $link['weight'],
+      ])->save();
+
+      $created_or_updated++;
+    }
+
+    $legacy_home_ids = \Drupal::entityQuery('menu_link_content')
+      ->accessCheck(FALSE)
+      ->condition('menu_name', 'main')
+      ->condition('title', 'Home')
+      ->execute();
+
+    if ($legacy_home_ids) {
+      $legacy_homes = $storage->loadMultiple($legacy_home_ids);
+
+      $accueil_ids = \Drupal::entityQuery('menu_link_content')
+        ->accessCheck(FALSE)
+        ->condition('menu_name', 'main')
+        ->condition('title', 'Accueil')
+        ->execute();
+
+      foreach ($legacy_homes as $legacy_home) {
+        if ($accueil_ids) {
+          $legacy_home->delete();
+        }
+        else {
+          $legacy_home->set('title', 'Accueil');
+          $legacy_home->set('link', ['uri' => 'internal:/accueil']);
+          $legacy_home->set('enabled', TRUE);
+          $legacy_home->set('weight', 0);
+          $legacy_home->save();
+        }
+
+        $created_or_updated++;
+      }
+    }
+
+    return $created_or_updated;
+  }
+
+}

--- a/web/themes/custom/emerging_digital/css/layout.css
+++ b/web/themes/custom/emerging_digital/css/layout.css
@@ -29,8 +29,13 @@
   width: 100%;
 }
 
+.page-header__inner .region-header > * {
+  margin-block: 0;
+}
+
 .page-header .block-system-branding-block {
   margin: 0;
+  flex-shrink: 0;
 }
 
 .page-header .site-logo img {
@@ -51,47 +56,60 @@
   text-decoration: none;
 }
 
-.page-header .menu {
+.page-header .block-system-menu-blockmain {
+  margin: 0 0 0 auto;
+}
+
+.page-header .main-navigation__list {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1);
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.page-header .block-system-menu-blockmain {
+.page-header .main-navigation__item,
+.page-header .main-navigation__sublist {
+  list-style: none;
   margin: 0;
+  padding: 0;
 }
 
-.page-header .block-system-menu-blockmain .menu {
-  justify-content: flex-end;
-}
-
-.page-header .menu-item {
-  margin: 0;
-}
-
-.page-header .menu a {
+.page-header .main-navigation__link {
   color: var(--color-text);
   display: inline-flex;
   align-items: center;
-  min-height: 2.25rem;
-  padding: 0.35rem 0.8rem;
+  justify-content: center;
+  min-height: 2.4rem;
+  padding: 0.4rem 0.9rem;
   border-radius: 999px;
   font-weight: 500;
   line-height: 1;
   text-decoration: none;
-  transition: color 160ms ease, background-color 160ms ease;
+  transition: color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
 }
 
-.page-header .menu a:hover,
-.page-header .menu a:focus-visible,
-.page-header .menu .menu-item--active-trail > a,
-.page-header .menu a.is-active {
+.page-header .main-navigation__link:hover {
   color: var(--color-primary);
   background: #edf4ff;
+}
+
+.page-header .main-navigation__link:focus-visible {
+  color: var(--color-primary);
+  background: #edf4ff;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.page-header .main-navigation__item.is-active-trail > .main-navigation__link,
+.page-header .main-navigation__link.is-active,
+.page-header .main-navigation__link[aria-current="page"] {
+  color: var(--color-primary);
+  font-weight: 700;
+  background: #e5efff;
+  box-shadow: inset 0 0 0 1px #c8dafc;
 }
 
 .page-footer__inner {
@@ -142,23 +160,24 @@
 
 @media (max-width: 48rem) {
   .page-header__inner .region-header {
-    display: grid;
+    flex-wrap: wrap;
     gap: var(--space-2);
   }
 
   .page-header .block-system-menu-blockmain {
     width: 100%;
+    margin-inline-start: 0;
   }
 
-  .page-header .block-system-menu-blockmain .menu {
+  .page-header .main-navigation__list {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-1);
     width: 100%;
   }
 
-  .page-header .menu a {
-    justify-content: center;
+  .page-header .main-navigation__link {
     width: 100%;
+    min-height: 2.5rem;
   }
 }

--- a/web/themes/custom/emerging_digital/css/layout.css
+++ b/web/themes/custom/emerging_digital/css/layout.css
@@ -54,16 +54,44 @@
 .page-header .menu {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  align-items: center;
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+.page-header .block-system-menu-blockmain {
+  margin: 0;
+}
+
+.page-header .block-system-menu-blockmain .menu {
+  justify-content: flex-end;
+}
+
+.page-header .menu-item {
+  margin: 0;
+}
+
 .page-header .menu a {
   color: var(--color-text);
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
   font-weight: 500;
+  line-height: 1;
   text-decoration: none;
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.page-header .menu a:hover,
+.page-header .menu a:focus-visible,
+.page-header .menu .menu-item--active-trail > a,
+.page-header .menu a.is-active {
+  color: var(--color-primary);
+  background: #edf4ff;
 }
 
 .page-footer__inner {
@@ -114,11 +142,23 @@
 
 @media (max-width: 48rem) {
   .page-header__inner .region-header {
-    flex-direction: column;
-    align-items: flex-start;
+    display: grid;
+    gap: var(--space-2);
   }
 
-  .page-header .menu {
-    gap: var(--space-2) var(--space-3);
+  .page-header .block-system-menu-blockmain {
+    width: 100%;
+  }
+
+  .page-header .block-system-menu-blockmain .menu {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-1);
+    width: 100%;
+  }
+
+  .page-header .menu a {
+    justify-content: center;
+    width: 100%;
   }
 }

--- a/web/themes/custom/emerging_digital/templates/navigation/menu--main.html.twig
+++ b/web/themes/custom/emerging_digital/templates/navigation/menu--main.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override for the Main navigation menu.
+ */
+#}
+
+{% import _self as menus %}
+
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('main-navigation__list') }}>
+    {% else %}
+      <ul class="main-navigation__sublist">
+    {% endif %}
+    {% for item in items %}
+      {% set item_classes = [
+        'main-navigation__item',
+        item.in_active_trail ? 'is-active-trail',
+      ] %}
+      {% set link_attributes = item.url.getOption('attributes')|default({}) %}
+      {% set link_classes = (link_attributes.class|default([]))|merge(['main-navigation__link']) %}
+      <li{{ item.attributes.addClass(item_classes) }}>
+        {{ link(item.title, item.url, link_attributes|merge({'class': link_classes})) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
### Motivation
- Corriger le problème où seul « Home » était affiché et garantir la présence des liens publics attendus dans le menu principal via le système de menu Drupal. 
- Intégrer correctement le menu dans le header et appliquer un style lisible et cohérent. 
- Rendre la navigation utilisable et accessible sur mobile sans coder les liens en dur.

### Description
- Ajout d’un gestionnaire partagé `MainNavigationManager::ensureMainNavigationLinks()` qui crée/met à jour les liens `Accueil, Services, IA & Drupal, Cas clients, Contact` dans le menu `main` en s’appuyant sur les entités `menu_link_content` (fichier `web/modules/custom/emerging_digital_content/src/MainNavigationManager.php`).
- Appel du gestionnaire depuis l’installation (`emerging_digital_content_install()` dans `web/modules/custom/emerging_digital_content/emerging_digital_content.install`) et depuis le post-update (`emerging_digital_content_post_update_main_navigation_links()` dans `web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php`) afin d’aligner les environnements neufs et existants.
- Amélioration du rendu et du comportement responsive du menu header dans `web/themes/custom/emerging_digital/css/layout.css` pour affichage horizontal desktop, états hover/focus/active et grille mobile 2 colonnes tap-friendly.
- Cette PR référence l’issue cible avec `Closes #51`.

### Testing
- Lint PHP exécuté avec succès sur `web/modules/custom/emerging_digital_content/emerging_digital_content.install`, `web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php` et `web/modules/custom/emerging_digital_content/src/MainNavigationManager.php` via `php -l` (tous OK). 
- Aucune erreur de syntaxe détectée après les changements et les patches appliqués (build-local smoke tests non lancés ici). 
- Automatisations supplémentaires (CI/drupal BrowserTestBase) doivent être exécutées par le pipeline CI avant fusion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e356786c0c8321a9923ee544bc7fc5)