### PR TITLE
Document HTTPS and canonical domain configuration

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -2,63 +2,117 @@
 
 ## Objectif
 
-Ce projet utilise une politique canonique : **HTTPS sans `www`**.
+La production applique une politique canonique stricte : **HTTPS sans `www`**.
 
 - URL canonique : `https://emergingdigital.be`
-- Domaine secondaire couvert : `https://www.emergingdigital.be`
+- Redirection obligatoire depuis `http://emergingdigital.be`
+- Redirection obligatoire depuis `http://www.emergingdigital.be`
+- Redirection obligatoire depuis `https://www.emergingdigital.be`
 
-## Certificat TLS
+## Certificat TLS (Let’s Encrypt + Certbot)
 
-- Fournisseur du certificat : **Let’s Encrypt**
-- Outil utilisé : **Certbot** avec plugin **Nginx**
-- Domaines couverts : `emergingdigital.be` et `www.emergingdigital.be`
+- AC utilisée : **Let’s Encrypt**
+- Client ACME : **Certbot**
+- Intégration serveur web : plugin **Nginx** (`python3-certbot-nginx`)
+- Domaines couverts par le certificat :
+  - `emergingdigital.be`
+  - `www.emergingdigital.be`
 
-## Installation de Certbot
+## Installation (Ubuntu / Debian)
 
 ```bash
+sudo apt update
 sudo apt install certbot python3-certbot-nginx -y
 ```
 
-## Émission du certificat
+## Émission initiale du certificat
 
 ```bash
 sudo certbot --nginx -d emergingdigital.be -d www.emergingdigital.be
 ```
 
-## Renouvellement (test à blanc)
+Cette commande :
+
+1. valide les challenges ACME ;
+2. installe le certificat ;
+3. met à jour la configuration Nginx ;
+4. peut proposer la redirection HTTP -> HTTPS.
+
+## Renouvellement automatique
+
+Le renouvellement est géré automatiquement par le timer systemd installé avec Certbot.
+
+### Vérifier le timer
+
+```bash
+systemctl list-timers | grep certbot
+sudo systemctl status certbot.timer
+```
+
+### Tester le renouvellement (dry-run)
 
 ```bash
 sudo certbot renew --dry-run
 ```
 
-## Emplacement habituel des certificats
+> Exécuter ce test après l’émission initiale puis régulièrement (ex. après changement Nginx/firewall).
 
-```text
-/etc/letsencrypt/live/emergingdigital.be/
+## Commandes de diagnostic
+
+### Certificat et échéance
+
+```bash
+sudo certbot certificates
+openssl s_client -connect emergingdigital.be:443 -servername emergingdigital.be </dev/null 2>/dev/null | openssl x509 -noout -dates -subject -issuer
 ```
 
-## Diagnostic rapide
+### Nginx
 
 ```bash
 sudo nginx -t
 sudo systemctl status nginx
-sudo certbot certificates
-sudo certbot renew --dry-run
 ```
 
-## Règles de sécurité
+### Vérification des redirections canoniques
 
-- Ne jamais versionner de certificats.
-- Ne jamais versionner de clés privées.
+```bash
+curl -I http://emergingdigital.be
+curl -I http://www.emergingdigital.be
+curl -I https://www.emergingdigital.be
+curl -I https://emergingdigital.be
+```
 
-## Périmètre de configuration dans ce dépôt
+Attendus :
 
-La configuration Nginx de production n’est pas versionnée ici et reste gérée sur le serveur par Certbot.
+- les trois premières URLs retournent une redirection (301/308) vers `https://emergingdigital.be` ;
+- `https://emergingdigital.be` répond en HTTPS sans redirection vers `www`.
 
-Concernant la configuration Drupal versionnée (fichier `web/sites/default/settings.php`) :
+## Politique canonique à maintenir
 
-- aucune valeur `base_url` n’est définie ;
-- aucun `trusted_host_patterns` n’est défini ;
-- aucun paramètre `reverse_proxy` n’est défini.
+La politique cible est :
 
-Ces éléments doivent être gérés par environnement si nécessaires, sans stocker de secrets dans Git.
+- **Canonique unique** : `https://emergingdigital.be`
+- **Aucun accès canonique en HTTP**
+- **Aucun accès canonique en `www`**
+
+Toute modification de vhost Nginx doit préserver ces règles.
+
+## Emplacements sensibles (non versionnés)
+
+Les certificats et clés privées restent exclusivement sur le serveur :
+
+- `/etc/letsencrypt/live/emergingdigital.be/`
+- `/etc/letsencrypt/archive/`
+- `/etc/letsencrypt/renewal/`
+
+Ne jamais versionner :
+
+- certificats (`fullchain.pem`, `cert.pem`) ;
+- clés privées (`privkey.pem`) ;
+- secrets liés à l’infrastructure.
+
+## Périmètre dépôt
+
+La configuration Nginx de production n’est pas versionnée dans ce dépôt Drupal.
+
+Ce dépôt documente la procédure d’exploitation mais ne stocke ni certificat ni secret.


### PR DESCRIPTION
### Motivation

- Provide a clear operational runbook for production HTTPS covering issuance, renewal, diagnostics and the canonical URL policy (`https://emergingdigital.be`).
- Record the intended Let’s Encrypt + Certbot setup and the domains covered so on-call operators can maintain TLS and redirects reliably.
- Ensure repository scope and security guidance are explicit so no certificates or secrets are versioned in the repo.
- Closes #<TICKET_NUMBER>

### Description

- Add and expand `docs/https.md` with installation steps for `certbot` (`python3-certbot-nginx`), initial issuance commands, renewal guidance and diagnostic commands for certificate, Nginx and redirect checks.
- Document the canonical policy: canonical host is `https://emergingdigital.be`, with redirects from `http://` and from `www` (`www.emergingdigital.be`), and the expected redirect checks using `curl -I`.
- Explicitly list sensitive Let’s Encrypt paths (`/etc/letsencrypt/...`) and state that certificates and private keys must not be committed to the repo.
- Confirm that the deployment guide references `docs/https.md` and that no Drupal application files or secrets were modified.

### Testing

- Verified that `docs/https.md` exists and its content includes issuance, renewal and diagnostic commands for `certbot` and `nginx`.
- Verified that `docs/deployment.md` references `docs/https.md` so the runbook is discoverable from deployment instructions.
- No runtime TLS operations (certificate issuance or renewal) were executed in this environment; the document instructs operators to run `sudo certbot renew --dry-run` in production to validate renewal behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88387c7d083218fb8c30939224dd6)