### PR TITLE
Add production deployment documentation and `scripts/deploy.sh` automated deploy script

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -52,3 +52,10 @@ Un serveur PHP local est démarré sur `127.0.0.1:8888` et la base SQLite est ut
 ```powershell
 ddev exec env SIMPLETEST_BASE_URL=http://agency-website-drupal.ddev.site SIMPLETEST_DB=mysql://db:db@db/db vendor/bin/phpunit -c web/core/phpunit.xml.dist --exclude-group unstable_ia --exclude-group unstable_language_switcher web/modules/custom/agency_project_tests/tests
 ```
+
+
+## Déploiement automatique (production)
+
+Le déploiement production est documenté dans `docs/deployment.md` et automatisé via `scripts/deploy.sh`.
+
+Ce script n'est **pas** exécuté par la CI actuelle ; il constitue la base d'un futur workflow GitHub Actions de déploiement contrôlé (approval manuel, secrets GitHub, SSH vers serveur).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,259 @@
+# Déploiement manuel en production (GandiCloud)
+
+## 1) Principe général du déploiement
+
+Le déploiement repose sur une structure **à releases timestampées** :
+
+- chaque version est installée dans un dossier dédié sous `/var/www/agency/releases/<timestamp>` ;
+- le lien symbolique `/var/www/agency/current` pointe vers la release active ;
+- les éléments persistants sont partagés via `/var/www/agency/shared` ;
+- un rollback consiste à repointer `current` vers une release précédente.
+
+Cette approche permet des changements atomiques de version et limite les interruptions de service.
+
+## 2) Prérequis
+
+Vérifier avant tout déploiement :
+
+- accès SSH au serveur Ubuntu 24.04 LTS ;
+- accès à l’utilisateur de déploiement `deploy` ;
+- accès GitHub opérationnel via deploy key (lecture du dépôt) ;
+- `composer` (2.9+) disponible côté serveur ;
+- base de données MariaDB déjà configurée ;
+- fichier partagé `settings.php` déjà présent :
+  `/var/www/agency/shared/settings/settings.php`.
+
+## 3) Procédure de déploiement manuel
+
+> Exemple avec la branche `main`. Adapter `BRANCH` selon la version à déployer.
+> **Important :** copier-coller le bloc de variables complet à chaque déploiement pour éviter de réutiliser d’anciennes valeurs de shell.
+
+### 3.1 Connexion et préparation
+
+```bash
+ssh ubuntu@emergingdigital
+sudo -iu deploy
+
+unset PROJECT_ROOT RELEASES_DIR SHARED_DIR REPO_URL BRANCH TIMESTAMP NEW_RELEASE
+
+PROJECT_ROOT=/var/www/agency
+RELEASES_DIR="$PROJECT_ROOT/releases"
+SHARED_DIR="$PROJECT_ROOT/shared"
+REPO_URL="git@github.com:E-merging-digital/agency-website-drupal.git"
+BRANCH="main"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+NEW_RELEASE="$RELEASES_DIR/$TIMESTAMP"
+
+mkdir -p "$RELEASES_DIR" "$SHARED_DIR"
+mkdir -p "$SHARED_DIR/files" "$SHARED_DIR/private" "$SHARED_DIR/settings"
+```
+
+### 3.2 Vérifications avant clone (important)
+
+```bash
+whoami
+printf 'REPO_URL=%s\nBRANCH=%s\nNEW_RELEASE=%s\n' "$REPO_URL" "$BRANCH" "$NEW_RELEASE"
+ssh -T git@github.com || true
+git ls-remote "$REPO_URL" -h "refs/heads/$BRANCH"
+```
+
+Attendus :
+
+- `whoami` retourne `deploy` ;
+- `REPO_URL` n’est **pas vide** et ne contient pas `<org>/<repo>` ;
+- le test SSH GitHub répond (même avec un message sans shell interactif) ;
+- `git ls-remote` retourne un hash (sinon, accès dépôt incorrect).
+
+### 3.3 Création de la release et récupération du code
+
+```bash
+git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$NEW_RELEASE"
+cd "$NEW_RELEASE"
+```
+
+### 3.4 Installation des dépendances
+
+```bash
+composer install --no-dev --optimize-autoloader
+```
+
+### 3.5 Liens symboliques des éléments partagés
+
+```bash
+# Fichiers publics Drupal
+rm -rf "$NEW_RELEASE/web/sites/default/files"
+ln -sfn "$SHARED_DIR/files" "$NEW_RELEASE/web/sites/default/files"
+
+# settings.php partagé
+rm -f "$NEW_RELEASE/web/sites/default/settings.php"
+ln -sfn "$SHARED_DIR/settings/settings.php" "$NEW_RELEASE/web/sites/default/settings.php"
+```
+
+### 3.6 Activation de la nouvelle release
+
+```bash
+ln -sfn "$NEW_RELEASE" "$PROJECT_ROOT/current"
+cd "$PROJECT_ROOT/current"
+```
+
+### 3.7 Mises à jour Drupal post-déploiement
+
+```bash
+vendor/bin/drush updb -y
+vendor/bin/drush cim -y
+vendor/bin/drush cr
+```
+
+### 3.8 Nginx
+
+En général, le changement de symlink suffit. Recharger Nginx uniquement si nécessaire :
+
+```bash
+sudo systemctl reload nginx
+```
+
+## 4) Procédure de rollback
+
+### 4.1 Identifier la release précédente
+
+```bash
+ls -1dt /var/www/agency/releases/*
+```
+
+### 4.2 Repointer `current`
+
+```bash
+PREVIOUS_RELEASE="/var/www/agency/releases/<timestamp_precedent>"
+ln -sfn "$PREVIOUS_RELEASE" /var/www/agency/current
+cd /var/www/agency/current
+vendor/bin/drush cr
+```
+
+### 4.3 Point d’attention base de données
+
+Le rollback de code est rapide via symlink, mais le rollback de base de données **n’est pas automatique**.
+Si des updates Drupal ont modifié le schéma/données, prévoir une stratégie de restauration DB séparée.
+
+## 5) Vérifications après déploiement
+
+Exécuter les contrôles suivants :
+
+```bash
+cd /var/www/agency/current
+vendor/bin/drush status
+vendor/bin/drush config:status
+curl -I http://emergingdigital.be
+```
+
+Puis compléter par :
+
+- vérification visuelle des pages clés du site ;
+- vérification des logs Drupal (watchdog / journal système).
+
+## 6) Commandes de maintenance utiles
+
+### Lister les releases
+
+```bash
+ls -1dt /var/www/agency/releases/*
+```
+
+### Supprimer les anciennes releases (garder les 3 dernières)
+
+```bash
+cd /var/www/agency/releases
+ls -1dt */ | tail -n +4 | xargs -r rm -rf
+```
+
+### Vider le cache Drupal
+
+```bash
+cd /var/www/agency/current
+vendor/bin/drush cr
+```
+
+### Consulter le watchdog
+
+```bash
+cd /var/www/agency/current
+vendor/bin/drush watchdog:show
+```
+
+## 7) Dépannage rapide
+
+### Erreur `fatal: repository '' does not exist`
+
+Cette erreur signifie que `REPO_URL` est vide, mal défini, resté avec une valeur placeholder (`<org>/<repo>`), ou que la deploy key n'a pas accès au dépôt.
+Recharger explicitement les variables puis retenter le clone :
+
+```bash
+REPO_URL="git@github.com:E-merging-digital/agency-website-drupal.git"
+BRANCH="main"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+NEW_RELEASE="/var/www/agency/releases/$TIMESTAMP"
+
+printf 'REPO_URL=%s\n' "$REPO_URL"
+[[ "$REPO_URL" == *"<org>/<repo>"* ]] && echo "REPO_URL invalide" && return 1
+git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$NEW_RELEASE"
+```
+
+Si l’erreur persiste, vérifier que la deploy key GitHub est bien attachée au dépôt `E-merging-digital/agency-website-drupal` avec accès en lecture.
+
+## 8) Précautions importantes
+
+- Ne jamais modifier directement une release active.
+- Ne jamais committer `settings.php`.
+- Ne jamais versionner de secrets (tokens, mots de passe, clés privées).
+- Ne jamais supprimer le dossier `/var/www/agency/shared`.
+- Ne pas appliquer de permissions globales de type `chmod 664` sur tout le projet : cela casse les exécutables (Composer/Drush).
+- Si correction de permissions nécessaire, préférer :
+
+```bash
+chmod -R ug+rwX /var/www/agency/current
+```
+
+## 9) Perspective CI/CD
+
+Cette procédure manuelle sert de base à l’automatisation future (ex. GitHub Actions) :
+
+- construction d’une release ;
+- installation des dépendances ;
+- bascule atomique du symlink `current` ;
+- exécution des commandes Drupal post-déploiement ;
+- vérifications.
+
+Aucun workflow CI/CD n’est créé à ce stade : ce document définit la référence opérationnelle.
+
+## 10) Procédure automatique (script)
+
+Un script de déploiement est disponible : `scripts/deploy.sh`.
+
+### Usage standard
+
+```bash
+ssh ubuntu@emergingdigital
+sudo -iu deploy
+cd /var/www/agency/current
+
+BRANCH=main /var/www/agency/current/scripts/deploy.sh
+```
+
+### Variables supportées
+
+```bash
+PROJECT_ROOT=/var/www/agency
+RELEASES_DIR=/var/www/agency/releases
+SHARED_DIR=/var/www/agency/shared
+REPO_URL=git@github.com:E-merging-digital/agency-website-drupal.git
+BRANCH=main
+KEEP_RELEASES=3
+RUN_NGINX_RELOAD=0
+```
+
+Exemple avec reload Nginx :
+
+```bash
+BRANCH=main RUN_NGINX_RELOAD=1 /var/www/agency/current/scripts/deploy.sh
+```
+
+Le script applique la même logique que la procédure manuelle : validation GitHub, clone timestampé, `composer install`, symlinks partagés, bascule `current`, `drush updb`, `drush cim`, `drush cr`, puis nettoyage des anciennes releases.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/agency}"
+RELEASES_DIR="${RELEASES_DIR:-$PROJECT_ROOT/releases}"
+SHARED_DIR="${SHARED_DIR:-$PROJECT_ROOT/shared}"
+REPO_URL="${REPO_URL:-git@github.com:E-merging-digital/agency-website-drupal.git}"
+BRANCH="${BRANCH:-main}"
+KEEP_RELEASES="${KEEP_RELEASES:-3}"
+RUN_NGINX_RELOAD="${RUN_NGINX_RELOAD:-0}"
+
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+NEW_RELEASE="$RELEASES_DIR/$TIMESTAMP"
+
+log() {
+  printf '[deploy] %s\n' "$*"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing command: $1" >&2; exit 1; }
+}
+
+require_cmd git
+require_cmd composer
+require_cmd php
+
+if [[ "${REPO_URL}" == *"<org>/<repo>"* ]]; then
+  echo "REPO_URL invalide: ${REPO_URL}" >&2
+  exit 1
+fi
+
+log "User: $(whoami)"
+log "Branch: $BRANCH"
+log "Repository: $REPO_URL"
+log "Release: $NEW_RELEASE"
+
+mkdir -p "$RELEASES_DIR" "$SHARED_DIR/files" "$SHARED_DIR/private" "$SHARED_DIR/settings"
+
+if [[ ! -f "$SHARED_DIR/settings/settings.php" ]]; then
+  echo "Fichier manquant: $SHARED_DIR/settings/settings.php" >&2
+  exit 1
+fi
+
+log "Validation accès GitHub"
+ssh -T git@github.com || true
+git ls-remote "$REPO_URL" -h "refs/heads/$BRANCH" >/dev/null
+
+log "Clone release"
+git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$NEW_RELEASE"
+
+cd "$NEW_RELEASE"
+log "Composer install"
+composer install --no-dev --optimize-autoloader
+
+log "Liens partagés"
+rm -rf "$NEW_RELEASE/web/sites/default/files"
+ln -sfn "$SHARED_DIR/files" "$NEW_RELEASE/web/sites/default/files"
+rm -f "$NEW_RELEASE/web/sites/default/settings.php"
+ln -sfn "$SHARED_DIR/settings/settings.php" "$NEW_RELEASE/web/sites/default/settings.php"
+
+log "Bascule current"
+ln -sfn "$NEW_RELEASE" "$PROJECT_ROOT/current"
+cd "$PROJECT_ROOT/current"
+
+log "Drush post-deploy"
+vendor/bin/drush updb -y
+vendor/bin/drush cim -y
+vendor/bin/drush cr
+
+if [[ "$RUN_NGINX_RELOAD" == "1" ]]; then
+  log "Reload nginx"
+  sudo systemctl reload nginx
+fi
+
+log "Nettoyage anciennes releases"
+cd "$RELEASES_DIR"
+ls -1dt */ | tail -n +$((KEEP_RELEASES + 1)) | xargs -r rm -rf
+
+log "Déploiement terminé"


