### PR TITLE
Issue #370: migrate remaining custom plugin annotations to attributes

### DIFF
--- a/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
+++ b/web/modules/custom/agency_ai_translation/src/Plugin/Action/AiTranslateNodesBulkAction.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Drupal\agency_ai_translation\Plugin\Action;
 
 use Drupal\agency_ai_translation\Service\AiTranslationManager;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\ConfigurableActionBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,13 +21,12 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Action de masse de traduction IA.
- *
- * @Action(
- *   id = "agency_ai_translate_nodes_bulk_action",
- *   label = @Translation("Traduire avec IA vers une langue cible"),
- *   type = "node"
- * )
  */
+#[Action(
+  id: 'agency_ai_translate_nodes_bulk_action',
+  label: new TranslatableMarkup('Traduire avec IA vers une langue cible'),
+  type: 'node',
+)]
 final class AiTranslateNodesBulkAction extends ConfigurableActionBase implements ContainerFactoryPluginInterface {
 
   public function __construct(

--- a/web/modules/custom/emerging_digital_content/src/Plugin/Block/FooterBrandingBlock.php
+++ b/web/modules/custom/emerging_digital_content/src/Plugin/Block/FooterBrandingBlock.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\emerging_digital_content\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 
 /**
  * Provides a footer branding block.
- *
- * @Block(
- *   id = "emerging_digital_footer_branding",
- *   admin_label = @Translation("Footer branding"),
- *   category = @Translation("Emerging Digital")
- * )
  */
+#[Block(
+  id: 'emerging_digital_footer_branding',
+  admin_label: new TranslatableMarkup('Footer branding'),
+  category: new TranslatableMarkup('Emerging Digital'),
+)]
 final class FooterBrandingBlock extends BlockBase {
 
   /**

--- a/web/modules/custom/emerging_digital_content/src/Plugin/Block/LanguageSwitcherBlock.php
+++ b/web/modules/custom/emerging_digital_content/src/Plugin/Block/LanguageSwitcherBlock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\emerging_digital_content\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\ContentEntityInterface;
@@ -12,18 +13,18 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a cacheable language switcher block.
- *
- * @Block(
- *   id = "emerging_digital_language_switcher",
- *   admin_label = @Translation("Language switcher"),
- *   category = @Translation("Emerging Digital")
- * )
  */
+#[Block(
+  id: 'emerging_digital_language_switcher',
+  admin_label: new TranslatableMarkup('Language switcher'),
+  category: new TranslatableMarkup('Emerging Digital'),
+)]
 final class LanguageSwitcherBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   public function __construct(


### PR DESCRIPTION
## Objectif

Migrer les trois dernières annotations de plugins project-owned vers les attributs PHP Drupal, sans changement fonctionnel.

## Changements

- `LanguageSwitcherBlock` : `@Block` -> `#[Block(...)]` ;
- `FooterBrandingBlock` : `@Block` -> `#[Block(...)]` ;
- `AiTranslateNodesBulkAction` : `@Action` -> `#[Action(...)]` ;
- `TranslatableMarkup` utilisé pour les labels/catégories des attributs.

## Rescan custom

Avant modification, le scan de `web/modules/custom` a confirmé exactement :

- 2 occurrences `@Block` : les deux blocs ci-dessus ;
- 1 occurrence `@Action` : l'action ci-dessus ;
- 0 `@EntityType` ;
- 0 `@FieldType` ;
- 0 `@Mail` ;
- 0 `@EntityReferenceSelection`.

Le diff est limité à ces trois fichiers et ne modifie aucune logique métier.

## Validation attendue

La CI du dépôt doit valider Composer, PHPCS, PHPStan, drupal-check et la suite PHPUnit custom sur le HEAD exact.

Closes #370