### PR TITLE
Ticket #91: stabilize config exports for Link Checker and Pathauto

### DIFF
--- a/config/sync/core.entity_view_display.node.ai_feature.default.yml
+++ b/config/sync/core.entity_view_display.node.ai_feature.default.yml
@@ -21,12 +21,19 @@ targetEntityType: node
 bundle: ai_feature
 mode: default
 content:
-  field_short_description:
+  field_concrete_example:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 2
+    region: content
+  field_customer_benefit:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_detailed_description:
     type: text_default
@@ -35,12 +42,12 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  field_concrete_example:
+  field_short_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 0
     region: content
   field_use_cases:
     type: text_default
@@ -48,13 +55,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
-    region: content
-  field_customer_benefit:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
     region: content
   links:
     settings: {  }

--- a/config/sync/linkchecker.settings.yml
+++ b/config/sync/linkchecker.settings.yml
@@ -3,6 +3,7 @@ _core:
 check_links_types: 0
 default_url_scheme: 'https://'
 base_path: emergingdigital.be
+search_published_contents_only: true
 extract:
   from_a: true
   from_audio: false
@@ -31,7 +32,6 @@ check:
   library: core
   interval: 2419200
   useragent: 'Drupal (+https://drupal.org/)'
-search_published_contents_only: true
 error:
   action_status_code_301: 0
   action_status_code_404: 0

--- a/config/sync/pathauto.pattern.node_ai_feature.yml
+++ b/config/sync/pathauto.pattern.node_ai_feature.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_ai_feature
 label: 'Content path pattern (Fonctionnalité IA fallback)'
 type: 'canonical_entities:node'
-pattern: 'ia/[node:title]'
+pattern: '/ia/[node:title]'
 selection_criteria:
   8d7f8da3-6ec4-44ed-85e5-00296c84173b:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.node_article.yml
+++ b/config/sync/pathauto.pattern.node_article.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_article
 label: 'Content path pattern (Article fallback)'
 type: 'canonical_entities:node'
-pattern: 'actualites/[node:title]'
+pattern: '/actualites/[node:title]'
 selection_criteria:
   482ce287-8564-4e03-97f3-ec6a958703d8:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.node_case_client.yml
+++ b/config/sync/pathauto.pattern.node_case_client.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_case_client
 label: 'Content path pattern (Cas client fallback)'
 type: 'canonical_entities:node'
-pattern: 'cas-clients/[node:title]'
+pattern: '/cas-clients/[node:title]'
 selection_criteria:
   ca74dee3-e177-4818-91b6-83009a5b3f75:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.node_page.yml
+++ b/config/sync/pathauto.pattern.node_page.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_page
 label: 'Content path pattern (Page fallback)'
 type: 'canonical_entities:node'
-pattern: '[node:title]'
+pattern: '/[node:title]'
 selection_criteria:
   2d5dcbce-aad6-4424-bca0-4b9d1a9ad2b0:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.node_service.yml
+++ b/config/sync/pathauto.pattern.node_service.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_service
 label: 'Content path pattern (Service fallback)'
 type: 'canonical_entities:node'
-pattern: 'services/[node:title]'
+pattern: '/services/[node:title]'
 selection_criteria:
   5d6066ce-be42-4d75-ae05-c4044020944c:
     id: 'entity_bundle:node'

