### PR TITLE
Ticket #78: add first SEO service pages

### DIFF
--- a/web/modules/custom/emerging_digital_content/content_sync/catalog.yml
+++ b/web/modules/custom/emerging_digital_content/content_sync/catalog.yml
@@ -14,6 +14,34 @@ contents:
       en:
         title: 'Drupal Agency Belgium'
         alias: /drupal-agency-belgium
+  - id: creation-site-drupal
+    entity_type: node
+    bundle: service
+    file: node/creation-site-drupal.yml
+    business_aliases:
+      fr: /creation-site-drupal
+      en: /drupal-website-creation
+    translations:
+      fr:
+        title: 'Création de site Drupal'
+        alias: /creation-site-drupal
+      en:
+        title: 'Drupal Website Creation'
+        alias: /drupal-website-creation
+  - id: maintenance-drupal
+    entity_type: node
+    bundle: service
+    file: node/maintenance-drupal.yml
+    business_aliases:
+      fr: /maintenance-drupal
+      en: /drupal-maintenance
+    translations:
+      fr:
+        title: 'Maintenance Drupal'
+        alias: /maintenance-drupal
+      en:
+        title: 'Drupal Maintenance'
+        alias: /drupal-maintenance
   - id: services
     entity_type: node
     bundle: page

--- a/web/modules/custom/emerging_digital_content/content_sync/node/creation-site-drupal.yml
+++ b/web/modules/custom/emerging_digital_content/content_sync/node/creation-site-drupal.yml
@@ -1,0 +1,90 @@
+translations:
+  fr:
+    fields:
+      field_short_description:
+        value: >-
+          Création de site Drupal sur mesure pour PME, ASBL et institutions :
+          architecture éditoriale, UX, développement, accessibilité,
+          performance et SEO technique.
+        format: basic_html
+      field_detailed_description:
+        value: >-
+          <p>Emerging Digital conçoit et développe des sites Drupal pensés pour
+          durer : une structure éditoriale claire, un socle technique fiable et
+          des pages prêtes pour le référencement naturel dès la mise en ligne.
+          </p><h2>Une création Drupal structurée</h2><ul><li>Cadrage des
+          objectifs, des audiences et des parcours clés.</li><li>Architecture
+          de contenu réutilisable pour des équipes éditoriales autonomes.</li>
+          <li>Développement Drupal 11 propre, maintenable et compatible avec
+          vos contraintes d'hébergement.</li><li>Accessibilité, performance,
+          sécurité et SEO technique intégrés dès la conception.</li><li>
+          Préparation des contenus multilingues et des workflows éditoriaux.
+          </li></ul><p>Cette page complète notre positionnement d'<a
+          href="/agence-drupal-belgique">agence Drupal en Belgique</a>. Vous
+          pouvez aussi consulter nos <a href="/services">services Drupal</a>,
+          notre offre de <a href="/maintenance-drupal">maintenance Drupal</a>
+          et notre approche <a href="/ia-drupal">IA &amp; Drupal</a>.</p>
+        format: basic_html
+  en:
+    fields:
+      field_short_description:
+        value: >-
+          Custom Drupal website creation for SMEs, non-profits and
+          institutions: editorial architecture, UX, development, accessibility,
+          performance and technical SEO.
+        format: basic_html
+      field_detailed_description:
+        value: >-
+          <p>Emerging Digital designs and builds Drupal websites made to last:
+          a clear editorial structure, a reliable technical foundation and pages
+          ready for organic search from launch.</p><h2>A structured Drupal
+          build</h2><ul><li>Framing goals, audiences and key user journeys.
+          </li><li>Reusable content architecture for autonomous editorial
+          teams.</li><li>Clean and maintainable Drupal 11 development aligned
+          with your hosting constraints.</li><li>Accessibility, performance,
+          security and technical SEO integrated from the start.</li><li>
+          Preparation for multilingual content and editorial workflows.</li>
+          </ul><p>This page extends our <a href="/drupal-agency-belgium">Drupal
+          agency in Belgium</a> positioning. You can also explore our <a
+          href="/services">Drupal services</a>, our <a
+          href="/drupal-maintenance">Drupal maintenance</a> offer and our <a
+          href="/ai-drupal">AI &amp; Drupal</a> approach.</p>
+        format: basic_html
+promotions:
+  - target:
+      label: 'Services page'
+      aliases:
+        fr: /services
+        en: /services
+    translations:
+      fr:
+        title: 'Création de site Drupal'
+        description: >-
+          Conception et développement de sites Drupal clairs, accessibles,
+          performants et prêts pour le SEO.
+        url: /creation-site-drupal
+      en:
+        title: 'Drupal Website Creation'
+        description: >-
+          Design and development of clear, accessible, performant Drupal
+          websites ready for SEO.
+        url: /drupal-website-creation
+  - target:
+      label: Homepage
+      front: true
+      aliases:
+        fr: /accueil
+        en: /home
+    translations:
+      fr:
+        title: 'Création de site Drupal'
+        description: >-
+          Un site Drupal conçu pour vos contenus, vos équipes et votre
+          référencement naturel.
+        url: /creation-site-drupal
+      en:
+        title: 'Drupal Website Creation'
+        description: >-
+          A Drupal website designed for your content, your teams and your
+          organic search visibility.
+        url: /drupal-website-creation

