### PR TITLE
Issue #350: document production maintenance and version log

### DIFF
--- a/docs/operations/production-maintenance.md
+++ b/docs/operations/production-maintenance.md
@@ -1,0 +1,426 @@
+# Procédure de maintenance de production
+
+Cette procédure décrit les opérations de maintenance du serveur de production du
+site agence Drupal. Elle couvre les mises à jour Ubuntu, PHP, MariaDB et Drupal.
+
+Elle complète le mécanisme de déploiement applicatif existant dans
+`scripts/deploy-production.sh`. Elle ne remplace pas ce script et ne doit pas le
+modifier sans ticket explicite.
+
+## Principes obligatoires
+
+- Une intervention planifiée doit être rattachée à une issue GitHub.
+- Une modification de documentation ou de code suit le workflow : une issue, une
+  branche, une Pull Request.
+- Ne jamais modifier directement `main`.
+- Ne jamais committer de secret, token, mot de passe, adresse IP privée, clé SSH
+  ou contenu de `settings.php` de production.
+- Ne jamais modifier le `settings.php` de production dans Git.
+- Ne pas mélanger mise à jour système et modification fonctionnelle du site dans
+  une même intervention, sauf nécessité documentée.
+- Ne pas effectuer de migration majeure de MariaDB sans ticket, sauvegarde,
+  procédure de migration et test de restauration dédiés.
+- Toujours distinguer les commandes réellement exécutées des commandes seulement
+  proposées ou simulées.
+- Toute intervention terminée doit être consignée dans
+  `docs/operations/production-version-log.md` par une PR dédiée ou par la PR du
+  ticket concerné.
+
+## Périmètres de maintenance
+
+### Maintenance système
+
+Concerne Ubuntu, le noyau Linux, Nginx, PHP-FPM, les bibliothèques système et les
+outils de la VM.
+
+### Maintenance de la base de données
+
+Concerne les mises à jour correctives de la branche MariaDB déjà utilisée. Une
+mise à jour majeure, par exemple de MariaDB 10.11 vers 11.x ou 12.x, est hors de
+cette procédure courante.
+
+### Maintenance applicative Drupal
+
+Concerne le code versionné, Composer, les mises à jour de base Drupal, les imports
+de configuration, Config Split et Content Sync. Elle passe normalement par une
+PR mergée puis par `scripts/deploy-production.sh`.
+
+## 1. Préparer l'intervention
+
+Avant toute modification :
+
+1. Créer ou identifier l'issue GitHub de l'intervention.
+2. Vérifier que le périmètre et les versions cibles sont explicites.
+3. Prévoir une fenêtre de maintenance.
+4. Créer un snapshot de la VM chez l'hébergeur.
+5. Vérifier l'espace disque disponible :
+
+```bash
+hostname
+date
+df -h
+free -h
+```
+
+6. Vérifier l'état de la release et des services :
+
+```bash
+readlink -f /var/www/agency/current
+git -C /var/www/agency/current log -1 --oneline
+
+php -v
+sudo mariadb -NBe "SELECT VERSION();"
+nginx -v
+uname -r
+
+sudo systemctl is-active nginx
+sudo systemctl is-active php8.4-fpm
+sudo systemctl is-active mariadb
+sudo systemctl --failed --no-pager
+```
+
+7. Vérifier Drupal :
+
+```bash
+sudo -u deploy -H bash -lc '
+  cd /var/www/agency/current
+  vendor/bin/drush status
+  vendor/bin/drush state:get system.maintenance_mode
+  vendor/bin/drush config:status
+  composer audit
+'
+```
+
+Une dérive de configuration Drupal ne doit pas être corrigée automatiquement
+pendant une maintenance système. Elle doit être analysée séparément.
+
+## 2. Vérifier les mises à jour disponibles
+
+Actualiser les index sans installer de paquet :
+
+```bash
+sudo apt-get update
+apt list --upgradable
+```
+
+Vérifier les versions installées et candidates des composants sensibles :
+
+```bash
+apt-cache policy \
+  php8.4-cli \
+  php8.4-fpm \
+  php8.4-common \
+  mariadb-server \
+  mariadb-client \
+  nginx
+```
+
+Simuler une mise à jour standard :
+
+```bash
+sudo apt-get --simulate upgrade
+```
+
+Simuler une mise à jour complète, notamment lorsqu'un nouveau noyau est proposé :
+
+```bash
+sudo apt-get --simulate full-upgrade
+```
+
+Ne pas poursuivre si la simulation prévoit :
+
+- la suppression inattendue de Nginx, PHP-FPM, MariaDB, SSH ou d'un paquet
+  indispensable ;
+- un changement majeur de MariaDB ;
+- le remplacement de PHP 8.4 par une autre branche ;
+- un nombre important de suppressions non expliqué ;
+- une source de paquets inconnue ou non approuvée.
+
+## 3. Sauvegarder avant intervention
+
+### Sauvegarde de la base Drupal
+
+```bash
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+BACKUPS="/var/www/agency/shared/backups"
+
+sudo -u deploy -H bash -lc "
+  cd /var/www/agency/current
+  vendor/bin/drush sql:dump \
+    --gzip \
+    --result-file='$BACKUPS/pre-maintenance-$TIMESTAMP.sql.gz'
+"
+```
+
+Vérifier que le fichier existe et n'est pas vide :
+
+```bash
+sudo test -s "/var/www/agency/shared/backups/pre-maintenance-$TIMESTAMP.sql.gz"
+```
+
+### Sauvegarde des configurations système concernées
+
+Adapter la liste au périmètre réel :
+
+```bash
+sudo tar -C / -czf \
+  "/var/www/agency/shared/backups/system-config-$TIMESTAMP.tar.gz" \
+  etc/php/8.4 \
+  etc/nginx \
+  etc/mysql
+```
+
+Ne jamais ajouter ces archives dans Git.
+
+## 4. Activer le mode maintenance Drupal
+
+```bash
+sudo -u deploy -H bash -lc '
+  cd /var/www/agency/current
+  vendor/bin/drush state:set system.maintenance_mode 1 --input-format=integer
+  vendor/bin/drush cr
+  vendor/bin/drush state:get system.maintenance_mode
+'
+```
+
+Le résultat attendu est `1`.
+
+Avant de poursuivre, conserver une seconde session SSH ouverte lorsque cela est
+possible.
+
+## 5. Installer les mises à jour
+
+### Mise à jour ciblée de PHP 8.4
+
+Utiliser une mise à jour ciblée lorsque seule la branche PHP 8.4 doit évoluer.
+Commencer par identifier les paquets installés :
+
+```bash
+dpkg-query -W \
+  -f='${binary:Package}\t${Status}\t${Version}\n' \
+  'php8.4*' 2>/dev/null
+```
+
+Simuler ensuite l'installation ciblée, puis exécuter la même commande sans
+`--simulate` lorsque le résultat est correct.
+
+Exemple :
+
+```bash
+sudo apt-get --simulate install --only-upgrade \
+  php8.4 php8.4-cli php8.4-common php8.4-fpm php8.4-opcache
+```
+
+La liste réelle doit inclure toutes les extensions PHP 8.4 installées sur le
+serveur.
+
+### Mise à jour Ubuntu complète
+
+Lorsqu'un nouveau noyau ou des dépendances nécessaires sont retenus par
+`upgrade`, utiliser :
+
+```bash
+sudo apt-get full-upgrade
+```
+
+Lire la liste proposée avant de confirmer. Ne pas utiliser `-y` lors d'une
+intervention manuelle si la liste n'a pas déjà été validée par simulation.
+
+### MariaDB
+
+Une mise à jour corrective peut être appliquée seulement si la version candidate
+reste dans la branche 10.11 :
+
+```bash
+apt-cache policy mariadb-server mariadb-client
+```
+
+Si la version installée est identique à la version candidate, aucune action
+MariaDB n'est nécessaire.
+
+## 6. Valider les configurations et redémarrer les services
+
+Après une mise à jour PHP :
+
+```bash
+sudo php-fpm8.4 -t
+sudo systemctl restart php8.4-fpm
+```
+
+Après une mise à jour MariaDB :
+
+```bash
+sudo systemctl restart mariadb
+```
+
+Toujours valider et recharger Nginx :
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Contrôler les services :
+
+```bash
+sudo systemctl is-active nginx
+sudo systemctl is-active php8.4-fpm
+sudo systemctl is-active mariadb
+sudo systemctl --failed --no-pager
+```
+
+## 7. Redémarrer la VM lorsque requis
+
+Vérifier :
+
+```bash
+if [ -f /var/run/reboot-required ]; then
+  echo "Redémarrage requis"
+  cat /var/run/reboot-required.pkgs 2>/dev/null || true
+else
+  echo "Aucun redémarrage requis"
+fi
+```
+
+Si un nouveau noyau ou un composant système essentiel l'exige :
+
+```bash
+sudo reboot
+```
+
+Après reconnexion :
+
+```bash
+uname -r
+php -v
+sudo mariadb -NBe "SELECT VERSION();"
+
+sudo systemctl is-active nginx
+sudo systemctl is-active php8.4-fpm
+sudo systemctl is-active mariadb
+sudo systemctl --failed --no-pager
+```
+
+Ne jamais supprimer l'ancien noyau avant d'avoir confirmé que la VM redémarre
+correctement sur le nouveau.
+
+## 8. Valider Drupal après intervention
+
+```bash
+sudo -u deploy -H bash -lc '
+  cd /var/www/agency/current
+  vendor/bin/drush status
+  vendor/bin/drush sql:query "SELECT 1;"
+  vendor/bin/drush cr
+  composer audit
+'
+```
+
+Vérifier également :
+
+- la page d'accueil publique ;
+- le formulaire de contact ;
+- `/admin/reports/status` ;
+- les erreurs Nginx et PHP-FPM récentes ;
+- l'absence de service en échec.
+
+Exemples :
+
+```bash
+sudo journalctl -u php8.4-fpm --since "30 minutes ago" --no-pager
+sudo tail -n 100 /var/log/nginx/error.log
+```
+
+## 9. Désactiver le mode maintenance
+
+```bash
+sudo -u deploy -H bash -lc '
+  cd /var/www/agency/current
+  vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer
+  vendor/bin/drush cr
+  vendor/bin/drush state:get system.maintenance_mode
+'
+```
+
+Le résultat attendu est `0`.
+
+En cas d'échec pendant l'intervention, tenter de désactiver le mode maintenance
+avant de quitter, sauf si le site doit volontairement rester indisponible pour
+éviter une corruption.
+
+## 10. Nettoyer prudemment
+
+Après validation complète et après redémarrage sur le nouveau noyau :
+
+```bash
+sudo apt-get --simulate autoremove --purge
+```
+
+Examiner les paquets proposés. Si la liste est correcte :
+
+```bash
+sudo apt-get autoremove --purge
+```
+
+Conserver au moins un noyau précédent fonctionnel comme solution de secours.
+
+## 11. Déployer une mise à jour applicative Drupal
+
+Les modifications Drupal doivent être validées localement, mergées dans `main`,
+puis déployées avec le script existant :
+
+```bash
+sudo -u deploy -H bash -lc '
+  /var/www/agency/current/scripts/deploy-production.sh main
+'
+```
+
+Ce script gère notamment la nouvelle release, Composer, la sauvegarde SQL, le
+mode maintenance, `drush updb`, `drush cim`, Config Split, Content Sync et le
+basculement du lien `current`.
+
+Ne pas lancer un `drush cim` global manuellement pour corriger une dérive non
+analysée.
+
+## 12. Retour arrière
+
+Le retour arrière dépend du type d'échec.
+
+### Déploiement Drupal
+
+Le script de déploiement conserve les releases précédentes. Utiliser une release
+précédente seulement après analyse, en préservant les fichiers partagés et le
+`settings.php` partagé.
+
+### Base de données
+
+Restaurer la sauvegarde SQL seulement si cela est nécessaire et après avoir
+confirmé la compatibilité avec la release active.
+
+### Mise à jour système
+
+En cas d'échec grave :
+
+1. utiliser la console de l'hébergeur ;
+2. démarrer sur le noyau précédent si nécessaire ;
+3. restaurer le snapshot de VM si la remise en état manuelle n'est pas fiable.
+
+Une restauration de snapshot peut annuler des données créées après le snapshot.
+Cette conséquence doit être prise en compte avant toute restauration.
+
+## 13. Consigner l'intervention
+
+Ajouter une entrée à `docs/operations/production-version-log.md` avec :
+
+- date et fenêtre d'intervention ;
+- issue ou PR associée ;
+- versions avant et après ;
+- commandes ou catégories d'opérations réellement exécutées ;
+- sauvegardes créées ;
+- redémarrage effectué ou non ;
+- validations obtenues ;
+- anomalies et décisions de non-action ;
+- limites et risques résiduels.
+
+Ne pas consigner de secret, d'adresse privée, de clé, de mot de passe, de contenu
+de configuration sensible ou de sortie contenant des données personnelles.

