### PR TITLE
ci: align GitHub Actions workflow on PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup PHP 8.3
+      - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           tools: composer:v2
           coverage: none
           extensions: sqlite3
@@ -43,7 +43,7 @@ jobs:
         run: composer validate --strict
 
       - name: Install dependencies (with require-dev)
-        run: composer install --prefer-dist --no-progress --no-interaction
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
       - name: Run quality scripts defined in composer.json
         run: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,7 +2,7 @@
 
 ## Objectif
 
-La CI exécute un pipeline ciblé pour Drupal 11 / PHP 8.3 sur GitHub Actions, avec :
+La CI exécute un pipeline ciblé pour Drupal 11 / PHP 8.4 sur GitHub Actions, avec :
 
 - validation Composer stricte ;
 - installation des dépendances (avec `require-dev`) ;
@@ -59,3 +59,18 @@ ddev exec env SIMPLETEST_BASE_URL=http://agency-website-drupal.ddev.site SIMPLET
 Le déploiement production est documenté dans `docs/deployment.md` et automatisé via `scripts/deploy.sh`.
 
 Ce script n'est **pas** exécuté par la CI actuelle ; il constitue la base d'un futur workflow GitHub Actions de déploiement contrôlé (approval manuel, secrets GitHub, SSH vers serveur).
+
+
+## Version PHP de la CI
+
+La CI est désormais alignée sur **PHP 8.4** pour refléter les environnements réels du projet :
+
+- **production** : Ubuntu 24.04 + PHP 8.4 ;
+- **local** : DDEV en PHP 8.4 ;
+- **CI GitHub Actions** : setup-php configuré en PHP 8.4.
+
+Cet alignement réduit les écarts de comportement entre local, CI et production, et limite les faux positifs/négatifs de validation.
+
+### Modifier la version PHP si nécessaire
+
+Si une évolution future impose un changement de version, mettre à jour la clé `php-version` dans `.github/workflows/ci.yml` (étape `shivammathur/setup-php@v2`) puis vérifier les exécutions CI associées.


### PR DESCRIPTION
### Motivation

- Aligner la version PHP utilisée par la CI sur l’environnement de production (Ubuntu 24.04 + PHP 8.4) et l’environnement local DDEV (PHP 8.4) pour réduire les écarts de comportement entre local, CI et production.

### Description

- Mise à jour de `.github/workflows/ci.yml` pour utiliser `shivammathur/setup-php@v2` avec `php-version: '8.4'` et renommer l’étape en `Setup PHP 8.4`.
- Ajustement de la commande d’installation Composer dans le workflow pour `composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction` afin d’optimiser l’autoload en CI.
- Mise à jour de `docs/ci.md` pour remplacer toute référence à PHP 8.3 par PHP 8.4 et ajout d’une section `Version PHP de la CI` expliquant le choix et la procédure pour modifier la clé `php-version` dans le workflow.
- Aucun changement sur le code Drupal, les dépendances, les modules ou les secrets.

### Testing

- Vérification du diff des fichiers modifiés avec `git diff -- .github/workflows/ci.yml docs/ci.md` (résultat attendu: modifications présentes) — succès.
- Inspection des fichiers mis à jour avec `nl -ba .github/workflows/ci.yml` et `nl -ba docs/ci.md` pour valider les valeurs `php-version: '8.4'` et la nouvelle section de documentation — succès.
- Vérification de la version PHP de l’environnement d’exécution local avec `php -v` — sortie fournie et validée localement; la validation finale de l’exécution du pipeline sera effectuée par les runs GitHub Actions sur la PR (la CI doit passer en vert pour clore la tâche).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88161295c8321bc7f79440e21a934)