--- a/web/modules/custom/emerging_digital_content/content_sync/node/maintenance-drupal.yml
+++ b/web/modules/custom/emerging_digital_content/content_sync/node/maintenance-drupal.yml
@@ -1,0 +1,88 @@
+translations:
+  fr:
+    fields:
+      field_short_description:
+        value: >-
+          Maintenance Drupal pour sites existants : mises à jour, sécurité,
+          support éditorial, performance, accessibilité et amélioration SEO
+          continue.
+        format: basic_html
+      field_detailed_description:
+        value: >-
+          <p>Emerging Digital assure la maintenance de sites Drupal qui doivent
+          rester stables, sécurisés et faciles à faire évoluer sans bloquer les
+          équipes métiers.</p><h2>Une maintenance Drupal orientée continuité</h2>
+          <ul><li>Mises à jour Drupal core, modules contrib et dépendances
+          Composer.</li><li>Surveillance des risques de sécurité, corrections
+          et priorisation technique.</li><li>Support aux équipes éditoriales et
+          amélioration des workflows de publication.</li><li>Optimisation des
+          performances, de l'accessibilité et du référencement naturel.</li>
+          <li>Petites évolutions fonctionnelles, audits et préparation des
+          montées de version.</li></ul><p>Cette offre prolonge notre approche
+          d'<a href="/agence-drupal-belgique">agence Drupal en Belgique</a>.
+          Elle peut compléter une <a href="/creation-site-drupal">création de
+          site Drupal</a>, nos <a href="/services">services Drupal</a> et les
+          usages <a href="/ia-drupal">IA &amp; Drupal</a> utiles aux équipes
+          éditoriales.</p>
+        format: basic_html
+  en:
+    fields:
+      field_short_description:
+        value: >-
+          Drupal maintenance for existing websites: updates, security,
+          editorial support, performance, accessibility and continuous SEO
+          improvement.
+        format: basic_html
+      field_detailed_description:
+        value: >-
+          <p>Emerging Digital maintains Drupal websites that need to stay
+          stable, secure and easy to evolve without slowing down business
+          teams.</p><h2>Drupal maintenance focused on continuity</h2><ul><li>
+          Updates for Drupal core, contributed modules and Composer
+          dependencies.</li><li>Security risk monitoring, fixes and technical
+          prioritisation.</li><li>Editorial team support and publication
+          workflow improvements.</li><li>Performance, accessibility and organic
+          search optimisation.</li><li>Small feature improvements, audits and
+          preparation for major upgrades.</li></ul><p>This offer extends our <a
+          href="/drupal-agency-belgium">Drupal agency in Belgium</a> approach.
+          It can support a <a href="/drupal-website-creation">Drupal website
+          creation</a>, our <a href="/services">Drupal services</a> and useful
+          <a href="/ai-drupal">AI &amp; Drupal</a> editorial workflows.</p>
+        format: basic_html
+promotions:
+  - target:
+      label: 'Services page'
+      aliases:
+        fr: /services
+        en: /services
+    translations:
+      fr:
+        title: 'Maintenance Drupal'
+        description: >-
+          Mises à jour, sécurité, support et amélioration continue pour garder
+          votre site Drupal fiable.
+        url: /maintenance-drupal
+      en:
+        title: 'Drupal Maintenance'
+        description: >-
+          Updates, security, support and continuous improvement to keep your
+          Drupal website reliable.
+        url: /drupal-maintenance
+  - target:
+      label: Homepage
+      front: true
+      aliases:
+        fr: /accueil
+        en: /home
+    translations:
+      fr:
+        title: 'Maintenance Drupal'
+        description: >-
+          Un accompagnement technique régulier pour sécuriser et faire évoluer
+          votre site Drupal.
+        url: /maintenance-drupal
+      en:
+        title: 'Drupal Maintenance'
+        description: >-
+          Regular technical support to secure and evolve your Drupal website.
+        url: /drupal-maintenance

