### PR TITLE
Ticket 49 - Remplacer le sélecteur de langue par un bloc cacheable

### DIFF
--- a/config/sync/block.block.emerging_digital_languagedropdownswitchercontent.yml
+++ b/config/sync/block.block.emerging_digital_languagedropdownswitchercontent.yml
@@ -3,7 +3,7 @@ langcode: fr
 status: true
 dependencies:
   module:
-    - lang_dropdown
+    - emerging_digital_content
   theme:
     - emerging_digital
 id: emerging_digital_languagedropdownswitchercontent
@@ -11,35 +11,10 @@ theme: emerging_digital
 region: header_language
 weight: 0
 provider: null
-plugin: 'language_dropdown_block:language_interface'
+plugin: emerging_digital_language_switcher
 settings:
-  id: 'language_dropdown_block:language_interface'
-  label: 'Language dropdown switcher (Interface)'
+  id: emerging_digital_language_switcher
+  label: 'Language switcher'
   label_display: '0'
-  provider: lang_dropdown
-  showall: true
-  hide_only_one: true
-  tohome: false
-  width: 165
-  display: 1
-  widget: 0
-  msdropdown:
-    visible_rows: 5
-    rounded: true
-    animation: slideDown
-    event: click
-    skin: ldsSkin
-    custom_skin: ''
-  chosen:
-    disable_search: true
-    no_results_text: 'No language match'
-  ddslick:
-    ddslick_height: 0
-    showSelectedHTML: true
-    imagePosition: left
-    skin: ddsDefault
-    custom_skin: ''
-  languageicons:
-    flag_position: 1
-  hidden_languages: {  }
+  provider: emerging_digital_content
 visibility: {  }

--- a/docs/ticket-49-homepage-cacheability.md
+++ b/docs/ticket-49-homepage-cacheability.md
@@ -1,0 +1,110 @@
+# Ticket 49 - Diagnostic cacheability homepage /fr
+
+Issue: https://github.com/E-merging-digital/agency-website-drupal/issues/165
+
+## Constat initial
+
+Mesure anonyme avant correction, apres `drush cr`:
+
+```text
+HTTP/1.1 200 OK
+Cache-Control: max-age=3600, public
+X-Drupal-Cache: MISS
+X-Drupal-Dynamic-Cache: MISS
+X-Drupal-Cache-Tags: ... CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form ...
+X-Drupal-Cache-Contexts: ... session.exists ... user.permissions user.roles
+```
+
+La page est statique visuellement, mais le bloc place en region `header_language`
+utilisait le plugin contrib `language_dropdown_block:language_interface`.
+
+## Cause identifiee
+
+La source de `CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form` est le bloc
+`block.block.emerging_digital_languagedropdownswitchercontent`.
+
+Le module contrib `lang_dropdown` construit ce bloc via Form API:
+
+```php
+$form = $this->formBuilder->getForm(LanguageDropdownForm::class, ...);
+```
+
+Le rendu HTML contenait donc un formulaire de switcher de langue, meme si aucun
+formulaire metier n'etait visible sur la homepage. La desactivation temporaire
+du bloc a fait disparaitre le tag `CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form`.
+
+## Verifications
+
+- `emerging_digital_messages`: pas la source du tag `form`.
+- `emerging_digital_main_menu`: pas la source du tag `form`.
+- `emerging_digital_footer_menu`: pas la source du tag `form`.
+- `emerging_digital_content`: pas la source du tag `form` sur `/fr`.
+- `emerging_digital_footer_branding`: pas la source du tag `form`.
+- Webform: le theme rend le Webform `contact` uniquement pour le paragraphe
+  UUID `855b08da-0ec9-4261-883a-d27f214606e6`, rattache a la page Contact
+  (`/contact`), pas a la homepage `/fr`.
+- Preprocess `emerging_digital`: aucun preprocess homepage ne rend de Webform.
+- BigPipe: active. Le contexte `cookies:big_pipe_nojs` est attendu. Aucun lazy
+  builder custom n'a ete trouve dans `web/themes/custom` ou `web/modules/custom`.
+
+## Contextes restants
+
+Apres suppression du formulaire du header, les contextes suivants restent:
+
+```text
+session.exists
+user.permissions
+user.roles:authenticated
+```
+
+Ils ne proviennent pas du formulaire `lang_dropdown`: ils restent presents meme
+quand le bloc de langue est desactive. Ils sont lies au rendu Drupal core des
+blocs, menus, access checks et contexte de session/BigPipe. Ils ne rendent pas
+la reponse privee tant qu'aucune session anonyme n'est demarree.
+
+## Correction appliquee
+
+Correction minimale appliquee:
+
+- remplacement du plugin de bloc `language_dropdown_block:language_interface`
+  par un bloc custom `emerging_digital_language_switcher`;
+- conservation de la meme region `header_language`;
+- conservation de l'UI existante (`language-switcher`, JS/CSS du theme);
+- rendu de liens HTML stateless `/fr` et `/en`;
+- aucune suppression du changement de langue;
+- aucun changement dans les modules contrib.
+
+Fichiers:
+
+- `config/sync/block.block.emerging_digital_languagedropdownswitchercontent.yml`
+- `web/modules/custom/emerging_digital_content/src/Plugin/Block/LanguageSwitcherBlock.php`
+
+## Mesure apres correction
+
+Mesure anonyme apres `drush cr`:
+
+```text
+HTTP/1.1 200 OK
+Cache-Control: max-age=3600, public
+X-Drupal-Cache: MISS
+X-Drupal-Dynamic-Cache: MISS
+X-Drupal-Cache-Tags: block_view ... rendered user:1
+X-Drupal-Cache-Contexts: cookies:big_pipe_nojs languages:language_content languages:language_interface languages:language_url route.menu_active_trails:footer route.menu_active_trails:main session.exists theme timezone url.path url.query_args url.site user.permissions user.roles:authenticated
+```
+
+Le tag `CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form` n'est plus present.
+La reponse ne contient pas de `Set-Cookie` et reste `public`.
+
+Verification HTML:
+
+```text
+language-switcher present
+lang_dropdown_form absent
+<form absent
+```
+
+## Notes
+
+Un test temporaire avec le bloc langue core `language_block:language_interface`
+a bien supprime le formulaire, mais a declenche une session anonyme dans cette
+configuration locale. Il n'a donc pas ete retenu.

