### PR TITLE
Finaliser le branding du header et le style des boutons de formulaire

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: ijfbzDTN4CbE7Sr-6ubWzy_t1vH4OtU1doNCLssVz-4
 langcode: fr
 uuid: 6ea8f5bb-0ecf-491e-b6ae-c8b71a6b6abd
-name: 'E-MERGING DIGITAL'
+name: 'Emerging Digital'
 mail: admin@example.com
 slogan: 'Stratégie digitale, solutions durables'
 page:

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: ijfbzDTN4CbE7Sr-6ubWzy_t1vH4OtU1doNCLssVz-4
 langcode: fr
 uuid: 6ea8f5bb-0ecf-491e-b6ae-c8b71a6b6abd
-name: 'Emerging Digital'
+name: 'E-MERGING DIGITAL'
 mail: admin@example.com
 slogan: 'Stratégie digitale, solutions durables'
 page:

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -75,6 +75,19 @@ button:focus-visible,
   box-shadow: 0 6px 14px rgb(17 24 39 / 12%);
 }
 
+
+.webform-submission-form .form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.webform-submission-form .form-actions .webform-button--submit,
+.webform-submission-form .form-actions .form-submit {
+  opacity: 1;
+  visibility: visible;
+}
 .ed-section {
   position: relative;
   padding-block: clamp(2.5rem, 6vw, 5rem);

--- a/web/themes/custom/emerging_digital/css/layout.css
+++ b/web/themes/custom/emerging_digital/css/layout.css
@@ -52,7 +52,7 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   width: 100%;
 }
 
@@ -92,11 +92,10 @@
 .page-header .site-name {
   margin: 0;
   font-family: var(--font-heading);
-  font-size: clamp(1rem, 1.25vw, 1.3rem);
+  font-size: clamp(0.98rem, 1.2vw, 1.2rem);
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: -0.01em;
-  text-transform: uppercase;
 }
 
 .page-header .site-name a {
@@ -108,8 +107,7 @@
   margin: 0;
   color: var(--color-muted);
   font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .page-header .menu,
@@ -126,7 +124,7 @@
 
 .page-header .block-system-menu-blockmain .main-navigation__list {
   justify-content: flex-end;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 
@@ -308,9 +306,9 @@
   align-items: center;
   justify-content: center;
   min-height: 2.25rem;
-  padding: 0.35rem 0.8rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 0.94rem;
   line-height: 1.1;
   text-decoration: none;
@@ -541,6 +539,14 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-1);
+    width: 100%;
+  }
+
+  .page-header .main-navigation__item {
+    min-width: 0;
+  }
+
+  .page-header .main-navigation__link {
     width: 100%;
   }
 

--- a/web/themes/custom/emerging_digital/images/branding/emerging-digital-mark.svg
+++ b/web/themes/custom/emerging_digital/images/branding/emerging-digital-mark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Emerging Digital mark</title>
-  <desc id="desc">Monogram icon used for Emerging Digital site branding.</desc>
+  <title id="title">E-merging Digital mark</title>
+  <desc id="desc">Monogram icon used for E-merging Digital site branding.</desc>
   <rect x="0" y="0" width="64" height="64" rx="14" fill="#0F2A4A"/>
   <path d="M17 16h30v8H25v8h20v8H25v8h22v8H17V16z" fill="#6AD6FF"/>
 </svg>

--- a/web/themes/custom/emerging_digital/images/branding/emerging-digital-mark.svg
+++ b/web/themes/custom/emerging_digital/images/branding/emerging-digital-mark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Denvid LI mark</title>
-  <desc id="desc">Monogram icon used for the global site branding.</desc>
+  <title id="title">Emerging Digital mark</title>
+  <desc id="desc">Monogram icon used for Emerging Digital site branding.</desc>
   <rect x="0" y="0" width="64" height="64" rx="14" fill="#0F2A4A"/>
   <path d="M17 16h30v8H25v8h20v8H25v8h22v8H17V16z" fill="#6AD6FF"/>
 </svg>

--- a/web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig
@@ -4,15 +4,15 @@
  * Theme override for the site branding block.
  */
 #}
+{% set brand_mark = directory ~ '/images/branding/emerging-digital-mark.svg' %}
+
 <div{{ attributes.addClass('site-branding') }}>
   {{ title_prefix }}
   {{ title_suffix }}
 
-{% if site_logo %}
-    <a href="{{ path('<front>') }}" rel="home" class="site-logo">
-      <img src="{{ site_logo }}" alt="" width="64" height="64" loading="eager" decoding="async" fetchpriority="high" />
-    </a>
-  {% endif %}
+  <a href="{{ path('<front>') }}" rel="home" class="site-logo" aria-label="{{ 'Back to homepage'|t }}">
+    <img src="{{ brand_mark }}" alt="{{ site_name ?: 'Emerging Digital' }}" width="64" height="64" loading="eager" decoding="async" fetchpriority="high" />
+  </a>
 
   <div class="site-branding__text">
     {% if site_name %}


### PR DESCRIPTION
### Motivation
- Finaliser l’en-tête et l’identité visuelle sans refonte ni création de structure Drupal, en garantissant que le nom du site, le logo (symbole SVG) et le favicon soient correctement exposés via la configuration et le thème.
- Assurer un rendu lisible et accessible du header et du menu sur mobile/tablette/desktop avec des états hover/focus/active visibles.
- Rendre les boutons de formulaire (en particulier les boutons `Webform`) visibles et conformes au design system existant.

### Description
- Mise à jour du nom du site dans la configuration synchronisée en remplaçant `E-MERGING DIGITAL` par `Emerging Digital` dans `config/sync/system.site.yml` pour aligner le branding global.
- Remplacement du rendu de branding dans le thème en ajoutant `web/themes/custom/emerging_digital/templates/block/block--system-branding-block.html.twig` pour utiliser le symbole SVG (`images/branding/emerging-digital-mark.svg`) et rendre le `site_name` en HTML (pas de texte du logo embarqué dans le SVG), avec `aria-label` sur le lien vers la page d’accueil.
- Correction des métadonnées du SVG marque (`web/themes/custom/emerging_digital/images/branding/emerging-digital-mark.svg`) pour refléter l’identité `Emerging Digital`.
- Ajustements CSS pour le header/menus et formulaires dans `web/themes/custom/emerging_digital/css/layout.css` et `web/themes/custom/emerging_digital/css/components.css` pour améliorer espacements, typo, comportement responsive et garantir la visibilité/présence du `webform-button--submit`.

### Testing
- `git commit` a été effectué avec succès et le commit contient les fichiers modifiés (5 fichiers changés, 35 insertions, 16 suppressions). 
- Tentatives d’export/import de configuration avec `ddev drush cex -y` et `./vendor/bin/drush cex -y` ont échoué en raison de l’environnement (commande `ddev` ou `drush` non disponible dans cet environnement de CI/sandbox). 
- Tentatives d’import + vidage de cache `ddev drush cim -y && ddev drush cr` et `./vendor/bin/drush cim -y && ./vendor/bin/drush cr` ont échoué pour la même raison. 
- Vérifications Git locales effectuées: `git status`, création de branche `feature/finaliser-header-branding`, `git add` + `git commit`, et `git show --stat --oneline -1` (réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee091678e48321ada0908d2071429b)