### PR TITLE
feat: consentement cookies simple pour contenus externes

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   dynamic_page_cache: 0
   editor: 0
   emerging_digital_content: 0
+  emerging_digital_cookie_consent: 0
   entity_reference_revisions: 0
   field: 0
   field_ui: 0

--- a/config/sync/emerging_digital_cookie_consent.settings.yml
+++ b/config/sync/emerging_digital_cookie_consent.settings.yml
@@ -1,0 +1,1 @@
+policy_path: ''

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
   <description>Drupal coding standards for custom code only.</description>
 
   <config name="drupal_core_version" value="11"/>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,yml"/>
 
   <file>web/modules/custom</file>
   <file>web/themes/custom</file>

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -6,6 +6,7 @@
  */
 
 declare(strict_types=1);
+
 use Drupal\emerging_digital_content\MainNavigationManager;
 
 /**

--- a/web/modules/custom/emerging_digital_cookie_consent/config/install/emerging_digital_cookie_consent.settings.yml
+++ b/web/modules/custom/emerging_digital_cookie_consent/config/install/emerging_digital_cookie_consent.settings.yml
@@ -1,0 +1,1 @@
+policy_path: ''

--- a/web/modules/custom/emerging_digital_cookie_consent/config/schema/emerging_digital_cookie_consent.schema.yml
+++ b/web/modules/custom/emerging_digital_cookie_consent/config/schema/emerging_digital_cookie_consent.schema.yml
@@ -1,0 +1,7 @@
+emerging_digital_cookie_consent.settings:
+  type: config_object
+  label: 'Paramètres du consentement cookies Emerging Digital'
+  mapping:
+    policy_path:
+      type: string
+      label: 'Chemin de la politique de cookies'

--- a/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
+++ b/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
@@ -1,0 +1,128 @@
+.ed-cookie-banner {
+  position: fixed;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+}
+
+.ed-cookie-banner__content {
+  width: min(880px, 100%);
+  background: #0f172a;
+  color: #fff;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ed-cookie-banner__text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.ed-cookie-banner__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.ed-cookie-banner__btn {
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.5rem 0.85rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.ed-cookie-banner__btn--primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.ed-cookie-banner__btn--secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.6);
+  color: #fff;
+}
+
+.ed-cookie-banner__link {
+  color: #bfdbfe;
+}
+
+.ed-cookie-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  z-index: 1100;
+}
+
+.ed-cookie-modal.is-open {
+  display: grid;
+  place-items: center;
+}
+
+.ed-cookie-modal__panel {
+  width: min(560px, calc(100% - 2rem));
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.2rem;
+}
+
+.ed-cookie-modal__title {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.ed-cookie-modal__description {
+  margin-top: 0;
+  color: #334155;
+}
+
+.ed-cookie-modal__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.ed-cookie-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.ed-cookie-placeholder {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.ed-cookie-placeholder iframe {
+  min-height: 280px;
+  width: 100%;
+}
+
+.ed-cookie-placeholder__message {
+  padding: 1rem;
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+}
+
+.ed-cookie-placeholder__message p {
+  margin-top: 0;
+}
+
+@media (max-width: 800px) {
+  .ed-cookie-banner__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
+++ b/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
@@ -29,16 +29,37 @@
 
 .ed-cookie-banner__actions {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.45rem;
+  min-width: 235px;
+}
+
+.ed-cookie-banner__row {
+  width: 100%;
+  display: flex;
   gap: 0.5rem;
-  flex-wrap: wrap;
+}
+
+.ed-cookie-banner__row--primary .ed-cookie-banner__btn {
+  flex: 1 1 0;
+}
+
+.ed-cookie-banner__row--secondary {
+  justify-content: flex-end;
 }
 
 .ed-cookie-banner__btn {
   border: 1px solid transparent;
   border-radius: 6px;
-  padding: 0.5rem 0.85rem;
+  padding: 0.55rem 0.9rem;
   cursor: pointer;
   font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: visible;
+  min-height: 40px;
+  min-width: 0;
 }
 
 .ed-cookie-banner__btn--primary {
@@ -50,6 +71,16 @@
   background: transparent;
   border-color: rgba(255, 255, 255, 0.6);
   color: #fff;
+}
+
+.ed-cookie-banner__btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: #cbd5e1;
+  font-size: 0.875rem;
+  font-weight: 500;
+  min-height: 32px;
+  padding: 0.25rem 0.4rem;
 }
 
 .ed-cookie-banner__link {
@@ -124,5 +155,15 @@
   .ed-cookie-banner__content {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .ed-cookie-banner__actions {
+    width: 100%;
+    min-width: 0;
+    align-items: stretch;
+  }
+
+  .ed-cookie-banner__row--secondary {
+    justify-content: flex-start;
   }
 }

--- a/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
+++ b/web/modules/custom/emerging_digital_cookie_consent/css/cookie-consent.css
@@ -60,6 +60,16 @@
   overflow: visible;
   min-height: 40px;
   min-width: 0;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.ed-cookie-banner__btn:hover {
+  filter: brightness(1.04);
+}
+
+.ed-cookie-banner__btn:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
 }
 
 .ed-cookie-banner__btn--primary {
@@ -74,13 +84,18 @@
 }
 
 .ed-cookie-banner__btn--ghost {
-  background: transparent;
-  border-color: transparent;
-  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #e2e8f0;
   font-size: 0.875rem;
   font-weight: 500;
-  min-height: 32px;
-  padding: 0.25rem 0.4rem;
+  min-height: 34px;
+  padding: 0.3rem 0.6rem;
+}
+
+.ed-cookie-banner__btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.5);
 }
 
 .ed-cookie-banner__link {
@@ -130,6 +145,21 @@
   gap: 0.5rem;
 }
 
+.ed-cookie-modal .ed-cookie-banner__btn--secondary {
+  background: #fff;
+  border-color: #94a3b8;
+  color: #1e293b;
+}
+
+.ed-cookie-modal .ed-cookie-banner__btn--secondary:hover {
+  background: #f8fafc;
+  border-color: #64748b;
+}
+
+.ed-cookie-modal .ed-cookie-banner__btn--secondary:focus-visible {
+  outline: 2px solid #2563eb;
+}
+
 .ed-cookie-placeholder {
   border: 1px solid #e2e8f0;
   border-radius: 10px;
@@ -164,6 +194,6 @@
   }
 
   .ed-cookie-banner__row--secondary {
-    justify-content: flex-start;
+    justify-content: flex-end;
   }
 }

--- a/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.info.yml
+++ b/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.info.yml
@@ -1,0 +1,7 @@
+name: 'Emerging Digital Cookie Consent'
+type: module
+description: 'Gestion simple du consentement cookies pour les contenus externes.'
+package: 'Emerging Digital'
+core_version_requirement: '^11'
+dependencies:
+  - drupal:system

--- a/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.libraries.yml
+++ b/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.libraries.yml
@@ -1,0 +1,10 @@
+banner:
+  version: 1.x
+  css:
+    component:
+      css/cookie-consent.css: {}
+  js:
+    js/cookie-consent.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.module
+++ b/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.module
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Hooks pour le module de consentement cookies.
+ */
+
+/**
+ * Implements hook_page_attachments().
+ */
+function emerging_digital_cookie_consent_page_attachments(array &$attachments): void {
+  $config = \Drupal::config('emerging_digital_cookie_consent.settings');
+  $policy_path = trim((string) $config->get('policy_path'));
+
+  $attachments['#attached']['library'][] = 'emerging_digital_cookie_consent/banner';
+  $attachments['#attached']['drupalSettings']['emergingDigitalCookieConsent'] = [
+    'policyPath' => $policy_path,
+  ];
+}