--- a/docs/ticket-83-link-checker.md
+++ b/docs/ticket-83-link-checker.md
@@ -44,4 +44,13 @@ ddev drush linkchecker:clear --uri=http://agency-website-drupal.ddev.site
 ddev drush linkchecker:check --uri=http://agency-website-drupal.ddev.site
 ```
 
+En DDEV, Drupal configure son client HTTP avec le certificat Traefik du projet.
+Cela permet aussi une exécution avec l'URL HTTPS DDEV sans désactiver la
+vérification TLS :
+
+```bash
+ddev drush linkchecker:clear --uri=https://agency-website-drupal.ddev.site
+ddev drush linkchecker:check --uri=https://agency-website-drupal.ddev.site
+```
+
 En environnement public, cron doit utiliser l'URL publique du site afin que les liens internes soient vérifiés contre le domaine canonique.

--- a/docs/ticket-91-config-drift.md
+++ b/docs/ticket-91-config-drift.md
@@ -1,0 +1,75 @@
+# Ticket 91 - Stabilisation des derives de configuration
+
+Issue GitHub : https://github.com/E-merging-digital/agency-website-drupal/issues/245
+
+## Causes racines
+
+### Pathauto
+
+Les patterns fallback `node_ai_feature`, `node_article`, `node_case_client`,
+`node_page` et `node_service` etaient versionnes sans slash initial, par
+exemple `ia/[node:title]`.
+
+La configuration active Drupal/Pathauto normalise ces patterns avec un slash
+initial, par exemple `/ia/[node:title]`. Un `drush cex` reexportait donc les
+memes patterns a chaque passage.
+
+La correction consiste a versionner la forme canonique exportee par Drupal. Les
+patterns multilingues FR/EN utilisaient deja cette forme et les aliases
+editoriaux restent geres par Content Sync avec `pathauto: false`.
+
+### Link Checker
+
+`linkchecker.settings` etait fonctionnellement correct, mais l'ordre exporte
+ne suivait pas l'ordre du schema actif du module contrib. Drupal reexportait
+uniquement le placement de `search_published_contents_only`.
+
+Les erreurs locales `cURL error 60` venaient d'une cause distincte : en DDEV,
+Link Checker utilise le client HTTP Drupal/Guzzle. Le routeur DDEV sert un
+certificat TLS local Traefik qui n'etait pas dans le trust store utilise par
+Guzzle dans le conteneur web.
+
+`settings.php` configure maintenant, uniquement en DDEV, le parametre
+`$settings['http_client_config']['verify']` vers le certificat Traefik du
+projet, avec fallback vers le CA mkcert global DDEV. La verification TLS reste
+active ; aucun `verify: false` ni contournement SSL n'est introduit.
+
+### Display AI Feature
+
+Le display `core.entity_view_display.node.ai_feature.default` etait stable
+fonctionnellement, mais l'ordre des composants dans le YAML ne correspondait
+pas a l'ordre canonique de l'export actif.
+
+Les poids restent inchanges :
+
+- `field_short_description`: 0
+- `field_detailed_description`: 1
+- `field_concrete_example`: 2
+- `field_use_cases`: 3
+- `field_customer_benefit`: 4
+- `links`: 100
+
+Le rendu public garde donc le meme ordre, mais l'export devient reproductible.
+
+## Comportement attendu
+
+- `ddev drush cim -y` ne doit pas modifier les menus ni `system.site:page.front`.
+- `ddev drush cex -y` doit rester propre apres un premier export canonique.
+- Les aliases Content Sync restent explicites et ne doivent pas etre regeneres.
+- Les patterns Pathauto fallback restent avec slash initial dans la config.
+- Link Checker peut verifier l'URL HTTPS DDEV sans erreur cURL 60.
+
+## Verification Link Checker en DDEV
+
+```bash
+ddev drush cr
+ddev drush linkchecker:clear --uri=https://agency-website-drupal.ddev.site
+ddev drush linkchecker:check --uri=https://agency-website-drupal.ddev.site
+```
+
+Pour isoler un probleme TLS local :
+
+```bash
+ddev exec curl -I -s https://agency-website-drupal.ddev.site/fr
+ddev exec curl --cacert /mnt/ddev_config/traefik/certs/agency-website-drupal.crt -I -s https://agency-website-drupal.ddev.site/fr
+```

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -25,6 +25,23 @@ if (file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }
 
+// Let Drupal/Guzzle trust the HTTPS certificate served by the DDEV router.
+if (getenv('IS_DDEV_PROJECT') === 'true') {
+  $ddev_project = getenv('DDEV_PROJECT');
+  $ddev_project_cert = $ddev_project
+    ? '/mnt/ddev_config/traefik/certs/' . $ddev_project . '.crt'
+    : '';
+  $ddev_caroot = getenv('CAROOT') ?: '/mnt/ddev-global-cache/mkcert';
+  $ddev_root_ca = $ddev_caroot . '/rootCA.pem';
+
+  if (is_readable($ddev_project_cert)) {
+    $settings['http_client_config']['verify'] = $ddev_project_cert;
+  }
+  elseif (is_readable($ddev_root_ca)) {
+    $settings['http_client_config']['verify'] = $ddev_root_ca;
+  }
+}
+
 if (file_exists(__DIR__ . '/settings.local.php')) {
   require __DIR__ . '/settings.local.php';
 }


### PR DESCRIPTION
- Stabilise les exports Pathauto
- Corrige Link Checker TLS en DDEV sans désactiver la vérification SSL
- Stabilise l’ordre YAML du display AI Feature
- Aucun changement Content Sync
- Aucun changement menu
- system.site:page.front inchangé
- Validations OK