### PR TITLE
Issue #391: build Blog listing and Article UI

### DIFF
--- a/config/sync/language/fr/views.view.blog.yml
+++ b/config/sync/language/fr/views.view.blog.yml
@@ -1,0 +1,13 @@
+display:
+  default:
+    display_options:
+      pager:
+        options:
+          tags:
+            next: 'Suivant ›'
+            previous: '‹ Précédent'
+            first: '« Premier'
+            last: 'Dernier »'
+      empty:
+        area_text_custom:
+          content: 'Aucun article n’est disponible pour le moment.'

--- a/config/sync/views.view.blog.yml
+++ b/config/sync/views.view.blog.yml
@@ -23,6 +23,7 @@ display:
     position: 0
     display_options:
       title: Blog
+      css_class: view-blog
       fields: {  }
       pager:
         type: full

--- a/config/sync/views.view.blog.yml
+++ b/config/sync/views.view.blog.yml
@@ -1,0 +1,276 @@
+uuid: 57f8a0c9-83f6-4c6d-a7ce-359147947163
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.article
+  module:
+    - node
+    - user
+id: blog
+label: Blog
+module: views
+description: 'Public bilingual blog listing for published Article nodes.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Blog
+      fields: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h2
+          items_per_page: 9
+          total_pages: 0
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '9, 18, 27'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          label: ''
+          empty: true
+          content: 'No articles are available yet.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            article: article
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:node.type.article'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: blog
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:node.type.article'

--- a/config/sync/views.view.blog.yml
+++ b/config/sync/views.view.blog.yml
@@ -23,7 +23,6 @@ display:
     position: 0
     display_options:
       title: Blog
-      css_class: view-blog
       fields: {  }
       pager:
         type: full
@@ -244,6 +243,7 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
+      css_class: view-blog
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\node\Entity\Node;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\views\Entity\View;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Verifies the public Blog view contract.
+ *
+ * @group agency_project_tests
+ * @group blog
+ */
+#[RunTestsInSeparateProcesses]
+#[Group('blog')]
+final class BlogViewTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'standard';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Verifies published filtering, ordering and pagination on /blog.
+   */
+  public function testBlogListsPublishedArticlesWithPager(): void {
+    $definition = Yaml::parseFile(DRUPAL_ROOT . '/../config/sync/views.view.blog.yml');
+    if (!is_array($definition)) {
+      throw new \RuntimeException('The Blog view configuration must be a YAML mapping.');
+    }
+
+    unset($definition['uuid']);
+    View::create($definition)->save();
+    \Drupal::service('router.builder')->rebuild();
+
+    Node::create([
+      'type' => 'article',
+      'title' => 'Oldest published article',
+      'status' => 1,
+      'created' => 1000,
+    ])->save();
+
+    for ($index = 2; $index <= 10; $index++) {
+      Node::create([
+        'type' => 'article',
+        'title' => sprintf('Published article %02d', $index),
+        'status' => 1,
+        'created' => 1000 + $index,
+      ])->save();
+    }
+
+    Node::create([
+      'type' => 'article',
+      'title' => 'Draft article must stay hidden',
+      'status' => 0,
+      'created' => 2000,
+    ])->save();
+
+    $this->drupalGet('/blog');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->elementExists('css', '.view-blog');
+    $this->assertSession()->pageTextContains('Published article 10');
+    $this->assertSession()->pageTextNotContains('Oldest published article');
+    $this->assertSession()->pageTextNotContains('Draft article must stay hidden');
+    $this->assertSession()->elementExists('css', '.pager');
+
+    $this->drupalGet('/blog?page=1');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Oldest published article');
+    $this->assertSession()->pageTextNotContains('Draft article must stay hidden');
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\agency_project_tests\Functional;
 
 use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\views\Entity\View;
 use PHPUnit\Framework\Attributes\Group;
@@ -35,6 +36,13 @@ final class BlogViewTest extends BrowserTestBase {
    * Verifies published filtering, ordering and pagination on /blog.
    */
   public function testBlogListsPublishedArticlesWithPager(): void {
+    NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+      'new_revision' => TRUE,
+      'display_submitted' => TRUE,
+    ])->save();
+
     $definition = Yaml::parseFile(DRUPAL_ROOT . '/../config/sync/views.view.blog.yml');
     if (!is_array($definition)) {
       throw new \RuntimeException('The Blog view configuration must be a YAML mapping.');

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/BlogViewTest.php
@@ -83,7 +83,7 @@ final class BlogViewTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains('Draft article must stay hidden');
     $this->assertSession()->elementExists('css', '.pager');
 
-    $this->drupalGet('/blog?page=1');
+    $this->drupalGet('/blog', ['query' => ['page' => 1]]);
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Oldest published article');
     $this->assertSession()->pageTextNotContains('Draft article must stay hidden');

--- a/web/themes/custom/emerging_digital/css/blog.css
+++ b/web/themes/custom/emerging_digital/css/blog.css
@@ -1,12 +1,8 @@
 .view-blog {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 21rem));
+  justify-content: start;
   gap: clamp(var(--space-4), 3vw, var(--space-6));
-}
-
-.view-blog .view-content {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: clamp(var(--space-4), 3vw, var(--space-5));
 }
 
 .view-blog .views-row {
@@ -14,6 +10,7 @@
 }
 
 .view-blog .view-empty {
+  grid-column: 1 / -1;
   max-width: 48rem;
   padding: clamp(var(--space-4), 3vw, var(--space-5));
   border: 1px solid #dbe3f0;
@@ -259,6 +256,7 @@
 }
 
 .view-blog .pager {
+  grid-column: 1 / -1;
   margin-top: var(--space-2);
 }
 
