### PR TITLE
feat: automate production deployment (script + docs)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -182,3 +182,57 @@ Cette procédure manuelle sert de base à l’automatisation future (ex. GitHub 
 - vérifications.
 
 Aucun workflow CI/CD n’est créé à ce stade : ce document définit la référence opérationnelle.
+
+
+## 9) Déploiement automatisé
+
+Le script `scripts/deploy-production.sh` automatise la procédure de déploiement en production en conservant le même modèle à releases.
+
+### 9.1 Utilisation
+
+```bash
+bash scripts/deploy-production.sh main
+```
+
+- Le paramètre de branche est optionnel (`main` par défaut).
+- Le script crée une release horodatée sous `/var/www/agency/releases`.
+- Il exécute l’installation Composer, les symlinks partagés, le backup DB, le mode maintenance, les commandes Drush et le nettoyage.
+
+### 9.2 Logs et backups
+
+- Logs de déploiement : `/var/www/agency/shared/deployments.log`
+- Backups base de données : `/var/www/agency/shared/backups`
+
+Chaque exécution journalise notamment : timestamp, branche, commit, chemin de release, utilisateur Linux et statut final (`success` / `failure`).
+
+### 9.3 Politique de conservation
+
+- Releases : conservation des **3** plus récentes (sans supprimer la release active).
+- Backups DB : conservation des **10** plus récents.
+
+### 9.4 Rollback après déploiement automatisé
+
+1. Lister les releases disponibles :
+
+```bash
+ls -1dt /var/www/agency/releases/*
+```
+
+2. Repointer `current` vers la release cible :
+
+```bash
+ROLLBACK_RELEASE="/var/www/agency/releases/<timestamp_precedent>"
+ln -sfn "$ROLLBACK_RELEASE" /var/www/agency/current
+```
+
+3. Finaliser côté Drupal :
+
+```bash
+cd /var/www/agency/current
+vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer
+vendor/bin/drush cr
+```
+
+4. Vérifier le fonctionnement du site et les logs (`deployments.log`, watchdog Drupal).
+
+> Important : le rollback de code est immédiat via symlink, mais la restauration DB reste une opération séparée (à faire depuis les backups SQL si nécessaire).

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BRANCH="${1:-main}"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+
+PROJECT_ROOT="/var/www/agency"
+RELEASES_DIR="/var/www/agency/releases"
+SHARED_DIR="/var/www/agency/shared"
+BACKUPS_DIR="/var/www/agency/shared/backups"
+LOG_FILE="/var/www/agency/shared/deployments.log"
+REPO_URL="git@github.com:<org>/<repo>.git"
+CURRENT_LINK="$PROJECT_ROOT/current"
+NEW_RELEASE="$RELEASES_DIR/$TIMESTAMP"
+ACTIVE_RELEASE=""
+DEPLOY_USER="$(id -un)"
+COMMIT_HASH="unknown"
+DEPLOY_STATUS="failure"
+
+log() {
+  local message="$1"
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$message" | tee -a "$LOG_FILE"
+}
+
+fail_trap() {
+  local exit_code="$?"
+  local line_no="${1:-unknown}"
+
+  log "ERROR: Deployment failed at line ${line_no} with exit code ${exit_code}."
+
+  if [[ -L "$CURRENT_LINK" ]] && [[ -x "$CURRENT_LINK/vendor/bin/drush" ]]; then
+    log "Attempting to disable maintenance mode on active release after failure."
+    "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer || true
+    "$CURRENT_LINK/vendor/bin/drush" cr || true
+  else
+    log "No active release with Drush detected to disable maintenance mode after failure."
+  fi
+
+  log "Deployment metadata: timestamp=${TIMESTAMP} branch=${BRANCH} commit=${COMMIT_HASH} release=${NEW_RELEASE} user=${DEPLOY_USER} status=${DEPLOY_STATUS}"
+  exit "$exit_code"
+}
+
+trap 'fail_trap $LINENO' ERR
+
+mkdir -p "$RELEASES_DIR" "$SHARED_DIR" "$BACKUPS_DIR" "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+
+log "Starting deployment for branch '${BRANCH}'."
+log "Creating new release directory: ${NEW_RELEASE}"
+
+if [[ -e "$NEW_RELEASE" ]]; then
+  log "ERROR: Release directory already exists: ${NEW_RELEASE}"
+  exit 1
+fi
+
+mkdir -p "$NEW_RELEASE"
+
+git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$NEW_RELEASE"
+COMMIT_HASH="$(git -C "$NEW_RELEASE" rev-parse --short HEAD)"
+log "Repository cloned at commit ${COMMIT_HASH}."
+
+composer --working-dir="$NEW_RELEASE" install --no-dev --optimize-autoloader
+log "Composer dependencies installed."
+
+mkdir -p "$SHARED_DIR/files" "$SHARED_DIR/private" "$SHARED_DIR/settings"
+ln -sfn "$SHARED_DIR/files" "$NEW_RELEASE/web/sites/default/files"
+ln -sfn "$SHARED_DIR/settings/settings.php" "$NEW_RELEASE/web/sites/default/settings.php"
+log "Shared symlinks created for files and settings.php."
+
+if [[ -L "$CURRENT_LINK" ]]; then
+  ACTIVE_RELEASE="$(readlink -f "$CURRENT_LINK")"
+  log "Active release detected: ${ACTIVE_RELEASE}"
+
+  if [[ -x "$CURRENT_LINK/vendor/bin/drush" ]]; then
+    DB_BACKUP="$BACKUPS_DIR/db-${TIMESTAMP}.sql.gz"
+    "$CURRENT_LINK/vendor/bin/drush" sql:dump --gzip --result-file="$DB_BACKUP"
+    log "Database backup created: ${DB_BACKUP}"
+
+    "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 1 --input-format=integer
+    "$CURRENT_LINK/vendor/bin/drush" cr
+    log "Maintenance mode enabled on active release."
+  else
+    log "WARNING: Drush not available on active release. Skipping DB backup and maintenance mode activation."
+  fi
+else
+  log "No current release detected. Skipping DB backup and maintenance mode activation."
+fi
+
+ln -sfn "$NEW_RELEASE" "$CURRENT_LINK"
+log "Current symlink switched to new release."
+
+"$CURRENT_LINK/vendor/bin/drush" updb -y
+"$CURRENT_LINK/vendor/bin/drush" cim -y
+"$CURRENT_LINK/vendor/bin/drush" cr
+log "Drupal update, config import and cache rebuild completed."
+
+"$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer
+"$CURRENT_LINK/vendor/bin/drush" cr
+log "Maintenance mode disabled on new release."
+
+mapfile -t all_releases < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+if (( ${#all_releases[@]} > 3 )); then
+  for release in "${all_releases[@]:3}"; do
+    release_path="$RELEASES_DIR/$release"
+    if [[ "$(readlink -f "$CURRENT_LINK")" != "$(readlink -f "$release_path")" ]]; then
+      rm -rf "$release_path"
+      log "Old release removed: ${release_path}"
+    fi
+  done
+fi
+
+mapfile -t all_backups < <(find "$BACKUPS_DIR" -maxdepth 1 -type f -name 'db-*.sql.gz' -printf '%f\n' | sort -r)
+if (( ${#all_backups[@]} > 10 )); then
+  for backup in "${all_backups[@]:10}"; do
+    rm -f "$BACKUPS_DIR/$backup"
+    log "Old backup removed: $BACKUPS_DIR/$backup"
+  done
+fi
+
+DEPLOY_STATUS="success"
+log "Deployment completed successfully."
+log "Deployment metadata: timestamp=${TIMESTAMP} branch=${BRANCH} commit=${COMMIT_HASH} release=${NEW_RELEASE} user=${DEPLOY_USER} status=${DEPLOY_STATUS}"


### PR DESCRIPTION
### Motivation

- Automate the manual production deployment described in `docs/deployment.md` into a single, maintainable script while keeping all Drupal application, Twig, CSS/JS, configuration, modules and content unchanged. 
- Provide a repeatable, logged, timestamped release flow with DB backup, maintenance-mode handling, post-deploy Drush commands and retention policies to reduce manual error. 
- Ensure the change is limited to deployment tooling and documentation only. 
- Closes #128.

### Description

- Added `scripts/deploy-production.sh`, a strict `bash` script (`set -Eeuo pipefail`) that accepts an optional branch argument (default `main`) and defines the required project paths and `REPO_URL`. 
- The script creates a timestamped release directory, clones the repo there, runs `composer install --no-dev --optimize-autoloader`, and creates shared symlinks for `files` and the shared `settings.php`. 
- If an active release exists the script attempts a compressed DB dump via Drush from the current release, enables maintenance mode, switches the `current` symlink to the new release, runs `vendor/bin/drush updb -y`, `vendor/bin/drush cim -y` and `vendor/bin/drush cr`, then disables maintenance mode. 
- The script implements structured logging to `/var/www/agency/shared/deployments.log`, retention cleanup (keep 3 releases, keep 10 DB backups), and a failure trap that logs the error, attempts to disable maintenance mode on the active release if possible, and exits non-zero. 
- Updated `docs/deployment.md` with a new section “Déploiement automatisé” that documents usage (`bash scripts/deploy-production.sh main`), log and backup locations, retention policy and rollback procedure.

### Testing

- Performed a shell syntax check with `bash -n scripts/deploy-production.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fd214e2c8321b6a609976f0430fb)