### PR TITLE
Issue #346: update AI and Webform contrib modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "composer/installers": "^2.3",
         "drupal/admin_toolbar": "^3.6",
-        "drupal/ai": "^1.2.12",
+        "drupal/ai": "^1.4.4",
         "drupal/ai_provider_openai": "^1.2.1",
         "drupal/config_split": "^2.0",
         "drupal/core-composer-scaffold": "^11.4",
@@ -40,7 +40,7 @@
         "drupal/schema_metatag": "^3.0",
         "drupal/simple_sitemap": "^4.2",
         "drupal/token": "^1.16",
-        "drupal/webform": "^6.3@beta",
+        "drupal/webform": "^6.3",
         "drush/drush": "^13.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer/installers": "^2.3",
         "drupal/admin_toolbar": "^3.6",
         "drupal/ai": "^1.4.4",
-        "drupal/ai_provider_openai": "^1.2.1",
+        "drupal/ai_provider_openai": "^1.2.3",
         "drupal/config_split": "^2.0",
         "drupal/core-composer-scaffold": "^11.4",
         "drupal/core-project-message": "^11.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1230ae3a43439cb157ed9674c3d9e04b",
+    "content-hash": "d7d471c916921b804f6307d6a27be3c5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1051,17 +1051,17 @@
         },
         {
             "name": "drupal/ai",
-            "version": "1.4.3",
+            "version": "1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ai.git",
-                "reference": "1.4.3"
+                "reference": "1.4.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ai-1.4.3.zip",
-                "reference": "1.4.3",
-                "shasum": "b4370be47117ef3dbfadaa1356b310c21acab58e"
+                "url": "https://ftp.drupal.org/files/projects/ai-1.4.4.zip",
+                "reference": "1.4.4",
+                "shasum": "cb2188358266caa6365258cf61f316b019bb4c6a"
             },
             "require": {
                 "drupal/core": "^10.5 || ^11.2",
@@ -1091,8 +1091,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.4.3",
-                    "datestamp": "1782325927",
+                    "version": "1.4.4",
+                    "datestamp": "1783520097",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2990,17 +2990,17 @@
         },
         {
             "name": "drupal/webform",
-            "version": "6.3.0-rc2",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform.git",
-                "reference": "6.3.0-rc2"
+                "reference": "6.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform-6.3.0-rc2.zip",
-                "reference": "6.3.0-rc2",
-                "shasum": "833904081e5eab7e8e36250fea3652c797ddfb28"
+                "url": "https://ftp.drupal.org/files/projects/webform-6.3.0.zip",
+                "reference": "6.3.0",
+                "shasum": "67b09271edfd2fb38dc699ff733911ad500ae5d7"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11.0"
@@ -3045,11 +3045,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.3.0-rc2",
-                    "datestamp": "1782137794",
+                    "version": "6.3.0",
+                    "datestamp": "1783989705",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -14635,8 +14635,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "drupal/default_content": 15,
-        "drupal/webform": 10
+        "drupal/default_content": 15
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7d471c916921b804f6307d6a27be3c5",
+    "content-hash": "54e5ec4d721c9f9cee9cb0911e7d5e08",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1193,17 +1193,17 @@
         },
         {
             "name": "drupal/ai_provider_openai",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ai_provider_openai.git",
-                "reference": "1.2.2"
+                "reference": "1.2.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ai_provider_openai-1.2.2.zip",
-                "reference": "1.2.2",
-                "shasum": "0f6b7d7631fddff38b128edb53f3fed4860719a4"
+                "url": "https://ftp.drupal.org/files/projects/ai_provider_openai-1.2.3.zip",
+                "reference": "1.2.3",
+                "shasum": "8698bda2b03cb2d99a2911a19321ef4039314a6f"
             },
             "require": {
                 "drupal/ai": "^1.2.0",
@@ -1213,8 +1213,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.2.2",
-                    "datestamp": "1782325859",
+                    "version": "1.2.3",
+                    "datestamp": "1783612214",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Summary

- Update drupal/ai from 1.4.3 to 1.4.4.
- Update drupal/ai_provider_openai from 1.2.2 to 1.2.3.
- Update drupal/webform from 6.3.0-rc2 to 6.3.0 stable.
- Keep the committed change limited to composer.json and composer.lock.

## Validation

- ddev composer validate
- ddev composer audit
- ddev drush updb -y
- ddev drush cim -y
- ddev drush cr
- ddev drush config:status
- ddev composer lint:phpcs
- ddev composer lint:phpstan
- ddev composer lint:drupal-check
- ddev composer test:homepage-smoke
- ddev composer test:contact
- ddev composer test:project-functional

## Notes

- No OpenAI configuration was activated.
- No AI chatbot was added or activated.
- No tracking, menu, homepage, secret, production settings.php or deploy script change.
- web/autoload_runtime.php exists locally as an ignored file and was not added.
- Remaining Drupal/contrib deprecations are documented but non-blocking for this update.
- Windows XSym Symlinks messages appeared locally but tests completed successfully with exit code 0.

Closes #346
