### PR TITLE
feat(tests): base de tests automatisés Drupal 11 pour workflows critiques

### DIFF
--- a/docs/ticket-28-tests-base.md
+++ b/docs/ticket-28-tests-base.md
@@ -1,0 +1,28 @@
+# Ticket 28 — Base de tests automatisés
+
+## Ce qui est couvert
+
+- Workflow de traduction IA individuelle avec écran de confirmation.
+- Exécution de l’action de masse depuis `/admin/content`.
+- Vérification de la création de traduction en langue cible (`en`) et du contenu traduit.
+- Vérification de base de l’alias de traduction (quand un alias EN existe).
+- Formulaire de contact public : affichage des champs, cas invalide, cas valide.
+
+## Limites actuelles
+
+- Le test contact cible le module `contact` cœur Drupal. Si le module `webform` est requis en environnement projet, un test dédié `webform` devra être ajouté quand le module sera disponible dans le dépôt.
+- La génération d’alias Pathauto est validée de manière pragmatique (absence d’alias brut `/node/{nid}` lorsqu’un alias EN est généré).
+
+## Lancer les tests en local
+
+```bash
+ddev drush cr
+vendor/bin/phpunit web/modules/custom/agency_ai_translation/tests/src/Functional/AiTranslationWorkflowTest.php
+vendor/bin/phpunit web/modules/custom/agency_ai_translation/tests/src/Functional/ContactFormTest.php
+```
+
+Ou la suite complète :
+
+```bash
+vendor/bin/phpunit
+```

--- a/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
+++ b/web/modules/custom/agency_ai_translation/agency_ai_translation.routing.yml
@@ -1,6 +1,15 @@
 agency_ai_translation.translate_node:
   path: '/admin/content/ai-translate/node/{node}/to/{target_langcode}'
   defaults:
+    _form: '\Drupal\agency_ai_translation\Form\TranslateNodeConfirmForm'
+    _title: 'Confirmer la génération de traduction (IA)'
+  requirements:
+    _permission: 'access content'
+    target_langcode: '[a-z_]+'
+
+agency_ai_translation.translate_node_execute:
+  path: '/admin/content/ai-translate/node/{node}/to/{target_langcode}/execute'
+  defaults:
     _controller: '\Drupal\agency_ai_translation\Controller\TranslateNodeController::translate'
     _title: 'Générer une traduction (IA)'
   requirements:

