### PR TITLE
Ticket #76: fix root URL sitemap redirects

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.post_update.php
@@ -1471,6 +1471,46 @@ function emerging_digital_content_post_update_issue_110_language_switcher_alignm
 }
 
 /**
+ * Excludes homepage aliases from Simple Sitemap entity URLs.
+ */
+function emerging_digital_content_post_update_issue_217_exclude_front_page_aliases_from_sitemap(array &$sandbox): string {
+  unset($sandbox);
+
+  if (!\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    return 'Simple Sitemap is not enabled; no homepage sitemap override was applied.';
+  }
+
+  $front_page = (string) \Drupal::config('system.site')->get('page.front');
+  if (!preg_match('@^/node/(\d+)$@', $front_page, $matches)) {
+    return sprintf(
+      'Front page %s is not a node path; no homepage sitemap override was applied.',
+      $front_page,
+    );
+  }
+
+  $node = Node::load((int) $matches[1]);
+  if (!$node instanceof Node) {
+    return sprintf(
+      'Front page %s does not resolve to an existing node; no homepage sitemap override was applied.',
+      $front_page,
+    );
+  }
+
+  /** @var \Drupal\simple_sitemap\Manager\EntityManager $entity_manager */
+  $entity_manager = \Drupal::service('simple_sitemap.entity_manager');
+  $entity_manager->setEntityInstanceSettings('node', (string) $node->id(), [
+    'index' => FALSE,
+  ]);
+
+  \Drupal::service('simple_sitemap.generator')->generate('backend');
+
+  return sprintf(
+    'Homepage node/%d is excluded from Simple Sitemap entity URLs; final language front URLs remain published through the custom "/" sitemap link.',
+    $node->id(),
+  );
+}
+
+/**
  * Resolves a stable system path for the French front page.
  */
 function _emerging_digital_content_resolve_front_page_system_path(): string {


### PR DESCRIPTION
Correction du sitemap afin d’exclure les URLs entity redirigées de la homepage historique node/5.

Le sitemap publie désormais les URLs finales canoniques /fr et /en, sans /fr/accueil, /en/home ni /node/5.

Validations :
- git diff --check
- ddev drush updb -y
- ddev drush cr
- curl HTTP/HTTPS local
- sitemap local
- PHPCS
- PHPStan
- Drupal Check

Aucun changement sur :
- menus
- system.site:page.front
- deploy-production.sh
- workflows GitHub Actions