### PR TITLE
Add Schema.org fields to Metatag defaults, update meta tokens, and add SEO test/docs

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -43,6 +43,7 @@ module:
   menu_ui: 0
   metatag: 0
   metatag_open_graph: 0
+  schema_metatag: 0
   metatag_twitter_cards: 0
   mysql: 0
   node: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -43,7 +43,6 @@ module:
   menu_ui: 0
   metatag: 0
   metatag_open_graph: 0
-  schema_metatag: 0
   metatag_twitter_cards: 0
   mysql: 0
   node: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -51,12 +51,12 @@ module:
   path: 0
   path_alias: 0
   redirect: 0
-  schema_metatag: 0
-  search: 0
   schema_article: 0
+  schema_metatag: 0
   schema_organization: 0
   schema_web_page: 0
   schema_web_site: 0
+  search: 0
   serialization: 0
   shortcut: 0
   simple_sitemap: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -53,6 +53,10 @@ module:
   path_alias: 0
   redirect: 0
   search: 0
+  schema_article: 0
+  schema_organization: 0
+  schema_web_page: 0
+  schema_web_site: 0
   serialization: 0
   shortcut: 0
   simple_sitemap: 0

--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -7,14 +7,20 @@ _core:
 id: front
 label: 'Front page'
 tags:
-  title: 'Drupal, accessibilité & IA utile | [site:name]'
-  description: 'Agence Drupal 11 pour PME, ASBL et institutions : sites structurés, accessibilité web et IA utile dans le CMS.'
+  title: '[site:name] | [site:slogan]'
+  description: '[site:slogan]'
   canonical_url: '[site:url]'
   shortlink: '[site:url]'
-  og_title: 'Drupal, accessibilité & IA utile | [site:name]'
-  og_description: 'Agence Drupal 11 pour PME, ASBL et institutions : sites structurés, accessibilité web et IA utile dans le CMS.'
+  og_title: '[site:name] | [site:slogan]'
+  og_description: '[site:slogan]'
   og_url: '[site:url]'
   og_type: website
-  twitter_cards_type: summary
-  twitter_cards_title: 'Drupal, accessibilité & IA utile | [site:name]'
-  twitter_cards_description: 'Agence Drupal 11 pour PME, ASBL et institutions : sites structurés, accessibilité web et IA utile dans le CMS.'
+  twitter_cards_type: summary_large_image
+  twitter_cards_title: '[site:name] | [site:slogan]'
+  twitter_cards_description: '[site:slogan]'
+  schema_web_site_type: WebSite
+  schema_web_site_name: '[site:name]'
+  schema_web_site_url: '[site:url]'
+  schema_organization_type: Organization
+  schema_organization_name: '[site:name]'
+  schema_organization_url: '[site:url]'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -7,10 +7,14 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | E-merging Digital'
+  title: '[node:title] | [site:name]'
   description: '[node:summary]'
   canonical_url: '[node:url]'
-  og_title: '[node:title] | E-merging Digital'
+  og_title: '[node:title] | [site:name]'
   og_description: '[node:summary]'
   og_url: '[node:url]'
   og_type: article
+  twitter_cards_type: summary_large_image
+  twitter_cards_title: '[node:title] | [site:name]'
+  twitter_cards_description: '[node:summary]'
+  schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__ai_feature.yml
+++ b/config/sync/metatag.metatag_defaults.node__ai_feature.yml
@@ -17,3 +17,5 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
+
+  schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__ai_feature.yml
+++ b/config/sync/metatag.metatag_defaults.node__ai_feature.yml
@@ -17,5 +17,4 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
-
   schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -17,5 +17,4 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
-
   schema_article_type: Article

--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -17,3 +17,5 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
+
+  schema_article_type: Article

--- a/config/sync/metatag.metatag_defaults.node__case_client.yml
+++ b/config/sync/metatag.metatag_defaults.node__case_client.yml
@@ -17,3 +17,5 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
+
+  schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__case_client.yml
+++ b/config/sync/metatag.metatag_defaults.node__case_client.yml
@@ -17,5 +17,4 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
-
   schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__page.yml
+++ b/config/sync/metatag.metatag_defaults.node__page.yml
@@ -17,5 +17,4 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: 'Page institutionnelle de [site:name].'
-
   schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__page.yml
+++ b/config/sync/metatag.metatag_defaults.node__page.yml
@@ -17,3 +17,5 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: 'Page institutionnelle de [site:name].'
+
+  schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__service.yml
+++ b/config/sync/metatag.metatag_defaults.node__service.yml
@@ -17,3 +17,5 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
+
+  schema_web_page_type: WebPage

--- a/config/sync/metatag.metatag_defaults.node__service.yml
+++ b/config/sync/metatag.metatag_defaults.node__service.yml
@@ -17,5 +17,4 @@ tags:
   twitter_cards_type: summary
   twitter_cards_title: '[node:title] | [site:name]'
   twitter_cards_description: '[node:field_short_description:value]'
-
   schema_web_page_type: WebPage