--- a/web/modules/custom/agency_ai_translation/tests/src/Functional/AiTranslationWorkflowTest.php
+++ b/web/modules/custom/agency_ai_translation/tests/src/Functional/AiTranslationWorkflowTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_ai_translation\Functional;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\path_alias\Entity\PathAlias;
+use Drupal\Tests\agency_ai_translation\Support\StaticTranslationHttpClient;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Vérifie les workflows critiques de traduction IA.
+ *
+ * @group agency_ai_translation
+ */
+final class AiTranslationWorkflowTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'agency_ai_translation',
+    'content_translation',
+    'language',
+    'locale',
+    'node',
+    'path',
+    'system',
+    'user',
+    'views',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Utilisateur de test.
+   */
+  private $translatorUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    if (!ConfigurableLanguage::load('fr')) {
+      ConfigurableLanguage::createFromLangcode('fr')->save();
+    }
+    if (!ConfigurableLanguage::load('en')) {
+      ConfigurableLanguage::createFromLangcode('en')->save();
+    }
+
+    $this->container->get('content_translation.manager')->setEnabled('node', 'page', TRUE);
+
+    $this->container->get('state')->set('agency_ai_translation.api_key', 'test-key');
+    $this->container->set('http_client', new StaticTranslationHttpClient());
+
+    $this->translatorUser = $this->drupalCreateUser([
+      'access administration pages',
+      'access content overview',
+      'administer content types',
+      'administer languages',
+      'administer url aliases',
+      'create page content',
+      'edit any page content',
+      'trigger ai translation',
+    ]);
+  }
+
+  /**
+   * Teste le workflow de traduction individuelle avec confirmation.
+   */
+  public function testSingleActionCreatesTranslationAndAlias(): void {
+    $this->drupalLogin($this->translatorUser);
+
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => 'Bonjour monde',
+      'langcode' => 'fr',
+      'status' => 1,
+    ]);
+
+    PathAlias::create([
+      'path' => '/node/' . $node->id(),
+      'alias' => '/fr/bonjour-monde',
+      'langcode' => 'fr',
+    ])->save();
+
+    $this->drupalGet('/admin/content');
+    $this->assertSession()->linkExists('Générer EN (IA)');
+
+    $this->clickLink('Générer EN (IA)');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Source : FR. Cible : EN.');
+
+    $this->submitForm([], 'Lancer la traduction IA');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $reloaded = $this->container->get('entity_type.manager')->getStorage('node')->load($node->id());
+    self::assertNotNull($reloaded);
+    self::assertTrue($reloaded->hasTranslation('en'));
+
+    $translation = $reloaded->getTranslation('en');
+    self::assertStringStartsWith('EN: ', $translation->label());
+
+    $enAliases = $this->container->get('entity_type.manager')->getStorage('path_alias')->loadByProperties([
+      'path' => '/node/' . $node->id(),
+      'langcode' => 'en',
+    ]);
+
+    if ($enAliases !== []) {
+      $alias = reset($enAliases);
+      self::assertNotFalse($alias);
+      self::assertNotSame('/node/' . $node->id(), $alias->getAlias());
+    }
+  }
+
+  /**
+   * Teste l’action de masse depuis /admin/content.
+   */
+  public function testBulkActionCreatesTranslation(): void {
+    $this->drupalLogin($this->translatorUser);
+
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => 'Contenu à traduire en masse',
+      'langcode' => 'fr',
+      'status' => 1,
+    ]);
+
+    $this->drupalGet('/admin/content');
+    $this->assertSession()->fieldExists('Action');
+    $this->assertSession()->fieldExists('Langue cible (IA)');
+
+    $edit = [
+      'nodes[' . $node->id() . ']' => TRUE,
+      'action' => 'agency_ai_translate_nodes_bulk_action',
+      'agency_ai_translation_target_langcode' => 'en',
+    ];
+
+    $this->submitForm($edit, 'Apply to selected items');
+
+    $reloaded = $this->container->get('entity_type.manager')->getStorage('node')->load($node->id());
+    self::assertNotNull($reloaded);
+    self::assertTrue($reloaded->hasTranslation('en'));
+    self::assertStringStartsWith('EN: ', $reloaded->getTranslation('en')->label());
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/tests/src/Functional/AiTranslationWorkflowTest.php
+++ b/web/modules/custom/agency_ai_translation/tests/src/Functional/AiTranslationWorkflowTest.php
@@ -8,6 +8,7 @@ use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\Tests\agency_ai_translation\Support\StaticTranslationHttpClient;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\user\UserInterface;
 
 /**
  * Vérifie les workflows critiques de traduction IA.
@@ -37,9 +38,11 @@ final class AiTranslationWorkflowTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
-   * Utilisateur de test.
+   * Utilisateur dédié aux scénarios de traduction.
+   *
+   * @var \Drupal\user\UserInterface
    */
