### PR TITLE
Issue #366: migrate DDEV to MariaDB 11.8

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,7 +12,6 @@ database:
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-nodejs_version: "24"
 corepack_enable: true
 default_container_timeout: "240"
 
@@ -23,28 +22,26 @@ default_container_timeout: "240"
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
-# See https://docs.ddev.com/en/stable/users/quickstart/ for more
+# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
 # information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
+# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to DDEV's behavior,
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
 # so this can break upgrades.
 
-# webimage: <docker_image>
-# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
-# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
+# webimage: <docker_image>  # nginx/php docker image.
 
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8, 12.3
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
 #   MySQL versions can be 5.5-8.0, 8.4
-#   PostgreSQL versions can be 9-18
+#   PostgreSQL versions can be 9-17
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
 # router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
@@ -54,18 +51,27 @@ default_container_timeout: "240"
 # "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
 # as leaving Xdebug enabled all the time is a big performance hit.
 
-# xhgui_http_port: "8143"
-# xhgui_https_port: "8142"
-# The XHGui ports can be changed from the default 8143 and 8142
+# xhgui_https_port: 8142
+# Can be used to change the router https port for xhgui application
 # Very rarely used
 
-# host_xhgui_port: "8142"
-# Can be used to change the host binding port of the XHGui
+# xhgui_http_port: 8143
+# Can be used to change the router http port for xhgui application
+# Very rarely used
+
+# host_xhgui_port: 8142
+# Can be used to change the host binding port of the xhgui
 # application. Rarely used; only when port conflict and
 # bind_all_ports is used (normally with router disabled)
 
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
+
 # xhprof_mode: [prepend|xhgui|global]
-# Default is "xhgui"
+# Set to "xhgui" to enable XHGui features
+# "xhgui" will become default in a future major release
 
 # webserver_type: nginx-fpm, apache-fpm, generic
 
@@ -83,20 +89,22 @@ default_container_timeout: "240"
 # commands are executed.
 
 # composer_version: "2"
-# You can set it to "" or "2" (default) for Composer v2
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
 # to use the latest major version available at the time your container is built.
-# It is also possible to use any other Composer version channel. This includes:
+# It is also possible to use each other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
 #   - stable
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev utility rebuild".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
 
-# nodejs_version: "24"
+# nodejs_version: "22"
 # change from the default system Node.js version to any other version.
-# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
-# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
+# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
 
 # corepack_enable: false
 # Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
@@ -129,7 +137,7 @@ default_container_timeout: "240"
 
 # ddev_version_constraint: ""
 # Example:
-# ddev_version_constraint: ">= 1.24.8"
+# ddev_version_constraint: ">= 1.22.4"
 # This will enforce that the running ddev version is within this constraint.
 # See https://github.com/Masterminds/semver#checking-version-constraints for
 # supported constraint formats
@@ -156,8 +164,10 @@ default_container_timeout: "240"
 #   - "global":  uses the value from the global config.
 #   - "none":    disables performance optimization for this project.
 #   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
 #
-# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -186,10 +196,10 @@ default_container_timeout: "240"
 # The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
 # Extra Debian packages that are needed in the webimage can be added here
 
-# dbimage_extra_packages: [netcat, telnet, sudo]
+# dbimage_extra_packages: [telnet,netcat]
 # Extra Debian packages that are needed in the dbimage can be added here
 
 # use_dns_when_possible: true
@@ -201,15 +211,12 @@ default_container_timeout: "240"
 # project_tld: ddev.site
 # The top-level domain used for project URLs
 # The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
 
-# share_default_provider: ngrok
-# The default share provider to use for "ddev share"
-# Defaults to global configuration, usually "ngrok"
-# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
-
-# share_provider_args: --basic-auth username:pass1234
-# Provide extra flags to the share provider script
-# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
 
 # disable_settings_management: false
 # If true, DDEV will not create CMS-specific settings files like
@@ -271,7 +278,7 @@ default_container_timeout: "240"
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'use_dns_when_possible: true' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
@@ -281,13 +288,13 @@ default_container_timeout: "240"
 # web_environment: []
 # or
 # additional_hostnames: []
-# can have their intended effect. 'override_config' affects only behavior of the
+# can have their intended affect. 'override_config' affects only behavior of the
 # config.*.yaml file it exists in.
 
 # Many DDEV commands can be extended to run tasks before or after the
 # DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,10 +8,11 @@ additional_hostnames: []
 additional_fqdns: []
 database:
     type: mariadb
-    version: "10.11"
+    version: "11.8"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
+nodejs_version: "24"
 corepack_enable: true
 default_container_timeout: "240"
 
@@ -22,26 +23,28 @@ default_container_timeout: "240"
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
-# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
+# See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
+# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# is not recommended, as the images are often closely tied to DDEV's behavior,
 # so this can break upgrades.
 
-# webimage: <docker_image>  # nginx/php docker image.
+# webimage: <docker_image>
+# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
+# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
 
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8, 12.3
 #   MySQL versions can be 5.5-8.0, 8.4
-#   PostgreSQL versions can be 9-17
+#   PostgreSQL versions can be 9-18
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
 # router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
