### PR TITLE
ci: align GitHub Actions with stable custom Drupal test scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: PHP Quality
+  quality-and-tests:
+    name: Quality & Custom Tests
     runs-on: ubuntu-latest
+
+    env:
+      SIMPLETEST_BASE_URL: http://127.0.0.1:8888
+      SIMPLETEST_DB: sqlite://localhost/tmp/simpletest.sqlite
 
     steps:
       - name: Checkout
@@ -18,23 +22,47 @@ jobs:
       - name: Setup PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3.0'
+          php-version: '8.3'
           tools: composer:v2
           coverage: none
+          extensions: sqlite3
 
-      - name: Verify PHP version
-        run: |
-          php -v
-          php -r "exit(version_compare(PHP_VERSION, '8.3.0', '>=') ? 0 : 1);"
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Validate composer.json
         run: composer validate --strict
 
-      - name: Install dependencies
+      - name: Install dependencies (with require-dev)
         run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Install BrowserTest dependencies
-        run: composer require --dev drupal/core-dev:^11.3 --with-all-dependencies --prefer-dist --no-progress --no-interaction
+      - name: Run quality scripts defined in composer.json
+        run: |
+          scripts="$(composer run-script --list)"
 
-      - name: Run CI checks (including homepage smoke test)
-        run: composer ci
+          if echo "$scripts" | grep -qE '^\s*lint:phpcs\b'; then
+            composer lint:phpcs
+          fi
+
+          if echo "$scripts" | grep -qE '^\s*lint:phpstan\b'; then
+            composer lint:phpstan
+          fi
+
+          if echo "$scripts" | grep -qE '^\s*lint:drupal-check\b'; then
+            composer lint:drupal-check
+          fi
+
+      - name: Start local web server for BrowserTestBase
+        run: php -S 127.0.0.1:8888 -t web >/tmp/php-server.log 2>&1 &
+
+      - name: Run custom PHPUnit suite only (exclude unstable_ia)
+        run: vendor/bin/phpunit -c web/core/phpunit.xml.dist --exclude-group unstable_ia web/modules/custom/agency_project_tests/tests

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,52 @@
+# CI GitHub Actions
+
+## Objectif
+
+La CI exécute un pipeline ciblé pour Drupal 11 / PHP 8.3 sur GitHub Actions, avec :
+
+- validation Composer stricte ;
+- installation des dépendances (avec `require-dev`) ;
+- contrôles qualité déclarés dans `composer.json` uniquement ;
+- exécution PHPUnit strictement limitée aux tests custom stables.
+
+## Déclenchement
+
+Le workflow est défini dans `.github/workflows/ci.yml` et se lance sur :
+
+- `push` vers `main` ;
+- `pull_request`.
+
+## Pourquoi seuls les tests custom sont exécutés
+
+La CI exécute explicitement cette commande :
+
+```bash
+vendor/bin/phpunit -c web/core/phpunit.xml.dist --exclude-group unstable_ia web/modules/custom/agency_project_tests/tests
+```
+
+Conséquences :
+
+- aucun lancement global de PHPUnit ;
+- aucun scan de `web/core` ni de `web/modules/contrib` ;
+- seuls les tests du module custom `agency_project_tests` sont ciblés.
+
+## Pourquoi `unstable_ia` est exclu
+
+Les tests IA du module `agency_ai_translation` sont marqués instables via le groupe `unstable_ia`.
+
+La CI les exclut explicitement avec `--exclude-group unstable_ia` pour garantir un pipeline fiable et reproductible, sans tentative de stabilisation forcée et sans dépendance à des appels externes (OpenAI).
+
+## Environnement de tests
+
+Le workflow configure :
+
+- `SIMPLETEST_BASE_URL=http://127.0.0.1:8888`
+- `SIMPLETEST_DB=sqlite://localhost/tmp/simpletest.sqlite`
+
+Un serveur PHP local est démarré sur `127.0.0.1:8888` et la base SQLite est utilisée pour les tests BrowserTestBase en CI.
+
+## Commande locale (PowerShell via ddev)
+
+```powershell
+ddev exec env SIMPLETEST_BASE_URL=http://agency-website-drupal.ddev.site SIMPLETEST_DB=mysql://db:db@db/db vendor/bin/phpunit -c web/core/phpunit.xml.dist --exclude-group unstable_ia web/modules/custom/agency_project_tests/tests
+```


### PR DESCRIPTION
### Motivation
- Provide a focused, reliable GitHub Actions pipeline for Drupal 11 / PHP 8.3 that only runs stable custom tests and excludes unstable IA tests. 
- Ensure Composer validation, install (including `require-dev`) and Composer caching are present to reproduce CI environments. 
- This change closes issue `#102` by adding the workflow and documentation requested.

### Description
- Add and configure `.github/workflows/ci.yml` to run on `push` to `main` and on `pull_request`, set `php 8.3`, add Composer cache handling, and set `SIMPLETEST_BASE_URL` and `SIMPLETEST_DB` to use a local PHP server and SQLite. 
- Run quality scripts only when declared in `composer.json` by conditionally invoking `composer lint:phpcs`, `composer lint:phpstan`, and `composer lint:drupal-check`, and start a local PHP server for BrowserTestBase. 
- Run PHPUnit strictly with `vendor/bin/phpunit -c web/core/phpunit.xml.dist --exclude-group unstable_ia web/modules/custom/agency_project_tests/tests` to target only `agency_project_tests` and explicitly exclude the `unstable_ia` group. 
- Add `docs/ci.md` documenting CI behavior, rationale for running only custom tests, the exclusion of `unstable_ia`, the test environment variables, and the local PowerShell command for reproducing the run.

### Testing
- Ran `composer validate --strict` against the repository and it completed successfully. 
- No full CI run was executed in this environment; the workflow is prepared to run on GitHub for `push`/`pull_request` events. 
- The changes were linted/validated via Composer metadata checks and the workflow will execute PHPUnit on GitHub using the configured command when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbeaddab0832187ab8245bbe1a4d2)