--- a/web/modules/custom/emerging_digital_content/src/Plugin/Block/LanguageSwitcherBlock.php
+++ b/web/modules/custom/emerging_digital_content/src/Plugin/Block/LanguageSwitcherBlock.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\emerging_digital_content\Plugin\Block;
+
+use Drupal\Component\Render\MarkupInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Markup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides a cacheable language switcher block.
+ *
+ * @Block(
+ *   id = "emerging_digital_language_switcher",
+ *   admin_label = @Translation("Language switcher"),
+ *   category = @Translation("Emerging Digital")
+ * )
+ */
+final class LanguageSwitcherBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly RequestStack $requestStack,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $prefixes = ['en' => 'en', 'fr' => 'fr'];
+    $current_langcode = $this->getCurrentLangcode($prefixes);
+    $links = [];
+
+    foreach ($prefixes as $langcode => $prefix) {
+      $links[$langcode] = [
+        'label' => $this->getLanguageLabel($langcode),
+        'href' => $this->buildLanguageHref($langcode, $prefixes),
+        'hreflang' => $langcode,
+        'active' => $langcode === $current_langcode,
+      ];
+    }
+
+    return [
+      '#markup' => $this->buildSwitcherMarkup($links),
+      '#cache' => [
+        'contexts' => [
+          'url.path',
+          'url.query_args',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds the switcher markup from already escaped language link data.
+   */
+  private function buildSwitcherMarkup(array $links): MarkupInterface {
+    $active_label = '';
+    foreach ($links as $link) {
+      if ($link['active']) {
+        $active_label = $link['label'];
+        break;
+      }
+    }
+
+    $active_label = $active_label ?: (string) reset($links)['label'];
+    $items = '';
+
+    foreach ($links as $link) {
+      $item_class = 'language-switcher__item' . ($link['active'] ? ' is-active' : '');
+      if ($link['active']) {
+        $items .= '<li class="' . Html::escape($item_class) . '"><span class="language-switcher__link is-active" aria-current="true">' . Html::escape($link['label']) . '</span></li>';
+      }
+      else {
+        $items .= '<li class="' . Html::escape($item_class) . '"><a href="' . Html::escape($link['href']) . '" hreflang="' . Html::escape($link['hreflang']) . '">' . Html::escape($link['label']) . '</a></li>';
+      }
+    }
+
+    return Markup::create(
+      '<div class="language-switcher" data-language-switcher>' .
+      '<button type="button" class="language-switcher__toggle" aria-expanded="false" aria-haspopup="true" aria-controls="language-switcher-menu">' .
+      '<span class="language-switcher__current">' . Html::escape($active_label) . '</span>' .
+      '<span class="language-switcher__icon" aria-hidden="true">&#9662;</span>' .
+      '<span class="visually-hidden">Choisir la langue</span>' .
+      '</button>' .
+      '<ul id="language-switcher-menu" class="language-switcher__menu" hidden>' . $items . '</ul>' .
+      '</div>'
+    );
+  }
+
+  /**
+   * Builds a language href without invoking Drupal URL generators.
+   */
+  private function buildLanguageHref(string $targetLangcode, array $prefixes): string {
+    $request = $this->requestStack->getCurrentRequest();
+    $query = $request ? $request->query->all() : [];
+    $target_path = $this->buildPrefixedPath($prefixes[$targetLangcode], $prefixes);
+    $query_string = $query ? '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986) : '';
+
+    return $target_path . $query_string;
+  }
+
+  /**
+   * Gets the current language from the first URL path segment.
+   */
+  private function getCurrentLangcode(array $prefixes): string {
+    $request = $this->requestStack->getCurrentRequest();
+    $first_segment = $request ? strtok(trim($request->getPathInfo(), '/'), '/') : '';
+    $langcode = array_search($first_segment, $prefixes, TRUE);
+
+    return is_string($langcode) ? $langcode : (string) array_key_first($prefixes);
+  }
+
+  /**
+   * Builds the target path by replacing the current language prefix.
+   */
+  private function buildPrefixedPath(string $targetPrefix, array $prefixes): string {
+    $request = $this->requestStack->getCurrentRequest();
+    $path = $request ? trim($request->getPathInfo(), '/') : '';
+    $segments = $path === '' ? [] : explode('/', $path);
+    $current_langcode = $this->getCurrentLangcode($prefixes);
+
+    if ($segments && $segments[0] === $prefixes[$current_langcode]) {
+      array_shift($segments);
+    }
+
+    return '/' . $targetPrefix . ($segments ? '/' . implode('/', $segments) : '');
+  }
+
+  /**
+   * Gets a short native language label for the configured site languages.
+   */
+  private function getLanguageLabel(string $langcode): string {
+    return match ($langcode) {
+      'fr' => 'Français',
+      'en' => 'English',
+      default => strtoupper($langcode),
+    };
+  }
+
+}


### PR DESCRIPTION
## Objectif

Identifier et corriger la cause empêchant la homepage /fr d’être correctement cacheable.

## Réalisé

- Identification de la cause : le bloc lang_dropdown rendait un formulaire via Form API.
- Remplacement par un bloc custom stateless LanguageSwitcherBlock.
- Mise à jour de la configuration du bloc de langue.
- Ajout du rapport docs/ticket-49-homepage-cacheability.md.

## Vérifications

- /fr retourne Cache-Control: max-age=3600, public.
- Le tag CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form n’est plus présent.
- Aucun formulaire <form> n’est présent sur la homepage.
- Le sélecteur de langue est bien rendu.
- Pas de Set-Cookie observé.
- Tests ciblés hors unstable_language_switcher : OK.

## Notes

La suite complète agency_project_tests a dépassé 10 minutes. Le groupe instable language switcher reste à traiter séparément.