### PR TITLE
feat(ai): réactiver l’intégration OpenAI via Key environnementale (issue #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,3 +356,32 @@ Option recommandée (sans automatisation implicite) :
 4. Vider le cache (`ddev drush cr`) et vérifier le rendu.
 
 Cette approche évite les effets de bord des post-updates complexes et laisse la main à l’équipe éditoriale.
+
+## Ticket #93 — Réactivation OpenAI via variable d’environnement
+
+Objectif : réactiver l’intégration OpenAI sans exposer de secret dans la configuration exportée.
+
+### Ce qui est versionné
+
+- `config/sync/key.key.openai_api_key.yml`
+  - Key Drupal `openai_api_key`
+  - Provider : `environment`
+  - Variable attendue : `OPENAI_API_KEY`
+- `config/sync/ai_provider_openai.settings.yml`
+  - Provider OpenAI branché sur la Key `openai_api_key`
+
+### Ce qui **n’est pas** versionné
+
+- La valeur de la clé OpenAI (`sk-...`) n’apparaît jamais dans Git.
+- La clé reste fournie uniquement par l’environnement DDEV.
+
+### Vérification locale
+
+```bash
+ddev drush cr
+ddev drush cex -y
+git diff config/sync
+ddev drush cim -y
+```
+
+Contrôle attendu : aucun secret en clair dans `config/sync` et provider OpenAI utilisable depuis l’UI Drupal.

--- a/README.md
+++ b/README.md
@@ -365,9 +365,10 @@ Objectif : réactiver l’intégration OpenAI sans exposer de secret dans la con
 
 - `config/sync/key.key.openai_api_key.yml`
   - Key Drupal `openai_api_key`
-  - Provider : `environment`
+  - Provider : `env`
   - Variable attendue : `OPENAI_API_KEY`
 - `config/sync/ai_provider_openai.settings.yml`
+  - Configuration minimale conforme au schéma (`api_key` uniquement)
   - Provider OpenAI branché sur la Key `openai_api_key`
 
 ### Ce qui **n’est pas** versionné

--- a/config/sync/ai_provider_openai.settings.yml
+++ b/config/sync/ai_provider_openai.settings.yml
@@ -1,0 +1,11 @@
+uuid: c9be8672-8ef9-4de4-a906-8105f82da8bb
+langcode: en
+status: true
+dependencies:
+  module:
+    - ai_provider_openai
+    - key
+api_key: openai_api_key
+organization: ''
+project: ''
+base_url: ''

--- a/config/sync/ai_provider_openai.settings.yml
+++ b/config/sync/ai_provider_openai.settings.yml
@@ -1,11 +1,1 @@
-uuid: c9be8672-8ef9-4de4-a906-8105f82da8bb
-langcode: en
-status: true
-dependencies:
-  module:
-    - ai_provider_openai
-    - key
 api_key: openai_api_key
-organization: ''
-project: ''
-base_url: ''

--- a/config/sync/key.key.openai_api_key.yml
+++ b/config/sync/key.key.openai_api_key.yml
@@ -9,6 +9,8 @@ label: 'OpenAI API key'
 description: 'Clé OpenAI injectée depuis la variable d’environnement OPENAI_API_KEY.'
 key_type: authentication
 key_type_settings: {  }
-key_provider: environment
+key_provider: env
 key_provider_settings:
   env_variable: OPENAI_API_KEY
+  base64_encoded: false
+  strip_line_breaks: false

--- a/config/sync/key.key.openai_api_key.yml
+++ b/config/sync/key.key.openai_api_key.yml
@@ -1,0 +1,14 @@
+uuid: 4c58c1d5-29a1-4a6d-9fd4-5d4fb94a8a93
+langcode: en
+status: true
+dependencies:
+  module:
+    - key
+id: openai_api_key
+label: 'OpenAI API key'
+description: 'Clé OpenAI injectée depuis la variable d’environnement OPENAI_API_KEY.'
+key_type: authentication
+key_type_settings: {  }
+key_provider: environment
+key_provider_settings:
+  env_variable: OPENAI_API_KEY


### PR DESCRIPTION
### Motivation
- Réactiver proprement l’intégration OpenAI en utilisant la variable d’environnement `OPENAI_API_KEY` sans stocker la clé en clair dans la configuration exportée, en s’appuyant sur le module `key` pour une gestion sûre et maintenable des secrets.

### Description
- Ajout de `config/sync/key.key.openai_api_key.yml` qui crée une Key Drupal `openai_api_key` avec `key_provider: environment` et `env_variable: OPENAI_API_KEY`.
- Ajout de `config/sync/ai_provider_openai.settings.yml` qui configure le provider OpenAI pour utiliser la Key `openai_api_key` (`api_key: openai_api_key`).
- Mise à jour de `README.md` pour documenter le ticket #93, indiquer ce qui est versionné et fournir les commandes de vérification à exécuter en environnement local.
- Aucune valeur secrète n’est stockée dans `config/sync` et la configuration reste simple et réversible.

### Testing
- Examen Git (`git diff -- config/sync` et `git status --short`) a confirmé la présence des deux fichiers YAML ajoutés et l’absence de secret en clair dans l’export, et ces vérifications ont réussi.
- Tentatives d’exécution des commandes `ddev drush cr`, `ddev drush cex -y` et `ddev drush cim -y` ont échoué dans cet environnement car le binaire `ddev` n’est pas disponible, empêchant l’import/validation runtime ici.
- Une tentative de `composer install` a échoué en raison d’erreurs réseau/tunnel dans ce conteneur, empêchant la vérification complète des modules côté runtime.
- Recommandation finale : exécuter localement les commandes `ddev drush cr`, `ddev drush cex -y` et `ddev drush cim -y` dans un environnement DDEV où `OPENAI_API_KEY` est défini pour valider le provider et vérifier l’absence de fuite de secret (Closes #93).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92909efe883218109a3ddb9e3030c)