--- a/docs/operations/production-version-log.md
+++ b/docs/operations/production-version-log.md
@@ -61,7 +61,8 @@ exécuté et vérifié sur le serveur.
 
 ## 2026-07-17 — Mise à jour système et PHP de production
 
-- Issue / PR : issue #350 créée pour formaliser la procédure et ce journal
+- Issue / PR : issue #350 créée après l'intervention pour formaliser la procédure
+  et ce journal
 - Environnement : production
 - Résultat : succès
 
@@ -72,7 +73,7 @@ exécuté et vérifié sur le serveur.
 | Ubuntu | 24.04.4 LTS | 24.04.4 LTS | Paquets standards mis à jour |
 | Noyau actif | 6.8.0-110-generic | 6.8.0-136-generic | Nouveau noyau installé et VM redémarrée |
 | Nginx | 1.24.0 Ubuntu | 1.24.0 Ubuntu | Service validé, version inchangée |
-| PHP CLI / PHP-FPM | 8.4.20 | 8.4.23 | Mise à jour corrective de sécurité |
+| PHP | 8.4.20 | 8.4.23 | Mise à jour corrective de la branche 8.4 |
 | MariaDB | 10.11.14 Ubuntu | 10.11.14 Ubuntu | Aucune mise à jour disponible dans les dépôts configurés |
 | Drupal | 11.4.4 | 11.4.4 | Bootstrap et cache validés, version inchangée |
 | Drush | 13.7.4 | 13.7.4 | Version inchangée |
