### PR TITLE
Migrate `google_tag` config to v2.x format and update analytics documentation

### DIFF
--- a/config/splits/production/google_tag.container.default.yml
+++ b/config/splits/production/google_tag.container.default.yml
@@ -6,15 +6,10 @@ dependencies:
     - google_tag
 id: default
 label: 'Google Analytics 4'
-container_id: G-K5TDNZCPTY
+weight: 0
+tag_container_ids:
+  google_tag: G-K5TDNZCPTY
+advanced_settings: {  }
+dimensions_metrics: {  }
 conditions: {  }
 events: {  }
-include_environment: false
-environment_id: ''
-environment_token: ''
-include_classes: false
-allowlist_classes: ''
-blocklist_classes: ''
-include_environment_prefix: false
-environment_prefix: ''
-html_container: google_tag.container.default

--- a/config/sync/google_tag.container.default.yml
+++ b/config/sync/google_tag.container.default.yml
@@ -6,15 +6,9 @@ dependencies:
     - google_tag
 id: default
 label: 'Google Analytics 4'
-container_id: ''
+weight: 0
+tag_container_ids: {  }
+advanced_settings: {  }
+dimensions_metrics: {  }
 conditions: {  }
 events: {  }
-include_environment: false
-environment_id: ''
-environment_token: ''
-include_classes: false
-allowlist_classes: ''
-blocklist_classes: ''
-include_environment_prefix: false
-environment_prefix: ''
-html_container: google_tag.container.default

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -27,19 +27,33 @@ Valeur placeholder utilisée si l'ID réel n'est pas encore fourni :
 
 ID actuellement prévu pour la production : `G-K5TDNZCPTY` (à conserver uniquement dans la config de split production).
 
+## Format de configuration attendu (`google_tag` 2.x)
+
+Le module `google_tag` en version 2.x lit les identifiants via la clé `tag_container_ids`.
+Le format historique `container_id` (et `html_container`) est obsolète et n'est pas appliqué dans cette version.
+La configuration exportée en 2.x inclut aussi des blocs comme `weight`, `advanced_settings` et `dimensions_metrics` : conserver cette structure évite un état `Different` après `drush cim`.
+
+Exemple attendu pour GA4 en production :
+
+```yaml
+tag_container_ids:
+  google_tag: G-K5TDNZCPTY
+```
+
+⚠️ Attention : selon la version majeure du module, la structure YAML peut différer. Toujours vérifier le schéma attendu par la version installée avant de modifier la config.
+
 ## Activation du split production
 
 Le split concerné est : `config_split.config_split.production`.
 
-L'activation doit être faite **uniquement sur le serveur de production**, dans le fichier :
-
-- `/var/www/agency/shared/settings/settings.php`
-
-Ligne attendue :
+- Dans `config/sync`, ce split reste avec `status: false`.
+- En production uniquement, `settings.php` force son activation avec :
 
 ```php
 $config['config_split.config_split.production']['status'] = TRUE;
 ```
+
+Ce mécanisme permet de conserver une base locale/dev sûre (tracking désactivé), puis d'activer GA4 uniquement en production au moment du `drush cim`.
 
 ### Important
 


### PR DESCRIPTION
### Motivation

- Align the stored Google Tag configuration with `google_tag` 2.x schema so production config matches the module's expected keys and avoids config drift during `drush cim`.
- Keep local/dev config inert while allowing production-only activation via the existing config split mechanism.
- Document the expected format and activation procedure for GA4 to prevent accidental changes in local environments.

### Description

- Replaced deprecated `container_id`/`html_container` layout with the v2.x keys `weight`, `tag_container_ids`, `advanced_settings`, and `dimensions_metrics` in `config/splits/production/google_tag.container.default.yml` and `config/sync/google_tag.container.default.yml`.
- Set the production split instance (`config/splits/production/google_tag.container.default.yml`) to include the GA4 ID under `tag_container_ids: { google_tag: G-K5TDNZCPTY }` and left the sync copy with empty `tag_container_ids` and `status: false` for local/dev.
- Cleaned up obsolete environment/class fields from the new config structure so the file matches the module schema and avoids a persistent `Different` state.
- Updated `docs/analytics.md` to explain the v2.x format, show the expected `tag_container_ids` YAML sample, warn about schema differences across major versions, and restate the recommended method to activate the production split via `settings.php`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b0c4cca48321a35bbbd1d335907d)