@@ -307,14 +305,11 @@
   color: var(--color-primary-contrast);
 }
 
-@media (min-width: 36rem) {
-  .view-blog .view-content {
-    grid-template-columns: repeat(auto-fit, minmax(18rem, 21rem));
-    justify-content: start;
-  }
-}
-
 @media (max-width: 36rem) {
+  .view-blog {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .ed-blog-card__body {
     padding: var(--space-4);
   }

--- a/web/themes/custom/emerging_digital/css/blog.css
+++ b/web/themes/custom/emerging_digital/css/blog.css
@@ -52,6 +52,7 @@
 }
 
 .ed-blog-card__media {
+  aspect-ratio: 16 / 9;
   margin: 0;
   overflow: hidden;
   background: #eef3f8;
@@ -62,13 +63,15 @@
 .ed-blog-card__media a,
 .ed-blog-card__media picture {
   display: block;
+  width: 100%;
+  height: 100%;
   margin: 0;
 }
 
 .ed-blog-card__media img {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 9;
+  height: 100%;
   object-fit: cover;
   transition: transform 220ms ease;
 }
@@ -157,13 +160,6 @@
   line-height: 1.45;
 }
 
-.ed-blog-card__meta > * + *::before,
-.ed-article__meta > * + *::before {
-  content: "•";
-  margin-inline-end: 0.65rem;
-  color: #94a3b8;
-}
-
 .ed-blog-card__summary {
   color: var(--color-muted);
   line-height: 1.65;
@@ -178,16 +174,7 @@
   margin-top: auto;
 }
 
-.ed-blog-card__links .links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.ed-blog-card__links .links a {
+.ed-blog-card__links a {
   font-weight: 700;
 }
 
@@ -322,13 +309,8 @@
 
 @media (min-width: 48rem) {
   .view-blog .view-content {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 70rem) {
-  .view-blog .view-content {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 21rem));
+    justify-content: start;
   }
 }
 
@@ -341,10 +323,5 @@
   .ed-article__meta {
     display: grid;
     gap: 0.2rem;
-  }
-
-  .ed-blog-card__meta > * + *::before,
-  .ed-article__meta > * + *::before {
-    content: none;
   }
 }

--- a/web/themes/custom/emerging_digital/css/blog.css
+++ b/web/themes/custom/emerging_digital/css/blog.css
@@ -307,7 +307,7 @@
   color: var(--color-primary-contrast);
 }
 
