### PR TITLE
Remove hero background visuals on mobile for improved readability

### DIFF
--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -483,18 +483,16 @@ button:focus-visible,
 }
 
 @media (max-width: 48rem) {
+  .ed-section--hero {
+    background: var(--color-surface);
+  }
+
   .ed-section--hero::before {
-    width: 100%;
-    background: linear-gradient(180deg, rgb(255 255 255 / 86%) 0%, rgb(255 255 255 / 74%) 44%, rgb(255 255 255 / 20%) 100%);
+    content: none;
   }
 
   .ed-section--hero::after {
-    right: -3.5rem;
-    top: auto;
-    bottom: -4rem;
-    transform: none;
-    width: min(20rem, 74vw);
-    opacity: 0.82;
+    content: none;
   }
 
   .ed-actions,


### PR DESCRIPTION
### Motivation
- Improve hero text readability on small screens by removing the decorative hero image and overlay at `max-width: 48rem` so the content remains clear and legible on mobile.

### Description
- Update `web/themes/custom/emerging_digital/css/components.css` to set `.ed-section--hero` background to `var(--color-surface)` and disable the hero pseudo-elements `::before` and `::after` inside the mobile media query (`@media (max-width: 48rem)`), leaving desktop behavior unchanged; Closes #<ticket-number>.

### Testing
- Ran `git diff --check` which passed.
- Attempted `ddev drush cr` but it could not be executed in this environment because `ddev` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d5a569988321abe4f5e71b011757)