--- a/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.module
+++ b/web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.module
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * @file
  * Hooks pour le module de consentement cookies.
  */
+
+declare(strict_types=1);
 
 /**
  * Implements hook_page_attachments().

--- a/web/modules/custom/emerging_digital_cookie_consent/js/cookie-consent.js
+++ b/web/modules/custom/emerging_digital_cookie_consent/js/cookie-consent.js
@@ -65,9 +65,13 @@
           ${policyMarkup}
         </p>
         <div class="ed-cookie-banner__actions">
-          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-action="reject">Refuser</button>
-          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-action="preferences">Préférences</button>
-          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--primary" data-ed-cookie-action="accept">Accepter</button>
+          <div class="ed-cookie-banner__row ed-cookie-banner__row--primary">
+            <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-action="reject">Refuser</button>
+            <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--primary" data-ed-cookie-action="accept">Accepter</button>
+          </div>
+          <div class="ed-cookie-banner__row ed-cookie-banner__row--secondary">
+            <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--ghost" data-ed-cookie-action="preferences">Préférences</button>
+          </div>
         </div>
       </div>
     `;

--- a/web/modules/custom/emerging_digital_cookie_consent/js/cookie-consent.js
+++ b/web/modules/custom/emerging_digital_cookie_consent/js/cookie-consent.js
@@ -1,0 +1,244 @@
+(function (Drupal, once, drupalSettings) {
+  'use strict';
+
+  const STORAGE_KEY = 'ed_cookie_consent_v1';
+
+  function readConsent() {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null) {
+        return null;
+      }
+
+      return {
+        necessary: true,
+        external: Boolean(parsed.external),
+      };
+    }
+    catch (error) {
+      return null;
+    }
+  }
+
+  function writeConsent(externalAccepted) {
+    const payload = {
+      necessary: true,
+      external: Boolean(externalAccepted),
+      updatedAt: new Date().toISOString(),
+    };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    window.dispatchEvent(new CustomEvent('ed-cookie-consent-updated', { detail: payload }));
+  }
+
+  function getPolicyLink() {
+    const path = drupalSettings.emergingDigitalCookieConsent?.policyPath;
+    if (typeof path === 'string' && path.trim().length > 0) {
+      return path.trim();
+    }
+    return '';
+  }
+
+  function createBanner() {
+    if (document.getElementById('ed-cookie-banner')) {
+      return;
+    }
+
+    const policyLink = getPolicyLink();
+    const policyMarkup = policyLink
+      ? `<a href="${policyLink}" class="ed-cookie-banner__link">Politique de cookies</a>`
+      : '';
+
+    const banner = document.createElement('div');
+    banner.id = 'ed-cookie-banner';
+    banner.className = 'ed-cookie-banner';
+    banner.innerHTML = `
+      <div class="ed-cookie-banner__content" role="dialog" aria-live="polite" aria-label="Préférences cookies">
+        <p class="ed-cookie-banner__text">
+          Nous utilisons des cookies techniques nécessaires et, avec votre accord,
+          des contenus externes (ex: Google Maps).
+          ${policyMarkup}
+        </p>
+        <div class="ed-cookie-banner__actions">
+          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-action="reject">Refuser</button>
+          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-action="preferences">Préférences</button>
+          <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--primary" data-ed-cookie-action="accept">Accepter</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(banner);
+
+    banner.addEventListener('click', function (event) {
+      const action = event.target?.dataset?.edCookieAction;
+      if (!action) {
+        return;
+      }
+
+      if (action === 'accept') {
+        writeConsent(true);
+        banner.remove();
+        return;
+      }
+
+      if (action === 'reject') {
+        writeConsent(false);
+        banner.remove();
+        return;
+      }
+
+      if (action === 'preferences') {
+        openPreferencesModal();
+      }
+    });
+  }
+
+  function openPreferencesModal() {
+    let modal = document.getElementById('ed-cookie-preferences-modal');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.id = 'ed-cookie-preferences-modal';
+      modal.className = 'ed-cookie-modal';
+      modal.innerHTML = `
+        <div class="ed-cookie-modal__panel" role="dialog" aria-modal="true" aria-label="Préférences cookies">
+          <h2 class="ed-cookie-modal__title">Préférences cookies</h2>
+          <p class="ed-cookie-modal__description">Les cookies nécessaires sont toujours actifs.</p>
+          <label class="ed-cookie-modal__option">
+            <input type="checkbox" data-ed-cookie-toggle="external" />
+            Activer les contenus externes (Google Maps, services tiers)
+          </label>
+          <div class="ed-cookie-modal__actions">
+            <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--secondary" data-ed-cookie-modal-action="cancel">Annuler</button>
+            <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--primary" data-ed-cookie-modal-action="save">Enregistrer</button>
+          </div>
+        </div>
+      `;
+      document.body.appendChild(modal);
+
+      modal.addEventListener('click', function (event) {
+        const action = event.target?.dataset?.edCookieModalAction;
+        if (!action) {
+          return;
+        }
+
+        if (action === 'cancel') {
+          modal.classList.remove('is-open');
+        }
+
+        if (action === 'save') {
+          const toggle = modal.querySelector('[data-ed-cookie-toggle="external"]');
+          const accepted = Boolean(toggle?.checked);
+          writeConsent(accepted);
+          modal.classList.remove('is-open');
+
+          const banner = document.getElementById('ed-cookie-banner');
+          if (banner) {
+            banner.remove();
+          }
+        }
+      });
+    }
+
+    const consent = readConsent();
+    const toggle = modal.querySelector('[data-ed-cookie-toggle="external"]');
+    if (toggle) {
+      toggle.checked = Boolean(consent?.external);
+    }
+
+    modal.classList.add('is-open');
+  }
+
+  function isGoogleMapsIframe(iframe) {
+    const src = (iframe.getAttribute('src') || '').toLowerCase();
+    return src.includes('google.com/maps') || src.includes('google.fr/maps');
+  }
+
+  function blockExternalIframe(iframe) {
+    if (!iframe.getAttribute('src')) {
+      return;
+    }
+
+    if (!isGoogleMapsIframe(iframe)) {
+      return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'ed-cookie-placeholder';
+    iframe.parentNode.insertBefore(wrapper, iframe);
+    wrapper.appendChild(iframe);
+
+    iframe.dataset.edCookieBlockedSrc = iframe.getAttribute('src');
+    iframe.removeAttribute('src');
+    iframe.setAttribute('loading', 'lazy');
+
+    const placeholder = document.createElement('div');
+    placeholder.className = 'ed-cookie-placeholder__message';
+    placeholder.innerHTML = `
+      <p>Google Maps est désactivé tant que vous n'acceptez pas les contenus externes.</p>
+      <button type="button" class="ed-cookie-banner__btn ed-cookie-banner__btn--primary" data-ed-cookie-action="accept-external">Autoriser les contenus externes</button>
+    `;
+
+    wrapper.appendChild(placeholder);
+
+    placeholder.addEventListener('click', function (event) {
+      const action = event.target?.dataset?.edCookieAction;
+      if (action === 'accept-external') {
+        writeConsent(true);
+        const banner = document.getElementById('ed-cookie-banner');
+        if (banner) {
+          banner.remove();
+        }
+      }
+    });
+  }
+
+  function applyConsentToEmbeds() {
+    const consent = readConsent();
+    const externalAccepted = Boolean(consent?.external);
+
+    document.querySelectorAll('iframe[data-ed-cookie-blocked-src]').forEach(function (iframe) {
+      const wrapper = iframe.closest('.ed-cookie-placeholder');
+      const message = wrapper ? wrapper.querySelector('.ed-cookie-placeholder__message') : null;
+      if (externalAccepted) {
+        if (!iframe.getAttribute('src')) {
+          iframe.setAttribute('src', iframe.dataset.edCookieBlockedSrc);
+        }
+        if (message) {
+          message.remove();
+        }
+      }
+      else if (message) {
+        message.style.display = '';
+      }
+    });
+  }
+
+  Drupal.behaviors.emergingDigitalCookieConsent = {
+    attach(context) {
+      once('ed-cookie-consent-init', 'body', context).forEach(function () {
+        const consent = readConsent();
+        if (!consent) {
+          createBanner();
+        }
+
+        document.querySelectorAll('iframe').forEach(function (iframe) {
+          if (iframe.dataset.edCookieBlockedSrc) {
+            return;
+          }
+          blockExternalIframe(iframe);
+        });
+
+        applyConsentToEmbeds();
+
+        window.addEventListener('ed-cookie-consent-updated', function () {
+          applyConsentToEmbeds();
+        });
+      });
+    },
+  };
+})(Drupal, once, drupalSettings);

--- a/web/themes/custom/emerging_digital/emerging_digital.theme
+++ b/web/themes/custom/emerging_digital/emerging_digital.theme
@@ -1,11 +1,13 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * @file
  * Theme hooks and preprocess functions for the Emerging Digital theme.
  */