### PR DESCRIPTION
### Motivation

- Provide an operational, repeatable production deployment procedure and a basis for future CI/CD automation.
- Centralize deployment knowledge (manual and automated) so releases use timestamped directories and shared persistent data.
- Ensure the repository contains a safe, opinionated deploy script that can be adopted by a future GitHub Actions workflow.

### Description

- Added `docs/deployment.md` which documents a manual production deployment workflow, rollback steps, maintenance commands, precautions, and the intended CI/CD perspective.
- Added `scripts/deploy.sh`, an executable deploy script that implements timestamped releases, `current` symlink promotion, shared `files` and `settings.php` symlinks, `composer install --no-dev --optimize-autoloader`, `drush updb`, `drush cim`, `drush cr`, optional Nginx reload controlled by `RUN_NGINX_RELOAD`, and cleanup of old releases controlled by `KEEP_RELEASES`.
- Added a short note to `docs/ci.md` referencing the new deployment documentation and clarifying that the deploy script is not executed by the current CI pipeline.
- The script includes basic safety checks like `set -euo pipefail`, required command checks (`git`, `composer`, `php`), validation of `REPO_URL`, and verification of the presence of the shared `settings.php` file.

### Testing

- No automated tests were executed for these documentation and scripting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ab28acfc832184e137f00aa4e42a)