### PR TITLE
feat(analytics): add GA4 via Google Tag with production Config Split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/core-recipe-unpack": "^11.3",
         "drupal/core-recommended": "^11.3",
         "drupal/default_content": "^2.0@alpha",
+        "drupal/google_tag": "^2.0",
         "drupal/hal": "^2.0",
         "drupal/key": "^1.20",
         "drupal/lang_dropdown": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b34923104175fa46c1cd44e7daa3af1",
+    "content-hash": "90bdbee087b20972a620d931575ad0d6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1969,6 +1969,78 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/google_tag",
+            "version": "2.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/google_tag.git",
+                "reference": "2.0.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/google_tag-2.0.9.zip",
+                "reference": "2.0.9",
+                "shasum": "78749a4520f6d89ca374061ac4f85f561118b3f1"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/commerce": "^2.0 || ^3.0",
+                "drupal/commerce_wishlist": "^3.0@beta",
+                "drupal/csp": "^1.0 || ~2.1.1",
+                "drupal/google_analytics": "^4.0",
+                "drupal/search_api": "^1.28.0",
+                "drupal/token": "^1.11.0",
+                "drupal/webform": "^6.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.9",
+                    "datestamp": "1756130983",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "acquia",
+                    "homepage": "https://www.drupal.org/user/1231722"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "kaynen",
+                    "homepage": "https://www.drupal.org/user/733308"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
+                },
+                {
+                    "name": "solotandem",
+                    "homepage": "https://www.drupal.org/user/240748"
+                }
+            ],
+            "description": "Provides support for Google Tag and Google Tag Manager in Drupal.",
+            "homepage": "https://www.drupal.org/project/google_tag",
+            "support": {
+                "source": "https://git.drupalcode.org/project/google_tag"
             }
         },
         {

--- a/config/splits/production/google_tag.container.default.yml
+++ b/config/splits/production/google_tag.container.default.yml
@@ -1,0 +1,20 @@
+uuid: aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+langcode: en
+status: true
+dependencies:
+  module:
+    - google_tag
+id: default
+label: 'Google Analytics 4'
+container_id: G-XXXXXXXXXX
+conditions: {  }
+events: {  }
+include_environment: false
+environment_id: ''
+environment_token: ''
+include_classes: false
+allowlist_classes: ''
+blocklist_classes: ''
+include_environment_prefix: false
+environment_prefix: ''
+html_container: google_tag.container.default

--- a/config/splits/production/google_tag.container.default.yml
+++ b/config/splits/production/google_tag.container.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - google_tag
 id: default
 label: 'Google Analytics 4'
-container_id: G-XXXXXXXXXX
+container_id: G-K5TDNZCPTY
 conditions: {  }
 events: {  }
 include_environment: false

--- a/config/sync/config_split.config_split.production.yml
+++ b/config/sync/config_split.config_split.production.yml
@@ -1,0 +1,17 @@
+uuid: 11111111-2222-4333-8444-555555555555
+langcode: en
+status: false
+dependencies: {  }
+id: production
+label: Production
+description: 'Production-only overrides (analytics, etc.).'
+weight: 0
+stackable: false
+no_patching: false
+storage: ../config/splits/production
+folder: ../config/splits/production
+module: {  }
+theme: {  }
+complete_list:
+  - google_tag.container.default
+partial_list: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -14,6 +14,7 @@ module:
   ckeditor5: 0
   comment: 0
   config: 0
+  config_split: 0
   config_translation: 0
   contextual: 0
   datetime: 0
@@ -28,6 +29,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  google_tag: 0
   hal: 0
   help: 0
   history: 0

--- a/config/sync/google_tag.container.default.yml
+++ b/config/sync/google_tag.container.default.yml
@@ -1,0 +1,20 @@
+uuid: aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+langcode: en
+status: false
+dependencies:
+  module:
+    - google_tag
+id: default
+label: 'Google Analytics 4'
+container_id: ''
+conditions: {  }
+events: {  }
+include_environment: false
+environment_id: ''
+environment_token: ''
+include_classes: false
+allowlist_classes: ''
+blocklist_classes: ''
+include_environment_prefix: false
+environment_prefix: ''
+html_container: google_tag.container.default

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,67 @@
+# Analytics (GA4) via Drupal Google Tag + Config Split
+
+## Pourquoi `google_tag` et pas `google_analytics`
+
+Le projet utilise le module **Google Tag** (`drupal/google_tag`) car il est aligné avec les usages GA4 récents et la gestion moderne des tags côté Google.
+Le module historique `google_analytics` n'est pas retenu ici pour éviter une approche legacy.
+
+> Règle projet : **aucun script GA4 en dur dans Twig** et **aucun JS custom** pour injecter le tracking.
+
+## Obtenir un Measurement ID GA4 (`G-XXXXXXXXXX`)
+
+1. Ouvrir Google Analytics.
+2. Aller dans **Admin** (roue dentée).
+3. Dans la colonne **Property**, ouvrir **Data streams**.
+4. Choisir le flux Web du site.
+5. Copier le **Measurement ID** au format `G-XXXXXXXXXX`.
+
+## Configuration Drupal retenue
+
+- Le module `google_tag` est activé dans la config Drupal.
+- La configuration `google_tag.container.default` existe en base mais est **inactive par défaut** dans `config/sync` (local/DDEV).
+- Le split `production` porte la version active de `google_tag.container.default` avec un ID de mesure.
+
+Valeur placeholder utilisée si l'ID réel n'est pas encore fourni :
+
+- `G-XXXXXXXXXX`
+
+## Config Split production
+
+Le split `production` doit être activé uniquement en environnement de production (via `settings.php`/`settings.prod.php` selon la convention projet).
+
+Quand le split est actif :
+
+- `google_tag.container.default` est surchargé avec `status: true`
+- `container_id` contient l'ID GA4 réel
+
+Quand le split est inactif (local/DDEV) :
+
+- `google_tag.container.default` reste `status: false`
+- aucun script Google Tag n'est injecté
+
+## Vérifier que le script est présent en production
+
+Méthodes recommandées :
+
+1. Ouvrir la home en production puis inspecter le HTML rendu.
+2. Vérifier la présence des marqueurs Google Tag (`gtag` / chargement Google tag).
+3. Utiliser Tag Assistant (ou DevTools réseau) pour confirmer le chargement.
+
+## Vérifier qu'il est absent en local/DDEV
+
+1. Ouvrir la home en local.
+2. Inspecter le HTML source.
+3. Vérifier qu'aucun script Google Tag/GA4 n'est injecté.
+
+## Désactiver le tracking
+
+Deux options propres :
+
+1. Désactiver le split `production` pour l'environnement concerné.
+2. Ou forcer `status: false` sur `google_tag.container.default` dans la config appliquée.
+
+## Rappel important
+
+- **Ne jamais** coder GA4 en Twig.
+- **Ne jamais** injecter GA4 via JS custom.
+- Toute gestion Analytics doit passer par la config Drupal + Config Split.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -25,6 +25,8 @@ Valeur placeholder utilisée si l'ID réel n'est pas encore fourni :
 
 - `G-XXXXXXXXXX`
 
+ID actuellement prévu pour la production : `G-K5TDNZCPTY` (à conserver uniquement dans la config de split production).
+
 ## Config Split production
 
 Le split `production` doit être activé uniquement en environnement de production (via `settings.php`/`settings.prod.php` selon la convention projet).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,6 +3,7 @@
 ## Références complémentaires
 
 - Configuration HTTPS (Let's Encrypt / Certbot, politique canonique) : `docs/https.md`
+- Configuration Analytics GA4 (Google Tag + Config Split) : `docs/analytics.md`
 
 ## 1) Principe général du déploiement
 


### PR DESCRIPTION
### Motivation

- Add GA4 tracking using the modern Drupal `google_tag` module instead of manual Twig/JS injection to follow best practices.
- Ensure the GA4 Measurement ID and activation are only present in production by leveraging `config_split` so local/DDEV stays tracking-free.
- Provide clear runbook documentation for team members to configure, verify and disable analytics without touching templates or custom JS.

### Description

- Add `drupal/google_tag` to `composer.json` so the Google Tag module is managed by Composer; the lock file was not updated in this environment due to outbound restrictions.  
- Register `config_split` and `google_tag` in `config/sync/core.extension.yml` so both modules are part of exported config state.  
- Add a production Config Split definition at `config/sync/config_split.config_split.production.yml` and storage folder `config/splits/production/` that contains the production-only override.  
- Add a disabled-by-default container config at `config/sync/google_tag.container.default.yml` (local-safe) and the production override at `config/splits/production/google_tag.container.default.yml` with placeholder `container_id: G-XXXXXXXXXX`.  
- Add `docs/analytics.md` explaining why `google_tag` is used, how to obtain a GA4 Measurement ID, how to set it in production via the split, how to verify presence/absence, and how to disable tracking, and reference it from `docs/deployment.md`.

### Testing

- Ran `composer validate`, which completed but reported a lock mismatch because `composer.lock` could not be updated in this environment (network restrictions prevented running `composer require`).  
- Attempted `composer require drupal/google_tag`, which failed with a network/curl error (`CONNECT tunnel failed, response 403`) preventing package installation and lock refresh.  
- Attempted `vendor/bin/drush cr`, `vendor/bin/drush cex -y` and `vendor/bin/drush config:status`, but `drush` was unavailable in this environment so the commands could not run.  
- Created the feature branch, committed the config and docs changes, and prepared the pull request (see PR description); configuration import and runtime verification must be executed in an environment with Composer/Drush and network access (CI or production deploy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88917daf48321bd270d9ab373d78a)