+
+declare(strict_types=1);
+
+use Drupal\webform\Entity\Webform;
 
 /**
  * Implements hook_preprocess_paragraph().
@@ -29,7 +31,7 @@ function emerging_digital_preprocess_paragraph(array &$variables): void {
   }
 
   if ($bundle === 'text_block' && $paragraph->uuid() === '855b08da-0ec9-4261-883a-d27f214606e6') {
-    $contact_webform = \Drupal\webform\Entity\Webform::load('contact');
+    $contact_webform = Webform::load('contact');
     if ($contact_webform) {
       $variables['contact_webform'] = \Drupal::entityTypeManager()
         ->getViewBuilder('webform')


### PR DESCRIPTION
### Motivation
- Fournir une gestion simple et maintenable du consentement cookies pour le site, empêcher le chargement de contenus externes (notamment Google Maps) avant consentement et préparer une base pour le lien vers la future page « Politique de cookies » sans hardcoder de liens dans les templates Twig.

### Description
- Ajout d’un module custom `emerging_digital_cookie_consent` avec `info.yml`, `libraries.yml`, `module` hook et fichiers de config d’installation et de schema pour Drupal 11.
- Attachement global de la librairie via `hook_page_attachments()` et exposition de `policyPath` à `drupalSettings` pour éviter du HTML ou Twig codé en dur.
- Implémentation front en JS (Drupal behavior + `once`) qui affiche une bannière sobre (`Accepter` / `Refuser` / `Préférences`), stocke la décision dans `localStorage` et applique une logique à deux catégories (`necessary` toujours actif, `external` opt-in).
- Détection et blocage explicite des iframes Google Maps tant que la catégorie « contenus externes » n’est pas acceptée, plus styles CSS responsive et ajout de la configuration dans `config/sync` (activation du module et fichier `emerging_digital_cookie_consent.settings.yml`).

### Testing
- `php -l web/modules/custom/emerging_digital_cookie_consent/emerging_digital_cookie_consent.module` — réussi.
- `php -l web/modules/custom/emerging_digital_cookie_consent/config/schema/emerging_digital_cookie_consent.schema.yml` — réussi.
- Vérification de la configuration synchronisée avec `git diff -- config/sync` montrant l’activation du module — OK.
- Tentatives de `ddev composer require`, `ddev drush cr`, `ddev drush updb -y` et `ddev drush cim -y` ont échoué pour des raisons d’environnement (commande `ddev` non disponible) et réseau (`composer` vers `packages.drupal.org` renvoyant `403`), donc les commandes d’installation / import de configuration n’ont pas pu être exécutées dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60f4e71fc8321ba3fa473b5d13c8a)