@@ -51,27 +54,18 @@ default_container_timeout: "240"
 # "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
 # as leaving Xdebug enabled all the time is a big performance hit.
 
-# xhgui_https_port: 8142
-# Can be used to change the router https port for xhgui application
+# xhgui_http_port: "8143"
+# xhgui_https_port: "8142"
+# The XHGui ports can be changed from the default 8143 and 8142
 # Very rarely used
 
-# xhgui_http_port: 8143
-# Can be used to change the router http port for xhgui application
-# Very rarely used
-
-# host_xhgui_port: 8142
-# Can be used to change the host binding port of the xhgui
+# host_xhgui_port: "8142"
+# Can be used to change the host binding port of the XHGui
 # application. Rarely used; only when port conflict and
 # bind_all_ports is used (normally with router disabled)
 
-# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
-# Note that for most people the commands
-# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
-# as leaving Xhprof enabled all the time is a big performance hit.
-
 # xhprof_mode: [prepend|xhgui|global]
-# Set to "xhgui" to enable XHGui features
-# "xhgui" will become default in a future major release
+# Default is "xhgui"
 
 # webserver_type: nginx-fpm, apache-fpm, generic
 
@@ -89,22 +83,20 @@ default_container_timeout: "240"
 # commands are executed.
 
 # composer_version: "2"
-# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# You can set it to "" or "2" (default) for Composer v2
 # to use the latest major version available at the time your container is built.
-# It is also possible to use each other Composer version channel. This includes:
+# It is also possible to use any other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
 #   - stable
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev debug rebuild".
+# To reinstall Composer after the image was built, run "ddev utility rebuild".
 
-# nodejs_version: "22"
+# nodejs_version: "24"
 # change from the default system Node.js version to any other version.
-# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
-# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
-# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
-# can specify any version, and is more robust than using 'nvm'.
+# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
 
 # corepack_enable: false
 # Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
@@ -137,7 +129,7 @@ default_container_timeout: "240"
 
 # ddev_version_constraint: ""
 # Example:
-# ddev_version_constraint: ">= 1.22.4"
+# ddev_version_constraint: ">= 1.24.8"
 # This will enforce that the running ddev version is within this constraint.
 # See https://github.com/Masterminds/semver#checking-version-constraints for
 # supported constraint formats
@@ -164,10 +156,8 @@ default_container_timeout: "240"
 #   - "global":  uses the value from the global config.
 #   - "none":    disables performance optimization for this project.
 #   - "mutagen": enables Mutagen for this project.
-#   - "nfs":     enables NFS for this project.
 #
-# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
-# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -196,10 +186,10 @@ default_container_timeout: "240"
 # The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
 # Extra Debian packages that are needed in the webimage can be added here
 
-# dbimage_extra_packages: [telnet,netcat]
+# dbimage_extra_packages: [netcat, telnet, sudo]
 # Extra Debian packages that are needed in the dbimage can be added here
 
 # use_dns_when_possible: true
@@ -211,12 +201,15 @@ default_container_timeout: "240"
 # project_tld: ddev.site
 # The top-level domain used for project URLs
 # The default "ddev.site" allows DNS lookup via a wildcard
-# If you prefer you can change this to "ddev.local" to preserve
-# pre-v1.9 behavior.
 
-# ngrok_args: --basic-auth username:pass1234
-# Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
+# share_default_provider: ngrok
+# The default share provider to use for "ddev share"
+# Defaults to global configuration, usually "ngrok"
+# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
+
+# share_provider_args: --basic-auth username:pass1234
+# Provide extra flags to the share provider script
+# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
 
 # disable_settings_management: false
 # If true, DDEV will not create CMS-specific settings files like
@@ -278,7 +271,7 @@ default_container_timeout: "240"
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
@@ -288,13 +281,13 @@ default_container_timeout: "240"
 # web_environment: []
 # or
 # additional_hostnames: []
-# can have their intended affect. 'override_config' affects only behavior of the
+# can have their intended effect. 'override_config' affects only behavior of the
 # config.*.yaml file it exists in.
 
 # Many DDEV commands can be extended to run tasks before or after the
 # DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:


### PR DESCRIPTION
## Objectif

Migrer l'environnement DDEV du projet de MariaDB 10.11 vers MariaDB 11.8 avec la primitive DDEV supportée.

## Validation locale

- volume initial : MariaDB 10.11
- export SQL pré-migration créé hors dépôt et conservé
- ddev utility migrate-database mariadb:11.8 : GREEN
- volume final / SELECT VERSION() : MariaDB 11.8.x
- nombre de tables identique avant/après
- mariadb-check --check-upgrade : GREEN
- Drush bootstrap/updb/cim/cr/config:status : GREEN
- Content Sync validate + dry-run : GREEN
- Composer validate/audit : GREEN
- PHPCS/PHPStan/drupal-check : GREEN
- homepage/contact/project-functional : GREEN
- diff : .ddev/config.yaml uniquement

La production n'est pas modifiée par cette PR. Elle reste bloquée dans #367 jusqu'au merge et à la CI GREEN de #366.

Closes #366