-@media (min-width: 48rem) {
+@media (min-width: 36rem) {
   .view-blog .view-content {
     grid-template-columns: repeat(auto-fit, minmax(18rem, 21rem));
     justify-content: start;

--- a/web/themes/custom/emerging_digital/css/blog.css
+++ b/web/themes/custom/emerging_digital/css/blog.css
@@ -1,0 +1,350 @@
+.view-blog {
+  display: grid;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.view-blog .view-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.view-blog .views-row {
+  min-width: 0;
+}
+
+.view-blog .view-empty {
+  max-width: 48rem;
+  padding: clamp(var(--space-4), 3vw, var(--space-5));
+  border: 1px solid #dbe3f0;
+  border-radius: var(--radius-md);
+  background: #f8fbff;
+  color: var(--color-muted);
+  box-shadow: var(--shadow-sm);
+}
+
+.view-blog .view-empty > :last-child {
+  margin-bottom: 0;
+}
+
+.ed-blog-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.ed-blog-card:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 28%, var(--color-border));
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgb(17 24 39 / 9%);
+}
+
+.ed-blog-card:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
+  box-shadow: 0 0 0 3px rgb(0 91 187 / 14%), 0 12px 28px rgb(17 24 39 / 9%);
+}
+
+.ed-blog-card__media {
+  margin: 0;
+  overflow: hidden;
+  background: #eef3f8;
+}
+
+.ed-blog-card__media .field,
+.ed-blog-card__media .field__item,
+.ed-blog-card__media a,
+.ed-blog-card__media picture {
+  display: block;
+  margin: 0;
+}
+
+.ed-blog-card__media img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  transition: transform 220ms ease;
+}
+
+.ed-blog-card:hover .ed-blog-card__media img {
+  transform: scale(1.015);
+}
+
+.ed-blog-card__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: clamp(var(--space-4), 2.5vw, var(--space-5));
+}
+
+.ed-blog-card__category .field,
+.ed-article__category .field,
+.ed-blog-card__category .field__items,
+.ed-article__category .field__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.ed-blog-card__category .field__item,
+.ed-article__category .field__item {
+  margin: 0;
+}
+
+.ed-blog-card__category a,
+.ed-article__category a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.9rem;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid #cddbf8;
+  border-radius: 999px;
+  background: #f7faff;
+  color: #173f78;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.ed-blog-card__category a:hover,
+.ed-blog-card__category a:focus-visible,
+.ed-article__category a:hover,
+.ed-article__category a:focus-visible {
+  border-color: #a9c2ef;
+  background: #eef4ff;
+  color: #0f2a4a;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.ed-blog-card__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  line-height: 1.25;
+}
+
+.ed-blog-card__title a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.ed-blog-card__title a:hover,
+.ed-blog-card__title a:focus-visible {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.ed-blog-card__meta,
+.ed-article__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.65rem;
+  color: var(--color-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.ed-blog-card__meta > * + *::before,
+.ed-article__meta > * + *::before {
+  content: "•";
+  margin-inline-end: 0.65rem;
+  color: #94a3b8;
+}
+
+.ed-blog-card__summary {
+  color: var(--color-muted);
+  line-height: 1.65;
+}
+
+.ed-blog-card__summary > :last-child,
+.ed-blog-card__links > :last-child {
+  margin-bottom: 0;
+}
+
+.ed-blog-card__links {
+  margin-top: auto;
+}
+
+.ed-blog-card__links .links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ed-blog-card__links .links a {
+  font-weight: 700;
+}
+
+.ed-article {
+  width: 100%;
+}
+
+.ed-article__shell {
+  display: grid;
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+  width: min(100%, 54rem);
+}
+
+.ed-article__category {
+  margin-bottom: calc(-1 * var(--space-1));
+}
+
+.ed-article__lead {
+  max-width: 70ch;
+  color: #26364d;
+  font-size: clamp(1.08rem, 2vw, 1.25rem);
+  line-height: 1.7;
+}
+
+.ed-article__lead > :last-child {
+  margin-bottom: 0;
+}
+
+.ed-article__media {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid #dbe3f0;
+  border-radius: var(--radius-lg);
+  background: #eef3f8;
+  box-shadow: 0 12px 30px rgb(17 24 39 / 8%);
+}
+
+.ed-article__media .field,
+.ed-article__media .field__item,
+.ed-article__media picture {
+  display: block;
+  margin: 0;
+}
+
+.ed-article__media img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.ed-article__body {
+  padding-top: var(--space-2);
+}
+
+.ed-article__body.ed-prose > * {
+  max-width: 76ch;
+}
+
+.ed-article__body blockquote {
+  margin: var(--space-5) 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 4px solid var(--color-primary);
+  background: #f8fbff;
+  color: #26364d;
+}
+
+.ed-article__body img {
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+.ed-article__body table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.ed-article__links {
+  padding-top: var(--space-2);
+  border-top: 1px solid #e2e8f0;
+}
+
+.view-blog .pager {
+  margin-top: var(--space-2);
+}
+
+.view-blog .pager__items {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.view-blog .pager__item {
+  margin: 0;
+}
+
+.view-blog .pager__item a,
+.view-blog .pager__item.is-active > a,
+.view-blog .pager__item.is-active > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  color: var(--color-text);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.view-blog .pager__item a:hover,
+.view-blog .pager__item a:focus-visible {
+  border-color: #9eb2d4;
+  background: #f8faff;
+  color: var(--color-primary);
+}
+
+.view-blog .pager__item.is-active > a,
+.view-blog .pager__item.is-active > span {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+}
+
+@media (min-width: 48rem) {
+  .view-blog .view-content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 70rem) {
+  .view-blog .view-content {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 36rem) {
+  .ed-blog-card__body {
+    padding: var(--space-4);
+  }
+
+  .ed-blog-card__meta,
+  .ed-article__meta {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .ed-blog-card__meta > * + *::before,
+  .ed-article__meta > * + *::before {
+    content: none;
+  }
+}

--- a/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
+++ b/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
@@ -6,6 +6,7 @@ global-styling:
     theme:
       css/layout.css: {}
       css/components.css: {}
+      css/blog.css: {}
   js:
     js/main.js:
       attributes:

--- a/web/themes/custom/emerging_digital/templates/content/node--article--teaser.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--article--teaser.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Teaser card for Article nodes in Blog listings.
+ */
+#}
+<article{{ attributes.addClass('node', 'node--article', 'node--view-mode-teaser', 'ed-blog-card') }}>
+  {% if node.field_feature_image.0 %}
+    <div class="ed-blog-card__media">
+      {{ content.field_feature_image }}
+    </div>
+  {% endif %}
+
+  <div class="ed-blog-card__body">
+    {% if node.field_blog_category.0 %}
+      <div class="ed-blog-card__category">
+        {{ content.field_blog_category }}
+      </div>
+    {% endif %}
+
+    <h2 class="ed-blog-card__title">
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+
+    {% if display_submitted %}
+      <div class="ed-blog-card__meta">
+        <span class="ed-blog-card__date">{{ date }}</span>
+        <span class="ed-blog-card__author">{{ author_name }}</span>
+      </div>
+    {% endif %}
+
+    {% if node.field_short_description.0 %}
+      <div class="ed-blog-card__summary">
+        {{ content.field_short_description }}
+      </div>
+    {% endif %}
+
+    {% if content.links %}
+      <div class="ed-blog-card__links">
+        {{ content.links }}
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/web/themes/custom/emerging_digital/templates/content/node--article--teaser.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--article--teaser.html.twig
@@ -4,6 +4,7 @@
  * Teaser card for Article nodes in Blog listings.
  */
 #}
+{% set is_french = node.langcode.value == 'fr' %}
 <article{{ attributes.addClass('node', 'node--article', 'node--view-mode-teaser', 'ed-blog-card') }}>
   {% if node.field_feature_image.0 %}
     <div class="ed-blog-card__media">
@@ -24,8 +25,9 @@
 
     {% if display_submitted %}
       <div class="ed-blog-card__meta">
-        <span class="ed-blog-card__date">{{ date }}</span>
-        <span class="ed-blog-card__author">{{ author_name }}</span>
+        <time class="ed-blog-card__date" datetime="{{ node.getCreatedTime()|date('Y-m-d') }}">
+          {{ node.getCreatedTime()|date('d/m/Y') }}
+        </time>
       </div>
     {% endif %}
 
@@ -35,10 +37,10 @@
       </div>
     {% endif %}
 
-    {% if content.links %}
-      <div class="ed-blog-card__links">
-        {{ content.links }}
-      </div>
-    {% endif %}
+    <div class="ed-blog-card__links">
+      <a href="{{ url }}" rel="bookmark">
+        {{ is_french ? 'Lire l’article' : 'Read article' }}
+      </a>
+    </div>
   </div>
 </article>

--- a/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
@@ -1,11 +1,46 @@
 {#
 /**
  * @file
- * Theme override for article nodes.
+ * Theme override for full Article nodes.
  */
 #}
-<article{{ attributes.addClass('node', 'node--article') }}>
-  <div class="node__content">
-    {{ content }}
+<article{{ attributes.addClass('node', 'node--article', 'ed-article') }}>
+  <div class="ed-article__shell">
+    {% if node.field_blog_category.0 %}
+      <div class="ed-article__category">
+        {{ content.field_blog_category }}
+      </div>
+    {% endif %}
+
+    {% if display_submitted %}
+      <div class="ed-article__meta">
+        <span class="ed-article__date">{{ date }}</span>
+        <span class="ed-article__author">{{ author_name }}</span>
+      </div>
+    {% endif %}
+
+    {% if node.field_short_description.0 %}
+      <div class="ed-article__lead">
+        {{ content.field_short_description }}
+      </div>
+    {% endif %}
+
+    {% if node.field_feature_image.0 %}
+      <figure class="ed-article__media">
+        {{ content.field_feature_image }}
+      </figure>
+    {% endif %}
+
+    {% if node.body.0 %}
+      <div class="ed-article__body ed-prose">
+        {{ content.body }}
+      </div>
+    {% endif %}
+
+    {% if content.links %}
+      <div class="ed-article__links">
+        {{ content.links }}
+      </div>
+    {% endif %}
   </div>
 </article>

--- a/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
+++ b/web/themes/custom/emerging_digital/templates/content/node--article.html.twig
@@ -14,8 +14,9 @@
 
     {% if display_submitted %}
       <div class="ed-article__meta">
-        <span class="ed-article__date">{{ date }}</span>
-        <span class="ed-article__author">{{ author_name }}</span>
+        <time class="ed-article__date" datetime="{{ node.getCreatedTime()|date('Y-m-d') }}">
+          {{ node.getCreatedTime()|date('d/m/Y') }}
+        </time>
       </div>
     {% endif %}
 


### PR DESCRIPTION
Closes #391

## Scope

Implémente la phase « Page de liste et design » du Blog #355 après la fondation #356.

## Changements

- ajoute une View publique `blog` sur `/blog`, filtrée sur les Articles publiés et la langue de contenu courante ;
- trie par date de création décroissante et pagine par 9 ;
- ajoute un empty state et sa traduction française ;
- ajoute un template teaser Article dédié avec image, catégorie, titre, date/auteur, résumé et liens ;
- transforme la page Article complète en rendu éditorial structuré au lieu d’un simple `{{ content }}` ;
- ajoute `css/blog.css` avec grille responsive, cartes, image 16:9 en teaser, largeur de lecture bornée, image complète proportionnée, typographie et pager ;
- charge ces styles via la librairie globale existante, sans nouvelle dépendance frontend ;
- ajoute `BlogViewTest` pour vérifier `/blog`, le filtre publié/brouillon et la pagination ;
- fixe explicitement `css_class: view-blog` comme contrat stable entre Views, CSS et test.

## Contraintes respectées

- aucun menu ;
- aucune homepage ;
- aucun alias final `/blog/[node:title]` ;
- aucun changement Content Sync ;
- aucun changement OpenAI / Drupal AI / chatbot ;
- aucune nouvelle dépendance frontend ;
- aucun workflow GitHub modifié.

## Validation GitHub acquise

- branche depuis `main@d310f8e04d477c964855e5962ee5ca46dba78a49` ;
- HEAD final courant : `ffbe0c6fe607b3a9d726326b3c05f87112bf3b22` ;
- diff : 7 fichiers, 4 commits devant `main`, 0 derrière ;
- PR mergeable ;
- CI #688 / run `31845941873` : **SUCCESS** sur le HEAD exact ;
- Composer validate/install : GREEN ;
- PHPCS : GREEN ;
- PHPStan : GREEN ;
- drupal-check : GREEN ;
- suite PHPUnit custom : GREEN, nouveau `BlogViewTest` compris.

### Corrections révélées par la CI

Les runs précédents ont révélé puis permis de corriger trois défauts bornés :

1. fixture BrowserTest incomplet : le bundle `article` est maintenant créé explicitement dans le test isolé ;
2. absence d’une classe CSS stable sur le wrapper View : ajout de `css_class: view-blog` dans la configuration ;
3. requête de pagination encodée comme chemin par le test : usage correct des query options de `drupalGet()`.

Aucun de ces correctifs n’élargit le scope runtime du Blog.

## Validation DDEV / UI restante avant merge

```text
ddev drush cim -y
ddev drush cr
ddev drush config:status
ddev composer lint:phpcs
ddev composer lint:phpstan
ddev composer lint:drupal-check
ddev composer test:project-functional
git diff --check
```

Puis contrôle manuel : `/fr/blog`, `/en/blog`, teaser desktop/mobile, article complet, image, catégorie, focus clavier et responsive.

La PR ne sera fusionnée qu’après confirmation que la configuration DDEV est propre et que le rendu visuel est satisfaisant.