### PR TITLE
feat(seo): improve sitemap and metatag defaults (Closes #147)

### DIFF
--- a/config/sync/language/en/metatag.metatag_defaults.node.yml
+++ b/config/sync/language/en/metatag.metatag_defaults.node.yml
@@ -1,5 +1,9 @@
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
+  title: '[node:title] | E-merging Digital'
   description: '[node:summary]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | E-merging Digital'
+  og_description: '[node:summary]'
+  og_url: '[node:url]'
+  og_type: article

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -1,12 +1,16 @@
-uuid: 3f1e3e09-c98d-4082-a3b3-6a27d2d5e046
-langcode: fr
-status: true
-dependencies: {  }
 _core:
   default_config_hash: rpwvgyEURXLz_JjgMCrkS1rUv-0k3L79BpO-ReN7fDI
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
+  title: '[node:title] | E-merging Digital'
   description: '[node:summary]'
   canonical_url: '[node:url]'
+  og_title: '[node:title] | E-merging Digital'
+  og_description: '[node:summary]'
+  og_url: '[node:url]'
+  og_type: article
+uuid: ebb0a109-79db-455a-8c3c-389c7d4cc576
+langcode: fr
+status: true
+dependencies: {  }

--- a/config/sync/node.type.ai_feature.yml
+++ b/config/sync/node.type.ai_feature.yml
@@ -9,3 +9,10 @@ help: null
 new_revision: true
 preview_mode: 1
 display_submitted: false
+third_party_settings:
+  simple_sitemap:
+    sitemap:
+      default:
+        index: true
+        priority: '0.7'
+        changefreq: weekly

--- a/config/sync/node.type.article.yml
+++ b/config/sync/node.type.article.yml
@@ -9,3 +9,10 @@ help: null
 new_revision: true
 preview_mode: 1
 display_submitted: true
+third_party_settings:
+  simple_sitemap:
+    sitemap:
+      default:
+        index: true
+        priority: '0.7'
+        changefreq: weekly

--- a/config/sync/node.type.case_client.yml
+++ b/config/sync/node.type.case_client.yml
@@ -9,3 +9,10 @@ help: null
 new_revision: true
 preview_mode: 1
 display_submitted: false
+third_party_settings:
+  simple_sitemap:
+    sitemap:
+      default:
+        index: true
+        priority: '0.7'
+        changefreq: weekly

--- a/config/sync/node.type.page.yml
+++ b/config/sync/node.type.page.yml
@@ -9,3 +9,10 @@ help: null
 new_revision: true
 preview_mode: 1
 display_submitted: false
+third_party_settings:
+  simple_sitemap:
+    sitemap:
+      default:
+        index: true
+        priority: '0.7'
+        changefreq: weekly

--- a/config/sync/node.type.service.yml
+++ b/config/sync/node.type.service.yml
@@ -9,3 +9,10 @@ help: null
 new_revision: true
 preview_mode: 1
 display_submitted: false
+third_party_settings:
+  simple_sitemap:
+    sitemap:
+      default:
+        index: true
+        priority: '0.7'
+        changefreq: weekly

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -70,3 +70,5 @@ Disallow: /index.php/user/login
 Disallow: /index.php/user/logout
 Disallow: /index.php/media/oembed
 Disallow: /index.php/*/media/oembed
+
+Sitemap: https://emergingdigital.be/sitemap.xml


### PR DESCRIPTION
### Motivation
- Ensure the site publishes complete, multilingual sitemaps and consistent SEO metadata so search engines index only published content with correct titles, descriptions, canonical and OpenGraph data.
- Declare the sitemap in `robots.txt` so crawlers can discover the generated sitemap automatically.
- Export these settings as Drupal configuration so they are portable between environments and reproducible.

### Description
- Updated metatag defaults for nodes in `config/sync/metatag.metatag_defaults.node.yml` and the English override `config/sync/language/en/metatag.metatag_defaults.node.yml` to set the title pattern to `[node:title] | E-merging Digital` and add `description`, `canonical_url`, `og_title`, `og_description`, `og_url`, and `og_type` tags.
- Added Simple XML Sitemap third-party settings to all node bundle configs under `config/sync/node.type.*.yml` (`article`, `page`, `service`, `ai_feature`, `case_client`) to include them in the sitemap with `index: true`, `priority: '0.7'`, and `changefreq: weekly`.
- Added `Sitemap: https://emergingdigital.be/sitemap.xml` to `web/robots.txt` so crawlers can locate the sitemap.
- Changes are delivered as full configuration files under `config/sync/` and include the language override for English; no Twig templates were modified or hardcoded.

### Testing
- Ran `git diff --check` which returned no whitespace or diff errors and succeeded.
- Verified repository state with `git status --short` and committed the changes on branch `feature/issue-147-seo-sitemap` successfully.
- No CI or Drupal BrowserTestBase tests were executed in this session; CI should run on the PR to validate the required Drupal smoke `BrowserTestBase` as per project CI rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e1ef2d248321a40bcbcf7fdf754b)