### PR TITLE
Allow iframe embeds, add Contact map and harmonise Contact page layout

### DIFF
--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -57,6 +57,7 @@ settings:
         - '<h4 id>'
         - '<h5 id>'
         - '<h6 id>'
+        - '<iframe title src width height style loading referrerpolicy allowfullscreen>'
 image_upload:
   status: true
   scheme: public

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -34,7 +34,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align>'
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align> <iframe title src width height style loading referrerpolicy allowfullscreen>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_html_image_secure:

--- a/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
@@ -7,9 +7,9 @@ _meta:
   depends:
     dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92: paragraph
     88affed2-d7e1-44bc-8607-28f0111fc123: paragraph
-    855b08da-0ec9-4261-883a-d27f214606e6: paragraph
     8236e39f-2bcf-4758-a441-c9f6eb8f75f6: paragraph
-    e8fcb813-8e1a-4739-a80b-f941b34040c7: paragraph
+    855b08da-0ec9-4261-883a-d27f214606e6: paragraph
+    856cbeed-a7cd-430b-ba72-aca0b79b6022: paragraph
 default:
   uid:
     -
@@ -26,11 +26,11 @@ default:
     -
       entity: "88affed2-d7e1-44bc-8607-28f0111fc123"
     -
-      entity: "855b08da-0ec9-4261-883a-d27f214606e6"
-    -
       entity: "8236e39f-2bcf-4758-a441-c9f6eb8f75f6"
     -
-      entity: "e8fcb813-8e1a-4739-a80b-f941b34040c7"
+      entity: "855b08da-0ec9-4261-883a-d27f214606e6"
+    -
+      entity: "856cbeed-a7cd-430b-ba72-aca0b79b6022"
   path:
     -
       alias: /contact

--- a/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
@@ -8,6 +8,7 @@ _meta:
     dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92: paragraph
     88affed2-d7e1-44bc-8607-28f0111fc123: paragraph
     8236e39f-2bcf-4758-a441-c9f6eb8f75f6: paragraph
+    fe7288c1-8611-4fc9-8b3e-fdb6219038d2: paragraph
     855b08da-0ec9-4261-883a-d27f214606e6: paragraph
     856cbeed-a7cd-430b-ba72-aca0b79b6022: paragraph
 default:
@@ -27,6 +28,8 @@ default:
       entity: "88affed2-d7e1-44bc-8607-28f0111fc123"
     -
       entity: "8236e39f-2bcf-4758-a441-c9f6eb8f75f6"
+    -
+      entity: "fe7288c1-8611-4fc9-8b3e-fdb6219038d2"
     -
       entity: "855b08da-0ec9-4261-883a-d27f214606e6"
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
@@ -10,7 +10,7 @@ default:
       value: Coordonnées
   field_text:
     -
-      value: '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p><strong>Informations légales :</strong> SRL — BE 0746.356.206</p>'
+      value: '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p>E-MERGING DIGITAL SRL<br>BE 0746.356.206</p>'
       format: basic_html
   status:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
@@ -7,10 +7,10 @@ _meta:
 default:
   field_heading:
     -
-      value: Informations
+      value: Coordonnées
   field_text:
     -
-      value: Disponible pour projets en Wallonie et Bruxelles.
+      value: '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p><strong>Informations légales :</strong> SRL — BE 0746.356.206</p>'
       format: basic_html
   status:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/856cbeed-a7cd-430b-ba72-aca0b79b6022.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/856cbeed-a7cd-430b-ba72-aca0b79b6022.yml
@@ -1,0 +1,17 @@
+_meta:
+  version: 1.0
+  entity_type: paragraph
+  uuid: "856cbeed-a7cd-430b-ba72-aca0b79b6022"
+  bundle: text_block
+  default_langcode: en
+default:
+  field_heading:
+    -
+      value: Carte
+  field_text:
+    -
+      value: '<iframe title="Localisation Emerging Digital" src="https://www.google.com/maps?q=Rue%20des%20Peupliers%201%2C%204254%20Ligney%20(Geer)&output=embed" width="100%" height="380" style="border:0;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen></iframe>'
+      format: basic_html
+  status:
+    -
+      value: true

--- a/web/modules/custom/emerging_digital_content/content/paragraph/88affed2-d7e1-44bc-8607-28f0111fc123.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/88affed2-d7e1-44bc-8607-28f0111fc123.yml
@@ -5,9 +5,12 @@ _meta:
   bundle: text_block
   default_langcode: en
 default:
+  field_heading:
+    -
+      value: Intro
   field_text:
     -
