### PR TITLE
Issue #356: complete Article editorial foundation

### DIFF
--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -1,0 +1,94 @@
+uuid: aa4ef648-0900-4804-91a1-9b75f6135abe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.body
+    - field.field.node.article.field_blog_category
+    - field.field.node.article.field_feature_image
+    - field.field.node.article.field_sector
+    - field.field.node.article.field_short_description
+    - image.style.thumbnail
+    - node.type.article
+  module:
+    - image
+    - text
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 10
+    region: content
+    settings:
+      rows: 12
+      summary_rows: 3
+      placeholder: ''
+      show_summary: true
+    third_party_settings: {  }
+  field_blog_category:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_feature_image:
+    type: image_image
+    weight: 0
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_short_description:
+    type: text_textarea
+    weight: -5
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 20
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 25
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 40
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_sector: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -1,0 +1,63 @@
+uuid: 28ac2f67-64e5-40ab-89e8-b6de41aa146b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.body
+    - field.field.node.article.field_blog_category
+    - field.field.node.article.field_feature_image
+    - field.field.node.article.field_sector
+    - field.field.node.article.field_short_description
+    - image.style.large
+    - node.type.article
+  module:
+    - image
+    - text
+    - user
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  field_feature_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: large
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_blog_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_short_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_sector: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -19,6 +19,21 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_blog_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_feature_image:
     type: image
     label: hidden
@@ -30,27 +45,12 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_blog_category:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_short_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 2
-    region: content
-  body:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 3
     region: content
   links:
     settings: {  }

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -1,0 +1,58 @@
+uuid: 195aac13-b667-4eea-8c7a-b4fe866b852b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.article.body
+    - field.field.node.article.field_blog_category
+    - field.field.node.article.field_feature_image
+    - field.field.node.article.field_sector
+    - field.field.node.article.field_short_description
+    - image.style.medium
+    - node.type.article
+  module:
+    - image
+    - text
+    - user
+id: node.article.teaser
+targetEntityType: node
+bundle: article
+mode: teaser
+content:
+  field_feature_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: content
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_blog_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_short_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  body: true
+  field_sector: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -20,6 +20,14 @@ targetEntityType: node
 bundle: article
 mode: teaser
 content:
+  field_blog_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_feature_image:
     type: image
     label: hidden
@@ -30,14 +38,6 @@ content:
         attribute: lazy
     third_party_settings: {  }
     weight: 0
-    region: content
-  field_blog_category:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 1
     region: content
   field_short_description:
     type: text_default

--- a/config/sync/field.field.node.article.body.yml
+++ b/config/sync/field.field.node.article.body.yml
@@ -1,0 +1,29 @@
+uuid: b5ceebcb-fd1a-4866-963b-e341079d105a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.article
+  module:
+    - linkchecker
+    - text
+third_party_settings:
+  linkchecker:
+    scan: true
+    extractor: html_link_extractor
+id: node.article.body
+field_name: body
+entity_type: node
+bundle: article
+label: Contenu
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/sync/field.field.node.article.field_blog_category.yml
+++ b/config/sync/field.field.node.article.field_blog_category.yml
@@ -1,0 +1,24 @@
+uuid: 4333e2b0-998b-4d83-a015-58471fc3f625
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blog_category
+    - node.type.article
+    - taxonomy.vocabulary.blog_categories
+id: node.article.field_blog_category
+field_name: field_blog_category
+entity_type: node
+bundle: article
+label: 'Catégorie du blog'
+description: 'Catégorie éditoriale principale de l’article.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      blog_categories: blog_categories
+field_type: entity_reference

--- a/config/sync/field.field.node.article.field_feature_image.yml
+++ b/config/sync/field.field.node.article.field_feature_image.yml
@@ -1,0 +1,45 @@
+uuid: aa0a713f-f8db-436f-ac37-13c52dba19c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_feature_image
+    - node.type.article
+  module:
+    - content_translation
+    - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: '0'
+      title: '0'
+      file: file
+id: node.article.field_feature_image
+field_name: field_feature_image
+entity_type: node
+bundle: article
+label: 'Image principale'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: articles
+  file_extensions: 'png gif jpg jpeg webp'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.storage.node.field_blog_category.yml
+++ b/config/sync/field.storage.node.field_blog_category.yml
@@ -1,0 +1,20 @@
+uuid: df174271-4f44-40b0-b2d9-2c2eb2c25500
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_blog_category
+field_name: field_blog_category
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.taxonomy_term.blog_categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.blog_categories.yml
@@ -1,0 +1,18 @@
+uuid: 1c17c6cc-7700-4ee4-bece-cc404ccd5f75
+langcode: fr
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.blog_categories
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: taxonomy_term.blog_categories
+target_entity_type_id: taxonomy_term
+target_bundle: blog_categories
+default_langcode: site_default
+language_alterable: true

--- a/config/sync/taxonomy.vocabulary.blog_categories.yml
+++ b/config/sync/taxonomy.vocabulary.blog_categories.yml
@@ -1,0 +1,9 @@
+uuid: 2a5319eb-4524-41d2-bf33-646a42b2f2d3
+langcode: en
+status: true
+dependencies: {  }
+name: 'Catégories du blog'
+vid: blog_categories
+description: 'Catégories éditoriales principales du blog.'
+weight: 0
+new_revision: false

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - node.type.article
     - node.type.page
+    - taxonomy.vocabulary.blog_categories
     - taxonomy.vocabulary.tags
   module:
     - comment
+    - content_translation
     - contextual
     - file
     - node
@@ -30,6 +32,7 @@ permissions:
   - 'administer url aliases'
   - 'create article content'
   - 'create page content'
+  - 'create terms in blog_categories'
   - 'create terms in tags'
   - 'create url aliases'
   - 'delete article revisions'
