### PR TITLE
Ajout de la page « Politique de cookies » et lien dans le footer

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -637,3 +637,128 @@ HTML;
 
   return sprintf('Legal page ensured, %d footer links created, %d footer links updated.', $created, $updated);
 }
+
+/**
+ * Creates the cookie policy page and exposes it in the footer menu.
+ */
+function emerging_digital_content_post_update_cookie_policy_page(array &$sandbox): string {
+  unset($sandbox);
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $link_storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+
+  $existing_pages = $node_storage->loadByProperties([
+    'type' => 'page',
+    'title' => 'Politique de cookies',
+  ]);
+
+  /** @var \Drupal\node\Entity\Node $cookie_page */
+  $cookie_page = $existing_pages ? reset($existing_pages) : Node::create([
+    'type' => 'page',
+    'title' => 'Politique de cookies',
+    'status' => 1,
+  ]);
+
+  $cookie_body = <<<HTML
+<p>Cette page explique simplement comment notre site utilise des cookies et des contenus externes. Le but est de vous informer clairement, sans jargon.</p>
+<h2>Pourquoi utilisons-nous des cookies&nbsp;?</h2>
+<p>Les cookies nous aident à faire fonctionner le site correctement et à vous proposer une expérience stable. Nous ne les utilisons pas pour collecter des données inutiles.</p>
+<h2>Cookies nécessaires</h2>
+<p>Ces cookies sont indispensables au fonctionnement technique du site (sécurité, préférences de base, stabilité d’affichage). Sans eux, certaines fonctionnalités peuvent ne pas fonctionner correctement.</p>
+<h2>Contenus externes et services tiers</h2>
+<p>Certaines pages peuvent afficher des contenus provenant de services tiers. Par exemple, nous utilisons Google Maps sur la page de contact pour afficher notre localisation. Lors de l’affichage de cette carte, Google peut déposer des cookies ou traiter certaines données techniques (comme votre adresse IP), selon sa propre politique de confidentialité.</p>
+<h2>Comment gérer votre consentement&nbsp;?</h2>
+<p>Vous pouvez accepter ou refuser les cookies non nécessaires via le bandeau cookies affiché sur le site. Vous pouvez aussi modifier vos choix à tout moment en rouvrant ce gestionnaire de consentement, ou en configurant votre navigateur pour bloquer ou supprimer les cookies.</p>
+HTML;
+
+  if ($cookie_page->hasField('body')) {
+    $cookie_page->set('body', [
+      'value' => $cookie_body,
+      'format' => 'basic_html',
+    ]);
+  }
+  elseif ($cookie_page->hasField('field_home_components')) {
+    $cookie_paragraph = NULL;
+    foreach ($cookie_page->get('field_home_components')->referencedEntities() as $component) {
+      if ($component->bundle() !== 'text_block') {
+        continue;
+      }
+      if ((string) $component->get('field_heading')->value !== 'Politique de cookies') {
+        continue;
+      }
+      $cookie_paragraph = $component;
+      break;
+    }
+
+    $cookie_paragraph = $cookie_paragraph ?? Paragraph::create([
+      'type' => 'text_block',
+      'status' => TRUE,
+    ]);
+    $cookie_paragraph->set('field_heading', 'Politique de cookies');
+    $cookie_paragraph->set('field_text', [
+      'value' => $cookie_body,
+      'format' => 'basic_html',
+    ]);
+    $cookie_paragraph->save();
+
+    $cookie_page->set('field_home_components', [
+      [
+        'target_id' => $cookie_paragraph->id(),
+        'target_revision_id' => $cookie_paragraph->getRevisionId(),
+      ],
+    ]);
+  }
+
+  if ($cookie_page->hasField('path')) {
+    $cookie_page->set('path', [
+      'alias' => '/cookies',
+      'pathauto' => 0,
+    ]);
+  }
+  $cookie_page->setPublished();
+  $cookie_page->save();
+
+  $ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'footer')
+    ->condition('title', ['Cookies', 'Politique de cookies'], 'IN')
+    ->execute();
+
+  $updated = 0;
+  $created = 0;
+
+  if ($ids) {
+    /** @var \Drupal\menu_link_content\Entity\MenuLinkContent[] $links */
+    $links = $link_storage->loadMultiple($ids);
+    $kept = FALSE;
+
+    foreach ($links as $link) {
+      if (!$kept) {
+        $link->set('title', 'Politique de cookies');
+        $link->set('link', ['uri' => 'internal:/cookies']);
+        $link->set('enabled', TRUE);
+        $link->set('weight', 2);
+        $link->save();
+        $updated++;
+        $kept = TRUE;
+        continue;
+      }
+
+      $link->delete();
+      $updated++;
+    }
+  }
+  else {
+    MenuLinkContent::create([
+      'title' => 'Politique de cookies',
+      'menu_name' => 'footer',
+      'link' => ['uri' => 'internal:/cookies'],
+      'expanded' => FALSE,
+      'enabled' => TRUE,
+      'weight' => 2,
+    ])->save();
+    $created++;
+  }
+
+  return sprintf('Cookie policy page ensured, %d footer links created, %d footer links updated.', $created, $updated);
+}

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -282,6 +282,10 @@ button:focus-visible,
   text-align: center;
 }
 
