### PR TITLE
feat(cta): harmoniser les CTA de conversion vers la page Contact

### DIFF
--- a/web/modules/custom/emerging_digital_content/content/paragraph/cfe7d994-e099-44b4-a0cc-12c69760288e.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/cfe7d994-e099-44b4-a0cc-12c69760288e.yml
@@ -9,6 +9,10 @@ default:
     -
       value: Parlons de votre projet et trouvons la solution adaptée.
       format: basic_html
+  field_link:
+    -
+      uri: "internal:/contact"
+      title: Prendre contact
   status:
     -
       value: true

--- a/web/modules/custom/emerging_digital_content/content/paragraph/d36b8734-7d9e-4782-a2e5-efa82d8ecfea.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/d36b8734-7d9e-4782-a2e5-efa82d8ecfea.yml
@@ -9,6 +9,10 @@ default:
     -
       value: "Vous avez un projet similaire ? Discutons-en."
       format: basic_html
+  field_link:
+    -
+      uri: "internal:/contact"
+      title: Prendre contact
   status:
     -
       value: true

--- a/web/modules/custom/emerging_digital_content/content/paragraph/f4581518-8acc-4632-8b25-884776b3aeb4.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/f4581518-8acc-4632-8b25-884776b3aeb4.yml
@@ -9,6 +9,10 @@ default:
     -
       value: Découvrez comment intégrer l’IA dans votre site Drupal.
       format: basic_html
+  field_link:
+    -
+      uri: "internal:/contact"
+      title: Prendre contact
   status:
     -
       value: true

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -898,3 +898,51 @@ HTML;
 function emerging_digital_content_post_update_privacy_policy_and_contact_consent_rerun(array &$sandbox): string {
   return emerging_digital_content_post_update_privacy_policy_and_contact_consent($sandbox);
 }
+
+/**
+ * Backfills missing contact CTA links on strategic pages for installed sites.
+ */
+function emerging_digital_content_post_update_backfill_strategic_cta_contact_links(array &$sandbox): string {
+  unset($sandbox);
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $page_ids = \Drupal::entityQuery('node')
+    ->accessCheck(FALSE)
+    ->condition('type', 'page')
+    ->condition('title', ['Services', 'IA & Drupal', 'Cas clients'], 'IN')
+    ->execute();
+
+  if (!$page_ids) {
+    return 'No strategic pages found for CTA backfill.';
+  }
+
+  /** @var \Drupal\node\NodeInterface[] $pages */
+  $pages = $node_storage->loadMultiple($page_ids);
+  $updated = 0;
+
+  foreach ($pages as $page) {
+    if (!$page->hasField('field_home_components')) {
+      continue;
+    }
+
+    foreach ($page->get('field_home_components')->referencedEntities() as $component) {
+      if ($component->bundle() !== 'cta' || !$component->hasField('field_link')) {
+        continue;
+      }
+
+      $existing_link = $component->get('field_link')->first();
+      if ($existing_link && !empty($existing_link->getValue()['uri'])) {
+        continue;
+      }
+
+      $component->set('field_link', [
+        'uri' => 'internal:/contact',
+        'title' => 'Prendre contact',
+      ]);
+      $component->save();
+      $updated++;
+    }
+  }
+
+  return sprintf('%d CTA paragraph(s) updated with contact links.', $updated);
+}

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
@@ -1,7 +1,9 @@
 <section{{ attributes.addClass('ed-section', 'ed-section--cta-block') }}>
   <div class="ed-container">
     <div class="ed-cta">
-      <h2 class="ed-section__title">{{ paragraph.field_heading.value }}</h2>
+      {% if paragraph.field_heading.value %}
+        <h2 class="ed-section__title">{{ paragraph.field_heading.value }}</h2>
+      {% endif %}
       {% if paragraph.field_text.value %}
         <div class="ed-section__intro">{{ content.field_text }}</div>
       {% endif %}


### PR DESCRIPTION
### Motivation
- Rendre les blocs CTA de fin de page réellement actionnables et cohérents en ajoutant un bouton principal pointant vers la page Contact afin d'améliorer la conversion sans refonte.
- Éviter le rendu d’un `<h2>` vide quand aucun titre n’est renseigné pour conserver une sortie HTML propre et accessible.

### Description
- Ajout du lien CTA `internal:/contact` avec le libellé harmonisé `Prendre contact` dans les paragraphes CTA suivants : `web/modules/custom/emerging_digital_content/content/paragraph/cfe7d994-e099-44b4-a0cc-12c69760288e.yml`, `web/modules/custom/emerging_digital_content/content/paragraph/d36b8734-7d9e-4782-a2e5-efa82d8ecfea.yml` et `web/modules/custom/emerging_digital_content/content/paragraph/f4581518-8acc-4632-8b25-884776b3aeb4.yml`.
- Mise à jour du template réutilisable `web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig` pour n'afficher le titre que si `paragraph.field_heading.value` est renseigné, sans hardcoder de contenu dans Twig.
- Changements réalisés sur la branche `feature/cta-conversion-79` et prêts à être importés en configuration si nécessaire.

### Testing
- Tentative d’exécution des commandes demandées : `ddev drush cr`, `ddev drush cex -y` et `ddev drush cim -y` (échec car `ddev` indisponible dans cet environnement).
- Vérification `git diff config/sync` (OK : aucune différence de configuration exportée constatée).
- Modifications ajoutées et commitées localement (commit message : `feat(cta): add explicit contact actions on strategic pages`).

Closes #79

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b35981dc8321a5296574e43f9ac4)