@@ -40,8 +43,11 @@ permissions:
   - 'edit own article content'
   - 'edit own comments'
   - 'edit own page content'
+  - 'edit terms in blog_categories'
   - 'edit terms in tags'
   - 'revert all revisions'
+  - 'translate article node'
+  - 'translate blog_categories taxonomy_term'
   - 'view all revisions'
   - 'view own unpublished content'
   - 'view the administration theme'


### PR DESCRIPTION
Closes #356

## Scope

Complète uniquement la fondation Drupal du bundle Article pour le chantier Blog #355. Aucun changement de vue `/blog`, templates/styles finaux, menu, Content Sync, tracking, OpenAI, chatbot, `agency_ai_translation`, `settings.php`, CI ou déploiement.

## Audit initial

### Bundle et champs versionnés

- `node.type.article` existe, `new_revision: true`, `display_submitted: true` : auteur et dates restent natifs Drupal.
- `field_short_description` existe déjà : `text_long`, cardinalité 1, `required: false`, `translatable: true`.
- `field_sector` existe déjà : référence taxonomique, storage multi-valué (`cardinality: -1`), `required: false`, `translatable: true`. Il est conservé pour compatibilité mais n'est pas utilisé comme catégorie principale du Blog.
- le storage natif `node.body` existe : `text_with_summary`, cardinalité 1, traduisible ; l'instance `node.article.body` était absente.
- le storage `node.field_feature_image` existe déjà : image, cardinalité 1, traduisible ; il est réutilisé plutôt que dupliqué.
- aucun vocabulaire existant (`tags`, `secteur`, `type_service`, `localisation`, `type_fonctionnalite_ia`) ne représente une catégorie éditoriale principale du Blog ; création ciblée de `blog_categories`.

### Displays

Les configurations versionnées suivantes étaient absentes :

- `core.entity_form_display.node.article.default`
- `core.entity_view_display.node.article.default`
- `core.entity_view_display.node.article.teaser`

Elles sont matérialisées par cette PR avec une configuration fonctionnelle et sobre.

### Traduction et révisions

- `language.content_settings.node.article` active déjà Content Translation et rend la langue modifiable.
- `node.type.article` crée déjà une nouvelle révision par défaut.
- le nouveau vocabulaire `blog_categories` est rendu traduisible.
- le rôle `content_editor` reçoit les permissions bornées pour traduire Article et `blog_categories`, ainsi que créer/éditer les termes de ce vocabulaire.

### Pathauto

Des patterns Article existent déjà, dont le fallback `node_article` (`/actualites/[node:title]`) et les patterns linguistiques existants. Le pattern final Blog est hors scope : aucune configuration Pathauto n'est modifiée ici.

### Simple Sitemap

Simple Sitemap est déjà installé/configuré dans le projet et exposé dans les form displays éditoriaux existants. Le form display Article matérialisé conserve cette intégration. Aucun réglage global Sitemap n'est modifié.

### Compatibilité

Le changement est additif : aucun storage ou champ existant n'est supprimé ni retypé. `field_sector` est conservé. L'image et la catégorie ne sont pas rendues obligatoires au niveau du champ afin de ne pas rendre d'éventuels Articles historiques impossibles à rééditer ; l'ALT reste obligatoire dès qu'une image est fournie.

## Implémentation

- attache `body` à Article avec résumé visible dans le widget et champ traduisible ;
- réutilise `field_feature_image`, dossier `articles`, ALT obligatoire et ALT traduisible par traduction ;
- crée `blog_categories`, vocabulaire simple et traduisible ;
- crée `field_blog_category`, référence taxonomique cardinalité 1 ;
- ordonne le formulaire : titre, description courte, image, catégorie, corps, langue puis métadonnées ;
- configure les affichages `default` et `teaser` ;
- conserve `field_sector` sans le détourner en catégorie Blog ;
- complète uniquement les permissions éditoriales nécessaires.

## Validation acquise

GitHub / diff :

- [x] diff borné : 10 fichiers de configuration uniquement ;
- [x] 2 commits devant `main`, 0 derrière ;
- [x] PR mergeable ;
- [x] normalisation des deux view displays reproduite exactement depuis `ddev drush cex` et intégrée dans `008a9c67899411771bdb8b66a700b04f792f1533` ;
- [x] CI finale #683 / run `31841677874` GREEN sur le HEAD exact `008a9c67899411771bdb8b66a700b04f792f1533`.

DDEV local :

- [x] `ddev drush updb -y` ;
- [x] `ddev drush cim -y` — import réussi puis aucun changement à importer sur le HEAD final ;
- [x] `ddev drush cr` ;
- [x] `ddev drush config:status` — aucune différence DB/sync sur le HEAD final ;
- [x] `ddev composer lint:phpcs` ;
- [x] `ddev composer lint:phpstan` avec PHPStan 2.2.8 ;
- [x] `ddev composer lint:drupal-check` ;
- [x] `ddev composer test:project-functional` — 4 tests, 57 assertions ;
- [x] `git diff --check` ;
- [x] checkout Git propre après validation.

Les 20 dépréciations affichées par la suite fonctionnelle viennent de core/contrib déjà identifiés ; elles ne produisent aucune erreur de test et sont hors scope #356.

## Gate UI restant avant merge

- [ ] création/modification d'un Article ;
- [ ] création d'une nouvelle révision ;
- [ ] image avec ALT obligatoire ;
- [ ] sélection d'une catégorie `blog_categories` ;
- [ ] traduction FR/EN ;
- [ ] rendu `default` ;
- [ ] rendu `teaser`.

Tous les gates automatisés sont désormais GREEN. La PR ne sera fusionnée qu'après validation du gate UI ci-dessus.