### PR TITLE
feat(i18n): première traduction IA manuelle FR → EN (module custom)

### DIFF
--- a/config/sync/agency_ai_translation.settings.yml
+++ b/config/sync/agency_ai_translation.settings.yml
@@ -1,0 +1,3 @@
+endpoint: 'https://api.openai.com/v1/chat/completions'
+model: 'gpt-4o-mini'
+system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/config/sync/agency_ai_translation.settings.yml
+++ b/config/sync/agency_ai_translation.settings.yml
@@ -1,4 +1,4 @@
 endpoint: 'https://api.openai.com/v1/chat/completions'
 model: 'gpt-4o-mini'
 openai_key_id: 'openai_api_key'
-system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'
+system_prompt: 'You are a professional website translator. Translate the source content into the requested target language while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/config/sync/agency_ai_translation.settings.yml
+++ b/config/sync/agency_ai_translation.settings.yml
@@ -1,3 +1,4 @@
 endpoint: 'https://api.openai.com/v1/chat/completions'
 model: 'gpt-4o-mini'
+openai_key_id: 'openai_api_key'
 system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -2,6 +2,7 @@ _core:
   default_config_hash: 4GIX5Esnc_umpXUBj4IIocRX7Mt5fPhm4AgXfE3E56E
 module:
   admin_toolbar: 0
+  agency_ai_translation: 0
   ai: 0
   ai_provider_openai: 0
   announcements_feed: 0

--- a/config/sync/pathauto.pattern.node_ai_feature.yml
+++ b/config/sync/pathauto.pattern.node_ai_feature.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - node
 id: node_ai_feature
-label: 'Content path pattern (Fonctionnalité IA)'
+label: 'Content path pattern (Fonctionnalité IA fallback)'
 type: 'canonical_entities:node'
 pattern: 'ia/[node:title]'
 selection_criteria:
@@ -18,5 +18,5 @@ selection_criteria:
     bundles:
       ai_feature: ai_feature
 selection_logic: and
-weight: -6
+weight: -1
 relationships: {  }

--- a/config/sync/pathauto.pattern.node_ai_feature_en.yml
+++ b/config/sync/pathauto.pattern.node_ai_feature_en.yml
@@ -1,0 +1,31 @@
+uuid: a67eb4d4-86ea-4bf8-90ba-df2f3e5f17c5
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_ai_feature_en
+label: 'Content path pattern (Fonctionnalité IA EN)'
+type: 'canonical_entities:node'
+pattern: 'ai/[node:title]'
+selection_criteria:
+  87ea367d-f6b8-4904-a088-7424db19494f:
+    id: language
+    negate: false
+    uuid: 87ea367d-f6b8-4904-a088-7424db19494f
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      en: en
+  ee9d9a93-d0ef-4893-9333-5a2f7f5aed03:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: ee9d9a93-d0ef-4893-9333-5a2f7f5aed03
+    context_mapping:
+      node: node
+    bundles:
+      ai_feature: ai_feature
+selection_logic: and
+weight: -11
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_ai_feature_fr.yml
+++ b/config/sync/pathauto.pattern.node_ai_feature_fr.yml
@@ -1,0 +1,31 @@
+uuid: 7132638d-df2a-4f3d-ba4a-aeec03ef9231
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_ai_feature_fr
+label: 'Content path pattern (Fonctionnalité IA FR)'
+type: 'canonical_entities:node'
+pattern: 'ia/[node:title]'
+selection_criteria:
+  34e8f4f6-2d34-47a5-8f29-4eaecb8686e8:
+    id: language
+    negate: false
+    uuid: 34e8f4f6-2d34-47a5-8f29-4eaecb8686e8
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      fr: fr
+  a24e35ad-c7f6-48dc-aeb5-9d88217f8e84:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: a24e35ad-c7f6-48dc-aeb5-9d88217f8e84
+    context_mapping:
+      node: node
+    bundles:
+      ai_feature: ai_feature
+selection_logic: and
+weight: -12
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_case_client.yml
+++ b/config/sync/pathauto.pattern.node_case_client.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - node
 id: node_case_client
-label: 'Content path pattern (Cas client)'
+label: 'Content path pattern (Cas client fallback)'
 type: 'canonical_entities:node'
 pattern: 'cas-clients/[node:title]'
 selection_criteria:
@@ -18,5 +18,5 @@ selection_criteria:
     bundles:
       case_client: case_client
 selection_logic: and
-weight: -7
+weight: -1
 relationships: {  }

--- a/config/sync/pathauto.pattern.node_case_client_en.yml
+++ b/config/sync/pathauto.pattern.node_case_client_en.yml
@@ -1,0 +1,31 @@
+uuid: f5791824-e70f-466a-ba91-c98743984a13
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_case_client_en
+label: 'Content path pattern (Cas client EN)'
+type: 'canonical_entities:node'
+pattern: 'case-studies/[node:title]'
+selection_criteria:
+  5f7fdb6c-702f-4285-b657-2da37d4fd966:
+    id: language
+    negate: false
+    uuid: 5f7fdb6c-702f-4285-b657-2da37d4fd966
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      en: en
+  36ea85e2-3870-4d0f-9c59-f308f4b69457:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 36ea85e2-3870-4d0f-9c59-f308f4b69457
+    context_mapping:
+      node: node
+    bundles:
+      case_client: case_client
+selection_logic: and
+weight: -11
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_case_client_fr.yml
+++ b/config/sync/pathauto.pattern.node_case_client_fr.yml
@@ -1,0 +1,31 @@
+uuid: d6a2cd47-c67d-4ec8-9dfa-f1be9f4f8604
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_case_client_fr
+label: 'Content path pattern (Cas client FR)'
+type: 'canonical_entities:node'
+pattern: 'cas-clients/[node:title]'
+selection_criteria:
+  7e6f25f1-43da-4963-8787-4df5b7d8f205:
+    id: language
+    negate: false
+    uuid: 7e6f25f1-43da-4963-8787-4df5b7d8f205
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      fr: fr
+  0df52cbf-f39e-4763-aa74-4e989ec2116b:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 0df52cbf-f39e-4763-aa74-4e989ec2116b
+    context_mapping:
+      node: node
+    bundles:
+      case_client: case_client
+selection_logic: and
+weight: -12
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_page.yml
+++ b/config/sync/pathauto.pattern.node_page.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - node
 id: node_page
-label: 'Content path pattern (Page)'
+label: 'Content path pattern (Page fallback)'
 type: 'canonical_entities:node'
 pattern: '[node:title]'
 selection_criteria:
@@ -18,5 +18,5 @@ selection_criteria:
     bundles:
       page: page
 selection_logic: and
-weight: -10
+weight: -1
 relationships: {  }

--- a/config/sync/pathauto.pattern.node_page_en.yml
+++ b/config/sync/pathauto.pattern.node_page_en.yml
@@ -1,0 +1,31 @@
+uuid: 3d5d0b58-4d0f-475c-a702-3da53fa0a5e4
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_page_en
+label: 'Content path pattern (Page EN)'
+type: 'canonical_entities:node'
+pattern: '[node:title]'
+selection_criteria:
+  1e1f4cbc-65e9-45bb-a57e-c47e4cfa90f1:
+    id: language
+    negate: false
+    uuid: 1e1f4cbc-65e9-45bb-a57e-c47e4cfa90f1
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      en: en
+  8f0b8a7f-b863-4259-95f1-f03f3f9dacf4:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 8f0b8a7f-b863-4259-95f1-f03f3f9dacf4
+    context_mapping:
+      node: node
+    bundles:
+      page: page
+selection_logic: and
+weight: -11
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_page_fr.yml
+++ b/config/sync/pathauto.pattern.node_page_fr.yml
@@ -1,0 +1,31 @@
+uuid: 15d638e3-e68b-4874-b4ff-d0ec9ff9be2f
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_page_fr
+label: 'Content path pattern (Page FR)'
+type: 'canonical_entities:node'
+pattern: '[node:title]'
+selection_criteria:
+  b6f6fc97-8882-4203-b68e-a4c993193652:
+    id: language
+    negate: false
+    uuid: b6f6fc97-8882-4203-b68e-a4c993193652
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      fr: fr
+  c5fd08ca-417a-44a4-8a7c-14fbb989d86d:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: c5fd08ca-417a-44a4-8a7c-14fbb989d86d
+    context_mapping:
+      node: node
+    bundles:
+      page: page
+selection_logic: and
+weight: -12
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_service.yml
+++ b/config/sync/pathauto.pattern.node_service.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - node
 id: node_service
-label: 'Content path pattern (Service)'
+label: 'Content path pattern (Service fallback)'
 type: 'canonical_entities:node'
 pattern: 'services/[node:title]'
 selection_criteria:
@@ -18,5 +18,5 @@ selection_criteria:
     bundles:
       service: service
 selection_logic: and
-weight: -9
+weight: -1
 relationships: {  }

--- a/config/sync/pathauto.pattern.node_service_en.yml
+++ b/config/sync/pathauto.pattern.node_service_en.yml
@@ -1,0 +1,31 @@
+uuid: 164b4613-bae2-4fd0-ae3a-22943f9ccf7b
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_service_en
+label: 'Content path pattern (Service EN)'
+type: 'canonical_entities:node'
+pattern: 'services/[node:title]'
+selection_criteria:
+  3a89fc73-52fb-47e0-8fe1-5e59f2ccce15:
+    id: language
+    negate: false
+    uuid: 3a89fc73-52fb-47e0-8fe1-5e59f2ccce15
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      en: en
+  8a24e0f3-92e8-4ee6-8c85-620ca4a0dd8d:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 8a24e0f3-92e8-4ee6-8c85-620ca4a0dd8d
+    context_mapping:
+      node: node
+    bundles:
+      service: service
+selection_logic: and
+weight: -11
+relationships: {  }

--- a/config/sync/pathauto.pattern.node_service_fr.yml
+++ b/config/sync/pathauto.pattern.node_service_fr.yml
@@ -1,0 +1,31 @@
+uuid: cdc3a3c4-e8f2-4bc5-bdb5-cd76d9889f53
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: node_service_fr
+label: 'Content path pattern (Service FR)'
+type: 'canonical_entities:node'
+pattern: 'services/[node:title]'
+selection_criteria:
+  b2f807d8-e5e7-413f-b6b3-9f1650cc4c11:
+    id: language
+    negate: false
+    uuid: b2f807d8-e5e7-413f-b6b3-9f1650cc4c11
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      fr: fr
+  aa2c1942-3b4a-483b-bf9b-72215dc098c2:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: aa2c1942-3b4a-483b-bf9b-72215dc098c2
+    context_mapping:
+      node: node
+    bundles:
+      service: service
+selection_logic: and
+weight: -12
+relationships: {  }

--- a/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -1,0 +1,14 @@
+uuid: afb95202-30af-48d0-b654-a328c7fcc359
+langcode: en
+status: true
+dependencies:
+  module:
+    - agency_ai_translation
+    - node
+id: agency_ai_translate_nodes_bulk_action
+label: 'Traduire avec IA vers une langue cible'
+type: node
+plugin: agency_ai_translate_nodes_bulk_action
+configuration:
+  source_langcode: fr
+  target_langcode: en

--- a/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -11,4 +11,4 @@ type: node
 plugin: agency_ai_translate_nodes_bulk_action
 configuration:
   source_langcode: fr
-  target_langcode: en
+  target_langcode: ''

