### PR TITLE
Fix frontpage footer rendering to match internal pages

### DIFF
--- a/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
+++ b/web/themes/custom/emerging_digital/templates/layout/page--front.html.twig
@@ -17,14 +17,18 @@
 
   <footer class="page-footer" role="contentinfo">
     <div class="page-container page-footer__inner">
-      {{ page.footer }}
-      <nav aria-label="Navigation secondaire" class="footer-links">
-        <a href="/services">Services</a>
-        <a href="/ia-drupal">IA &amp; Drupal</a>
-        <a href="/cas-clients">Cas clients</a>
-        <a href="/contact">Contact</a>
-      </nav>
-      <p class="page-footer__tagline">Drupal + IA pragmatique pour PME &amp; ASBL en Wallonie et à Bruxelles.</p>
+      <div class="page-footer__top">
+        {% if page.footer_branding %}
+          <div class="page-footer__branding">
+            {{ page.footer_branding }}
+          </div>
+        {% endif %}
+        {% if page.footer %}
+          <div class="page-footer__legal">
+            {{ page.footer }}
+          </div>
+        {% endif %}
+      </div>
     </div>
   </footer>
 </div>


### PR DESCRIPTION
### Motivation
- Corriger l’incohérence du footer entre la page d’accueil et les pages internes qui provoquait l’affichage d’un menu hardcodé dans le footer et la disparition du label du bloc branding.

### Description
- Remplacement du markup hardcodé du footer dans `web/themes/custom/emerging_digital/templates/layout/page--front.html.twig` pour réutiliser la même structure que `page.html.twig` en rendant les régions `footer_branding` et `footer`.
- Suppression des liens et de la tagline hardcodés afin de laisser Drupal rendre les blocs/configurations de footer; changement committé sur la branche `feature/footer-frontpage-fix` (Closes #X).

### Testing
- Exécution de `ddev drush cr` a échoué dans cet environnement avec l’erreur `ddev: command not found`.
- Exécution de `ddev drush cex -y` a échoué dans cet environnement avec l’erreur `ddev: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee027c69388321a73b32e1b60c0824)