@@ -93,16 +94,17 @@ exécuté et vérifié sur le serveur.
 
 ### Sauvegardes et retour arrière
 
-- La procédure a prévu un snapshot de VM et une sauvegarde de base avant les
-  opérations sensibles.
-- Le noyau 6.8.0-134 a été conservé comme solution de repli.
+- La création préalable d'un snapshot de VM et d'une sauvegarde SQL avait été
+  recommandée, mais leur exécution n'est pas confirmée dans les sorties conservées
+  pour cette intervention.
+- Le noyau 6.8.0-134 a été conservé comme solution de repli vérifiable.
 - Aucun retour arrière n'a été nécessaire.
 
 ### Validations
 
 - Noyau actif confirmé : `6.8.0-136-generic`.
 - PHP CLI confirmé : `8.4.23`.
-- Drupal utilise PHP `8.4.23`.
+- Drupal utilise PHP `8.4.23` pour Drush.
 - MariaDB confirmée : `10.11.14-MariaDB-0ubuntu0.24.04.1`.
 - Nginx, PHP-FPM et MariaDB actifs.
 - Aucun service systemd en échec.

--- a/docs/operations/production-version-log.md
+++ b/docs/operations/production-version-log.md
@@ -1,0 +1,130 @@
+# Journal des versions de production
+
+Ce document consigne les versions et interventions réellement appliquées sur la
+production du site agence Drupal.
+
+Il est volontairement distinct des Pull Requests applicatives : une PR décrit ce
+qui doit être déployé, tandis que ce journal décrit ce qui a effectivement été
+exécuté et vérifié sur le serveur.
+
+## Règles de tenue du journal
+
+- Ajouter les nouvelles interventions en tête du document.
+- Ne consigner que des versions et opérations réellement vérifiées.
+- Indiquer explicitement les opérations simulées mais non exécutées.
+- Associer chaque entrée à une issue ou une Pull Request lorsque cela existe.
+- Ne jamais consigner de secret, clé, mot de passe, adresse IP privée, contenu de
+  `settings.php` ou sortie contenant des données personnelles.
+- Ne pas réécrire l'historique d'une intervention passée. Ajouter une correction
+  datée lorsqu'une information doit être rectifiée.
+- Une mise à jour majeure de PHP, MariaDB, Ubuntu ou Drupal doit disposer de son
+  propre ticket.
+
+## Modèle d'entrée
+
+```markdown
+## AAAA-MM-JJ — Titre de l'intervention
+
+- Issue / PR : #...
+- Opérateur : ...
+- Environnement : production
+- Fenêtre : ...
+- Résultat : succès / échec / partiel
+
+### Versions
+
+| Composant | Avant | Après | Action |
+| --- | --- | --- | --- |
+| Ubuntu | ... | ... | ... |
+| Noyau | ... | ... | ... |
+| Nginx | ... | ... | ... |
+| PHP | ... | ... | ... |
+| MariaDB | ... | ... | ... |
+| Drupal | ... | ... | ... |
+
+### Opérations réellement exécutées
+
+- ...
+
+### Sauvegardes et retour arrière
+
+- ...
+
+### Validations
+
+- ...
+
+### Anomalies, non-actions et risques résiduels
+
+- ...
+```
+
+## 2026-07-17 — Mise à jour système et PHP de production
+
+- Issue / PR : issue #350 créée pour formaliser la procédure et ce journal
+- Environnement : production
+- Résultat : succès
+
+### Versions
+
+| Composant | Avant | Après | Action |
+| --- | --- | --- | --- |
+| Ubuntu | 24.04.4 LTS | 24.04.4 LTS | Paquets standards mis à jour |
+| Noyau actif | 6.8.0-110-generic | 6.8.0-136-generic | Nouveau noyau installé et VM redémarrée |
+| Nginx | 1.24.0 Ubuntu | 1.24.0 Ubuntu | Service validé, version inchangée |
+| PHP CLI / PHP-FPM | 8.4.20 | 8.4.23 | Mise à jour corrective de sécurité |
+| MariaDB | 10.11.14 Ubuntu | 10.11.14 Ubuntu | Aucune mise à jour disponible dans les dépôts configurés |
+| Drupal | 11.4.4 | 11.4.4 | Bootstrap et cache validés, version inchangée |
+| Drush | 13.7.4 | 13.7.4 | Version inchangée |
+
+### Opérations réellement exécutées
+
+- Actualisation des index APT.
+- Vérification des versions installées et candidates de PHP et MariaDB.
+- Simulation de `apt-get upgrade` et de `apt-get full-upgrade`.
+- Mise à jour complète des paquets Ubuntu proposés.
+- Mise à jour de PHP 8.4.20 vers PHP 8.4.23 et de ses extensions installées.
+- Installation du noyau Linux 6.8.0-136.
+- Redémarrage de la VM.
+- Suppression par `autoremove --purge` de l'ancien noyau 6.8.0-110 et de ses
+  paquets associés.
+- Conservation du noyau 6.8.0-134 comme noyau de secours.
+- Reconstruction du cache Drupal.
+
+### Sauvegardes et retour arrière
+
+- La procédure a prévu un snapshot de VM et une sauvegarde de base avant les
+  opérations sensibles.
+- Le noyau 6.8.0-134 a été conservé comme solution de repli.
+- Aucun retour arrière n'a été nécessaire.
+
+### Validations
+
+- Noyau actif confirmé : `6.8.0-136-generic`.
+- PHP CLI confirmé : `8.4.23`.
+- Drupal utilise PHP `8.4.23`.
+- MariaDB confirmée : `10.11.14-MariaDB-0ubuntu0.24.04.1`.
+- Nginx, PHP-FPM et MariaDB actifs.
+- Aucun service systemd en échec.
+- Bootstrap Drupal réussi et base de données connectée.
+- Mode maintenance Drupal confirmé à `0`.
+- Cache Drupal reconstruit avec succès.
+- `composer audit` : aucune vulnérabilité connue.
+- Aucun paquet standard encore disponible après intervention.
+- Aucun redémarrage supplémentaire requis.
+- Aucun paquet supplémentaire proposé par `autoremove --purge` après nettoyage.
+
+### Anomalies, non-actions et risques résiduels
+
+- Ubuntu Pro / ESM Apps n'est pas activé. Le serveur annonce des correctifs ESM
+  Apps supplémentaires, distincts des mises à jour standards disponibles.
+- MariaDB est restée sur la version 10.11.14 fournie par Ubuntu. Aucun dépôt
+  MariaDB externe n'a été ajouté et aucune migration majeure n'a été réalisée.
+- La configuration Drupal présentait les différences suivantes :
+  `google_tag.container...` uniquement en base, `google_tag.settings` uniquement
+  en base et `system.mail` différent. Aucun `drush cim` global n'a été lancé pour
+  corriger cette dérive non analysée.
+- Les bibliothèques externes Webform sont restées hors périmètre.
+- Aucun fichier du dépôt, menu, contenu de homepage, tracking, secret,
+  configuration OpenAI, chatbot IA ou script de déploiement n'a été modifié par
+  l'intervention système.