-  private $translatorUser;
+  private UserInterface $translatorUser;
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/agency_ai_translation/tests/src/Functional/ContactFormTest.php
+++ b/web/modules/custom/agency_ai_translation/tests/src/Functional/ContactFormTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_ai_translation\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Couvre le formulaire de contact public (fallback si Webform absent).
+ *
+ * @group agency_ai_translation
+ */
+final class ContactFormTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'contact',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Vérifie affichage, cas invalide et cas valide.
+   */
+  public function testContactFormValidationAndSubmit(): void {
+    $this->drupalGet('/contact');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists('name');
+    $this->assertSession()->fieldExists('mail');
+    $this->assertSession()->fieldExists('subject[0][value]');
+    $this->assertSession()->fieldExists('message[0][value]');
+
+    $this->submitForm([
+      'name' => 'Test Contact',
+      'mail' => 'email-invalide',
+      'subject[0][value]' => 'Sujet test',
+      'message[0][value]' => 'Message test',
+    ], 'Send message');
+    $this->assertSession()->pageTextContains('mail is not valid');
+
+    $this->submitForm([
+      'name' => 'Test Contact',
+      'mail' => 'contact@example.com',
+      'subject[0][value]' => 'Sujet valide',
+      'message[0][value]' => 'Message valide',
+    ], 'Send message');
+    $this->assertSession()->pageTextContains('Your message has been sent.');
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/tests/src/Support/StaticTranslationHttpClient.php
+++ b/web/modules/custom/agency_ai_translation/tests/src/Support/StaticTranslationHttpClient.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_ai_translation\Support;
+
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Faux client HTTP pour rendre les tests de traduction déterministes.
+ */
+final class StaticTranslationHttpClient implements \GuzzleHttp\ClientInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function send(RequestInterface $request, array $options = []): ResponseInterface {
+    return $this->request($request->getMethod(), (string) $request->getUri(), $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface {
+    return Create::promiseFor($this->send($request, $options));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function request(string $method, $uri = '', array $options = []): ResponseInterface {
+    $source = '';
+    $payload = $options['json'] ?? [];
+    if (is_array($payload) && isset($payload['messages'][1]['content']) && is_string($payload['messages'][1]['content'])) {
+      $parts = explode("Source content:\n", $payload['messages'][1]['content'], 2);
+      $source = trim((string) ($parts[1] ?? ''));
+    }
+
+    $translated = $source === '' ? 'EN: translated' : 'EN: ' . $source;
+    $body = json_encode([
+      'choices' => [
+        [
+          'message' => [
+            'content' => $translated,
+          ],
+        ],
+      ],
+    ], JSON_THROW_ON_ERROR);
+
+    return new Response(200, ['Content-Type' => 'application/json'], $body);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface {
+    return Create::promiseFor($this->request($method, $uri, $options));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig(?string $option = NULL) {
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/agency_ai_translation/tests/src/Support/StaticTranslationHttpClient.php
+++ b/web/modules/custom/agency_ai_translation/tests/src/Support/StaticTranslationHttpClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_ai_translation\Support;
 
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response;
@@ -13,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Faux client HTTP pour rendre les tests de traduction déterministes.
  */
-final class StaticTranslationHttpClient implements \GuzzleHttp\ClientInterface {
+final class StaticTranslationHttpClient implements ClientInterface {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
### Motivation
- Sécuriser le projet contre des régressions déjà observées en ajoutant une base de tests fonctionnels centrée sur les workflows critiques de traduction IA, actions (individuelle et de masse), alias multilingues et le formulaire de contact. 
- Rendre ces tests déterministes et indépendants d’un provider externe en remplaçant les appels réseau réels par un faux client HTTP en test. 
- Closes #96

### Description
- Ajout d’une route de confirmation pour l’action individuelle en exposant `TranslateNodeConfirmForm` sur la route principale et création d’une route dédiée d’exécution pour le contrôleur (`TranslateNodeController::translate`).
- Ajout d’un client HTTP de test `StaticTranslationHttpClient` pour simuler des réponses de traduction et garantir la déterminisme des tests sans réseau.
- Ajout de tests fonctionnels : `AiTranslationWorkflowTest` couvrant l’action individuelle, le formulaire de confirmation, l’action de masse, l’injection du sélecteur de langue et la création de traduction/alias; et `ContactFormTest` pour valider le formulaire de contact (affichage, validation invalide, soumission valide).
- Ajout d’une documentation courte `docs/ticket-28-tests-base.md` expliquant comment lancer les tests en local et listant les limites connues (absence de `webform`/`pathauto` dans le dépôt actuel).

### Testing
- `php -l` sur les nouveaux fichiers de test et support a été exécuté et a réussi pour `StaticTranslationHttpClient.php`, `AiTranslationWorkflowTest.php` et `ContactFormTest.php` (pas d’erreurs de syntaxe). 
- Une tentative d’exécution de la commande d’environnement `ddev drush cr` a été lancée mais a échoué dans cet environnement d’exécution car `ddev` n’est pas installé (`ddev: command not found`).
- Une tentative d’exécution de la suite PHPUnit a été lancée mais a échoué localement car les dépendances `vendor` ne sont pas présentes (`vendor/bin/phpunit: No such file or directory`).
- La documentation inclut les commandes recommandées pour exécuter les tests en local : `ddev drush cr` puis `vendor/bin/phpunit` sur les fichiers de test ou la suite complète.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8920e4e88321a1d4e25d0368daab)