### PR TITLE
docs: add production HTTPS guide (Let’s Encrypt + Certbot)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,9 @@
 # Déploiement manuel en production (GandiCloud)
 
+## Références complémentaires
+
+- Configuration HTTPS (Let's Encrypt / Certbot, politique canonique) : `docs/https.md`
+
 ## 1) Principe général du déploiement
 
 Le déploiement repose sur une structure **à releases timestampées** :

--- a/docs/https.md
+++ b/docs/https.md
@@ -1,0 +1,64 @@
+# HTTPS en production
+
+## Objectif
+
+Ce projet utilise une politique canonique : **HTTPS sans `www`**.
+
+- URL canonique : `https://emergingdigital.be`
+- Domaine secondaire couvert : `https://www.emergingdigital.be`
+
+## Certificat TLS
+
+- Fournisseur du certificat : **Let’s Encrypt**
+- Outil utilisé : **Certbot** avec plugin **Nginx**
+- Domaines couverts : `emergingdigital.be` et `www.emergingdigital.be`
+
+## Installation de Certbot
+
+```bash
+sudo apt install certbot python3-certbot-nginx -y
+```
+
+## Émission du certificat
+
+```bash
+sudo certbot --nginx -d emergingdigital.be -d www.emergingdigital.be
+```
+
+## Renouvellement (test à blanc)
+
+```bash
+sudo certbot renew --dry-run
+```
+
+## Emplacement habituel des certificats
+
+```text
+/etc/letsencrypt/live/emergingdigital.be/
+```
+
+## Diagnostic rapide
+
+```bash
+sudo nginx -t
+sudo systemctl status nginx
+sudo certbot certificates
+sudo certbot renew --dry-run
+```
+
+## Règles de sécurité
+
+- Ne jamais versionner de certificats.
+- Ne jamais versionner de clés privées.
+
+## Périmètre de configuration dans ce dépôt
+
+La configuration Nginx de production n’est pas versionnée ici et reste gérée sur le serveur par Certbot.
+
+Concernant la configuration Drupal versionnée (fichier `web/sites/default/settings.php`) :
+
+- aucune valeur `base_url` n’est définie ;
+- aucun `trusted_host_patterns` n’est défini ;
+- aucun paramètre `reverse_proxy` n’est défini.
+
+Ces éléments doivent être gérés par environnement si nécessaires, sans stocker de secrets dans Git.


### PR DESCRIPTION
### Motivation

- Document the production HTTPS setup and the canonical URL policy (HTTPS without `www`) for the site hosted at `https://emergingdigital.be`.
- Provide clear operator instructions for certificate issuance, renewal and diagnostics using Let’s Encrypt and Certbot (Nginx plugin) without changing server configuration in the repository.
- Record the scope of versioned Drupal settings so deployers know which settings are not defined in the repo and must be managed per-environment.

### Description

- Add `docs/https.md` describing TLS provider (Let’s Encrypt), tool (`certbot` with Nginx plugin), covered domains, installation, issuance, dry-run renewal, certificate path, diagnostics, security reminders, and canonical policy (HTTPS without `www`).
- Update `docs/deployment.md` to include a reference link to `docs/https.md` under a new “Références complémentaires” section.
- Explicitly document the current state of versioned Drupal settings in `web/sites/default/settings.php` (no `base_url`, no `trusted_host_patterns`, no `reverse_proxy`) without introducing any new application configuration.
- Limit changes to documentation only and do not add certificates, secrets, modules, theme or server configuration files to the repository.

### Testing

- Verified repository and working branch context with `git branch --show-current` and `git status --short`, which reported the documentation changes as staged/modified.
- Searched the codebase for relevant Drupal settings with `rg -n "base_url|trusted_host_patterns|reverse_proxy|redirect" web/sites -g '*.php'` and inspected `web/sites/default/settings.php` to confirm no environment values are defined.
- Created `docs/https.md`, updated `docs/deployment.md`, and validated the resulting files by printing their contents with `nl -ba` and `sed`, confirming the new documentation is present and accurately references `docs/https.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87ec16c6883219876e8f9c30ad657)