### PR TITLE
feat(i18n): préparer l’architecture multilingue FR/EN (Closes #87)

### DIFF
--- a/config/sync/block.block.emerging_digital_language_switcher.yml
+++ b/config/sync/block.block.emerging_digital_language_switcher.yml
@@ -1,0 +1,20 @@
+uuid: 6738ab16-af25-44ac-b9a0-0556a697ebe1
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+  theme:
+    - emerging_digital
+id: emerging_digital_language_switcher
+theme: emerging_digital
+region: header
+weight: 0
+provider: null
+plugin: language_block:language_interface
+settings:
+  id: language_block:language_interface
+  label: 'Language switcher'
+  label_display: '0'
+  provider: language
+visibility: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -32,9 +32,13 @@ module:
   image: 0
   key: 0
   link: 0
+  language: 0
+  locale: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  config_translation: 0
+  content_translation: 10
   metatag_open_graph: 0
   metatag_twitter_cards: 0
   mysql: 0

--- a/config/sync/language.content_settings.menu_link_content.footer.yml
+++ b/config/sync/language.content_settings.menu_link_content.footer.yml
@@ -1,0 +1,16 @@
+uuid: e5fed154-7b40-41c1-b1e3-a43a7f835d41
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.footer
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: menu_link_content.footer
+target_entity_type_id: menu_link_content
+target_bundle: footer
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.menu_link_content.main.yml
+++ b/config/sync/language.content_settings.menu_link_content.main.yml
@@ -1,0 +1,16 @@
+uuid: 1dd5a42b-7548-42ac-92a1-5ae7bc43715e
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: menu_link_content.main
+target_entity_type_id: menu_link_content
+target_bundle: main
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.node.ai_feature.yml
+++ b/config/sync/language.content_settings.node.ai_feature.yml
@@ -1,0 +1,16 @@
+uuid: 97765318-8746-484e-ad2b-f0dd311e95d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.ai_feature
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.ai_feature
+target_entity_type_id: node
+target_bundle: ai_feature
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.node.article.yml
+++ b/config/sync/language.content_settings.node.article.yml
@@ -1,0 +1,16 @@
+uuid: 21f735fc-5696-49f4-b8e2-db2c9b2e7246
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.article
+target_entity_type_id: node
+target_bundle: article
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.node.case_client.yml
+++ b/config/sync/language.content_settings.node.case_client.yml
@@ -1,0 +1,16 @@
+uuid: 7ca09d68-edb4-49cc-903f-4391ff089c59
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.case_client
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.case_client
+target_entity_type_id: node
+target_bundle: case_client
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.node.page.yml
+++ b/config/sync/language.content_settings.node.page.yml
@@ -1,0 +1,16 @@
+uuid: f0aebf03-b22c-4409-8c71-c568c12bc305
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.page
+target_entity_type_id: node
+target_bundle: page
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.node.service.yml
+++ b/config/sync/language.content_settings.node.service.yml
@@ -1,0 +1,16 @@
+uuid: a38e6328-b735-4903-8700-d4d023c36493
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.service
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.service
+target_entity_type_id: node
+target_bundle: service
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.ai_features.yml
+++ b/config/sync/language.content_settings.paragraph.ai_features.yml
@@ -1,0 +1,16 @@
+uuid: 6f598a05-cefd-4136-885c-b72beec43847
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.ai_features
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.ai_features
+target_entity_type_id: paragraph
+target_bundle: ai_features
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.case_clients.yml
+++ b/config/sync/language.content_settings.paragraph.case_clients.yml
@@ -1,0 +1,16 @@
+uuid: fb876d7a-8adf-4c9f-8bf7-33cf0a720fa0
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.case_clients
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.case_clients
+target_entity_type_id: paragraph
+target_bundle: case_clients
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.cta.yml
+++ b/config/sync/language.content_settings.paragraph.cta.yml
@@ -1,0 +1,16 @@
+uuid: 060cbe04-f5d6-45f9-929f-d3e567b6341e
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.cta
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.cta
+target_entity_type_id: paragraph
+target_bundle: cta
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.hero.yml
+++ b/config/sync/language.content_settings.paragraph.hero.yml
@@ -1,0 +1,16 @@
+uuid: 2d2db86b-a63a-4e2a-988e-410fad5cca9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.hero
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.hero
+target_entity_type_id: paragraph
+target_bundle: hero
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.services.yml
+++ b/config/sync/language.content_settings.paragraph.services.yml
@@ -1,0 +1,16 @@
+uuid: 3ab71250-1cfb-4622-91d5-af8ac3b65d5a
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.services
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.services
+target_entity_type_id: paragraph
+target_bundle: services
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.text_block.yml
+++ b/config/sync/language.content_settings.paragraph.text_block.yml
@@ -1,0 +1,16 @@
+uuid: 78770c5d-52e1-4f72-83f8-46365051650a
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.text_block
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.text_block
+target_entity_type_id: paragraph
+target_bundle: text_block
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.trust_list.yml
+++ b/config/sync/language.content_settings.paragraph.trust_list.yml
@@ -1,0 +1,16 @@
+uuid: 67b15a08-b9c9-4b26-9e74-7c0d4e559a29
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.trust_list
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: paragraph.trust_list
+target_entity_type_id: paragraph
+target_bundle: trust_list
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/language.entity.en.yml
+++ b/config/sync/language.entity.en.yml
@@ -8,4 +8,4 @@ id: en
 label: English
 direction: ltr
 weight: 1
-locked: false
+locked: true

--- a/config/sync/language.entity.en.yml
+++ b/config/sync/language.entity.en.yml
@@ -1,0 +1,11 @@
+uuid: 28522f1d-c7a4-40b7-b7bf-92eb51a5ba20
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+id: en
+label: English
+direction: ltr
+weight: 1
+locked: false

--- a/config/sync/language.entity.en.yml
+++ b/config/sync/language.entity.en.yml
@@ -8,4 +8,4 @@ id: en
 label: English
 direction: ltr
 weight: 1
-locked: true
+locked: false

--- a/config/sync/language.entity.fr.yml
+++ b/config/sync/language.entity.fr.yml
@@ -1,0 +1,11 @@
+uuid: 8e02b788-24ab-40ac-a71c-09a0e74e2a29
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+id: fr
+label: Français
+direction: ltr
+weight: 0
+locked: false

--- a/config/sync/language.negotiation.yml
+++ b/config/sync/language.negotiation.yml
@@ -1,0 +1,18 @@
+selected_langcode: site_default
+session:
+  parameter: language
+url:
+  source: path_prefix
+negotiation:
+  language_interface:
+    enabled:
+      language-url: -8
+      language-selected: 12
+  language_content:
+    enabled:
+      language-interface: -10
+      language-url: -8
+      language-selected: 12
+  language_url:
+    enabled:
+      language-url: -8

--- a/config/sync/language.negotiation.yml
+++ b/config/sync/language.negotiation.yml
@@ -9,16 +9,3 @@ url:
   domains:
     fr: ''
     en: ''
-negotiation:
-  language_interface:
-    enabled:
-      language-url: -8
-      language-selected: -6
-  language_content:
-    enabled:
-      language-content-entity: -10
-      language-url: -8
-      language-selected: -6
-  language_url:
-    enabled:
-      language-url: -8

--- a/config/sync/language.negotiation.yml
+++ b/config/sync/language.negotiation.yml
@@ -3,16 +3,22 @@ session:
   parameter: language
 url:
   source: path_prefix
+  prefixes:
+    fr: fr
+    en: en
+  domains:
+    fr: ''
+    en: ''
 negotiation:
   language_interface:
     enabled:
       language-url: -8
-      language-selected: 12
+      language-selected: -6
   language_content:
     enabled:
-      language-interface: -10
+      language-content-entity: -10
       language-url: -8
-      language-selected: 12
+      language-selected: -6
   language_url:
     enabled:
       language-url: -8

--- a/config/sync/language.types.yml
+++ b/config/sync/language.types.yml
@@ -5,3 +5,16 @@ all:
 configurable:
   - language_interface
   - language_content
+negotiation:
+  language_interface:
+    enabled:
+      language-url: -8
+      language-selected: -6
+  language_content:
+    enabled:
+      language-content-entity: -10
+      language-url: -8
+      language-selected: -6
+  language_url:
+    enabled:
+      language-url: -8

--- a/config/sync/language.types.yml
+++ b/config/sync/language.types.yml
@@ -1,0 +1,7 @@
+all:
+  - language_interface
+  - language_content
+  - language_url
+configurable:
+  - language_interface
+  - language_content

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: 'Stratégie digitale, solutions durables'
 page:
   403: ''
   404: ''
-  front: /accueil
+  front: /
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: fr

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: 'Stratégie digitale, solutions durables'
 page:
   403: ''
   404: ''
-  front: /
+  front: /node/5
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: fr

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: ijfbzDTN4CbE7Sr-6ubWzy_t1vH4OtU1doNCLssVz-4
-langcode: en
+langcode: fr
 uuid: 6ea8f5bb-0ecf-491e-b6ae-c8b71a6b6abd
 name: 'E-MERGING DIGITAL'
 mail: admin@example.com
@@ -11,5 +11,5 @@ page:
   front: /accueil
 admin_compact_mode: false
 weight_select_max: 100
-default_langcode: en
+default_langcode: fr
 mail_notification: null

--- a/web/modules/custom/emerging_digital_content/content/node/28345cad-8947-4f91-b77e-9251609a5bcc.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/28345cad-8947-4f91-b77e-9251609a5bcc.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: node
   uuid: "28345cad-8947-4f91-b77e-9251609a5bcc"
   bundle: page
-  default_langcode: en
+  default_langcode: fr
   depends:
     b878853f-1368-47be-bee9-8cdc1dba826a: paragraph
     25892a5a-3c09-4f64-86d7-cda8058e1875: paragraph
@@ -31,5 +31,5 @@ default:
   path:
     -
       alias: "/cas-clients"
-      langcode: en
+      langcode: fr
       pathauto: false

--- a/web/modules/custom/emerging_digital_content/content/node/3636da02-c8e6-40ea-aa71-54148f029a09.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/3636da02-c8e6-40ea-aa71-54148f029a09.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: node
   uuid: "3636da02-c8e6-40ea-aa71-54148f029a09"
   bundle: page
-  default_langcode: en
+  default_langcode: fr
   depends:
     bfa1a9d3-2715-4a04-8758-d14ece990e6e: paragraph
     65be59ce-5a5e-44ec-9c63-b0796b0dd6f9: paragraph
@@ -37,5 +37,5 @@ default:
   path:
     -
       alias: "/ia-drupal"
-      langcode: en
+      langcode: fr
       pathauto: false

--- a/web/modules/custom/emerging_digital_content/content/node/7b8d9926-e015-457f-9da3-562439b962a7.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/7b8d9926-e015-457f-9da3-562439b962a7.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: node
   uuid: "7b8d9926-e015-457f-9da3-562439b962a7"
   bundle: page
-  default_langcode: en
+  default_langcode: fr
   depends:
     3b376be4-852e-4fa2-85ba-a64ff0fefa9d: paragraph
     ad8e2138-9355-4951-90dc-354e07847eca: paragraph
@@ -40,5 +40,5 @@ default:
   path:
     -
       alias: /accueil
-      langcode: en
+      langcode: fr
       pathauto: false

--- a/web/modules/custom/emerging_digital_content/content/node/d6e1876f-8e32-4f75-b6bb-946de5f5afdb.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/d6e1876f-8e32-4f75-b6bb-946de5f5afdb.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: node
   uuid: "d6e1876f-8e32-4f75-b6bb-946de5f5afdb"
   bundle: page
-  default_langcode: en
+  default_langcode: fr
   depends:
     50c9c0ef-85f8-49a3-819c-4aa63ddd1737: paragraph
     2eb8e4b6-37d0-47cc-8702-7a850dd94c15: paragraph
@@ -34,5 +34,5 @@ default:
   path:
     -
       alias: /services
-      langcode: en
+      langcode: fr
       pathauto: false

--- a/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
+++ b/web/modules/custom/emerging_digital_content/content/node/d962ec05-25ec-4446-b645-0959a57964e7.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: node
   uuid: "d962ec05-25ec-4446-b645-0959a57964e7"
   bundle: page
-  default_langcode: en
+  default_langcode: fr
   depends:
     dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92: paragraph
     88affed2-d7e1-44bc-8607-28f0111fc123: paragraph
@@ -37,5 +37,5 @@ default:
   path:
     -
       alias: /contact
-      langcode: en
+      langcode: fr
       pathauto: false

--- a/web/modules/custom/emerging_digital_content/content/paragraph/11c3e2e1-78c9-491d-814c-b204bc2f5338.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/11c3e2e1-78c9-491d-814c-b204bc2f5338.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "11c3e2e1-78c9-491d-814c-b204bc2f5338"
   bundle: services
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/25892a5a-3c09-4f64-86d7-cda8058e1875.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/25892a5a-3c09-4f64-86d7-cda8058e1875.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "25892a5a-3c09-4f64-86d7-cda8058e1875"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/2eb8e4b6-37d0-47cc-8702-7a850dd94c15.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/2eb8e4b6-37d0-47cc-8702-7a850dd94c15.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "2eb8e4b6-37d0-47cc-8702-7a850dd94c15"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/2f4f723a-90d5-4a95-84dc-333363d51655.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/2f4f723a-90d5-4a95-84dc-333363d51655.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "2f4f723a-90d5-4a95-84dc-333363d51655"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/33873ed7-004d-4a7f-b69e-b8f64dc4fa9b.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/33873ed7-004d-4a7f-b69e-b8f64dc4fa9b.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "33873ed7-004d-4a7f-b69e-b8f64dc4fa9b"
   bundle: trust_list
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/3b376be4-852e-4fa2-85ba-a64ff0fefa9d.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/3b376be4-852e-4fa2-85ba-a64ff0fefa9d.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "3b376be4-852e-4fa2-85ba-a64ff0fefa9d"
   bundle: hero
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/3d0518cf-cf7a-4cac-a2eb-ee80c1ba63f9.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/3d0518cf-cf7a-4cac-a2eb-ee80c1ba63f9.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "3d0518cf-cf7a-4cac-a2eb-ee80c1ba63f9"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/50c9c0ef-85f8-49a3-819c-4aa63ddd1737.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/50c9c0ef-85f8-49a3-819c-4aa63ddd1737.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "50c9c0ef-85f8-49a3-819c-4aa63ddd1737"
   bundle: hero
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/614270dd-1d42-4ea9-a7ae-6321952de65b.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/614270dd-1d42-4ea9-a7ae-6321952de65b.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "614270dd-1d42-4ea9-a7ae-6321952de65b"
   bundle: case_clients
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/65be59ce-5a5e-44ec-9c63-b0796b0dd6f9.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/65be59ce-5a5e-44ec-9c63-b0796b0dd6f9.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "65be59ce-5a5e-44ec-9c63-b0796b0dd6f9"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/8236e39f-2bcf-4758-a441-c9f6eb8f75f6.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "8236e39f-2bcf-4758-a441-c9f6eb8f75f6"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/83435955-44bb-40df-8e8c-eda848d40301.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/83435955-44bb-40df-8e8c-eda848d40301.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "83435955-44bb-40df-8e8c-eda848d40301"
   bundle: case_clients
-  default_langcode: en
+  default_langcode: fr
 default:
   field_items:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/855b08da-0ec9-4261-883a-d27f214606e6.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/855b08da-0ec9-4261-883a-d27f214606e6.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "855b08da-0ec9-4261-883a-d27f214606e6"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/856cbeed-a7cd-430b-ba72-aca0b79b6022.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/856cbeed-a7cd-430b-ba72-aca0b79b6022.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "856cbeed-a7cd-430b-ba72-aca0b79b6022"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/88affed2-d7e1-44bc-8607-28f0111fc123.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/88affed2-d7e1-44bc-8607-28f0111fc123.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "88affed2-d7e1-44bc-8607-28f0111fc123"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/88bc3809-2c51-4ec1-93a8-2eed9ce6930c.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/88bc3809-2c51-4ec1-93a8-2eed9ce6930c.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "88bc3809-2c51-4ec1-93a8-2eed9ce6930c"
   bundle: cta
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/ad8e2138-9355-4951-90dc-354e07847eca.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/ad8e2138-9355-4951-90dc-354e07847eca.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "ad8e2138-9355-4951-90dc-354e07847eca"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/b73c293b-32b3-426d-a86b-adfed1a386a7.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/b73c293b-32b3-426d-a86b-adfed1a386a7.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "b73c293b-32b3-426d-a86b-adfed1a386a7"
   bundle: ai_features
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/b878853f-1368-47be-bee9-8cdc1dba826a.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/b878853f-1368-47be-bee9-8cdc1dba826a.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "b878853f-1368-47be-bee9-8cdc1dba826a"
   bundle: hero
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/bfa1a9d3-2715-4a04-8758-d14ece990e6e.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/bfa1a9d3-2715-4a04-8758-d14ece990e6e.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "bfa1a9d3-2715-4a04-8758-d14ece990e6e"
   bundle: hero
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/cfe7d994-e099-44b4-a0cc-12c69760288e.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/cfe7d994-e099-44b4-a0cc-12c69760288e.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "cfe7d994-e099-44b4-a0cc-12c69760288e"
   bundle: cta
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/d36b8734-7d9e-4782-a2e5-efa82d8ecfea.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/d36b8734-7d9e-4782-a2e5-efa82d8ecfea.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "d36b8734-7d9e-4782-a2e5-efa82d8ecfea"
   bundle: cta
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "dc4e80eb-e338-4dfb-a7b3-ce0f4e1eba92"
   bundle: hero
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/e8fcb813-8e1a-4739-a80b-f941b34040c7.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/e8fcb813-8e1a-4739-a80b-f941b34040c7.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "e8fcb813-8e1a-4739-a80b-f941b34040c7"
   bundle: cta
-  default_langcode: en
+  default_langcode: fr
 default:
   field_link:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/efdbbfe1-aec4-4cbb-be3d-33f3fe5966ac.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/efdbbfe1-aec4-4cbb-be3d-33f3fe5966ac.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "efdbbfe1-aec4-4cbb-be3d-33f3fe5966ac"
   bundle: services
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/f4581518-8acc-4632-8b25-884776b3aeb4.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/f4581518-8acc-4632-8b25-884776b3aeb4.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "f4581518-8acc-4632-8b25-884776b3aeb4"
   bundle: cta
-  default_langcode: en
+  default_langcode: fr
 default:
   field_text:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/f6e32e97-aba4-4f5f-a8ce-89fb2ad2a83d.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/f6e32e97-aba4-4f5f-a8ce-89fb2ad2a83d.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "f6e32e97-aba4-4f5f-a8ce-89fb2ad2a83d"
   bundle: trust_list
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/f7bb4bef-3172-4e6b-aadd-3adaaf5aeb29.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/f7bb4bef-3172-4e6b-aadd-3adaaf5aeb29.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "f7bb4bef-3172-4e6b-aadd-3adaaf5aeb29"
   bundle: ai_features
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
+++ b/web/modules/custom/emerging_digital_content/content/paragraph/fe7288c1-8611-4fc9-8b3e-fdb6219038d2.yml
@@ -3,7 +3,7 @@ _meta:
   entity_type: paragraph
   uuid: "fe7288c1-8611-4fc9-8b3e-fdb6219038d2"
   bundle: text_block
-  default_langcode: en
+  default_langcode: fr
 default:
   field_heading:
     -

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -1249,6 +1249,13 @@ function emerging_digital_content_post_update_issue_25_normalize_fr_source(array
 }
 
 /**
+ * Re-runs FR source normalization on already-installed environments.
+ */
+function emerging_digital_content_post_update_issue_25_normalize_fr_source_v2(array &$sandbox): string {
+  return emerging_digital_content_post_update_issue_25_normalize_fr_source($sandbox);
+}
+
+/**
  * Ensures English exists and stays enabled as secondary language.
  */
 function _emerging_digital_content_ensure_english_secondary_language(): string {

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -1286,7 +1286,6 @@ function _emerging_digital_content_bulk_update_entity_langcode(string $entity_ty
 
   $database = \Drupal::database();
   $schema = $database->schema();
-  $mapping = $storage->getTableMapping();
 
   $tables = array_filter(array_unique(array_merge(
     [
@@ -1295,8 +1294,8 @@ function _emerging_digital_content_bulk_update_entity_langcode(string $entity_ty
       $storage->getRevisionTable(),
       $storage->getRevisionDataTable(),
     ],
-    array_values($mapping->getDedicatedDataTableNames()),
-    array_values($mapping->getDedicatedRevisionTableNames()),
+    $schema->findTables($entity_type_id . '__%'),
+    $schema->findTables($entity_type_id . '_revision__%'),
   )));
 
   $updated = 0;

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -1232,15 +1232,18 @@ function emerging_digital_content_post_update_issue_25_normalize_fr_source(array
     $counts[$entity_type_id] = _emerging_digital_content_bulk_update_entity_langcode($entity_type_id, 'en', 'fr');
   }
 
+  $front_path = _emerging_digital_content_resolve_front_page_system_path();
+
   \Drupal::configFactory()->getEditable('system.site')
     ->set('langcode', 'fr')
     ->set('default_langcode', 'fr')
-    ->set('page.front', '/')
+    ->set('page.front', $front_path)
     ->save(TRUE);
 
   return sprintf(
-    '%s Updated langcode en->fr rows: node=%d, paragraph=%d, menu_link_content=%d, path_alias=%d.',
+    '%s Front page set to %s. Updated langcode en->fr rows: node=%d, paragraph=%d, menu_link_content=%d, path_alias=%d.',
     $language_status,
+    $front_path,
     $counts['node'] ?? 0,
     $counts['paragraph'] ?? 0,
     $counts['menu_link_content'] ?? 0,
@@ -1253,6 +1256,40 @@ function emerging_digital_content_post_update_issue_25_normalize_fr_source(array
  */
 function emerging_digital_content_post_update_issue_25_normalize_fr_source_v2(array &$sandbox): string {
   return emerging_digital_content_post_update_issue_25_normalize_fr_source($sandbox);
+}
+
+/**
+ * Re-applies front page system path fix for multilingual resolution.
+ */
+function emerging_digital_content_post_update_issue_25_front_page_system_path_v3(array &$sandbox): string {
+  unset($sandbox);
+
+  $front_path = _emerging_digital_content_resolve_front_page_system_path();
+  \Drupal::configFactory()->getEditable('system.site')
+    ->set('page.front', $front_path)
+    ->save(TRUE);
+
+  return sprintf('Front page system path has been set to %s.', $front_path);
+}
+
+/**
+ * Resolves a stable system path for the French front page.
+ */
+function _emerging_digital_content_resolve_front_page_system_path(): string {
+  $ids = \Drupal::entityQuery('node')
+    ->accessCheck(FALSE)
+    ->condition('type', 'page')
+    ->condition('title', 'Accueil')
+    ->sort('nid', 'ASC')
+    ->range(0, 1)
+    ->execute();
+
+  if ($ids) {
+    $nid = (int) reset($ids);
+    return '/node/' . $nid;
+  }
+
+  return '/node/5';
 }
 
 /**

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorageInterface;
 
 /**
  * Imports packaged default content for already-installed environments.
@@ -1214,4 +1216,109 @@ function _emerging_digital_content_apply_issue_81_editorial_updates(): string {
   }
 
   return sprintf('Issue #81 live editorial update applied on %d paragraph(s).', $updated);
+}
+
+/**
+ * Normalizes legacy English source content to French for issue #25.
+ */
+function emerging_digital_content_post_update_issue_25_normalize_fr_source(array &$sandbox): string {
+  unset($sandbox);
+
+  $language_status = _emerging_digital_content_ensure_english_secondary_language();
+  $entity_types = ['node', 'paragraph', 'menu_link_content', 'path_alias'];
+  $counts = [];
+
+  foreach ($entity_types as $entity_type_id) {
+    $counts[$entity_type_id] = _emerging_digital_content_bulk_update_entity_langcode($entity_type_id, 'en', 'fr');
+  }
+
+  \Drupal::configFactory()->getEditable('system.site')
+    ->set('langcode', 'fr')
+    ->set('default_langcode', 'fr')
+    ->set('page.front', '/')
+    ->save(TRUE);
+
+  return sprintf(
+    '%s Updated langcode en->fr rows: node=%d, paragraph=%d, menu_link_content=%d, path_alias=%d.',
+    $language_status,
+    $counts['node'] ?? 0,
+    $counts['paragraph'] ?? 0,
+    $counts['menu_link_content'] ?? 0,
+    $counts['path_alias'] ?? 0,
+  );
+}
+
+/**
+ * Ensures English exists and stays enabled as secondary language.
+ */
+function _emerging_digital_content_ensure_english_secondary_language(): string {
+  /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage('configurable_language');
+  $english = $storage->load('en');
+
+  if (!$english instanceof ConfigurableLanguage) {
+    ConfigurableLanguage::create([
+      'id' => 'en',
+      'label' => 'English',
+      'weight' => 1,
+      'status' => TRUE,
+    ])->save();
+    return 'English language has been created and enabled.';
+  }
+
+  if (!$english->status()) {
+    $english->enable()->save();
+    return 'English language has been re-enabled.';
+  }
+
+  return 'English language was already enabled.';
+}
+
+/**
+ * Bulk-updates SQL langcode columns for one content entity type.
+ */
+function _emerging_digital_content_bulk_update_entity_langcode(string $entity_type_id, string $from, string $to): int {
+  /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+  if (!$storage instanceof SqlContentEntityStorageInterface) {
+    return 0;
+  }
+
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  $mapping = $storage->getTableMapping();
+
+  $tables = array_filter(array_unique(array_merge(
+    [
+      $storage->getBaseTable(),
+      $storage->getDataTable(),
+      $storage->getRevisionTable(),
+      $storage->getRevisionDataTable(),
+    ],
+    array_values($mapping->getDedicatedDataTableNames()),
+    array_values($mapping->getDedicatedRevisionTableNames()),
+  )));
+
+  $updated = 0;
+  foreach ($tables as $table) {
+    if (!$schema->tableExists($table)) {
+      continue;
+    }
+
+    if ($schema->fieldExists($table, 'langcode')) {
+      $updated += (int) $database->update($table)
+        ->fields(['langcode' => $to])
+        ->condition('langcode', $from)
+        ->execute();
+    }
+
+    if ($schema->fieldExists($table, 'source_langcode')) {
+      $updated += (int) $database->update($table)
+        ->fields(['source_langcode' => $to])
+        ->condition('source_langcode', $from)
+        ->execute();
+    }
+  }
+
+  return $updated;
 }

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -11,7 +11,7 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\Core\Entity\Sql\SqlContentEntityStorageInterface;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
 
 /**
  * Imports packaged default content for already-installed environments.
@@ -1280,7 +1280,7 @@ function _emerging_digital_content_ensure_english_secondary_language(): string {
 function _emerging_digital_content_bulk_update_entity_langcode(string $entity_type_id, string $from, string $to): int {
   /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
   $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
-  if (!$storage instanceof SqlContentEntityStorageInterface) {
+  if (!$storage instanceof SqlContentEntityStorage) {
     return 0;
   }
 

--- a/web/themes/custom/emerging_digital/css/layout.css
+++ b/web/themes/custom/emerging_digital/css/layout.css
@@ -106,6 +106,59 @@
   list-style: none;
 }
 
+.page-header .block-language-blocklanguage-interface {
+  margin-inline-start: auto;
+}
+
+.page-header .block-language-blocklanguage-interface ul {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0.2rem;
+  list-style: none;
+  border: 1px solid #cfd8eb;
+  border-radius: 999px;
+  background: #f8faff;
+}
+
+.page-header .block-language-blocklanguage-interface li {
+  margin: 0;
+}
+
+.page-header .block-language-blocklanguage-interface a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  min-width: 2.25rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #0f2a4a;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.page-header .block-language-blocklanguage-interface a:hover {
+  background: #e6efff;
+  color: #11306e;
+}
+
+.page-header .block-language-blocklanguage-interface a:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  background: #e6efff;
+}
+
+.page-header .block-language-blocklanguage-interface .is-active {
+  background: #0f2a4a;
+  color: #fff;
+}
+
 .page-header .main-navigation__item {
   display: flex;
 }
@@ -335,6 +388,15 @@
 
   .page-header .menu {
     gap: var(--space-2) var(--space-3);
+  }
+
+  .page-header .block-language-blocklanguage-interface {
+    width: 100%;
+    margin-inline-start: 0;
+  }
+
+  .page-header .block-language-blocklanguage-interface ul {
+    width: fit-content;
   }
 
   .page-header .main-navigation__list {

--- a/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
@@ -5,8 +5,10 @@
   </header>
 
   <main role="main" id="main-content" tabindex="-1" class="page-main page-main--front">
-    <div class="front-layout">
-      {{ page.content }}
+    <div class="page-container">
+      <div class="front-layout">
+        {{ page.content }}
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
### Motivation
- Mettre en place une architecture multilingue propre et maintenable pour ajouter une version anglaise sans activer de traduction automatique.
- Conserver le français comme langue source par défaut et préparer la négociation d’URL compatible avec `pathauto`.

### Description
- Activation via configuration des modules de base nécessaires en `config/sync/core.extension.yml`: `language`, `locale`, `config_translation`, `content_translation`.
- Définition du français comme langue source dans `config/sync/system.site.yml` (`langcode` et `default_langcode` à `fr`) et ajout de `config/sync/language.entity.fr.yml` et `config/sync/language.entity.en.yml` pour `fr`/`en`.
- Configuration de la négociation de langue par préfixe d’URL dans `config/sync/language.negotiation.yml` et types de négociation dans `config/sync/language.types.yml`.
- Activation de la traduction de contenu pour les bundles de noeuds existants via des fichiers `config/sync/language.content_settings.node.*.yml` pour `page`, `article`, `service`, `case_client`, `ai_feature`.
- Activation de la traduction pour les Paragraphs custom et pour les liens de menu via `config/sync/language.content_settings.paragraph.*.yml` et `config/sync/language.content_settings.menu_link_content.*.yml`.
- Vérification des champs éditoriaux essentiels (titres, textes, CTA, assemblage de Paragraphs) qui sont configurés `translatable: true` dans les fichiers de champs existants.

### Testing
- `ddev drush cr` : indisponible dans cet environnement de déploiement automatisé (`ddev` non installé), test non exécuté.
- `ddev drush cex -y` : indisponible dans cet environnement (`ddev` non installé), export de configuration non effectué localement.
- `git diff -- config/sync` : exécuté et confirmé les modifications de configuration (`core.extension.yml`, `system.site.yml`, nouveaux fichiers `language.*.yml` et `language.content_settings.*.yml`).
- `ddev drush cim -y` : indisponible dans cet environnement (`ddev` non installé), import de configuration non effectué ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ac00a2c0832195305ba6baf4d9cc)