--- a/web/modules/custom/emerging_digital_content/tests/src/Kernel/ContentSyncManagerTargetedWriteTest.php
+++ b/web/modules/custom/emerging_digital_content/tests/src/Kernel/ContentSyncManagerTargetedWriteTest.php
@@ -171,7 +171,7 @@ final class ContentSyncManagerTargetedWriteTest extends KernelTestBase {
     self::assertTrue($dry_run['summary']['all']);
     self::assertTrue($dry_run['summary']['dry_run']);
     self::assertFalse($dry_run['summary']['blocking_errors']);
-    self::assertCount(9, $dry_run['content_reports']);
+    self::assertCount(11, $dry_run['content_reports']);
     self::assertSame('agence-drupal-belgique', $dry_run['content_reports'][0]['id']);
     self::assertSame('would create managed entity', $dry_run['content_reports'][0]['planned_operation']);
     self::assertSame('unmapped', $dry_run['content_reports'][0]['mapping_status']);
@@ -181,27 +181,31 @@ final class ContentSyncManagerTargetedWriteTest extends KernelTestBase {
 
     $first_apply = $manager->sync('', FALSE, TRUE);
     self::assertSame([], $first_apply['errors']);
-    self::assertSame(1, $this->countServiceNodes());
+    self::assertSame(3, $this->countServiceNodes());
     self::assertSame(8, $this->countPageNodes());
     self::assertArrayHasKey('content_reports', $first_apply);
-    self::assertCount(9, $first_apply['content_reports']);
+    self::assertCount(11, $first_apply['content_reports']);
     self::assertSame('agence-drupal-belgique', $first_apply['content_reports'][0]['id']);
-    self::assertSame('services', $first_apply['content_reports'][1]['id']);
-    self::assertSame('ia-drupal', $first_apply['content_reports'][2]['id']);
-    self::assertSame('cas-clients', $first_apply['content_reports'][3]['id']);
-    self::assertSame('contact', $first_apply['content_reports'][4]['id']);
-    self::assertSame('mentions-legales', $first_apply['content_reports'][5]['id']);
-    self::assertSame('politique-confidentialite', $first_apply['content_reports'][6]['id']);
-    self::assertSame('politique-cookies', $first_apply['content_reports'][7]['id']);
-    self::assertSame('homepage', $first_apply['content_reports'][8]['id']);
+    self::assertSame('creation-site-drupal', $first_apply['content_reports'][1]['id']);
+    self::assertSame('maintenance-drupal', $first_apply['content_reports'][2]['id']);
+    self::assertSame('services', $first_apply['content_reports'][3]['id']);
+    self::assertSame('ia-drupal', $first_apply['content_reports'][4]['id']);
+    self::assertSame('cas-clients', $first_apply['content_reports'][5]['id']);
+    self::assertSame('contact', $first_apply['content_reports'][6]['id']);
+    self::assertSame('mentions-legales', $first_apply['content_reports'][7]['id']);
+    self::assertSame('politique-confidentialite', $first_apply['content_reports'][8]['id']);
+    self::assertSame('politique-cookies', $first_apply['content_reports'][9]['id']);
+    self::assertSame('homepage', $first_apply['content_reports'][10]['id']);
 
     $mapping = $mapping_repository->findByContentId('agence-drupal-belgique');
     self::assertNotNull($mapping);
     self::assertSame('created', $mapping->lastAction());
+    self::assertNotNull($mapping_repository->findByContentId('creation-site-drupal'));
+    self::assertNotNull($mapping_repository->findByContentId('maintenance-drupal'));
 
     $second_apply = $manager->sync('', FALSE, TRUE);
     self::assertSame([], $second_apply['errors']);
-    self::assertSame(1, $this->countServiceNodes());
+    self::assertSame(3, $this->countServiceNodes());
     self::assertSame(8, $this->countPageNodes());
 
     $updated_mapping = $mapping_repository->findByContentId('agence-drupal-belgique');


### PR DESCRIPTION
Ajout des premières pages services SEO via Content Sync :
- /creation-site-drupal
- /maintenance-drupal
- /drupal-website-creation
- /drupal-maintenance

Validations :
- git diff --check
- Content Sync validate
- dry-run ciblés
- apply ciblés
- full dry-run
- URLs publiques 200 OK
- sitemap OK
- PHPCS
- PHPStan
- Drupal Check
- Kernel test ContentSyncManagerTargetedWriteTest : 12 tests, 485 assertions

Dépréciations connues non bloquantes :
- paragraphs_module_implements_alter
- default_content EventSubscriberInterface return type

Aucun changement sur :
- menus
- system.site:page.front
- deploy-production.sh
- workflows GitHub Actions