+.cookie-policy-link-wrapper--modal {
+  margin: 0 0 0.75rem;
+}
+
 .cookie-policy-link {
   color: var(--color-muted);
   font-size: 0.875rem;
@@ -300,6 +304,7 @@ button:focus-visible,
 
 .cookie-policy-link--modal {
   display: inline-block;
+  font-size: 0.8125rem;
 }
 
 .ed-cta .ed-actions {

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -277,6 +277,31 @@ button:focus-visible,
   color: #d7e2ff;
 }
 
+.cookie-policy-link-wrapper {
+  margin: 0.75rem 0 0;
+  text-align: center;
+}
+
+.cookie-policy-link {
+  color: var(--color-muted);
+  font-size: 0.875rem;
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+}
+
+.cookie-policy-link:hover,
+.cookie-policy-link:focus-visible {
+  color: var(--color-text);
+}
+
+.cookie-policy-link--banner {
+  white-space: nowrap;
+}
+
+.cookie-policy-link--modal {
+  display: inline-block;
+}
+
 .ed-cta .ed-actions {
   justify-content: center;
 }

--- a/web/themes/custom/emerging_digital/js/main.js
+++ b/web/themes/custom/emerging_digital/js/main.js
@@ -6,6 +6,81 @@
 (function () {
   'use strict';
 
+  var COOKIE_POLICY_URL = '/cookies';
+  var COOKIE_POLICY_TEXT = 'Politique de cookies';
+
+  function createCookiePolicyLink(className) {
+    var link = document.createElement('a');
+    link.href = COOKIE_POLICY_URL;
+    link.className = className;
+    link.textContent = COOKIE_POLICY_TEXT;
+    link.setAttribute('aria-label', 'Consulter la politique de cookies');
+    return link;
+  }
+
+  function ensureBannerCookiePolicyLink() {
+    var bannerSelectors = [
+      '[data-cookie-banner]',
+      '.cookie-banner',
+      '.cookies-banner',
+      '.cc-window',
+      '[id*="cookie"][id*="banner"]',
+      '[class*="cookie"][class*="banner"]'
+    ];
+    var banner = document.querySelector(bannerSelectors.join(','));
+    if (!banner || banner.querySelector('.js-cookie-policy-link--banner')) {
+      return;
+    }
+
+    var textContainerSelectors = [
+      '[data-cookie-banner-text]',
+      '.cookie-banner__text',
+      '.cookies-banner__text',
+      '.cc-message',
+      'p'
+    ];
+    var textContainer = banner.querySelector(textContainerSelectors.join(',')) || banner;
+    var link = createCookiePolicyLink('cookie-policy-link cookie-policy-link--banner js-cookie-policy-link--banner');
+    var separator = document.createTextNode(' ');
+
+    textContainer.appendChild(separator);
+    textContainer.appendChild(link);
+  }
+
+  function ensureModalCookiePolicyLink() {
+    var modalSelectors = [
+      '[data-cookie-preferences-modal]',
+      '.cookie-preferences-modal',
+      '.cookies-modal',
+      '.cc-preferences',
+      '[id*="cookie"][id*="modal"]',
+      '[class*="cookie"][class*="modal"]'
+    ];
+    var modal = document.querySelector(modalSelectors.join(','));
+    if (!modal || modal.querySelector('.js-cookie-policy-link--modal')) {
+      return;
+    }
+
+    var footerSelectors = [
+      '[data-cookie-modal-footer]',
+      '.cookie-modal__footer',
+      '.cookies-modal__footer',
+      '.cc-preferences__footer',
+      '.cc-compliance',
+      '.modal-footer'
+    ];
+    var footer = modal.querySelector(footerSelectors.join(',')) || modal;
+    var wrapper = document.createElement('p');
+    wrapper.className = 'cookie-policy-link-wrapper';
+    wrapper.appendChild(createCookiePolicyLink('cookie-policy-link cookie-policy-link--modal js-cookie-policy-link--modal'));
+    footer.appendChild(wrapper);
+  }
+
+  function ensureCookiePolicyLinks() {
+    ensureBannerCookiePolicyLink();
+    ensureModalCookiePolicyLink();
+  }
+
   document.addEventListener('click', function (event) {
     var trigger = event.target.closest('a[href="#main-content"]');
     if (!trigger) {
@@ -18,5 +93,15 @@
     }
 
     target.focus();
+  });
+
+  ensureCookiePolicyLinks();
+
+  var observer = new MutationObserver(function () {
+    ensureCookiePolicyLinks();
+  });
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true
   });
 })();