--- a/docs/seo-metatag-schema.md
+++ b/docs/seo-metatag-schema.md
@@ -1,0 +1,25 @@
+# SEO classique: Metatag + Schema.org
+
+## Périmètre
+
+Cette configuration couvre uniquement le SEO classique (balises meta, Open Graph, Twitter/X Cards et Schema.org JSON-LD via Metatag).
+
+## Configurations exportées
+
+- Defaults globaux (`front`, `node`) avec tokens Drupal/Metatag.
+- Defaults par type de contenu (`page`, `article`, `service`, `case_client`, `ai_feature`).
+- Open Graph et Twitter/X Cards activés sur les defaults principaux.
+- Schema.org configuré selon le type:
+  - Front: `WebSite` + `Organization`
+  - Contenu générique: `WebPage`
+  - Article: `Article`
+
+## Commandes utiles
+
+- Export config (Drush):
+  - `drush config:export -y`
+  - Équivalent DDEV/PowerShell: `ddev drush config:export -y`
+
+- Exécuter les tests custom (hors groupe instable IA):
+  - `SIMPLETEST_BASE_URL=http://localhost SIMPLETEST_DB=mysql://db:db@db/db vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/agency_project_tests/tests --exclude-group unstable_ia`
+  - Équivalent DDEV/PowerShell: `ddev exec env SIMPLETEST_BASE_URL=http://agency-website-drupal.ddev.site SIMPLETEST_DB=mysql://db:db@db/db vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/agency_project_tests/tests --exclude-group unstable_ia`

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/SeoMetatagConfigurationTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/SeoMetatagConfigurationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Vérifie les defaults SEO Metatag + Schema.org attendus.
+ *
+ * @group agency_project_tests
+ */
+final class SeoMetatagConfigurationTest extends UnitTestCase {
+
+  /**
+   * Fichiers Metatag exportés attendus.
+   */
+  private const REQUIRED_METATAG_FILES = [
+    'config/sync/metatag.metatag_defaults.front.yml',
+    'config/sync/metatag.metatag_defaults.node.yml',
+    'config/sync/metatag.metatag_defaults.node__article.yml',
+    'config/sync/metatag.metatag_defaults.node__page.yml',
+    'config/sync/metatag.metatag_defaults.node__service.yml',
+    'config/sync/metatag.metatag_defaults.node__case_client.yml',
+    'config/sync/metatag.metatag_defaults.node__ai_feature.yml',
+  ];
+
+  /**
+   * Vérifie les defaults SEO dans les fichiers exportés config/sync.
+   */
+  public function testSeoMetatagDefaults(): void {
+    $repositoryRoot = dirname(__DIR__, 7);
+
+    foreach (self::REQUIRED_METATAG_FILES as $relativePath) {
+      $absolutePath = $repositoryRoot . '/' . $relativePath;
+      $this->assertFileExists($absolutePath);
+      $parsed = Yaml::parseFile($absolutePath);
+      $this->assertIsArray($parsed);
+      $tags = $parsed['tags'] ?? NULL;
+      $this->assertIsArray($tags);
+
+      foreach ([
+        'title',
+        'description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'twitter_cards_title',
+        'twitter_cards_description',
+      ] as $requiredTag) {
+        $this->assertArrayHasKey($requiredTag, $tags, sprintf('Missing "%s" in %s', $requiredTag, $relativePath));
+      }
+    }
+
+    $frontTags = (Yaml::parseFile($repositoryRoot . '/config/sync/metatag.metatag_defaults.front.yml'))['tags'];
+    $this->assertArrayHasKey('schema_web_site_type', $frontTags);
+    $this->assertArrayHasKey('schema_organization_type', $frontTags);
+
+    $nodeTags = (Yaml::parseFile($repositoryRoot . '/config/sync/metatag.metatag_defaults.node.yml'))['tags'];
+    $this->assertArrayHasKey('schema_web_page_type', $nodeTags);
+
+    $articleTags = (Yaml::parseFile($repositoryRoot . '/config/sync/metatag.metatag_defaults.node__article.yml'))['tags'];
+    $this->assertArrayHasKey('schema_article_type', $articleTags);
+  }
+
+}


### PR DESCRIPTION
### Motivation
- Unify and enrich site metadata by switching hardcoded titles/descriptions to site tokens and adding Schema.org JSON-LD fields to Metatag defaults for better SEO and sharing previews.
- Ensure Metatag defaults for different content types include consistent Open Graph, Twitter/X Cards, and Schema.org types.
- Provide documentation and an automated check to catch missing exported configuration in `config/sync`.

### Description
- Replaced hardcoded front page and node titles/descriptions with token-based values in `config/sync/metatag.metatag_defaults.front.yml` and `config/sync/metatag.metatag_defaults.node.yml` and adjusted Twitter card type to `summary_large_image`.
- Added Schema.org fields (`schema_web_site_*`, `schema_organization_*`, `schema_web_page_type`, `schema_article_type`) to the appropriate metatag defaults for front, node and content-type-specific defaults (article, page, service, case_client, ai_feature).
- Registered `schema_metatag` module in `config/sync/core.extension.yml` and added `docs/seo-metatag-schema.md` describing the configuration and useful commands.
- Added a PHPUnit unit test `SeoMetatagConfigurationTest` at `web/modules/custom/agency_project_tests/tests/src/Functional/SeoMetatagConfigurationTest.php` to validate exported metatag files and required tags/schema keys.

### Testing
- No automated CI tests were executed as part of this PR.
- A new PHPUnit test `SeoMetatagConfigurationTest` was added to assert presence of the exported metatag files and required tags/schema keys in `config/sync`.
- The test can be run locally with `vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/agency_project_tests/tests --exclude-group unstable_ia`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fda54f348321be2168561ef11ee5)