### PR TITLE
Optimisations front-end : images, scripts non bloquants et rendu initial (Closes #83)

### DIFF
--- a/web/themes/custom/emerging_digital/css/base.css
+++ b/web/themes/custom/emerging_digital/css/base.css
@@ -79,3 +79,9 @@ ul,
 ol {
   margin-block: 0 1em;
 }
+
+.page-container,
+.ed-container {
+  width: min(100% - (2 * var(--space-4)), var(--container-width));
+  margin-inline: auto;
+}

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -80,11 +80,6 @@ button:focus-visible,
   padding-block: clamp(2.5rem, 6vw, 5rem);
 }
 
-.ed-container {
-  width: min(100% - (2 * var(--space-4)), var(--container-width));
-  margin-inline: auto;
-}
-
 .ed-section__title {
   margin: 0 0 var(--space-3);
   font-size: clamp(1.55rem, 2.4vw, 2.35rem);

--- a/web/themes/custom/emerging_digital/css/layout.css
+++ b/web/themes/custom/emerging_digital/css/layout.css
@@ -1,8 +1,3 @@
-.page-container {
-  width: min(100% - (2 * var(--space-4)), var(--container-width));
-  margin-inline: auto;
-}
-
 .page-header,
 .page-footer {
   background: var(--color-surface);

--- a/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
+++ b/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
@@ -7,6 +7,8 @@ global-styling:
       css/layout.css: {}
       css/components.css: {}
   js:
-    js/main.js: {}
+    js/main.js:
+      attributes:
+        defer: true
   dependencies:
     - core/drupal

--- a/web/themes/custom/emerging_digital/emerging_digital.theme
+++ b/web/themes/custom/emerging_digital/emerging_digital.theme
@@ -72,3 +72,30 @@ function emerging_digital_page_attachments(array &$attachments): void {
     'emerging_digital_favicon_png',
   ];
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function emerging_digital_preprocess_image(array &$variables): void {
+  if (!isset($variables['attributes'])) {
+    return;
+  }
+
+  $uri = (string) ($variables['uri'] ?? '');
+  $is_brand_mark = str_contains($uri, '/images/branding/emerging-digital-mark.svg');
+
+  if ($is_brand_mark) {
+    $variables['attributes']['loading'] = 'eager';
+    $variables['attributes']['fetchpriority'] = 'high';
+    $variables['attributes']['decoding'] = 'async';
+    return;
+  }
+
+  if (empty($variables['attributes']['loading'])) {
+    $variables['attributes']['loading'] = 'lazy';
+  }
+
+  if (empty($variables['attributes']['decoding'])) {
+    $variables['attributes']['decoding'] = 'async';
+  }
+}

--- a/web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig
@@ -10,7 +10,7 @@
 
 {% if site_logo %}
     <a href="{{ path('<front>') }}" rel="home" class="site-logo">
-      <img src="{{ site_logo }}" alt="" decoding="async" fetchpriority="high" />
+      <img src="{{ site_logo }}" alt="" width="64" height="64" loading="eager" decoding="async" fetchpriority="high" />
     </a>
   {% endif %}
 

--- a/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
@@ -4,8 +4,7 @@
     <div class="page-container page-header__inner">{{ page.header }}</div>
   </header>
 
-  <main role="main" class="page-main page-main--front">
-    <a id="main-content" tabindex="-1"></a>
+  <main role="main" id="main-content" tabindex="-1" class="page-main page-main--front">
     <div class="front-layout">
       {{ page.content }}
     </div>

--- a/web/themes/custom/emerging_digital/templates/layout/page.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page.html.twig
@@ -20,8 +20,7 @@
     </section>
   {% endif %}
 
-  <main role="main" class="page-main">
-    <a id="main-content" tabindex="-1"></a>
+  <main role="main" id="main-content" tabindex="-1" class="page-main">
     <div class="page-container layout-grid {% if page.sidebar %}layout-grid--with-sidebar{% endif %}">
       <section class="layout-grid__content">
         {{ page.content }}


### PR DESCRIPTION
### Motivation
- Améliorer le chargement des pages et les Core Web Vitals sans modifier le rendu visuel ni ajouter de dépendances lourdes.
- Réduire le travail de rendu bloquant côté client et le CLS lié aux images de marque.

### Description
- Ajout de `defer` sur le JavaScript du thème en modifiant `web/themes/custom/emerging_digital/emerging_digital.libraries.yml` pour rendre `js/main.js` non bloquant. 
- Mise en place de `hook_preprocess_image()` dans `web/themes/custom/emerging_digital/emerging_digital.theme` pour définir `loading="lazy"` et `decoding="async"` par défaut, avec exception pour le monogramme de marque qui reçoit `loading="eager"`, `fetchpriority="high"`. 
- Ajout d’attributs `width`/`height`, `loading="eager"` et `fetchpriority="high"` sur le logo dans `web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig` pour réduire le CLS et prioriser son chargement. 
- Simplification HTML en positionnant `id="main-content"` directement sur la balise `<main>` dans les templates `page.html.twig` et `page--front.html.twig` pour un ciblage d’ancre plus direct.
- Déduplication d’une règle CSS commune en extrayant la règle de conteneur dans `css/base.css` et en supprimant les doublons dans `css/layout.css` et `css/components.css` pour une feuille de style plus maintenable.
- Ce changement vise à clore l’issue liée à ces optimisations (Closes #83). 

### Testing
- Linter PHP sur le thème a réussi avec `php -l web/themes/custom/emerging_digital/emerging_digital.theme` (OK). 
- Les commandes d’exécution de Drush via `ddev` n’ont pas pu être lancées dans cet environnement (`ddev` non disponible), donc `ddev drush cr`, `ddev drush cex -y` et `ddev drush cim -y` n’ont pas été exécutées (échec technique). 
- `git diff config/sync` a été lancé et n’a révélé aucun changement de configuration exportée (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7efdce11c8321a9fed05aa0375618)