### PR TITLE
Issue #325 - Refine homepage expertise reassurance

### DIFF
--- a/web/modules/custom/emerging_digital_content/content_sync/node/homepage.yml
+++ b/web/modules/custom/emerging_digital_content/content_sync/node/homepage.yml
@@ -54,6 +54,24 @@ components:
           field_secondary_link:
             - uri: 'internal:/en/services'
               title: 'See our expertise'
+  - id: homepage.expertise-reassurance
+    legacy_uuid: 517059c5-0767-4b95-903a-f2e1d96d887f
+    bundle: text_block
+    translations:
+      fr:
+        fields:
+          field_text:
+            - value: >-
+                <p><strong>Expertise principale :</strong> Drupal • PHP sur
+                mesure • Symfony • Laravel • Magento</p>
+              format: basic_html
+      en:
+        fields:
+          field_text:
+            - value: >-
+                <p><strong>Core expertise:</strong> Drupal • Custom PHP •
+                Symfony • Laravel • Magento</p>
+              format: basic_html
   - id: homepage.positioning
     legacy_uuid: ad8e2138-9355-4951-90dc-354e07847eca
     bundle: text_block

--- a/web/modules/custom/emerging_digital_content/tests/src/Kernel/ContentSyncManagerTargetedWriteTest.php
+++ b/web/modules/custom/emerging_digital_content/tests/src/Kernel/ContentSyncManagerTargetedWriteTest.php
@@ -920,7 +920,38 @@ final class ContentSyncManagerTargetedWriteTest extends KernelTestBase {
       $services_en_items,
     );
 
-    $homepage_items = $this->serviceCardItems($this->loadMappedNodeByContentId('homepage'), 'fr');
+    $homepage = $this->loadMappedNodeByContentId('homepage');
+    $homepage_components = $homepage->get('field_home_components')
+      ->referencedEntities();
+    self::assertSame(
+      ['hero', 'text_block', 'text_block'],
+      array_map(
+        static fn (Paragraph $paragraph): string => $paragraph->bundle(),
+        array_slice($homepage_components, 0, 3),
+      ),
+    );
+    self::assertStringContainsString(
+      'Expertise principale :',
+      $homepage_components[1]->getTranslation('fr')->get('field_text')->value,
+    );
+    self::assertStringContainsString(
+      'Drupal • PHP sur mesure • Symfony • Laravel • Magento',
+      $homepage_components[1]->getTranslation('fr')->get('field_text')->value,
+    );
+
+    $homepage_en_components = $homepage->getTranslation('en')
+      ->get('field_home_components')
+      ->referencedEntities();
+    self::assertStringContainsString(
+      'Core expertise:',
+      $homepage_en_components[1]->getTranslation('en')->get('field_text')->value,
+    );
+    self::assertStringContainsString(
+      'Drupal • Custom PHP • Symfony • Laravel • Magento',
+      $homepage_en_components[1]->getTranslation('en')->get('field_text')->value,
+    );
+
+    $homepage_items = $this->serviceCardItems($homepage, 'fr');
     self::assertCount(10, $homepage_items);
     self::assertContains(
       'Création de site Drupal|Un site Drupal conçu pour vos contenus, '

--- a/web/themes/custom/emerging_digital/css/components.css
+++ b/web/themes/custom/emerging_digital/css/components.css
@@ -480,6 +480,29 @@ html[lang="en"] .ed-section__content--contact-form .js-form-required::after {
   max-width: 62ch;
 }
 
+.ed-section--expertise-reassurance {
+  padding-block: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.ed-section--expertise-reassurance .ed-container {
+  display: flex;
+}
+
+.ed-section--expertise-reassurance .ed-section__content {
+  max-width: 100%;
+  color: #24364f;
+  font-size: clamp(0.98rem, 1.4vw, 1.08rem);
+  line-height: 1.55;
+}
+
+.ed-section--expertise-reassurance .ed-section__content p {
+  margin: 0;
+}
+
+.ed-section--expertise-reassurance strong {
+  color: #0f2a4a;
+}
+
 .ed-actions {
   display: flex;
   flex-wrap: wrap;

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--text-block.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--text-block.html.twig
@@ -7,6 +7,8 @@
   {% set section_classes = section_classes|merge(['ed-section--contact-details']) %}
 {% elseif paragraph.uuid.value == 'be01c4d4-b45d-4b08-aeb5-9ad05c860b6a' %}
   {% set section_classes = section_classes|merge(['ed-section--contact-map']) %}
+{% elseif paragraph.uuid.value == '517059c5-0767-4b95-903a-f2e1d96d887f' %}
+  {% set section_classes = section_classes|merge(['ed-section--expertise-reassurance']) %}
 {% endif %}
 
 <section{{ attributes.addClass(section_classes) }}>


### PR DESCRIPTION
Objectif
Finaliser la ligne de réassurance homepage.

Modifications
- Remplacement de « Développement PHP sur mesure » par « PHP sur mesure »
- Alignement FR/EN
- Validation des assertions Content Sync

Contraintes respectées
- Hero inchangé
- Menus inchangés
- Content Sync conservé
- Pas de modification SEO
- Pas de modification structurelle homepage