### PR TITLE
docs: clarify production config split activation for Google Tag in analytics.md

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -27,19 +27,30 @@ Valeur placeholder utilisée si l'ID réel n'est pas encore fourni :
 
 ID actuellement prévu pour la production : `G-K5TDNZCPTY` (à conserver uniquement dans la config de split production).
 
-## Config Split production
+## Activation du split production
 
-Le split `production` doit être activé uniquement en environnement de production (via `settings.php`/`settings.prod.php` selon la convention projet).
+Le split concerné est : `config_split.config_split.production`.
 
-Quand le split est actif :
+L'activation doit être faite **uniquement sur le serveur de production**, dans le fichier :
 
-- `google_tag.container.default` est surchargé avec `status: true`
-- `container_id` contient l'ID GA4 réel
+- `/var/www/agency/shared/settings/settings.php`
 
-Quand le split est inactif (local/DDEV) :
+Ligne attendue :
 
-- `google_tag.container.default` reste `status: false`
-- aucun script Google Tag n'est injecté
+```php
+$config['config_split.config_split.production']['status'] = TRUE;
+```
+
+### Important
+
+- `settings.php` de production n'est **pas versionné** dans ce dépôt.
+- Cette ligne ne doit **pas** être ajoutée dans la configuration locale/DDEV.
+- En local (DDEV), le split `production` doit rester désactivé.
+
+### Effet attendu
+
+- En production (split activé) : Google Tag est injecté selon la config du split.
+- En local/DDEV (split désactivé) : aucun script Google Tag n'est injecté.
 
 ## Vérifier que le script est présent en production
 


### PR DESCRIPTION
### Motivation

- Clarify how the production `config_split` should be activated so GA4 is injected only on production and never hardcoded in Twig or JS.
- Make explicit which config split is used and where to enable it on the production server to avoid accidental activation in local/DDEV environments.

### Description

- Renamed the section to `Activation du split production` and documented the split name `config_split.config_split.production` for clarity. 
- Added the expected production settings file path `/var/www/agency/shared/settings/settings.php` and the exact line to activate the split: ``$config['config_split.config_split.production']['status'] = TRUE;``.
- Explained that `settings.php` is not versioned, must not be changed for local/DDEV, and that the production split should be enabled only on the production server. 
- Added an `Effet attendu` section describing that Google Tag is injected in production when the split is active and not injected locally when the split is inactive.

### Testing

- This is a documentation-only change; no code unit tests were required. 
- Ran a local `markdownlint` check on the updated file and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f892dc3eb48321957320b49bea58fe)