### PR DESCRIPTION
## Résumé

- Ajouter une procédure complète de maintenance de production.
- Couvrir les précontrôles, simulations APT, sauvegardes, mode maintenance Drupal, mises à jour ciblées, redémarrage, validations, nettoyage et retour arrière.
- Distinguer maintenance Ubuntu/PHP/MariaDB et déploiement applicatif Drupal.
- Initialiser un journal des versions avec l’intervention réellement vérifiée du 17 juillet 2026.
- Documenter explicitement les informations non confirmées au lieu de les présenter comme exécutées.

## Fichiers ajoutés

- `docs/operations/production-maintenance.md`
- `docs/operations/production-version-log.md`

## Validations réellement effectuées

- Lecture de `AGENTS.md`.
- Lecture de `.github/ISSUE_TEMPLATE/task.yml`.
- Lecture de `scripts/deploy-production.sh`.
- Vérification du diff GitHub : uniquement les deux fichiers documentaires ajoutés.
- Vérification manuelle du contenu des deux documents sur la branche.

## Limites

- Aucun test DDEV ou lint local exécuté : la modification est documentaire et le dossier local Windows n’est pas accessible depuis cet environnement.
- Aucun changement de production exécuté par cette PR.
- Aucun `settings.php`, secret, menu, homepage, tracking, OpenAI, chatbot IA, configuration Drupal ou script de déploiement modifié.

Closes #350