--- a/web/modules/custom/agency_ai_translation/README.md
+++ b/web/modules/custom/agency_ai_translation/README.md
@@ -59,3 +59,4 @@ Fallback possible (non exporté) : champ mot de passe de la page de config (stoc
 ## Alias d’URL (Pathauto)
 - Si le module **Pathauto** est actif, l’alias de la traduction cible est régénéré après traduction.
 - Le champ `path` de la traduction cible est préparé avec `pathauto = 1` pour éviter de rester sur `/[lang]/node/[nid]`.
+- Les patterns Pathauto doivent être configurés par langue (ex: `node_page_fr`, `node_page_en`) pour des alias cohérents en multilingue.

--- a/web/modules/custom/agency_ai_translation/README.md
+++ b/web/modules/custom/agency_ai_translation/README.md
@@ -1,0 +1,57 @@
+# Agency AI Translation (FR -> EN)
+
+## Objectif
+Ce module ajoute un **déclenchement manuel** pour pré-traduire un contenu Drupal depuis le français (`fr`) vers l’anglais (`en`) via une IA compatible API Chat Completions.
+
+- Le FR reste la source éditoriale.
+- L’EN est une traduction secondaire.
+- Aucun déclenchement automatique à la sauvegarde.
+- Contrôle humain avant publication EN.
+
+## Workflow éditeur
+1. Ouvrir un contenu source en français.
+2. Dans les opérations du contenu, cliquer **Générer EN (IA)**.
+3. Confirmer l’action.
+4. Le module crée/met à jour la traduction `en`.
+5. L’éditeur est redirigé vers l’édition EN pour relecture/corrections.
+6. Publication EN manuelle uniquement.
+
+## Champs traités
+Le module traduit uniquement les champs translatables de type éditorial :
+- `string`, `string_long`
+- `text`, `text_long`, `text_with_summary`
+- `link` (titre du lien uniquement)
+- Paragraphs via `entity_reference_revisions` (récursif sur les champs éditoriaux translatables)
+
+## Champs exclus
+Par conception, les champs techniques ne sont pas traduits automatiquement, notamment :
+- images/fichiers
+- références d’entités hors paragraphs
+- dates, booléens, nombres, statuts, métadonnées système
+
+## Configuration
+Route d’admin : `/admin/config/content/agency-ai-translation`
+
+Paramètres exportés :
+- endpoint
+- model
+- system prompt
+
+### Gestion de la clé API (sans secret dans le code)
+Recommandé : `settings.php`
+
+```php
+$settings['agency_ai_translation.api_key'] = '...';
+```
+
+Alternative : variable d’environnement
+
+```bash
+export AGENCY_AI_TRANSLATION_API_KEY="..."
+```
+
+Fallback possible (non exporté) : champ mot de passe de la page de config (stocké en `state`).
+
+## Limites connues
+- Première version volontairement simple : traduction champ à champ.
+- La qualité dépend du modèle IA et du prompt configuré.

--- a/web/modules/custom/agency_ai_translation/README.md
+++ b/web/modules/custom/agency_ai_translation/README.md
@@ -1,20 +1,20 @@
-# Agency AI Translation (FR -> EN)
+# Agency AI Translation (multi-langue)
 
 ## Objectif
-Ce module ajoute un **déclenchement manuel** pour pré-traduire un contenu Drupal depuis le français (`fr`) vers l’anglais (`en`) via une IA compatible API Chat Completions.
+Ce module ajoute un **déclenchement manuel** pour pré-traduire un contenu Drupal vers une langue cible configurable via une IA compatible API Chat Completions.
 
-- Le FR reste la source éditoriale.
-- L’EN est une traduction secondaire.
+- La source est la langue courante du contenu.
+- La cible est choisie au déclenchement.
 - Aucun déclenchement automatique à la sauvegarde.
 - Contrôle humain avant publication EN.
 
 ## Workflow éditeur
-1. Ouvrir un contenu source en français.
-2. Dans les opérations du contenu, cliquer **Générer EN (IA)**.
+1. Ouvrir un contenu source.
+2. Dans les opérations du contenu, cliquer **Générer [langue] (IA)**.
 3. Confirmer l’action.
-4. Le module crée/met à jour la traduction `en`.
-5. L’éditeur est redirigé vers l’édition EN pour relecture/corrections.
-6. Publication EN manuelle uniquement.
+4. Le module crée/met à jour la traduction cible.
+5. L’éditeur est redirigé vers l’édition de la langue cible pour relecture/corrections.
+6. Publication manuelle uniquement.
 
 ## Champs traités
 Le module traduit uniquement les champs translatables de type éditorial :

--- a/web/modules/custom/agency_ai_translation/README.md
+++ b/web/modules/custom/agency_ai_translation/README.md
@@ -55,3 +55,7 @@ Fallback possible (non exporté) : champ mot de passe de la page de config (stoc
 ## Limites connues
 - Première version volontairement simple : traduction champ à champ.
 - La qualité dépend du modèle IA et du prompt configuré.
+
+## Alias d’URL (Pathauto)
+- Si le module **Pathauto** est actif, l’alias de la traduction cible est régénéré après traduction.
+- Le champ `path` de la traduction cible est préparé avec `pathauto = 1` pour éviter de rester sur `/[lang]/node/[nid]`.

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.info.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.info.yml
@@ -1,0 +1,10 @@
+name: 'Agency AI Translation'
+type: module
+description: 'Traduction assistée par IA du français vers l’anglais pour les contenus éditoriaux.'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - drupal:content_translation
+  - drupal:language
+  - drupal:node
+  - drupal:paragraphs

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.info.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.info.yml
@@ -1,6 +1,6 @@
 name: 'Agency AI Translation'
 type: module
-description: 'Traduction assistée par IA du français vers l’anglais pour les contenus éditoriaux.'
+description: 'Traduction assistée par IA entre langues configurées pour les contenus éditoriaux.'
 core_version_requirement: ^11
 package: Custom
 dependencies:

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.links.menu.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.links.menu.yml
@@ -1,0 +1,5 @@
+agency_ai_translation.settings:
+  title: 'Traduction IA FR -> EN'
+  description: 'Configurer l’intégration IA pour la pré-traduction éditoriale.'
+  route_name: agency_ai_translation.settings
+  parent: system.admin_config_content

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -64,40 +64,6 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
     return;
   }
 
-  $actionElement = NULL;
-  if (isset($form['action']) && is_array($form['action'])) {
-    $actionElement = &$form['action'];
-  }
-  elseif (isset($form['actions']['action']) && is_array($form['actions']['action'])) {
-    $actionElement = &$form['actions'];
-  }
-  elseif (isset($form['header']['action']) && is_array($form['header']['action'])) {
-    $actionElement = &$form['header'];
-  }
-  elseif (isset($form['header']['actions']['action']) && is_array($form['header']['actions']['action'])) {
-    $actionElement = &$form['header']['actions'];
-  }
-  else {
-    foreach ($form as &$element) {
-      if (!is_array($element)) {
-        continue;
-      }
-      if (isset($element['action']) && is_array($element['action'])) {
-        $actionElement = &$element;
-        break;
-      }
-      if (isset($element['actions']) && is_array($element['actions']) && isset($element['actions']['action']) && is_array($element['actions']['action'])) {
-        $actionElement = &$element['actions'];
-        break;
-      }
-    }
-    unset($element);
-  }
-
-  if ($actionElement === NULL) {
-    return;
-  }
-
   $languages = \Drupal::languageManager()->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
   $options = [];
   foreach ($languages as $language) {
@@ -108,23 +74,87 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
     return;
   }
 
-  $actionElement['agency_ai_translation_target_langcode'] = [
+  $inserted = FALSE;
+  $inserted = agency_ai_translation_attach_target_language_select($form, $options) || $inserted;
+  if (isset($form['actions']) && is_array($form['actions'])) {
+    $inserted = agency_ai_translation_attach_target_language_select($form['actions'], $options) || $inserted;
+  }
+  if (isset($form['header']) && is_array($form['header'])) {
+    $inserted = agency_ai_translation_attach_target_language_select($form['header'], $options) || $inserted;
+    if (isset($form['header']['actions']) && is_array($form['header']['actions'])) {
+      $inserted = agency_ai_translation_attach_target_language_select($form['header']['actions'], $options) || $inserted;
+    }
+  }
+
+  if (!$inserted) {
+    foreach ($form as &$element) {
+      if (!is_array($element)) {
+        continue;
+      }
+      $inserted = agency_ai_translation_attach_target_language_select($element, $options) || $inserted;
+      if (isset($element['actions']) && is_array($element['actions'])) {
+        $inserted = agency_ai_translation_attach_target_language_select($element['actions'], $options) || $inserted;
+      }
+    }
+    unset($element);
+  }
+
+  if (!$inserted) {
+    return;
+  }
+
+  $form['#validate'][] = 'agency_ai_translation_bulk_action_validate';
+}
+
+/**
+ * Attache le sélecteur de langue cible à un conteneur d'actions de masse.
+ */
+function agency_ai_translation_attach_target_language_select(array &$container, array $options): bool {
+  if (!isset($container['action']) || !is_array($container['action'])) {
+    return FALSE;
+  }
+
+  if (isset($container['agency_ai_translation_target_langcode'])) {
+    return TRUE;
+  }
+
+  $container['agency_ai_translation_target_langcode'] = [
     '#type' => 'select',
     '#title' => t('Langue cible (IA)'),
     '#options' => $options,
     '#empty_option' => t('- Sélectionner -'),
     '#description' => t('Obligatoire pour l’action “Traduire avec IA vers une langue cible”.'),
     '#weight' => 5,
+    '#states' => [
+      'visible' => [
+        [':input[name="action"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+        'or',
+        [':input[name="action[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+        'or',
+        [':input[name="actions[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+        'or',
+        [':input[name="header[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+        'or',
+        [':input[name="header[actions][action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+      ],
+    ],
   ];
 
-  $form['#validate'][] = 'agency_ai_translation_bulk_action_validate';
+  return TRUE;
 }
 
 /**
  * Validation du sélecteur de langue cible pour l'action IA de masse.
  */
 function agency_ai_translation_bulk_action_validate(array &$form, FormStateInterface $form_state): void {
-  $selectedAction = (string) ($form_state->getValue('action') ?? '');
+  $selectedAction = '';
+  $actionValue = $form_state->getValue('action');
+  if (is_string($actionValue)) {
+    $selectedAction = $actionValue;
+  }
+  elseif (is_array($actionValue)) {
+    $selectedAction = (string) ($actionValue['action'] ?? '');
+  }
   if ($selectedAction === '' && is_array($form_state->getValue('actions'))) {
     $selectedAction = (string) (($form_state->getValue('actions')['action'] ?? ''));
   }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
@@ -19,10 +20,6 @@ function agency_ai_translation_entity_operation(EntityInterface $entity): array 
     return [];
   }
 
-  if ($entity->language()->getId() !== 'fr') {
-    return [];
-  }
-
   $account = \Drupal::currentUser();
   $hasTranslationPermission = $account->hasPermission('trigger ai translation')
     || $account->hasPermission('administer nodes');
@@ -31,11 +28,26 @@ function agency_ai_translation_entity_operation(EntityInterface $entity): array 
     return [];
   }
 
-  return [
-    'agency_ai_translate' => [
-      'title' => t('Générer EN (IA)'),
-      'weight' => 30,
-      'url' => Url::fromRoute('agency_ai_translation.translate_node', ['node' => $entity->id()]),
-    ],
-  ];
+  $sourceLangcode = $entity->language()->getId();
+  $languages = \Drupal::languageManager()->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
+  $operations = [];
+  $weight = 30;
+
+  foreach ($languages as $targetLanguage) {
+    $targetLangcode = $targetLanguage->getId();
+    if ($targetLangcode === $sourceLangcode) {
+      continue;
+    }
+
+    $operations['agency_ai_translate_' . $targetLangcode] = [
+      'title' => t('Générer @lang (IA)', ['@lang' => strtoupper($targetLangcode)]),
+      'weight' => $weight++,
+      'url' => Url::fromRoute('agency_ai_translation.translate_node', [
+        'node' => $entity->id(),
+        'target_langcode' => $targetLangcode,
+      ]),
+    ];
+  }
+
+  return $operations;
 }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -71,6 +71,12 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
   elseif (isset($form['actions']['action']) && is_array($form['actions']['action'])) {
     $actionElement = &$form['actions'];
   }
+  elseif (isset($form['header']['action']) && is_array($form['header']['action'])) {
+    $actionElement = &$form['header'];
+  }
+  elseif (isset($form['header']['actions']['action']) && is_array($form['header']['actions']['action'])) {
+    $actionElement = &$form['header']['actions'];
+  }
 
   if ($actionElement === NULL) {
     return;

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -66,7 +66,7 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
 
   $actionElement = NULL;
   if (isset($form['action']) && is_array($form['action'])) {
-    $actionElement = &$form;
+    $actionElement = &$form['action'];
   }
   elseif (isset($form['actions']['action']) && is_array($form['actions']['action'])) {
     $actionElement = &$form['actions'];
@@ -101,9 +101,6 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
   $languages = \Drupal::languageManager()->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
   $options = [];
   foreach ($languages as $language) {
-    if ($language->getId() === 'fr') {
-      continue;
-    }
     $options[$language->getId()] = strtoupper($language->getId()) . ' — ' . $language->getName();
   }
 
@@ -119,4 +116,44 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
     '#description' => t('Obligatoire pour l’action “Traduire avec IA vers une langue cible”.'),
     '#weight' => 5,
   ];
+
+  $form['#validate'][] = 'agency_ai_translation_bulk_action_validate';
+}
+
+/**
+ * Validation du sélecteur de langue cible pour l'action IA de masse.
+ */
+function agency_ai_translation_bulk_action_validate(array &$form, FormStateInterface $form_state): void {
+  $selectedAction = (string) ($form_state->getValue('action') ?? '');
+  if ($selectedAction === '' && is_array($form_state->getValue('actions'))) {
+    $selectedAction = (string) (($form_state->getValue('actions')['action'] ?? ''));
+  }
+  if ($selectedAction === '' && is_array($form_state->getValue('header'))) {
+    $headerValues = $form_state->getValue('header');
+    if (is_array($headerValues)) {
+      $selectedAction = (string) ($headerValues['action'] ?? ($headerValues['actions']['action'] ?? ''));
+    }
+  }
+
+  if ($selectedAction !== 'agency_ai_translate_nodes_bulk_action') {
+    return;
+  }
+
+  $targetLangcode = (string) ($form_state->getValue('agency_ai_translation_target_langcode') ?? '');
+  if ($targetLangcode === '' && is_array($form_state->getValue('action'))) {
+    $targetLangcode = (string) (($form_state->getValue('action')['agency_ai_translation_target_langcode'] ?? ''));
+  }
+  if ($targetLangcode === '' && is_array($form_state->getValue('actions'))) {
+    $targetLangcode = (string) (($form_state->getValue('actions')['agency_ai_translation_target_langcode'] ?? ''));
+  }
+  if ($targetLangcode === '' && is_array($form_state->getValue('header'))) {
+    $headerValues = $form_state->getValue('header');
+    if (is_array($headerValues)) {
+      $targetLangcode = (string) ($headerValues['agency_ai_translation_target_langcode'] ?? ($headerValues['actions']['agency_ai_translation_target_langcode'] ?? ''));
+    }
+  }
+
+  if ($targetLangcode === '') {
+    $form_state->setErrorByName('agency_ai_translation_target_langcode', t('Veuillez choisir une langue cible pour la traduction IA.'));
+  }
 }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -57,12 +57,22 @@ function agency_ai_translation_entity_operation(EntityInterface $entity): array 
  * Implements hook_form_alter().
  */
 function agency_ai_translation_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
-  if (!str_starts_with($form_id, 'views_form_content_')) {
+  if (
+    !str_starts_with($form_id, 'views_form_content_')
+    && $form_id !== 'node_admin_content'
+  ) {
     return;
   }
 
-  $actionOptions = $form['action']['#options'] ?? [];
-  if (!is_array($actionOptions) || !isset($actionOptions['agency_ai_translate_nodes_bulk_action'])) {
+  $actionElement = NULL;
+  if (isset($form['action']) && is_array($form['action'])) {
+    $actionElement = &$form;
+  }
+  elseif (isset($form['actions']['action']) && is_array($form['actions']['action'])) {
+    $actionElement = &$form['actions'];
+  }
+
+  if ($actionElement === NULL) {
     return;
   }
 
@@ -79,12 +89,12 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
     return;
   }
 
-  $form['agency_ai_translation_target_langcode'] = [
+  $actionElement['agency_ai_translation_target_langcode'] = [
     '#type' => 'select',
     '#title' => t('Langue cible (IA)'),
     '#options' => $options,
     '#empty_option' => t('- Sélectionner -'),
     '#description' => t('Obligatoire pour l’action “Traduire avec IA vers une langue cible”.'),
-    '#weight' => -10,
+    '#weight' => 5,
   ];
 }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -112,9 +112,30 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
   }
 
   if (!$inserted) {
-    return;
+    $form['agency_ai_translation_target_langcode'] = [
+      '#type' => 'select',
+      '#title' => t('Langue cible (IA)'),
+      '#options' => $options,
+      '#empty_option' => t('- Sélectionner -'),
+      '#description' => t('Choisissez la langue cible pour l’action “Traduire avec IA vers une langue cible”.'),
+      '#weight' => 100,
+      '#states' => [
+        'visible' => [
+          [':input[name="action"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+          'or',
+          [':input[name="action[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+          'or',
+          [':input[name="actions[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+          'or',
+          [':input[name="header[action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+          'or',
+          [':input[name="header[actions][action]"]' => ['value' => 'agency_ai_translate_nodes_bulk_action']],
+        ],
+      ],
+    ];
   }
 
+  $form['#attached']['library'][] = 'core/drupal.states';
   $form['#validate'][] = 'agency_ai_translation_bulk_action_validate';
 }
 

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * @file
  * Hooks du module Agency AI Translation.
  */
+
+declare(strict_types=1);
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * @file
+ * Hooks du module Agency AI Translation.
+ */
+
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -75,14 +75,22 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
   }
 
   $inserted = FALSE;
-  $inserted = agency_ai_translation_attach_target_language_select($form, $options) || $inserted;
+  if (agency_ai_translation_attach_target_language_select($form, $options)) {
+    $inserted = TRUE;
+  }
   if (isset($form['actions']) && is_array($form['actions'])) {
-    $inserted = agency_ai_translation_attach_target_language_select($form['actions'], $options) || $inserted;
+    if (agency_ai_translation_attach_target_language_select($form['actions'], $options)) {
+      $inserted = TRUE;
+    }
   }
   if (isset($form['header']) && is_array($form['header'])) {
-    $inserted = agency_ai_translation_attach_target_language_select($form['header'], $options) || $inserted;
+    if (agency_ai_translation_attach_target_language_select($form['header'], $options)) {
+      $inserted = TRUE;
+    }
     if (isset($form['header']['actions']) && is_array($form['header']['actions'])) {
-      $inserted = agency_ai_translation_attach_target_language_select($form['header']['actions'], $options) || $inserted;
+      if (agency_ai_translation_attach_target_language_select($form['header']['actions'], $options)) {
+        $inserted = TRUE;
+      }
     }
   }
 
@@ -91,9 +99,13 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
       if (!is_array($element)) {
         continue;
       }
-      $inserted = agency_ai_translation_attach_target_language_select($element, $options) || $inserted;
+      if (agency_ai_translation_attach_target_language_select($element, $options)) {
+        $inserted = TRUE;
+      }
       if (isset($element['actions']) && is_array($element['actions'])) {
-        $inserted = agency_ai_translation_attach_target_language_select($element['actions'], $options) || $inserted;
+        if (agency_ai_translation_attach_target_language_select($element['actions'], $options)) {
+          $inserted = TRUE;
+        }
       }
     }
     unset($element);

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -77,6 +77,22 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
   elseif (isset($form['header']['actions']['action']) && is_array($form['header']['actions']['action'])) {
     $actionElement = &$form['header']['actions'];
   }
+  else {
+    foreach ($form as $key => &$element) {
+      if (!is_array($element)) {
+        continue;
+      }
+      if (isset($element['action']) && is_array($element['action'])) {
+        $actionElement = &$element;
+        break;
+      }
+      if (isset($element['actions']) && is_array($element['actions']) && isset($element['actions']['action']) && is_array($element['actions']['action'])) {
+        $actionElement = &$element['actions'];
+        break;
+      }
+    }
+    unset($element);
+  }
 
   if ($actionElement === NULL) {
     return;

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -50,4 +51,40 @@ function agency_ai_translation_entity_operation(EntityInterface $entity): array 
   }
 
   return $operations;
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function agency_ai_translation_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  if (!str_starts_with($form_id, 'views_form_content_')) {
+    return;
+  }
+
+  $actionOptions = $form['action']['#options'] ?? [];
+  if (!is_array($actionOptions) || !isset($actionOptions['agency_ai_translate_nodes_bulk_action'])) {
+    return;
+  }
+
+  $languages = \Drupal::languageManager()->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
+  $options = [];
+  foreach ($languages as $language) {
+    if ($language->getId() === 'fr') {
+      continue;
+    }
+    $options[$language->getId()] = strtoupper($language->getId()) . ' — ' . $language->getName();
+  }
+
+  if ($options === []) {
+    return;
+  }
+
+  $form['agency_ai_translation_target_langcode'] = [
+    '#type' => 'select',
+    '#title' => t('Langue cible (IA)'),
+    '#options' => $options,
+    '#empty_option' => t('- Sélectionner -'),
+    '#description' => t('Obligatoire pour l’action “Traduire avec IA vers une langue cible”.'),
+    '#weight' => -10,
+  ];
 }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -78,7 +78,7 @@ function agency_ai_translation_form_alter(array &$form, FormStateInterface $form
     $actionElement = &$form['header']['actions'];
   }
   else {
-    foreach ($form as $key => &$element) {
+    foreach ($form as &$element) {
       if (!is_array($element)) {
         continue;
       }

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_entity_operation().
+ */
+function agency_ai_translation_entity_operation(EntityInterface $entity): array {
+  if (!$entity instanceof NodeInterface) {
+    return [];
+  }
+
+  if ($entity->language()->getId() !== 'fr') {
+    return [];
+  }
+
+  $account = \Drupal::currentUser();
+  if (!$account->hasPermission('trigger ai translation') || !$entity->access('update', $account)) {
+    return [];
+  }
+
+  return [
+    'agency_ai_translate' => [
+      'title' => t('Générer EN (IA)'),
+      'weight' => 30,
+      'url' => Url::fromRoute('agency_ai_translation.translate_node', ['node' => $entity->id()]),
+    ],
+  ];
+}

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.module
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.module
@@ -24,7 +24,10 @@ function agency_ai_translation_entity_operation(EntityInterface $entity): array 
   }
 
   $account = \Drupal::currentUser();
-  if (!$account->hasPermission('trigger ai translation') || !$entity->access('update', $account)) {
+  $hasTranslationPermission = $account->hasPermission('trigger ai translation')
+    || $account->hasPermission('administer nodes');
+
+  if (!$hasTranslationPermission || !$entity->access('update', $account)) {
     return [];
   }
 

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.permissions.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.permissions.yml
@@ -1,3 +1,3 @@
 trigger ai translation:
-  title: 'Déclencher une traduction IA FR -> EN'
-  description: 'Permet de lancer manuellement la traduction IA d’un contenu français vers l’anglais.'
+  title: 'Déclencher une traduction IA'
+  description: 'Permet de lancer manuellement la traduction IA d’un contenu vers une langue cible.'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.permissions.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.permissions.yml
@@ -1,0 +1,3 @@
+trigger ai translation:
+  title: 'Déclencher une traduction IA FR -> EN'
+  description: 'Permet de lancer manuellement la traduction IA d’un contenu français vers l’anglais.'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -4,8 +4,7 @@ agency_ai_translation.translate_node:
     _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
     _title: 'Générer la traduction anglaise (IA)'
   requirements:
-    _permission: 'trigger ai translation'
-    _entity_access: 'node.update'
+    _custom_access: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm::access'
 
 agency_ai_translation.settings:
   path: '/admin/config/content/agency-ai-translation'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -4,7 +4,7 @@ agency_ai_translation.translate_node:
     _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
     _title: 'Générer une traduction (IA)'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer nodes'
     target_langcode: '[a-z_]+'
 
 agency_ai_translation.settings:

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -1,0 +1,16 @@
+agency_ai_translation.translate_node:
+  path: '/admin/content/ai-translate/node/{node}/to-en'
+  defaults:
+    _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
+    _title: 'Générer la traduction anglaise (IA)'
+  requirements:
+    _permission: 'trigger ai translation'
+    _entity_access: 'node.update'
+
+agency_ai_translation.settings:
+  path: '/admin/config/content/agency-ai-translation'
+  defaults:
+    _form: '\\Drupal\\agency_ai_translation\\Form\\AiTranslationSettingsForm'
+    _title: 'Traduction IA FR -> EN'
+  requirements:
+    _permission: 'administer site configuration'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -1,10 +1,12 @@
 agency_ai_translation.translate_node:
-  path: '/admin/content/ai-translate/node/{node}/to-en'
+  path: '/admin/content/ai-translate/node/{node}/to/{target_langcode}'
   defaults:
     _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
-    _title: 'Générer la traduction anglaise (IA)'
+    _title: 'Générer une traduction (IA)'
   requirements:
-    _custom_access: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm::access'
+    _permission: 'trigger ai translation'
+    _entity_access: 'node.update'
+    target_langcode: '[a-z_]+'
 
 agency_ai_translation.settings:
   path: '/admin/config/content/agency-ai-translation'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -1,16 +1,16 @@
 agency_ai_translation.translate_node:
   path: '/admin/content/ai-translate/node/{node}/to/{target_langcode}'
   defaults:
-    _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
+    _controller: '\Drupal\agency_ai_translation\Controller\TranslateNodeController::translate'
     _title: 'Générer une traduction (IA)'
   requirements:
-    _permission: 'administer nodes'
+    _permission: 'access content'
     target_langcode: '[a-z_]+'
 
 agency_ai_translation.settings:
   path: '/admin/config/content/agency-ai-translation'
   defaults:
-    _form: '\\Drupal\\agency_ai_translation\\Form\\AiTranslationSettingsForm'
+    _form: '\Drupal\agency_ai_translation\Form\AiTranslationSettingsForm'
     _title: 'Traduction IA FR -> EN'
   requirements:
     _permission: 'administer site configuration'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -4,8 +4,7 @@ agency_ai_translation.translate_node:
     _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
     _title: 'Générer une traduction (IA)'
   requirements:
-    _permission: 'trigger ai translation,administer nodes'
-    _entity_access: 'node.update'
+    _permission: 'access administration pages'
     target_langcode: '[a-z_]+'
 
 agency_ai_translation.settings:

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -4,7 +4,7 @@ agency_ai_translation.translate_node:
     _form: '\\Drupal\\agency_ai_translation\\Form\\TranslateNodeConfirmForm'
     _title: 'Générer une traduction (IA)'
   requirements:
-    _permission: 'trigger ai translation'
+    _permission: 'trigger ai translation,administer nodes'
     _entity_access: 'node.update'
     target_langcode: '[a-z_]+'
 

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
@@ -1,0 +1,19 @@
+services:
+  agency_ai_translation.client:
+    class: Drupal\agency_ai_translation\Service\AiTranslationClient
+    arguments:
+      - '@config.factory'
+      - '@http_client'
+      - '@logger.channel.agency_ai_translation'
+      - '@state'
+
+  agency_ai_translation.manager:
+    class: Drupal\agency_ai_translation\Service\AiTranslationManager
+    arguments:
+      - '@agency_ai_translation.client'
+      - '@entity_field.manager'
+      - '@logger.channel.agency_ai_translation'
+
+  logger.channel.agency_ai_translation:
+    parent: logger.channel_base
+    arguments: ['agency_ai_translation']

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
@@ -14,6 +14,7 @@ services:
     arguments:
       - '@agency_ai_translation.client'
       - '@entity_field.manager'
+      - '@?pathauto.generator'
 
   logger.channel.agency_ai_translation:
     parent: logger.channel_base

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
@@ -3,6 +3,7 @@ services:
     class: Drupal\agency_ai_translation\Service\AiTranslationClient
     arguments:
       - '@config.factory'
+      - '@language_manager'
       - '@http_client'
       - '@logger.channel.agency_ai_translation'
       - '@state'

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
@@ -6,6 +6,7 @@ services:
       - '@http_client'
       - '@logger.channel.agency_ai_translation'
       - '@state'
+      - '@?key.repository'
 
   agency_ai_translation.manager:
     class: Drupal\agency_ai_translation\Service\AiTranslationManager

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.services.yml
@@ -12,7 +12,6 @@ services:
     arguments:
       - '@agency_ai_translation.client'
       - '@entity_field.manager'
-      - '@logger.channel.agency_ai_translation'
 
   logger.channel.agency_ai_translation:
     parent: logger.channel_base

--- a/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
@@ -1,0 +1,3 @@
+endpoint: 'https://api.openai.com/v1/chat/completions'
+model: 'gpt-4o-mini'
+system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
@@ -1,4 +1,4 @@
 endpoint: 'https://api.openai.com/v1/chat/completions'
 model: 'gpt-4o-mini'
 openai_key_id: 'openai_api_key'
-system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'
+system_prompt: 'You are a professional website translator. Translate the source content into the requested target language while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/agency_ai_translation.settings.yml
@@ -1,3 +1,4 @@
 endpoint: 'https://api.openai.com/v1/chat/completions'
 model: 'gpt-4o-mini'
+openai_key_id: 'openai_api_key'
 system_prompt: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.'

--- a/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -10,4 +10,4 @@ type: node
 plugin: agency_ai_translate_nodes_bulk_action
 configuration:
   source_langcode: fr
-  target_langcode: en
+  target_langcode: ''

--- a/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - agency_ai_translation
+    - node
+id: agency_ai_translate_nodes_bulk_action
+label: 'Traduire avec IA vers une langue cible'
+type: node
+plugin: agency_ai_translate_nodes_bulk_action
+configuration:
+  source_langcode: fr
+  target_langcode: en

--- a/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
+++ b/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
@@ -8,6 +8,9 @@ agency_ai_translation.settings:
     model:
       type: string
       label: 'Model'
+    openai_key_id:
+      type: string
+      label: 'Drupal Key ID for OpenAI'
     system_prompt:
       type: text
       label: 'System prompt'

--- a/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
+++ b/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
@@ -11,3 +11,14 @@ agency_ai_translation.settings:
     system_prompt:
       type: text
       label: 'System prompt'
+
+action.configuration.agency_ai_translate_nodes_bulk_action:
+  type: mapping
+  label: 'Configuration de l’action de masse de traduction IA'
+  mapping:
+    source_langcode:
+      type: string
+      label: 'Langue source'
+    target_langcode:
+      type: string
+      label: 'Langue cible'

--- a/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
+++ b/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
@@ -1,0 +1,13 @@
+agency_ai_translation.settings:
+  type: config_object
+  label: 'AI translation settings'
+  mapping:
+    endpoint:
+      type: uri
+      label: 'Chat completion endpoint'
+    model:
+      type: string
+      label: 'Model'
+    system_prompt:
+      type: text
+      label: 'System prompt'

--- a/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
+++ b/web/modules/custom/agency_ai_translation/config/schema/agency_ai_translation.schema.yml
@@ -9,7 +9,7 @@ agency_ai_translation.settings:
       type: string
       label: 'Model'
     openai_key_id:
-      type: string
+      type: machine_name
       label: 'Drupal Key ID for OpenAI'
     system_prompt:
       type: text

--- a/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
+++ b/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
@@ -51,7 +51,7 @@ final class TranslateNodeController extends ControllerBase {
     }
 
     try {
-      $translatedFieldsCount = $this->translationManager->translateEntityToLanguage($node, $target_langcode, 'fr');
+      $translatedFieldsCount = $this->translationManager->translateEntityToLanguage($node, $target_langcode, $node->language()->getId());
       $this->messenger()->addStatus($this->t('Traduction @target générée. @count champ(s) traité(s).', [
         '@target' => strtoupper($target_langcode),
         '@count' => $translatedFieldsCount,

--- a/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
+++ b/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
@@ -6,11 +6,10 @@ namespace Drupal\agency_ai_translation\Controller;
 
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * Contrôleur de traduction IA unitaire.
@@ -19,8 +18,6 @@ final class TranslateNodeController extends ControllerBase {
 
   public function __construct(
     private readonly AiTranslationManager $translationManager,
-    private readonly LanguageManagerInterface $languageManager,
-    private readonly AccountProxyInterface $currentUser,
   ) {}
 
   /**
@@ -29,8 +26,6 @@ final class TranslateNodeController extends ControllerBase {
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('agency_ai_translation.manager'),
-      $container->get('language_manager'),
-      $container->get('current_user'),
     );
   }
 
@@ -38,14 +33,14 @@ final class TranslateNodeController extends ControllerBase {
    * Lance la traduction IA puis redirige vers l'édition de la traduction cible.
    */
   public function translate(NodeInterface $node, string $target_langcode): RedirectResponse {
-    $hasPermission = $this->currentUser->hasPermission('trigger ai translation')
-      || $this->currentUser->hasPermission('administer nodes');
+    $hasPermission = $this->currentUser()->hasPermission('trigger ai translation')
+      || $this->currentUser()->hasPermission('administer nodes');
 
-    if (!$hasPermission || !$node->access('update', $this->currentUser)) {
-      throw $this->createAccessDeniedException();
+    if (!$hasPermission || !$node->access('update', $this->currentUser())) {
+      throw new AccessDeniedHttpException();
     }
 
-    if (!$this->languageManager->getLanguage($target_langcode)) {
+    if (!$this->languageManager()->getLanguage($target_langcode)) {
       $this->messenger()->addError($this->t('Langue cible invalide : @lang.', ['@lang' => $target_langcode]));
       return $this->redirectToNode($node);
     }

--- a/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
+++ b/web/modules/custom/agency_ai_translation/src/Controller/TranslateNodeController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Controller;
+
+use Drupal\agency_ai_translation\Service\AiTranslationManager;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Contrôleur de traduction IA unitaire.
+ */
+final class TranslateNodeController extends ControllerBase {
+
+  public function __construct(
+    private readonly AiTranslationManager $translationManager,
+    private readonly LanguageManagerInterface $languageManager,
+    private readonly AccountProxyInterface $currentUser,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('agency_ai_translation.manager'),
+      $container->get('language_manager'),
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * Lance la traduction IA puis redirige vers l'édition de la traduction cible.
+   */
+  public function translate(NodeInterface $node, string $target_langcode): RedirectResponse {
+    $hasPermission = $this->currentUser->hasPermission('trigger ai translation')
+      || $this->currentUser->hasPermission('administer nodes');
+
+    if (!$hasPermission || !$node->access('update', $this->currentUser)) {
+      throw $this->createAccessDeniedException();
+    }
+
+    if (!$this->languageManager->getLanguage($target_langcode)) {
+      $this->messenger()->addError($this->t('Langue cible invalide : @lang.', ['@lang' => $target_langcode]));
+      return $this->redirectToNode($node);
+    }
+
+    if ($target_langcode === $node->language()->getId()) {
+      $this->messenger()->addError($this->t('La langue cible doit être différente de la langue source.'));
+      return $this->redirectToNode($node);
+    }
+
+    try {
+      $translatedFieldsCount = $this->translationManager->translateEntityToLanguage($node, $target_langcode, 'fr');
+      $this->messenger()->addStatus($this->t('Traduction @target générée. @count champ(s) traité(s).', [
+        '@target' => strtoupper($target_langcode),
+        '@count' => $translatedFieldsCount,
+      ]));
+
+      return new RedirectResponse($node->toUrl('edit-form', ['query' => ['langcode' => $target_langcode]])->toString());
+    }
+    catch (\Throwable $exception) {
+      $this->messenger()->addError($this->t('Échec de la traduction IA : @message', ['@message' => $exception->getMessage()]));
+      return $this->redirectToNode($node);
+    }
+  }
+
+  /**
+   * Redirige vers le nœud source.
+   */
+  private function redirectToNode(NodeInterface $node): RedirectResponse {
+    return new RedirectResponse($node->toUrl()->toString());
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -65,7 +65,7 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
 
     $form['description'] = [
       '#type' => 'item',
-      '#markup' => $this->t('Définissez la clé API dans <code>settings.php</code> via <code>$settings["agency_ai_translation.api_key"]</code> (recommandé) ou via la variable d’environnement <code>AGENCY_AI_TRANSLATION_API_KEY</code>. Le champ ci-dessous est un fallback stocké en base (state), non exporté.'),
+      '#markup' => $this->t('Priorité de résolution : (1) configuration provider OpenAI + module Key, (2) key_id défini ci-dessous, puis (3) fallback legacy settings.php / variable d’environnement / state.'),
     ];
 
     $form['endpoint'] = [
@@ -79,6 +79,14 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Modèle'),
       '#default_value' => $config->get('model') ?: 'gpt-4o-mini',
+      '#required' => TRUE,
+    ];
+
+    $form['openai_key_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Key ID Drupal (module Key)'),
+      '#default_value' => $config->get('openai_key_id') ?: 'openai_api_key',
+      '#description' => $this->t('Identifiant de la clé dans le module Key (ex: openai_api_key).'),
       '#required' => TRUE,
     ];
 
@@ -105,6 +113,7 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
     $this->configFactory->getEditable('agency_ai_translation.settings')
       ->set('endpoint', $form_state->getValue('endpoint'))
       ->set('model', $form_state->getValue('model'))
+      ->set('openai_key_id', $form_state->getValue('openai_key_id'))
       ->set('system_prompt', $form_state->getValue('system_prompt'))
       ->save();
 

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\agency_ai_translation\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
@@ -15,22 +16,25 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 final class AiTranslationSettingsForm extends ConfigFormBase {
 
-  public function __construct(
-    StateInterface $state,
-  ) {
-    $this->state = $state;
-  }
-
   /**
    * State store.
    */
   protected StateInterface $state;
+
+  public function __construct(
+    ConfigFactoryInterface $configFactory,
+    StateInterface $state,
+  ) {
+    parent::__construct($configFactory);
+    $this->state = $state;
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): self {
     return new self(
+      $container->get('config.factory'),
       $container->get('state'),
     );
   }

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -93,7 +93,7 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
     $form['system_prompt'] = [
       '#type' => 'textarea',
       '#title' => $this->t('System prompt'),
-      '#default_value' => $config->get('system_prompt') ?: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.',
+      '#default_value' => $config->get('system_prompt') ?: 'You are a professional website translator. Translate the source content into the requested target language while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.',
       '#required' => TRUE,
     ];
 

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -13,14 +13,23 @@ use Drupal\Core\Site\Settings;
  */
 final class AiTranslationSettingsForm extends ConfigFormBase {
 
+  /**
+   * {@inheritdoc}
+   */
   public function getFormId(): string {
     return 'agency_ai_translation_settings_form';
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function getEditableConfigNames(): array {
     return ['agency_ai_translation.settings'];
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('agency_ai_translation.settings');
     $fromSettings = Settings::get('agency_ai_translation.api_key');
@@ -60,6 +69,9 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
     return parent::buildForm($form, $form_state);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->configFactory->getEditable('agency_ai_translation.settings')
       ->set('endpoint', $form_state->getValue('endpoint'))

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Configuration du module de traduction IA.
+ */
+final class AiTranslationSettingsForm extends ConfigFormBase {
+
+  public function getFormId(): string {
+    return 'agency_ai_translation_settings_form';
+  }
+
+  protected function getEditableConfigNames(): array {
+    return ['agency_ai_translation.settings'];
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('agency_ai_translation.settings');
+    $fromSettings = Settings::get('agency_ai_translation.api_key');
+
+    $form['description'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('Définissez la clé API dans <code>settings.php</code> via <code>$settings["agency_ai_translation.api_key"]</code> (recommandé) ou via la variable d’environnement <code>AGENCY_AI_TRANSLATION_API_KEY</code>. Le champ ci-dessous est un fallback stocké en base (state), non exporté.'),
+    ];
+
+    $form['endpoint'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Endpoint Chat Completions'),
+      '#default_value' => $config->get('endpoint') ?: 'https://api.openai.com/v1/chat/completions',
+      '#required' => TRUE,
+    ];
+
+    $form['model'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Modèle'),
+      '#default_value' => $config->get('model') ?: 'gpt-4o-mini',
+      '#required' => TRUE,
+    ];
+
+    $form['system_prompt'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('System prompt'),
+      '#default_value' => $config->get('system_prompt') ?: 'You are a professional website translator. Translate French into natural English while preserving meaning, tone, formatting, and calls-to-action. Return only translated text.',
+      '#required' => TRUE,
+    ];
+
+    $form['api_key_fallback'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Clé API fallback (state, non exportée)'),
+      '#description' => $fromSettings ? $this->t('Une clé est déjà fournie via settings.php.') : $this->t('Optionnel. Utilisé uniquement si aucune clé n’est trouvée dans settings.php ni dans la variable d’environnement.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->configFactory->getEditable('agency_ai_translation.settings')
+      ->set('endpoint', $form_state->getValue('endpoint'))
+      ->set('model', $form_state->getValue('model'))
+      ->set('system_prompt', $form_state->getValue('system_prompt'))
+      ->save();
+
+    $apiKeyFallback = trim((string) $form_state->getValue('api_key_fallback'));
+    if ($apiKeyFallback !== '') {
+      $this->state()->set('agency_ai_translation.api_key', $apiKeyFallback);
+    }
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -7,11 +7,33 @@ namespace Drupal\agency_ai_translation\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configuration du module de traduction IA.
  */
 final class AiTranslationSettingsForm extends ConfigFormBase {
+
+  public function __construct(
+    StateInterface $state,
+  ) {
+    $this->state = $state;
+  }
+
+  /**
+   * State store.
+   */
+  protected StateInterface $state;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('state'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -81,7 +103,7 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
 
     $apiKeyFallback = trim((string) $form_state->getValue('api_key_fallback'));
     if ($apiKeyFallback !== '') {
-      $this->state()->set('agency_ai_translation.api_key', $apiKeyFallback);
+      $this->state->set('agency_ai_translation.api_key', $apiKeyFallback);
     }
 
     parent::submitForm($form, $form_state);

--- a/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/AiTranslationSettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\agency_ai_translation\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
@@ -23,9 +24,10 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
 
   public function __construct(
     ConfigFactoryInterface $configFactory,
+    TypedConfigManagerInterface $typedConfigManager,
     StateInterface $state,
   ) {
-    parent::__construct($configFactory);
+    parent::__construct($configFactory, $typedConfigManager);
     $this->state = $state;
   }
 
@@ -35,6 +37,7 @@ final class AiTranslationSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('state'),
     );
   }

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\agency_ai_translation\Form;
 
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -33,6 +35,21 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
     return new self(
       $container->get('agency_ai_translation.manager'),
     );
+  }
+
+  /**
+   * Contrôle l'accès à l'action de traduction.
+   */
+  public static function access(NodeInterface $node, AccountInterface $account): AccessResult {
+    $sourceNode = $node->hasTranslation('fr') ? $node->getTranslation('fr') : $node;
+    $isFrenchSource = $sourceNode->language()->getId() === 'fr';
+
+    $hasTranslationPermission = $account->hasPermission('trigger ai translation')
+      || $account->hasPermission('administer nodes');
+
+    return AccessResult::allowedIf($isFrenchSource && $hasTranslationPermission)
+      ->andIf($sourceNode->access('update', $account, TRUE))
+      ->addCacheableDependency($sourceNode);
   }
 
   /**
@@ -77,9 +94,9 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
     if (!$node instanceof NodeInterface) {
       throw new \InvalidArgumentException('Nœud invalide.');
     }
-    $this->node = $node;
+    $this->node = $node->hasTranslation('fr') ? $node->getTranslation('fr') : $node;
 
-    if ($node->language()->getId() !== 'fr') {
+    if ($this->node->language()->getId() !== 'fr') {
       throw new \InvalidArgumentException('Seuls les contenus FR source peuvent être traduits.');
     }
 

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -7,6 +7,7 @@ namespace Drupal\agency_ai_translation\Form;
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -44,14 +45,14 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getQuestion(): string {
+  public function getQuestion(): TranslatableMarkup {
     return $this->t('Générer/mettre à jour la traduction anglaise de "@title" ?', ['@title' => $this->node?->label() ?? '']);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getDescription(): string {
+  public function getDescription(): TranslatableMarkup {
     return $this->t('Cette action traduit uniquement les champs éditoriaux (texte, résumé, CTA et paragraphs translatables). Les champs techniques ne sont pas modifiés.');
   }
 
@@ -65,7 +66,7 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getConfirmText(): string {
+  public function getConfirmText(): TranslatableMarkup {
     return $this->t('Lancer la traduction IA');
   }
 

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -104,6 +105,9 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
     }
     if ($this->targetLangcode === $this->sourceLangcode) {
       throw new \InvalidArgumentException('La langue cible doit être différente de la langue source.');
+    }
+    if (!$node->access('update', $this->currentUser())) {
+      throw new AccessDeniedHttpException();
     }
     $this->node = $node;
 

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Drupal\agency_ai_translation\Form;
 
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -20,12 +19,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class TranslateNodeConfirmForm extends ConfirmFormBase {
 
   /**
-   * Nœud source FR à traduire.
+   * Nœud source à traduire.
    */
   private ?NodeInterface $node = NULL;
 
+  /**
+   * Langue source.
+   */
+  private string $sourceLangcode = 'fr';
+
+  /**
+   * Langue cible.
+   */
+  private string $targetLangcode = 'en';
+
   public function __construct(
     private readonly AiTranslationManager $translationManager,
+    private readonly LanguageManagerInterface $languageManager,
   ) {}
 
   /**
@@ -34,22 +44,8 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('agency_ai_translation.manager'),
+      $container->get('language_manager'),
     );
-  }
-
-  /**
-   * Contrôle l'accès à l'action de traduction.
-   */
-  public static function access(NodeInterface $node, AccountInterface $account): AccessResult {
-    $sourceNode = $node->hasTranslation('fr') ? $node->getTranslation('fr') : $node;
-    $isFrenchSource = $sourceNode->language()->getId() === 'fr';
-
-    $hasTranslationPermission = $account->hasPermission('trigger ai translation')
-      || $account->hasPermission('administer nodes');
-
-    return AccessResult::allowedIf($isFrenchSource && $hasTranslationPermission)
-      ->andIf($sourceNode->access('update', $account, TRUE))
-      ->addCacheableDependency($sourceNode);
   }
 
   /**
@@ -63,14 +59,20 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getQuestion(): TranslatableMarkup {
-    return $this->t('Générer/mettre à jour la traduction anglaise de "@title" ?', ['@title' => $this->node?->label() ?? '']);
+    return $this->t('Générer/mettre à jour la traduction @target de "@title" ?', [
+      '@target' => strtoupper($this->targetLangcode),
+      '@title' => $this->node?->label() ?? '',
+    ]);
   }
 
   /**
    * {@inheritdoc}
    */
   public function getDescription(): TranslatableMarkup {
-    return $this->t('Cette action traduit uniquement les champs éditoriaux (texte, résumé, CTA et paragraphs translatables). Les champs techniques ne sont pas modifiés.');
+    return $this->t('Source : @source. Cible : @target. Cette action traduit uniquement les champs éditoriaux (texte, résumé, CTA et paragraphs translatables). Les champs techniques ne sont pas modifiés.', [
+      '@source' => strtoupper($this->sourceLangcode),
+      '@target' => strtoupper($this->targetLangcode),
+    ]);
   }
 
   /**
@@ -90,15 +92,20 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL, string $target_langcode = 'en'): array {
     if (!$node instanceof NodeInterface) {
       throw new \InvalidArgumentException('Nœud invalide.');
     }
-    $this->node = $node->hasTranslation('fr') ? $node->getTranslation('fr') : $node;
+    $this->sourceLangcode = $node->language()->getId();
+    $this->targetLangcode = $target_langcode;
 
-    if ($this->node->language()->getId() !== 'fr') {
-      throw new \InvalidArgumentException('Seuls les contenus FR source peuvent être traduits.');
+    if (!$this->languageManager->getLanguage($this->targetLangcode)) {
+      throw new \InvalidArgumentException('Langue cible invalide.');
     }
+    if ($this->targetLangcode === $this->sourceLangcode) {
+      throw new \InvalidArgumentException('La langue cible doit être différente de la langue source.');
+    }
+    $this->node = $node;
 
     return parent::buildForm($form, $form_state);
   }
@@ -108,9 +115,12 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     try {
-      $translatedFieldsCount = $this->translationManager->translateEntityToEnglish($this->node);
-      $this->messenger()->addStatus($this->t('Traduction EN générée. @count champ(s) traité(s). Vérifiez puis publiez manuellement la version anglaise.', ['@count' => $translatedFieldsCount]));
-      $form_state->setRedirect('entity.node.edit_form', ['node' => $this->node->id()], ['query' => ['langcode' => 'en']]);
+      $translatedFieldsCount = $this->translationManager->translateEntityToLanguage($this->node, $this->targetLangcode, $this->sourceLangcode);
+      $this->messenger()->addStatus($this->t('Traduction @target générée. @count champ(s) traité(s). Vérifiez puis publiez manuellement la version traduite.', [
+        '@target' => strtoupper($this->targetLangcode),
+        '@count' => $translatedFieldsCount,
+      ]));
+      $form_state->setRedirect('entity.node.edit_form', ['node' => $this->node->id()], ['query' => ['langcode' => $this->targetLangcode]]);
     }
     catch (\Throwable $exception) {
       $this->messenger()->addError($this->t('Échec de la traduction IA : @message', ['@message' => $exception->getMessage()]));

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -16,38 +16,62 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 final class TranslateNodeConfirmForm extends ConfirmFormBase {
 
+  /**
+   * Nœud source FR à traduire.
+   */
   private ?NodeInterface $node = NULL;
 
   public function __construct(
     private readonly AiTranslationManager $translationManager,
   ) {}
 
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('agency_ai_translation.manager'),
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getFormId(): string {
     return 'agency_ai_translation_translate_node_confirm';
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getQuestion(): string {
     return $this->t('Générer/mettre à jour la traduction anglaise de "@title" ?', ['@title' => $this->node?->label() ?? '']);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getDescription(): string {
     return $this->t('Cette action traduit uniquement les champs éditoriaux (texte, résumé, CTA et paragraphs translatables). Les champs techniques ne sont pas modifiés.');
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getCancelUrl(): Url {
     return $this->node ? $this->node->toUrl('canonical') : Url::fromRoute('<front>');
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getConfirmText(): string {
     return $this->t('Lancer la traduction IA');
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
     if (!$node instanceof NodeInterface) {
       throw new \InvalidArgumentException('Nœud invalide.');
@@ -61,6 +85,9 @@ final class TranslateNodeConfirmForm extends ConfirmFormBase {
     return parent::buildForm($form, $form_state);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     try {
       $translatedFieldsCount = $this->translationManager->translateEntityToEnglish($this->node);

--- a/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
+++ b/web/modules/custom/agency_ai_translation/src/Form/TranslateNodeConfirmForm.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Form;
+
+use Drupal\agency_ai_translation\Service\AiTranslationManager;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirmation manuelle de traduction IA.
+ */
+final class TranslateNodeConfirmForm extends ConfirmFormBase {
+
+  private ?NodeInterface $node = NULL;
+
+  public function __construct(
+    private readonly AiTranslationManager $translationManager,
+  ) {}
+
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('agency_ai_translation.manager'),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'agency_ai_translation_translate_node_confirm';
+  }
+
+  public function getQuestion(): string {
+    return $this->t('Générer/mettre à jour la traduction anglaise de "@title" ?', ['@title' => $this->node?->label() ?? '']);
+  }
+
+  public function getDescription(): string {
+    return $this->t('Cette action traduit uniquement les champs éditoriaux (texte, résumé, CTA et paragraphs translatables). Les champs techniques ne sont pas modifiés.');
+  }
+
+  public function getCancelUrl(): Url {
+    return $this->node ? $this->node->toUrl('canonical') : Url::fromRoute('<front>');
+  }
+
+  public function getConfirmText(): string {
+    return $this->t('Lancer la traduction IA');
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL): array {
+    if (!$node instanceof NodeInterface) {
+      throw new \InvalidArgumentException('Nœud invalide.');
+    }
+    $this->node = $node;
+
+    if ($node->language()->getId() !== 'fr') {
+      throw new \InvalidArgumentException('Seuls les contenus FR source peuvent être traduits.');
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    try {
+      $translatedFieldsCount = $this->translationManager->translateEntityToEnglish($this->node);
+      $this->messenger()->addStatus($this->t('Traduction EN générée. @count champ(s) traité(s). Vérifiez puis publiez manuellement la version anglaise.', ['@count' => $translatedFieldsCount]));
+      $form_state->setRedirect('entity.node.edit_form', ['node' => $this->node->id()], ['query' => ['langcode' => 'en']]);
+    }
+    catch (\Throwable $exception) {
+      $this->messenger()->addError($this->t('Échec de la traduction IA : @message', ['@message' => $exception->getMessage()]));
+      $form_state->setRedirectUrl($this->getCancelUrl());
+    }
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -7,9 +7,9 @@ namespace Drupal\agency_ai_translation\Plugin\Action;
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
 use Drupal\Core\Action\ConfigurableActionBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
@@ -32,7 +32,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     $plugin_definition,
     private readonly AiTranslationManager $translationManager,
     private readonly LanguageManagerInterface $languageManager,
-    private readonly MessengerInterface $messenger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -47,7 +46,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $plugin_definition,
       $container->get('agency_ai_translation.manager'),
       $container->get('language_manager'),
-      $container->get('messenger'),
     );
   }
 
@@ -135,10 +133,10 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     }
 
     if ($success > 0) {
-      $this->messenger->addStatus($this->formatPlural($success, '1 contenu traduit.', '@count contenus traduits.'));
+      $this->messenger()->addStatus($this->formatPlural($success, '1 contenu traduit.', '@count contenus traduits.'));
     }
     if ($errors > 0) {
-      $this->messenger->addWarning($this->formatPlural($errors, '1 contenu en erreur.', '@count contenus en erreur.'));
+      $this->messenger()->addWarning($this->formatPlural($errors, '1 contenu en erreur.', '@count contenus en erreur.'));
     }
   }
 
@@ -146,11 +144,11 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
    * {@inheritdoc}
    */
   public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE) {
-    $allowed = $object instanceof NodeInterface
+    $accessResult = AccessResult::allowedIf($object instanceof NodeInterface
       && $object->access('update', $account)
-      && ($account?->hasPermission('trigger ai translation') || $account?->hasPermission('administer nodes'));
+      && ($account?->hasPermission('trigger ai translation') || $account?->hasPermission('administer nodes')));
 
-    return $return_as_object ? $this->createAccessResult($allowed) : $allowed;
+    return $return_as_object ? $accessResult : $accessResult->isAllowed();
   }
 
 }

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -119,6 +119,12 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $request = $this->requestStack->getCurrentRequest();
       $requestTarget = $request?->request->get('agency_ai_translation_target_langcode');
       if (!is_string($requestTarget) || $requestTarget === '') {
+        $actionValues = $request?->request->all('action');
+        if (is_array($actionValues) && isset($actionValues['agency_ai_translation_target_langcode']) && is_string($actionValues['agency_ai_translation_target_langcode'])) {
+          $requestTarget = $actionValues['agency_ai_translation_target_langcode'];
+        }
+      }
+      if (!is_string($requestTarget) || $requestTarget === '') {
         $actionsValues = $request?->request->all('actions');
         if (is_array($actionsValues) && isset($actionsValues['agency_ai_translation_target_langcode']) && is_string($actionsValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $actionsValues['agency_ai_translation_target_langcode'];

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -119,19 +119,19 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $request = $this->requestStack->getCurrentRequest();
       $requestTarget = $request?->request->get('agency_ai_translation_target_langcode');
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $actionValues = $request?->request->all('action');
+        $actionValues = $request?->request->get('action');
         if (is_array($actionValues) && isset($actionValues['agency_ai_translation_target_langcode']) && is_string($actionValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $actionValues['agency_ai_translation_target_langcode'];
         }
       }
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $actionsValues = $request?->request->all('actions');
+        $actionsValues = $request?->request->get('actions');
         if (is_array($actionsValues) && isset($actionsValues['agency_ai_translation_target_langcode']) && is_string($actionsValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $actionsValues['agency_ai_translation_target_langcode'];
         }
       }
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $headerValues = $request?->request->all('header');
+        $headerValues = $request?->request->get('header');
         if (is_array($headerValues) && isset($headerValues['agency_ai_translation_target_langcode']) && is_string($headerValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $headerValues['agency_ai_translation_target_langcode'];
         }

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -121,7 +121,14 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     $sourceLangcode = (string) $this->configuration['source_langcode'];
     $targetLangcode = (string) $this->configuration['target_langcode'];
     if ($targetLangcode === '') {
-      $requestTarget = $this->requestStack->getCurrentRequest()?->request->get('agency_ai_translation_target_langcode');
+      $request = $this->requestStack->getCurrentRequest();
+      $requestTarget = $request?->request->get('agency_ai_translation_target_langcode');
+      if (!is_string($requestTarget) || $requestTarget === '') {
+        $actionsValues = $request?->request->all('actions');
+        if (is_array($actionsValues) && isset($actionsValues['agency_ai_translation_target_langcode']) && is_string($actionsValues['agency_ai_translation_target_langcode'])) {
+          $requestTarget = $actionsValues['agency_ai_translation_target_langcode'];
+        }
+      }
       if (is_string($requestTarget) && $requestTarget !== '') {
         $targetLangcode = $requestTarget;
       }

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -129,6 +129,15 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
           $requestTarget = $actionsValues['agency_ai_translation_target_langcode'];
         }
       }
+      if (!is_string($requestTarget) || $requestTarget === '') {
+        $headerValues = $request?->request->all('header');
+        if (is_array($headerValues) && isset($headerValues['agency_ai_translation_target_langcode']) && is_string($headerValues['agency_ai_translation_target_langcode'])) {
+          $requestTarget = $headerValues['agency_ai_translation_target_langcode'];
+        }
+        if (is_array($headerValues) && isset($headerValues['actions']) && is_array($headerValues['actions']) && isset($headerValues['actions']['agency_ai_translation_target_langcode']) && is_string($headerValues['actions']['agency_ai_translation_target_langcode'])) {
+          $requestTarget = $headerValues['actions']['agency_ai_translation_target_langcode'];
+        }
+      }
       if (is_string($requestTarget) && $requestTarget !== '') {
         $targetLangcode = $requestTarget;
       }

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -15,6 +15,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Action de masse de traduction IA.
@@ -34,6 +35,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     private readonly AiTranslationManager $translationManager,
     private readonly LanguageManagerInterface $languageManager,
     private readonly LoggerInterface $logger,
+    private readonly RequestStack $requestStack,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -49,6 +51,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $container->get('agency_ai_translation.manager'),
       $container->get('language_manager'),
       $container->get('logger.channel.agency_ai_translation'),
+      $container->get('request_stack'),
     );
   }
 
@@ -117,6 +120,12 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
   public function executeMultiple(array $entities): void {
     $sourceLangcode = (string) $this->configuration['source_langcode'];
     $targetLangcode = (string) $this->configuration['target_langcode'];
+    if ($targetLangcode === '') {
+      $requestTarget = $this->requestStack->getCurrentRequest()?->request->get('agency_ai_translation_target_langcode');
+      if (is_string($requestTarget) && $requestTarget !== '') {
+        $targetLangcode = $requestTarget;
+      }
+    }
     if ($targetLangcode === '') {
       $this->messenger()->addError($this->t('Veuillez choisir une langue cible avant d’exécuter l’action.'));
       return;

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -82,6 +82,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       '#title' => $this->t('Langue cible'),
       '#options' => $options,
       '#default_value' => $this->configuration['target_langcode'],
+      '#description' => $this->t('Langue cible utilisée pour cette exécution de l’action de masse.'),
       '#required' => TRUE,
     ];
 
@@ -115,8 +116,16 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
    * {@inheritdoc}
    */
   public function executeMultiple(array $entities): void {
+    $sourceLangcode = (string) $this->configuration['source_langcode'];
+    $targetLangcode = (string) $this->configuration['target_langcode'];
+    if ($sourceLangcode === $targetLangcode) {
+      $this->messenger()->addError($this->t('La langue cible doit être différente de la langue source.'));
+      return;
+    }
+
     $success = 0;
     $errors = 0;
+    $errorMessages = [];
 
     foreach ($entities as $entity) {
       if (!$entity instanceof NodeInterface) {
@@ -127,8 +136,18 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
         $this->execute($entity);
         $success++;
       }
-      catch (\Throwable) {
+      catch (\Throwable $exception) {
         $errors++;
+        if (count($errorMessages) < 3) {
+          $errorMessages[] = $this->t('Nœud @nid : @message', [
+            '@nid' => (string) $entity->id(),
+            '@message' => $exception->getMessage(),
+          ]);
+        }
+        \Drupal::logger('agency_ai_translation')->error('Échec traduction IA en masse pour le nœud @nid : @message', [
+          '@nid' => $entity->id(),
+          '@message' => $exception->getMessage(),
+        ]);
       }
     }
 
@@ -137,6 +156,9 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     }
     if ($errors > 0) {
       $this->messenger()->addWarning($this->formatPlural($errors, '1 contenu en erreur.', '@count contenus en erreur.'));
+      foreach ($errorMessages as $errorMessage) {
+        $this->messenger()->addWarning($errorMessage);
+      }
     }
   }
 

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -13,6 +13,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,6 +33,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     $plugin_definition,
     private readonly AiTranslationManager $translationManager,
     private readonly LanguageManagerInterface $languageManager,
+    private readonly LoggerInterface $logger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -46,6 +48,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $plugin_definition,
       $container->get('agency_ai_translation.manager'),
       $container->get('language_manager'),
+      $container->get('logger.channel.agency_ai_translation'),
     );
   }
 
@@ -144,7 +147,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
             '@message' => $exception->getMessage(),
           ]);
         }
-        \Drupal::logger('agency_ai_translation')->error('Échec traduction IA en masse pour le nœud @nid : @message', [
+        $this->logger->error('Échec traduction IA en masse pour le nœud @nid : @message', [
           '@nid' => $entity->id(),
           '@message' => $exception->getMessage(),
         ]);

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -118,20 +118,21 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     if ($targetLangcode === '') {
       $request = $this->requestStack->getCurrentRequest();
       $requestTarget = $request?->request->get('agency_ai_translation_target_langcode');
+      $requestData = $request ? $request->request->all() : [];
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $actionValues = $request?->request->get('action');
+        $actionValues = $requestData['action'] ?? NULL;
         if (is_array($actionValues) && isset($actionValues['agency_ai_translation_target_langcode']) && is_string($actionValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $actionValues['agency_ai_translation_target_langcode'];
         }
       }
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $actionsValues = $request?->request->get('actions');
+        $actionsValues = $requestData['actions'] ?? NULL;
         if (is_array($actionsValues) && isset($actionsValues['agency_ai_translation_target_langcode']) && is_string($actionsValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $actionsValues['agency_ai_translation_target_langcode'];
         }
       }
       if (!is_string($requestTarget) || $requestTarget === '') {
-        $headerValues = $request?->request->get('header');
+        $headerValues = $requestData['header'] ?? NULL;
         if (is_array($headerValues) && isset($headerValues['agency_ai_translation_target_langcode']) && is_string($headerValues['agency_ai_translation_target_langcode'])) {
           $requestTarget = $headerValues['agency_ai_translation_target_langcode'];
         }

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Plugin\Action;
+
+use Drupal\agency_ai_translation\Service\AiTranslationManager;
+use Drupal\Core\Action\ConfigurableActionBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Action de masse de traduction IA.
+ *
+ * @Action(
+ *   id = "agency_ai_translate_nodes_bulk_action",
+ *   label = @Translation("Traduire avec IA vers une langue cible"),
+ *   type = "node"
+ * )
+ */
+final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements ContainerFactoryPluginInterface {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly AiTranslationManager $translationManager,
+    private readonly LanguageManagerInterface $languageManager,
+    private readonly MessengerInterface $messenger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('agency_ai_translation.manager'),
+      $container->get('language_manager'),
+      $container->get('messenger'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'source_langcode' => 'fr',
+      'target_langcode' => 'en',
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $languages = $this->languageManager->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
+    $options = [];
+    foreach ($languages as $language) {
+      $options[$language->getId()] = strtoupper($language->getId()) . ' — ' . $language->getName();
+    }
+
+    $form['source_langcode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Langue source'),
+      '#options' => $options,
+      '#default_value' => $this->configuration['source_langcode'],
+      '#required' => TRUE,
+    ];
+
+    $form['target_langcode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Langue cible'),
+      '#options' => $options,
+      '#default_value' => $this->configuration['target_langcode'],
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['source_langcode'] = $form_state->getValue('source_langcode');
+    $this->configuration['target_langcode'] = $form_state->getValue('target_langcode');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL): void {
+    if (!$entity instanceof NodeInterface) {
+      return;
+    }
+
+    $this->translationManager->translateEntityToLanguage(
+      $entity,
+      (string) $this->configuration['target_langcode'],
+      (string) $this->configuration['source_langcode'],
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities): void {
+    $success = 0;
+    $errors = 0;
+
+    foreach ($entities as $entity) {
+      if (!$entity instanceof NodeInterface) {
+        continue;
+      }
+
+      try {
+        $this->execute($entity);
+        $success++;
+      }
+      catch (\Throwable) {
+        $errors++;
+      }
+    }
+
+    if ($success > 0) {
+      $this->messenger->addStatus($this->formatPlural($success, '1 contenu traduit.', '@count contenus traduits.'));
+    }
+    if ($errors > 0) {
+      $this->messenger->addWarning($this->formatPlural($errors, '1 contenu en erreur.', '@count contenus en erreur.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, ?AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $allowed = $object instanceof NodeInterface
+      && $object->access('update', $account)
+      && ($account?->hasPermission('trigger ai translation') || $account?->hasPermission('administer nodes'));
+
+    return $return_as_object ? $this->createAccessResult($allowed) : $allowed;
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -58,7 +58,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
   public function defaultConfiguration(): array {
     return [
       'source_langcode' => 'fr',
-      'target_langcode' => 'en',
+      'target_langcode' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -69,23 +69,19 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     $languages = $this->languageManager->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
     $options = [];
     foreach ($languages as $language) {
+      if ($language->getId() === 'fr') {
+        continue;
+      }
       $options[$language->getId()] = strtoupper($language->getId()) . ' — ' . $language->getName();
     }
-
-    $form['source_langcode'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Langue source'),
-      '#options' => $options,
-      '#default_value' => $this->configuration['source_langcode'],
-      '#required' => TRUE,
-    ];
 
     $form['target_langcode'] = [
       '#type' => 'select',
       '#title' => $this->t('Langue cible'),
+      '#empty_option' => $this->t('- Sélectionner -'),
       '#options' => $options,
       '#default_value' => $this->configuration['target_langcode'],
-      '#description' => $this->t('Langue cible utilisée pour cette exécution de l’action de masse.'),
+      '#description' => $this->t('Choix obligatoire avant exécution de la traduction de masse.'),
       '#required' => TRUE,
     ];
 
@@ -96,7 +92,7 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
-    $this->configuration['source_langcode'] = $form_state->getValue('source_langcode');
+    $this->configuration['source_langcode'] = 'fr';
     $this->configuration['target_langcode'] = $form_state->getValue('target_langcode');
   }
 
@@ -121,6 +117,10 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
   public function executeMultiple(array $entities): void {
     $sourceLangcode = (string) $this->configuration['source_langcode'];
     $targetLangcode = (string) $this->configuration['target_langcode'];
+    if ($targetLangcode === '') {
+      $this->messenger()->addError($this->t('Veuillez choisir une langue cible avant d’exécuter l’action.'));
+      return;
+    }
     if ($sourceLangcode === $targetLangcode) {
       $this->messenger()->addError($this->t('La langue cible doit être différente de la langue source.'));
       return;
@@ -162,6 +162,9 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       foreach ($errorMessages as $errorMessage) {
         $this->messenger()->addWarning($errorMessage);
       }
+    }
+    if ($success === 0 && $errors > 0) {
+      $this->messenger()->addWarning($this->t('0 contenu traduit.'));
     }
   }
 

--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -60,7 +60,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
    */
   public function defaultConfiguration(): array {
     return [
-      'source_langcode' => 'fr',
       'target_langcode' => '',
     ] + parent::defaultConfiguration();
   }
@@ -72,9 +71,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
     $languages = $this->languageManager->getLanguages(LanguageInterface::STATE_CONFIGURABLE);
     $options = [];
     foreach ($languages as $language) {
-      if ($language->getId() === 'fr') {
-        continue;
-      }
       $options[$language->getId()] = strtoupper($language->getId()) . ' — ' . $language->getName();
     }
 
@@ -95,7 +91,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
-    $this->configuration['source_langcode'] = 'fr';
     $this->configuration['target_langcode'] = $form_state->getValue('target_langcode');
   }
 
@@ -107,18 +102,18 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       return;
     }
 
-    $this->translationManager->translateEntityToLanguage(
-      $entity,
-      (string) $this->configuration['target_langcode'],
-      (string) $this->configuration['source_langcode'],
-    );
+    $targetLangcode = (string) $this->configuration['target_langcode'];
+    if ($targetLangcode === '') {
+      return;
+    }
+
+    $this->translationManager->translateEntityToLanguage($entity, $targetLangcode, $entity->language()->getId());
   }
 
   /**
    * {@inheritdoc}
    */
   public function executeMultiple(array $entities): void {
-    $sourceLangcode = (string) $this->configuration['source_langcode'];
     $targetLangcode = (string) $this->configuration['target_langcode'];
     if ($targetLangcode === '') {
       $request = $this->requestStack->getCurrentRequest();
@@ -146,11 +141,6 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       $this->messenger()->addError($this->t('Veuillez choisir une langue cible avant d’exécuter l’action.'));
       return;
     }
-    if ($sourceLangcode === $targetLangcode) {
-      $this->messenger()->addError($this->t('La langue cible doit être différente de la langue source.'));
-      return;
-    }
-
     $success = 0;
     $errors = 0;
     $errorMessages = [];
@@ -161,7 +151,11 @@ final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements
       }
 
       try {
-        $this->execute($entity);
+        $sourceLangcode = $entity->language()->getId();
+        if ($sourceLangcode === $targetLangcode) {
+          continue;
+        }
+        $this->translationManager->translateEntityToLanguage($entity, $targetLangcode, $sourceLangcode);
         $success++;
       }
       catch (\Throwable $exception) {

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
@@ -46,7 +46,10 @@ final class AiTranslationClient {
       'temperature' => 0.2,
       'messages' => [
         ['role' => 'system', 'content' => $systemPrompt],
-        ['role' => 'user', 'content' => "Traduire du français vers l’anglais sans ajouter de commentaire.\n\nTexte source :\n{$text}"],
+        [
+          'role' => 'user',
+          'content' => "Traduire du français vers l’anglais sans ajouter de commentaire.\n\nTexte source :\n{$text}",
+        ],
       ],
     ];
 

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\agency_ai_translation\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\State\StateInterface;
 use Drupal\key\KeyRepositoryInterface;
@@ -18,6 +19,7 @@ final class AiTranslationClient {
 
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
+    private readonly LanguageManagerInterface $languageManager,
     private readonly ClientInterface $httpClient,
     private readonly LoggerInterface $logger,
     private readonly StateInterface $state,
@@ -42,15 +44,18 @@ final class AiTranslationClient {
     $endpoint = (string) $config->get('endpoint');
     $model = (string) $config->get('model');
     $systemPrompt = (string) $config->get('system_prompt');
+    $sourceLanguageLabel = $this->getLanguageLabel($sourceLangcode);
+    $targetLanguageLabel = $this->getLanguageLabel($targetLangcode);
+    $systemPromptWithContext = trim($systemPrompt . "\n\nSource language: {$sourceLanguageLabel}\nTarget language: {$targetLanguageLabel}\nReturn only the translated content.");
 
     $payload = [
       'model' => $model,
       'temperature' => 0.2,
       'messages' => [
-        ['role' => 'system', 'content' => $systemPrompt],
+        ['role' => 'system', 'content' => $systemPromptWithContext],
         [
           'role' => 'user',
-          'content' => "Traduire de {$sourceLangcode} vers {$targetLangcode} sans ajouter de commentaire.\n\nTexte source :\n{$text}",
+          'content' => "Translate from {$sourceLanguageLabel} to {$targetLanguageLabel} without adding commentary.\n\nSource content:\n{$text}",
         ],
       ],
     ];
@@ -156,6 +161,14 @@ final class AiTranslationClient {
       }
     }
     return NULL;
+  }
+
+  /**
+   * Retourne le libellé Drupal d'une langue à partir de son code.
+   */
+  private function getLanguageLabel(string $langcode): string {
+    $language = $this->languageManager->getLanguage($langcode);
+    return $language ? $language->getName() : strtoupper($langcode);
   }
 
 }

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\State\StateInterface;
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Client HTTP pour traductions IA FR -> EN.
+ */
+final class AiTranslationClient {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly ClientInterface $httpClient,
+    private readonly LoggerInterface $logger,
+    private readonly StateInterface $state,
+  ) {}
+
+  /**
+   * Traduit un texte FR en EN via un provider de type OpenAI-compatible.
+   */
+  public function translateFrToEn(string $text): string {
+    $text = trim($text);
+    if ($text === '') {
+      return $text;
+    }
+
+    $config = $this->configFactory->get('agency_ai_translation.settings');
+    $apiKey = $this->resolveApiKey();
+    if ($apiKey === '') {
+      throw new \RuntimeException('Clé API absente. Configurez-la dans settings.php ou en variable d’environnement.');
+    }
+
+    $endpoint = (string) $config->get('endpoint');
+    $model = (string) $config->get('model');
+    $systemPrompt = (string) $config->get('system_prompt');
+
+    $payload = [
+      'model' => $model,
+      'temperature' => 0.2,
+      'messages' => [
+        ['role' => 'system', 'content' => $systemPrompt],
+        ['role' => 'user', 'content' => "Traduire du français vers l’anglais sans ajouter de commentaire.\n\nTexte source :\n{$text}"],
+      ],
+    ];
+
+    $response = $this->httpClient->request('POST', $endpoint, [
+      'headers' => [
+        'Authorization' => 'Bearer ' . $apiKey,
+        'Content-Type' => 'application/json',
+      ],
+      'json' => $payload,
+      'timeout' => 60,
+    ]);
+
+    $data = json_decode((string) $response->getBody(), TRUE, 512, JSON_THROW_ON_ERROR);
+    $translated = trim((string) ($data['choices'][0]['message']['content'] ?? ''));
+
+    if ($translated === '') {
+      $this->logger->warning('Réponse IA vide pour une tentative de traduction.');
+      return $text;
+    }
+
+    return $translated;
+  }
+
+  /**
+   * Retourne la clé API sans la persister en configuration exportable.
+   */
+  private function resolveApiKey(): string {
+    $settingsKey = Settings::get('agency_ai_translation.api_key', '');
+    if (is_string($settingsKey) && $settingsKey !== '') {
+      return $settingsKey;
+    }
+
+    $envKey = getenv('AGENCY_AI_TRANSLATION_API_KEY');
+    if (is_string($envKey) && $envKey !== '') {
+      return $envKey;
+    }
+
+    $stateKey = $this->state->get('agency_ai_translation.api_key', '');
+    return is_string($stateKey) ? $stateKey : '';
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
@@ -7,6 +7,7 @@ namespace Drupal\agency_ai_translation\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\State\StateInterface;
+use Drupal\key\KeyRepositoryInterface;
 use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
 
@@ -20,6 +21,7 @@ final class AiTranslationClient {
     private readonly ClientInterface $httpClient,
     private readonly LoggerInterface $logger,
     private readonly StateInterface $state,
+    private readonly ?KeyRepositoryInterface $keyRepository = NULL,
   ) {}
 
   /**
@@ -34,7 +36,7 @@ final class AiTranslationClient {
     $config = $this->configFactory->get('agency_ai_translation.settings');
     $apiKey = $this->resolveApiKey();
     if ($apiKey === '') {
-      throw new \RuntimeException('Clé API absente. Configurez-la dans settings.php ou en variable d’environnement.');
+      throw new \RuntimeException('Configuration OpenAI absente. Vérifiez d’abord la Key Drupal/provider OpenAI, puis les fallbacks éventuels.');
     }
 
     $endpoint = (string) $config->get('endpoint');
@@ -84,6 +86,29 @@ final class AiTranslationClient {
    * Retourne la clé API sans la persister en configuration exportable.
    */
   private function resolveApiKey(): string {
+    $settings = $this->configFactory->get('agency_ai_translation.settings');
+
+    // 1) Source de vérité prioritaire : provider OpenAI + module Key.
+    $providerConfig = $this->configFactory->get('ai_provider_openai.settings');
+    $providerKeyId = $this->firstNonEmptyString([
+      $providerConfig->get('key_id'),
+      $providerConfig->get('api_key'),
+      $providerConfig->get('api_key_name'),
+      $providerConfig->get('key'),
+    ]);
+    $providerKey = $this->resolveFromKeyIdOrRawValue($providerKeyId);
+    if ($providerKey !== '') {
+      return $providerKey;
+    }
+
+    // 2) Key ID configurable côté module.
+    $configuredKeyId = (string) $settings->get('openai_key_id');
+    $configuredKey = $this->resolveFromKeyIdOrRawValue($configuredKeyId);
+    if ($configuredKey !== '') {
+      return $configuredKey;
+    }
+
+    // 3) Fallbacks legacy.
     $settingsKey = Settings::get('agency_ai_translation.api_key', '');
     if (is_string($settingsKey) && $settingsKey !== '') {
       return $settingsKey;
@@ -96,6 +121,41 @@ final class AiTranslationClient {
 
     $stateKey = $this->state->get('agency_ai_translation.api_key', '');
     return is_string($stateKey) ? $stateKey : '';
+  }
+
+  /**
+   * Résout une valeur brute ou un identifiant Key Drupal.
+   */
+  private function resolveFromKeyIdOrRawValue(?string $candidate): string {
+    $candidate = trim((string) $candidate);
+    if ($candidate === '') {
+      return '';
+    }
+
+    if ($this->keyRepository) {
+      $key = $this->keyRepository->getKey($candidate);
+      if ($key) {
+        $resolvedValue = trim((string) $key->getKeyValue());
+        if ($resolvedValue !== '') {
+          return $resolvedValue;
+        }
+      }
+    }
+
+    // Si ce n'est pas un key_id résolvable, on traite la valeur comme brute.
+    return str_starts_with($candidate, 'sk-') ? $candidate : '';
+  }
+
+  /**
+   * Retourne la première chaîne non vide.
+   */
+  private function firstNonEmptyString(array $values): ?string {
+    foreach ($values as $value) {
+      if (is_string($value) && trim($value) !== '') {
+        return trim($value);
+      }
+    }
+    return NULL;
   }
 
 }

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationClient.php
@@ -23,9 +23,9 @@ final class AiTranslationClient {
   ) {}
 
   /**
-   * Traduit un texte FR en EN via un provider de type OpenAI-compatible.
+   * Traduit un texte entre deux langues via un provider OpenAI-compatible.
    */
-  public function translateFrToEn(string $text): string {
+  public function translate(string $text, string $sourceLangcode, string $targetLangcode): string {
     $text = trim($text);
     if ($text === '') {
       return $text;
@@ -48,7 +48,7 @@ final class AiTranslationClient {
         ['role' => 'system', 'content' => $systemPrompt],
         [
           'role' => 'user',
-          'content' => "Traduire du français vers l’anglais sans ajouter de commentaire.\n\nTexte source :\n{$text}",
+          'content' => "Traduire de {$sourceLangcode} vers {$targetLangcode} sans ajouter de commentaire.\n\nTexte source :\n{$text}",
         ],
       ],
     ];
@@ -71,6 +71,13 @@ final class AiTranslationClient {
     }
 
     return $translated;
+  }
+
+  /**
+   * Traduit du FR vers EN (compatibilité rétro).
+   */
+  public function translateFrToEn(string $text): string {
+    return $this->translate($text, 'fr', 'en');
   }
 
   /**

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -33,20 +33,33 @@ final class AiTranslationManager {
    *   Nombre de champs traduits.
    */
   public function translateEntityToEnglish(ContentEntityInterface $entity): int {
+    return $this->translateEntityToLanguage($entity, 'en', 'fr');
+  }
+
+  /**
+   * Traduit une entité source vers une langue cible.
+   *
+   * @return int
+   *   Nombre de champs traduits.
+   */
+  public function translateEntityToLanguage(ContentEntityInterface $entity, string $targetLangcode, string $sourceLangcode = 'fr'): int {
     if (!$entity->isTranslatable()) {
       throw new \InvalidArgumentException('Entité non traduisible.');
     }
-
-    $sourceLangcode = $entity->language()->getId();
-    if ($sourceLangcode !== 'fr') {
-      throw new \InvalidArgumentException('La source doit être en français (fr).');
+    if ($targetLangcode === $sourceLangcode) {
+      throw new \InvalidArgumentException('La langue cible doit être différente de la langue source.');
     }
 
-    $translatedEntity = $entity->hasTranslation('en')
-      ? $entity->getTranslation('en')
-      : $entity->addTranslation('en');
+    $sourceEntity = $entity->hasTranslation($sourceLangcode) ? $entity->getTranslation($sourceLangcode) : $entity;
+    if ($sourceEntity->language()->getId() !== $sourceLangcode) {
+      throw new \InvalidArgumentException(sprintf('La source doit être en %s.', $sourceLangcode));
+    }
 
-    $translatedCount = $this->translateFields($entity, $translatedEntity);
+    $translatedEntity = $entity->hasTranslation($targetLangcode)
+      ? $entity->getTranslation($targetLangcode)
+      : $entity->addTranslation($targetLangcode);
+
+    $translatedCount = $this->translateFields($sourceEntity, $translatedEntity, $sourceLangcode, $targetLangcode);
 
     $translatedEntity->save();
 
@@ -56,7 +69,7 @@ final class AiTranslationManager {
   /**
    * Traduit les champs éditoriaux translatables d'une entité.
    */
-  private function translateFields(ContentEntityInterface $source, ContentEntityInterface $target): int {
+  private function translateFields(ContentEntityInterface $source, ContentEntityInterface $target, string $sourceLangcode, string $targetLangcode): int {
     $count = 0;
     $definitions = $this->fieldManager->getFieldDefinitions($source->getEntityTypeId(), $source->bundle());
 
@@ -70,12 +83,12 @@ final class AiTranslationManager {
 
       $fieldType = $definition->getType();
       if (in_array($fieldType, self::TRANSLATABLE_FIELD_TYPES, TRUE)) {
-        $count += $this->translateSimpleField($source, $target, $fieldName, $fieldType);
+        $count += $this->translateSimpleField($source, $target, $fieldName, $fieldType, $sourceLangcode, $targetLangcode);
         continue;
       }
 
       if ($fieldType === 'entity_reference_revisions') {
-        $count += $this->translateParagraphReferences($source, $target, $fieldName);
+        $count += $this->translateParagraphReferences($source, $target, $fieldName, $sourceLangcode, $targetLangcode);
       }
     }
 
@@ -85,14 +98,14 @@ final class AiTranslationManager {
   /**
    * Traduit un champ éditorial simple (texte, summary, titre de lien).
    */
-  private function translateSimpleField(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName, string $fieldType): int {
+  private function translateSimpleField(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName, string $fieldType, string $sourceLangcode, string $targetLangcode): int {
     $items = $source->get($fieldName)->getValue();
 
     foreach ($items as $delta => $item) {
       if ($fieldType === 'link') {
         $title = trim((string) ($item['title'] ?? ''));
         if ($title !== '') {
-          $items[$delta]['title'] = $this->client->translateFrToEn($title);
+          $items[$delta]['title'] = $this->client->translate($title, $sourceLangcode, $targetLangcode);
         }
         continue;
       }
@@ -105,7 +118,7 @@ final class AiTranslationManager {
         if ($value === '') {
           continue;
         }
-        $items[$delta][$key] = $this->client->translateFrToEn($value);
+        $items[$delta][$key] = $this->client->translate($value, $sourceLangcode, $targetLangcode);
       }
     }
 
@@ -116,7 +129,7 @@ final class AiTranslationManager {
   /**
    * Traduit les Paragraphs référencés et rattache les révisions EN.
    */
-  private function translateParagraphReferences(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName): int {
+  private function translateParagraphReferences(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName, string $sourceLangcode, string $targetLangcode): int {
     $translatedReferences = [];
     $count = 0;
 
@@ -126,16 +139,16 @@ final class AiTranslationManager {
         continue;
       }
 
-      if ($paragraph->language()->getId() !== 'fr') {
+      if ($paragraph->language()->getId() !== $sourceLangcode) {
         $translatedReferences[] = ['target_id' => $paragraph->id(), 'target_revision_id' => $paragraph->getRevisionId()];
         continue;
       }
 
-      $paragraphTranslation = $paragraph->hasTranslation('en')
-        ? $paragraph->getTranslation('en')
-        : $paragraph->addTranslation('en');
+      $paragraphTranslation = $paragraph->hasTranslation($targetLangcode)
+        ? $paragraph->getTranslation($targetLangcode)
+        : $paragraph->addTranslation($targetLangcode);
 
-      $count += $this->translateFields($paragraph, $paragraphTranslation);
+      $count += $this->translateFields($paragraph, $paragraphTranslation, $sourceLangcode, $targetLangcode);
       $paragraphTranslation->save();
 
       $translatedReferences[] = [

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -6,7 +6,6 @@ namespace Drupal\agency_ai_translation\Service;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * Orchestre la traduction éditoriale FR -> EN pour noeuds et paragraphs.
@@ -25,7 +24,6 @@ final class AiTranslationManager {
   public function __construct(
     private readonly AiTranslationClient $client,
     private readonly EntityFieldManagerInterface $fieldManager,
-    private readonly LoggerInterface $logger,
   ) {}
 
   /**

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -62,9 +62,9 @@ final class AiTranslationManager {
 
     $translatedCount = $this->translateFields($sourceEntity, $translatedEntity, $sourceLangcode, $targetLangcode);
 
-    $this->preparePathAliasGeneration($translatedEntity);
-    $translatedEntity->save();
-    $this->generatePathAlias($translatedEntity);
+    $this->preparePathAliasGeneration($translatedEntity, $targetLangcode);
+    $translatedEntity->getUntranslated()->save();
+    $this->generatePathAlias($translatedEntity, $targetLangcode);
 
     return $translatedCount;
   }
@@ -170,7 +170,7 @@ final class AiTranslationManager {
   /**
    * Prépare la régénération Pathauto de l'alias sur la traduction cible.
    */
-  private function preparePathAliasGeneration(ContentEntityInterface $translatedEntity): void {
+  private function preparePathAliasGeneration(ContentEntityInterface $translatedEntity, string $targetLangcode): void {
     if (!$translatedEntity->hasField('path')) {
       return;
     }
@@ -182,14 +182,21 @@ final class AiTranslationManager {
     }
     $firstPath['alias'] = '';
     $firstPath['pathauto'] = 1;
+    $firstPath['langcode'] = $targetLangcode;
     $translatedEntity->set('path', [$firstPath]);
   }
 
   /**
    * Déclenche Pathauto si disponible pour générer un alias de traduction.
    */
-  private function generatePathAlias(ContentEntityInterface $translatedEntity): void {
+  private function generatePathAlias(ContentEntityInterface $translatedEntity, string $targetLangcode): void {
     if (!is_object($this->pathautoGenerator) || !method_exists($this->pathautoGenerator, 'updateEntityAlias')) {
+      return;
+    }
+
+    $reflection = new \ReflectionMethod($this->pathautoGenerator, 'updateEntityAlias');
+    if ($reflection->getNumberOfParameters() >= 3) {
+      $this->pathautoGenerator->updateEntityAlias($translatedEntity, 'update', ['language' => $targetLangcode]);
       return;
     }
 

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_translation\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Orchestre la traduction éditoriale FR -> EN pour noeuds et paragraphs.
+ */
+final class AiTranslationManager {
+
+  private const TRANSLATABLE_FIELD_TYPES = [
+    'string',
+    'string_long',
+    'text',
+    'text_long',
+    'text_with_summary',
+    'link',
+  ];
+
+  public function __construct(
+    private readonly AiTranslationClient $client,
+    private readonly EntityFieldManagerInterface $fieldManager,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * @return int
+   *   Nombre de champs traduits.
+   */
+  public function translateEntityToEnglish(ContentEntityInterface $entity): int {
+    if (!$entity->isTranslatable()) {
+      throw new \InvalidArgumentException('Entité non traduisible.');
+    }
+
+    $sourceLangcode = $entity->language()->getId();
+    if ($sourceLangcode !== 'fr') {
+      throw new \InvalidArgumentException('La source doit être en français (fr).');
+    }
+
+    $translatedEntity = $entity->hasTranslation('en')
+      ? $entity->getTranslation('en')
+      : $entity->addTranslation('en');
+
+    $translatedCount = $this->translateFields($entity, $translatedEntity);
+
+    $translatedEntity->save();
+
+    return $translatedCount;
+  }
+
+  private function translateFields(ContentEntityInterface $source, ContentEntityInterface $target): int {
+    $count = 0;
+    $definitions = $this->fieldManager->getFieldDefinitions($source->getEntityTypeId(), $source->bundle());
+
+    foreach ($definitions as $fieldName => $definition) {
+      if (!$definition->isTranslatable()) {
+        continue;
+      }
+      if (!$source->hasField($fieldName) || $source->get($fieldName)->isEmpty()) {
+        continue;
+      }
+
+      $fieldType = $definition->getType();
+      if (in_array($fieldType, self::TRANSLATABLE_FIELD_TYPES, TRUE)) {
+        $count += $this->translateSimpleField($source, $target, $fieldName, $fieldType);
+        continue;
+      }
+
+      if ($fieldType === 'entity_reference_revisions') {
+        $count += $this->translateParagraphReferences($source, $target, $fieldName);
+      }
+    }
+
+    return $count;
+  }
+
+  private function translateSimpleField(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName, string $fieldType): int {
+    $items = $source->get($fieldName)->getValue();
+
+    foreach ($items as $delta => $item) {
+      if ($fieldType === 'link') {
+        $title = trim((string) ($item['title'] ?? ''));
+        if ($title !== '') {
+          $items[$delta]['title'] = $this->client->translateFrToEn($title);
+        }
+        continue;
+      }
+
+      foreach (['value', 'summary'] as $key) {
+        if (!isset($item[$key])) {
+          continue;
+        }
+        $value = trim((string) $item[$key]);
+        if ($value === '') {
+          continue;
+        }
+        $items[$delta][$key] = $this->client->translateFrToEn($value);
+      }
+    }
+
+    $target->set($fieldName, $items);
+    return count($items);
+  }
+
+  private function translateParagraphReferences(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName): int {
+    $translatedReferences = [];
+    $count = 0;
+
+    foreach ($source->get($fieldName)->referencedEntities() as $paragraph) {
+      if (!$paragraph instanceof ContentEntityInterface || !$paragraph->isTranslatable()) {
+        $translatedReferences[] = ['target_id' => $paragraph->id(), 'target_revision_id' => $paragraph->getRevisionId()];
+        continue;
+      }
+
+      if ($paragraph->language()->getId() !== 'fr') {
+        $translatedReferences[] = ['target_id' => $paragraph->id(), 'target_revision_id' => $paragraph->getRevisionId()];
+        continue;
+      }
+
+      $paragraphTranslation = $paragraph->hasTranslation('en')
+        ? $paragraph->getTranslation('en')
+        : $paragraph->addTranslation('en');
+
+      $count += $this->translateFields($paragraph, $paragraphTranslation);
+      $paragraphTranslation->save();
+
+      $translatedReferences[] = [
+        'target_id' => $paragraphTranslation->id(),
+        'target_revision_id' => $paragraphTranslation->getRevisionId(),
+      ];
+    }
+
+    if ($translatedReferences !== []) {
+      $target->set($fieldName, $translatedReferences);
+    }
+
+    return $count;
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -29,6 +29,8 @@ final class AiTranslationManager {
   ) {}
 
   /**
+   * Traduit une entité source FR vers sa traduction EN.
+   *
    * @return int
    *   Nombre de champs traduits.
    */
@@ -53,6 +55,9 @@ final class AiTranslationManager {
     return $translatedCount;
   }
 
+  /**
+   * Traduit les champs éditoriaux translatables d'une entité.
+   */
   private function translateFields(ContentEntityInterface $source, ContentEntityInterface $target): int {
     $count = 0;
     $definitions = $this->fieldManager->getFieldDefinitions($source->getEntityTypeId(), $source->bundle());
@@ -79,6 +84,9 @@ final class AiTranslationManager {
     return $count;
   }
 
+  /**
+   * Traduit un champ éditorial simple (texte, summary, titre de lien).
+   */
   private function translateSimpleField(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName, string $fieldType): int {
     $items = $source->get($fieldName)->getValue();
 
@@ -107,6 +115,9 @@ final class AiTranslationManager {
     return count($items);
   }
 
+  /**
+   * Traduit les Paragraphs référencés et rattache les révisions EN.
+   */
   private function translateParagraphReferences(ContentEntityInterface $source, ContentEntityInterface $target, string $fieldName): int {
     $translatedReferences = [];
     $count = 0;

--- a/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
+++ b/web/modules/custom/agency_ai_translation/src/Service/AiTranslationManager.php
@@ -24,6 +24,7 @@ final class AiTranslationManager {
   public function __construct(
     private readonly AiTranslationClient $client,
     private readonly EntityFieldManagerInterface $fieldManager,
+    private readonly ?object $pathautoGenerator = NULL,
   ) {}
 
   /**
@@ -61,7 +62,9 @@ final class AiTranslationManager {
 
     $translatedCount = $this->translateFields($sourceEntity, $translatedEntity, $sourceLangcode, $targetLangcode);
 
+    $this->preparePathAliasGeneration($translatedEntity);
     $translatedEntity->save();
+    $this->generatePathAlias($translatedEntity);
 
     return $translatedCount;
   }
@@ -162,6 +165,35 @@ final class AiTranslationManager {
     }
 
     return $count;
+  }
+
+  /**
+   * Prépare la régénération Pathauto de l'alias sur la traduction cible.
+   */
+  private function preparePathAliasGeneration(ContentEntityInterface $translatedEntity): void {
+    if (!$translatedEntity->hasField('path')) {
+      return;
+    }
+
+    $pathValue = $translatedEntity->get('path')->getValue();
+    $firstPath = $pathValue[0] ?? [];
+    if (!is_array($firstPath)) {
+      $firstPath = [];
+    }
+    $firstPath['alias'] = '';
+    $firstPath['pathauto'] = 1;
+    $translatedEntity->set('path', [$firstPath]);
+  }
+
+  /**
+   * Déclenche Pathauto si disponible pour générer un alias de traduction.
+   */
+  private function generatePathAlias(ContentEntityInterface $translatedEntity): void {
+    if (!is_object($this->pathautoGenerator) || !method_exists($this->pathautoGenerator, 'updateEntityAlias')) {
+      return;
+    }
+
+    $this->pathautoGenerator->updateEntityAlias($translatedEntity, 'update');
   }
 
 }


### PR DESCRIPTION
### Motivation
- Ajouter une première brique de pré‑traduction assistée par IA pour générer une version anglaise à partir du français tout en gardant un contrôle humain avant publication. 
- Couvrir les contenus éditoriaux principaux (textes, résumés, CTA) et les Paragraphs sans casser l’architecture multilingue existante. 
- Respecter les contraintes de sécurité et de maintenance : pas de clé API hardcodée, pas de traduction automatique à chaque sauvegarde et déclenchement manuel côté admin. 
- Closes #91

### Description
- Ajout d’un module custom `agency_ai_translation` avec routing, permission, menu et page de config (`web/modules/custom/agency_ai_translation/*`).
- Implémentation d’un `hook_entity_operation` qui expose l’opération `Générer EN (IA)` uniquement pour les nœuds en `fr` et pour les comptes ayant la permission `trigger ai translation`.
- Service `AiTranslationClient` pour l’appel HTTP vers un endpoint Chat Completions configurable et sécurisation de la clé via `settings.php`, variable d’environnement `AGENCY_AI_TRANSLATION_API_KEY` ou fallback en `state` (non exporté). 
- Service `AiTranslationManager` qui crée/met à jour la traduction `en`, traduit uniquement les champs éditoriaux translatables (`string`, `string_long`, `text*`, `link` titre) et gère récursivement les Paragraphs (`entity_reference_revisions`).
- Formulaire de confirmation `TranslateNodeConfirmForm` pour déclencher manuellement la traduction et rediriger l’éditeur vers l’édition EN pour relecture, ainsi qu’un form de config `AiTranslationSettingsForm` pour `endpoint`, `model` et `system_prompt`.
- Fichiers de configuration par défaut et schéma (`config/install/agency_ai_translation.settings.yml`, `config/schema/agency_ai_translation.schema.yml`) et documentation dans `README.md` du module.

### Testing
- Vérifications de syntaxe PHP : `php -l` sur les fichiers du module — succès ✅.
- Tentatives de commande Drupal demandées : `ddev drush cr`, `ddev drush cex -y`, `ddev drush cim -y` — échec ⚠️ car `ddev` indisponible dans cet environnement. 
- Vérification de configuration : `git diff config/sync` — aucune différence détectée ✅.
- Le module a été ajouté au dépôt et commité (`web/modules/custom/agency_ai_translation`) et les fichiers créés sont listés dans le diff. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e136ca98832195af57280498a04c)