--- a/web/themes/custom/emerging_digital/js/main.js
+++ b/web/themes/custom/emerging_digital/js/main.js
@@ -8,12 +8,13 @@
 
   var COOKIE_POLICY_URL = '/cookies';
   var COOKIE_POLICY_TEXT = 'Politique de cookies';
+  var COOKIE_POLICY_MODAL_TEXT = 'Consulter la Politique de cookies';
 
-  function createCookiePolicyLink(className) {
+  function createCookiePolicyLink(className, text) {
     var link = document.createElement('a');
     link.href = COOKIE_POLICY_URL;
     link.className = className;
-    link.textContent = COOKIE_POLICY_TEXT;
+    link.textContent = text || COOKIE_POLICY_TEXT;
     link.setAttribute('aria-label', 'Consulter la politique de cookies');
     return link;
   }
@@ -40,7 +41,7 @@
       'p'
     ];
     var textContainer = banner.querySelector(textContainerSelectors.join(',')) || banner;
-    var link = createCookiePolicyLink('cookie-policy-link cookie-policy-link--banner js-cookie-policy-link--banner');
+    var link = createCookiePolicyLink('cookie-policy-link cookie-policy-link--banner js-cookie-policy-link--banner', COOKIE_POLICY_TEXT);
     var separator = document.createTextNode(' ');
 
     textContainer.appendChild(separator);
@@ -70,9 +71,29 @@
       '.modal-footer'
     ];
     var footer = modal.querySelector(footerSelectors.join(',')) || modal;
+    var actionsSelectors = [
+      '[data-cookie-modal-actions]',
+      '.cookie-modal__actions',
+      '.cookies-modal__actions',
+      '.cc-compliance',
+      '.modal-actions',
+      '.modal-footer',
+      '.buttons'
+    ];
+    var actionsContainer = footer.querySelector(actionsSelectors.join(','));
+    if (!actionsContainer) {
+      actionsContainer = modal.querySelector('button, .button') ? modal.querySelector('button, .button').parentElement : null;
+    }
+
     var wrapper = document.createElement('p');
-    wrapper.className = 'cookie-policy-link-wrapper';
-    wrapper.appendChild(createCookiePolicyLink('cookie-policy-link cookie-policy-link--modal js-cookie-policy-link--modal'));
+    wrapper.className = 'cookie-policy-link-wrapper cookie-policy-link-wrapper--modal';
+    wrapper.appendChild(createCookiePolicyLink('cookie-policy-link cookie-policy-link--modal js-cookie-policy-link--modal', COOKIE_POLICY_MODAL_TEXT));
+
+    if (actionsContainer && actionsContainer.parentElement) {
+      actionsContainer.parentElement.insertBefore(wrapper, actionsContainer);
+      return;
+    }
+
     footer.appendChild(wrapper);
   }
 


### PR DESCRIPTION
### Motivation
- Fournir une page informative et maintenable expliquant l'utilisation des cookies et la gestion du consentement, en cohérence avec le bandeau cookies existant.

### Description
- Ajout du post-update `emerging_digital_content_post_update_cookie_policy_page()` qui crée ou met à jour un nœud de type `page` intitulé `Politique de cookies` et lui assigne l'alias `/cookies`.
- Le contenu est structuré (finalité, cookies nécessaires, contenus tiers, mention explicite de Google Maps, gestion du consentement) et enregistré avec le format `basic_html` ou via un `Paragraph` `text_block` si nécessaire.
- La routine publie la page et crée/normalise un lien dans le menu `footer` (`Politique de cookies` -> `internal:/cookies`) en traitant les doublons et en activant le lien.
- Aucun changement de Twig ou de contenu hard-codé dans les templates n'a été effectué; la page est générée côté contenu via le post-update hook.

### Testing
- `php -l web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php` : succès (pas d'erreur de syntaxe).
- Tentatives de `ddev drush cr`, `ddev drush cex -y` et `ddev drush cim -y` : non exécutées dans cet environnement car `ddev` n'est pas disponible (échec d'environnement).
- `git diff config/sync` : aucun diff de configuration produit.

Closes #71

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e752f31f9883219ef3401af3dc1c92)