-      value: Nous analysons votre situation et vous proposons des solutions adaptées.
+      value: '<p>Parlons de votre projet digital. Décrivez vos objectifs : nous revenons vers vous avec une réponse claire, structurée et orientée résultats.</p>'
       format: basic_html
   status:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
@@ -10,7 +10,7 @@ default:
       value: Informations
   field_text:
     -
-      value: '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME et ASBL.</p><p>Premier échange sans engagement.</p>'
+      value: '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME, ASBL et organisations publiques.</p><p>Habitué à travailler sur des projets structurés et exigeants.</p><p>Premier échange sans engagement.</p>'
       format: basic_html
   status:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
@@ -1,0 +1,17 @@
+_meta:
+  version: 1.0
+  entity_type: paragraph
+  uuid: "fe7288c1-8611-4fc9-8b3e-fdb6219038d2"
+  bundle: text_block
+  default_langcode: en
+default:
+  field_heading:
+    -
+      value: Informations
+  field_text:
+    -
+      value: '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME et ASBL.</p><p>Premier échange sans engagement.</p>'
+      format: basic_html
+  status:
+    -
+      value: true

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -284,6 +284,7 @@ function emerging_digital_content_post_update_contact_page_professional_layout(a
   $hero = NULL;
   $intro = NULL;
   $coordinates = NULL;
+  $information = NULL;
   $form = NULL;
   $map = NULL;
   $extra_components = [];
@@ -320,6 +321,11 @@ function emerging_digital_content_post_update_contact_page_professional_layout(a
 
       if ($heading === 'Carte') {
         $map = $paragraph;
+        continue;
+      }
+
+      if ($heading === 'Informations') {
+        $information = $paragraph;
         continue;
       }
 
@@ -368,10 +374,23 @@ function emerging_digital_content_post_update_contact_page_professional_layout(a
     $map->save();
   }
 
+  $information_values = _emerging_digital_content_contact_information_values();
+  if ($information === NULL) {
+    $information = Paragraph::create($information_values);
+    $information->save();
+  }
+  else {
+    foreach ($information_values as $field_name => $value) {
+      $information->set($field_name, $value);
+    }
+    $information->save();
+  }
+
   $ordered_components = array_values(array_filter([
     $hero,
     $intro,
     $coordinates,
+    $information,
     $form,
     $map,
     ...$extra_components,
@@ -392,6 +411,13 @@ function emerging_digital_content_post_update_contact_page_professional_layout(a
  * Rejoue l'harmonisation de la page Contact sur les environnements existants.
  */
 function emerging_digital_content_post_update_contact_page_professional_layout_v2(array &$sandbox): string {
+  return emerging_digital_content_post_update_contact_page_professional_layout($sandbox);
+}
+
+/**
+ * Rejoue l'harmonisation Contact avec le bloc Informations de réassurance.
+ */
+function emerging_digital_content_post_update_contact_page_professional_layout_v3(array &$sandbox): string {
   return emerging_digital_content_post_update_contact_page_professional_layout($sandbox);
 }
 
@@ -435,6 +461,21 @@ function _emerging_digital_content_contact_map_values(): array {
     'field_heading' => 'Carte',
     'field_text' => [
       'value' => '<iframe title="Localisation Emerging Digital" src="https://www.google.com/maps?q=Rue%20des%20Peupliers%201%2C%204254%20Ligney%20(Geer)&output=embed" width="100%" height="380" style="border:0;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen></iframe>',
+      'format' => 'basic_html',
+    ],
+  ];
+}
+
+/**
+ * Valeurs de la section informations de la page Contact.
+ */
+function _emerging_digital_content_contact_information_values(): array {
+  return [
+    'type' => 'text_block',
+    'status' => TRUE,
+    'field_heading' => 'Informations',
+    'field_text' => [
+      'value' => '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME et ASBL.</p><p>Premier échange sans engagement.</p>',
       'format' => 'basic_html',
     ],
   ];

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Imports packaged default content for already-installed environments.
@@ -258,4 +259,176 @@ function emerging_digital_content_post_update_main_navigation_deduplicate_home_l
   }
 
   return sprintf('%d homepage links removed, %d homepage links updated.', $removed, $updated);
+}
+
+/**
+ * Harmonise la page Contact et supprime le CTA redondant.
+ */
+function emerging_digital_content_post_update_contact_page_professional_layout(array &$sandbox): string {
+  unset($sandbox);
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $existing = $node_storage->loadByProperties([
+    'type' => 'page',
+    'title' => 'Contact',
+  ]);
+
+  if (!$existing) {
+    return 'No Contact page found.';
+  }
+
+  /** @var \Drupal\node\Entity\Node $contact */
+  $contact = reset($existing);
+  $components = $contact->get('field_home_components')->referencedEntities();
+
+  $hero = NULL;
+  $intro = NULL;
+  $coordinates = NULL;
+  $form = NULL;
+  $map = NULL;
+  $extra_components = [];
+  $removed_cta = 0;
+
+  foreach ($components as $paragraph) {
+    if (!$paragraph instanceof Paragraph) {
+      continue;
+    }
+
+    $bundle = $paragraph->bundle();
+    $heading = trim((string) $paragraph->get('field_heading')->value);
+
+    if ($bundle === 'cta') {
+      $removed_cta++;
+      continue;
+    }
+
+    if ($bundle === 'hero' && $hero === NULL) {
+      $hero = $paragraph;
+      continue;
+    }
+
+    if ($bundle === 'text_block') {
+      if ($paragraph->uuid() === '855b08da-0ec9-4261-883a-d27f214606e6' || $heading === 'Formulaire') {
+        $form = $paragraph;
+        continue;
+      }
+
+      if ($heading === 'Coordonnées') {
+        $coordinates = $paragraph;
+        continue;
+      }
+
+      if ($heading === 'Carte') {
+        $map = $paragraph;
+        continue;
+      }
+
+      if ($intro === NULL) {
+        $intro = $paragraph;
+        continue;
+      }
+    }
+
+    $extra_components[] = $paragraph;
+  }
+
+  $intro_values = _emerging_digital_content_contact_intro_values();
+  if ($intro === NULL) {
+    $intro = Paragraph::create($intro_values);
+    $intro->save();
+  }
+  else {
+    foreach ($intro_values as $field_name => $value) {
+      $intro->set($field_name, $value);
+    }
+    $intro->save();
+  }
+
+  $coordinates_values = _emerging_digital_content_contact_coordinates_values();
+  if ($coordinates === NULL) {
+    $coordinates = Paragraph::create($coordinates_values);
+    $coordinates->save();
+  }
+  else {
+    foreach ($coordinates_values as $field_name => $value) {
+      $coordinates->set($field_name, $value);
+    }
+    $coordinates->save();
+  }
+
+  $map_values = _emerging_digital_content_contact_map_values();
+  if ($map === NULL) {
+    $map = Paragraph::create($map_values);
+    $map->save();
+  }
+  else {
+    foreach ($map_values as $field_name => $value) {
+      $map->set($field_name, $value);
+    }
+    $map->save();
+  }
+
+  $ordered_components = array_values(array_filter([
+    $hero,
+    $intro,
+    $coordinates,
+    $form,
+    $map,
+    ...$extra_components,
+  ]));
+
+  $contact->set('field_home_components', array_map(static function (Paragraph $paragraph): array {
+    return [
+      'target_id' => $paragraph->id(),
+      'target_revision_id' => $paragraph->getRevisionId(),
+    ];
+  }, $ordered_components));
+  $contact->save();
+
+  return sprintf('Contact page updated. Removed %d redundant CTA block(s).', $removed_cta);
+}
+
+/**
+ * Valeurs de la section intro de la page Contact.
+ */
+function _emerging_digital_content_contact_intro_values(): array {
+  return [
+    'type' => 'text_block',
+    'status' => TRUE,
+    'field_heading' => 'Intro',
+    'field_text' => [
+      'value' => '<p>Parlons de votre projet digital. Décrivez vos objectifs : nous revenons vers vous avec une réponse claire, structurée et orientée résultats.</p>',
+      'format' => 'basic_html',
+    ],
+  ];
+}
+
+/**
+ * Valeurs de la section coordonnées de la page Contact.
+ */
+function _emerging_digital_content_contact_coordinates_values(): array {
+  return [
+    'type' => 'text_block',
+    'status' => TRUE,
+    'field_heading' => 'Coordonnées',
+    'field_text' => [
+      'value' => '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p><strong>Informations légales :</strong> SRL — BE 0746.356.206</p>',
+      'format' => 'basic_html',
+    ],
+  ];
+}
+
+/**
+ * Valeurs de la section carte de la page Contact.
+ */
+function _emerging_digital_content_contact_map_values(): array {
+  return [
+    'type' => 'text_block',
+    'status' => TRUE,
+    'field_heading' => 'Carte',
+    'field_text' => [
+      'value' => '<iframe title="Localisation Emerging Digital" src="https://www.google.com/maps?q=Rue%20des%20Peupliers%201%2C%204254%20Ligney%20(Geer)&output=embed" width="100%" height="380" style="border:0;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen></iframe>',
+      'format' => 'basic_html',
+    ],
+  ];
 }

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -412,7 +412,7 @@ function _emerging_digital_content_contact_coordinates_values(): array {
     'status' => TRUE,
     'field_heading' => 'Coordonnées',
     'field_text' => [
-      'value' => '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p><strong>Informations légales :</strong> SRL — BE 0746.356.206</p>',
+      'value' => '<p><strong>Adresse :</strong> Rue des Peupliers 1, 4254 Ligney (Geer)</p><p><strong>Email :</strong> <a href="mailto:jonathan@emergingdigital.be">jonathan@emergingdigital.be</a></p><p><strong>Téléphone :</strong> <a href="tel:+32475722884">+32 475/72.28.84</a></p><p>E-MERGING DIGITAL SRL<br>BE 0746.356.206</p>',
       'format' => 'basic_html',
     ],
   ];

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -422,6 +422,13 @@ function emerging_digital_content_post_update_contact_page_professional_layout_v
 }
 
 /**
+ * Rejoue l'harmonisation Contact avec contenu Informations enrichi.
+ */
+function emerging_digital_content_post_update_contact_page_professional_layout_v4(array &$sandbox): string {
+  return emerging_digital_content_post_update_contact_page_professional_layout($sandbox);
+}
+
+/**
  * Valeurs de la section intro de la page Contact.
  */
 function _emerging_digital_content_contact_intro_values(): array {
@@ -475,7 +482,7 @@ function _emerging_digital_content_contact_information_values(): array {
     'status' => TRUE,
     'field_heading' => 'Informations',
     'field_text' => [
-      'value' => '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME et ASBL.</p><p>Premier échange sans engagement.</p>',
+      'value' => '<p>Disponible pour projets en Wallonie et Bruxelles.</p><p>Interventions pour PME, ASBL et organisations publiques.</p><p>Habitué à travailler sur des projets structurés et exigeants.</p><p>Premier échange sans engagement.</p>',
       'format' => 'basic_html',
     ],
   ];

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -389,6 +389,13 @@ function emerging_digital_content_post_update_contact_page_professional_layout(a
 }
 
 /**
+ * Rejoue l'harmonisation de la page Contact sur les environnements existants.
+ */
+function emerging_digital_content_post_update_contact_page_professional_layout_v2(array &$sandbox): string {
+  return emerging_digital_content_post_update_contact_page_professional_layout($sandbox);
+}
+
+/**
  * Valeurs de la section intro de la page Contact.
  */
 function _emerging_digital_content_contact_intro_values(): array {

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -88,6 +88,26 @@ button:focus-visible,
   max-width: min(100%, 52rem);
 }
 
+.ed-section__content > * + * {
+  margin-top: var(--space-3);
+}
+
+.ed-section__content p {
+  line-height: 1.65;
+}
+
+.ed-section__content a {
+  overflow-wrap: anywhere;
+}
+
+.ed-section__content iframe {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
 .ed-section__content--contact-form form {
   display: grid;
   gap: var(--space-3);


### PR DESCRIPTION
### Motivation
- Enable embedding of a Google Maps iframe in rich text fields and HTML filter so the Contact page can include a map. 
- Harmonise the Contact page content by removing a redundant CTA and ensuring intro, coordinates and map blocks are present and ordered consistently. 
- Improve styling and content for the Contact page so the embedded map and contact text display cleanly.

### Description
- Permit `<iframe>` tags and attributes in the editor and HTML filter by updating `config/sync/editor.editor.basic_html.yml` and `config/sync/filter.format.basic_html.yml` to include `iframe` with `title src width height style loading referrerpolicy allowfullscreen`. 
- Add a new paragraph entity (UUID `856cbeed-a7cd-430b-ba72-aca0b79b6022`) containing the Google Maps iframe and update existing paragraph content to include translated headings and full contact details. 
- Update the Contact node YAML to include the new map paragraph and reorder referenced components accordingly. 
- Add `emerging_digital_content_post_update_contact_page_professional_layout` and helper functions plus a `use` import for `Paragraph` to the module post-update file to programmatically create or update the intro, coordinates, and map paragraphs, remove redundant `cta` blocks, and reorder `field_home_components`. 
- Add CSS rules in `web/themes/custom/emerging_digital/css/components.css` to style section content, improve typography, and make `iframe` display responsively with border radius and shadow.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a4cb80d48321bf0eef00b87ffa32)