### PR TITLE
Issue #393: finalize Blog SEO aliases

### DIFF
--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -10,6 +10,7 @@ tags:
   canonical_url: '[node:url]'
   description: '[node:field_short_description:value]'
   og_description: '[node:field_short_description:value]'
+  og_image: '[node:field_feature_image:entity:url]'
   og_title: '[node:title] | [site:name]'
   og_type: article
   og_url: '[node:url]'
@@ -21,8 +22,9 @@ tags:
   schema_article_id: '[node:url]'
   schema_article_main_entity_of_page: '[node:url]'
   schema_article_publisher: 'a:3:{s:5:"@type";s:12:"Organization";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";}'
-  twitter_cards_type: summary
+  twitter_cards_type: summary_large_image
   twitter_cards_description: '[node:field_short_description:value]'
+  twitter_cards_image: '[node:field_feature_image:entity:url]'
   twitter_cards_title: '[node:title] | [site:name]'
   title: '[node:title] | [site:name]'
   schema_article_type: Article

--- a/config/sync/pathauto.pattern.content_path_pattern_article.yml
+++ b/config/sync/pathauto.pattern.content_path_pattern_article.yml
@@ -13,19 +13,19 @@ selection_criteria:
   6b28608b-aac9-4729-a6b0-e010019d2bc1:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 6b28608b-aac9-4729-a6b0-e010019d2bc1
     context_mapping:
       node: node
     bundles:
       article: article
+    uuid: 6b28608b-aac9-4729-a6b0-e010019d2bc1
   bb6f62a9-704e-48bc-aff5-ecd09a79a565:
     id: language
     negate: false
-    uuid: bb6f62a9-704e-48bc-aff5-ecd09a79a565
     context_mapping:
       language: 'node:langcode:language'
     langcodes:
       fr: fr
+    uuid: bb6f62a9-704e-48bc-aff5-ecd09a79a565
 selection_logic: and
 weight: -10
 relationships:

--- a/config/sync/pathauto.pattern.content_path_pattern_article.yml
+++ b/config/sync/pathauto.pattern.content_path_pattern_article.yml
@@ -8,7 +8,7 @@ dependencies:
 id: content_path_pattern_article
 label: 'Content path pattern (Article)'
 type: 'canonical_entities:node'
-pattern: '/actualites/[node:title]'
+pattern: '/blog/[node:title]'
 selection_criteria:
   6b28608b-aac9-4729-a6b0-e010019d2bc1:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.content_path_pattern_article_en.yml
+++ b/config/sync/pathauto.pattern.content_path_pattern_article_en.yml
@@ -13,19 +13,19 @@ selection_criteria:
   a5b1ccb7-e39a-434a-899b-706a49ef615f:
     id: 'entity_bundle:node'
     negate: false
-    uuid: a5b1ccb7-e39a-434a-899b-706a49ef615f
     context_mapping:
       node: node
     bundles:
       article: article
+    uuid: a5b1ccb7-e39a-434a-899b-706a49ef615f
   894c4bf9-3b01-45e9-bab9-c2a5df03155a:
     id: language
     negate: false
-    uuid: 894c4bf9-3b01-45e9-bab9-c2a5df03155a
     context_mapping:
       language: 'node:langcode:language'
     langcodes:
       en: en
+    uuid: 894c4bf9-3b01-45e9-bab9-c2a5df03155a
 selection_logic: and
 weight: -10
 relationships:

--- a/config/sync/pathauto.pattern.content_path_pattern_article_en.yml
+++ b/config/sync/pathauto.pattern.content_path_pattern_article_en.yml
@@ -8,7 +8,7 @@ dependencies:
 id: content_path_pattern_article_en
 label: 'Content path pattern (Article)'
 type: 'canonical_entities:node'
-pattern: '/news/[node:title]'
+pattern: '/blog/[node:title]'
 selection_criteria:
   a5b1ccb7-e39a-434a-899b-706a49ef615f:
     id: 'entity_bundle:node'

--- a/config/sync/pathauto.pattern.node_article.yml
+++ b/config/sync/pathauto.pattern.node_article.yml
@@ -12,11 +12,11 @@ selection_criteria:
   482ce287-8564-4e03-97f3-ec6a958703d8:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 482ce287-8564-4e03-97f3-ec6a958703d8
     context_mapping:
       node: node
     bundles:
       article: article
+    uuid: 482ce287-8564-4e03-97f3-ec6a958703d8
 selection_logic: and
 weight: -8
 relationships: {  }

--- a/config/sync/pathauto.pattern.node_article.yml
+++ b/config/sync/pathauto.pattern.node_article.yml
@@ -7,7 +7,7 @@ dependencies:
 id: node_article
 label: 'Content path pattern (Article fallback)'
 type: 'canonical_entities:node'
-pattern: '/actualites/[node:title]'
+pattern: '/blog/[node:title]'
 selection_criteria:
   482ce287-8564-4e03-97f3-ec6a958703d8:
     id: 'entity_bundle:node'

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/BlogSeoConfigTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/BlogSeoConfigTest.php
@@ -47,9 +47,9 @@ final class BlogSeoConfigTest extends TestCase {
   }
 
   /**
-   * Verifies that the existing Article metadata follows the canonical node URL.
+   * Verifies canonical and social metadata for Blog Articles.
    */
-  public function testArticleMetatagUsesCanonicalNodeUrl(): void {
+  public function testArticleMetatagUsesCanonicalUrlAndFeatureImage(): void {
     $configuration = $this->loadConfiguration('metatag.metatag_defaults.node__article.yml');
     $tags = $configuration['tags'] ?? [];
 
@@ -59,6 +59,9 @@ final class BlogSeoConfigTest extends TestCase {
     self::assertSame('[node:url]', $tags['schema_article_id'] ?? NULL);
     self::assertSame('[node:url]', $tags['schema_article_main_entity_of_page'] ?? NULL);
     self::assertSame('[node:field_short_description:value]', $tags['description'] ?? NULL);
+    self::assertSame('[node:field_feature_image:entity:url]', $tags['og_image'] ?? NULL);
+    self::assertSame('[node:field_feature_image:entity:url]', $tags['twitter_cards_image'] ?? NULL);
+    self::assertSame('summary_large_image', $tags['twitter_cards_type'] ?? NULL);
   }
 
   /**

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/BlogSeoConfigTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/BlogSeoConfigTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Verifies the versioned technical SEO contract for Blog Articles.
+ *
+ * @group agency_project_tests
+ * @group blog
+ */
+#[Group('blog')]
+final class BlogSeoConfigTest extends TestCase {
+
+  /**
+   * Verifies neutral Blog aliases and language-specific Pathauto criteria.
+   */
+  public function testArticlePathautoPatternsUseNeutralBlogAlias(): void {
+    $patterns = [
+      'pathauto.pattern.content_path_pattern_article.yml' => 'fr',
+      'pathauto.pattern.content_path_pattern_article_en.yml' => 'en',
+      'pathauto.pattern.node_article.yml' => NULL,
+    ];
+
+    foreach ($patterns as $filename => $expected_language) {
+      $configuration = $this->loadConfiguration($filename);
+
+      self::assertSame('canonical_entities:node', $configuration['type'] ?? NULL);
+      self::assertSame('/blog/[node:title]', $configuration['pattern'] ?? NULL);
+
+      $criteria = $configuration['selection_criteria'] ?? [];
+      self::assertIsArray($criteria);
+      self::assertTrue($this->hasArticleBundleCriterion($criteria));
+
+      if ($expected_language === NULL) {
+        self::assertFalse($this->hasLanguageCriterion($criteria));
+      }
+      else {
+        self::assertTrue($this->hasLanguageCriterion($criteria, $expected_language));
+      }
+    }
+  }
+
+  /**
+   * Verifies that the existing Article metadata follows the canonical node URL.
+   */
+  public function testArticleMetatagUsesCanonicalNodeUrl(): void {
+    $configuration = $this->loadConfiguration('metatag.metatag_defaults.node__article.yml');
+    $tags = $configuration['tags'] ?? [];
+
+    self::assertIsArray($tags);
+    self::assertSame('[node:url]', $tags['canonical_url'] ?? NULL);
+    self::assertSame('[node:url]', $tags['og_url'] ?? NULL);
+    self::assertSame('[node:url]', $tags['schema_article_id'] ?? NULL);
+    self::assertSame('[node:url]', $tags['schema_article_main_entity_of_page'] ?? NULL);
+    self::assertSame('[node:field_short_description:value]', $tags['description'] ?? NULL);
+  }
+
+  /**
+   * Loads one configuration file from the repository sync directory.
+   */
+  private function loadConfiguration(string $filename): array {
+    $path = dirname(DRUPAL_ROOT) . '/config/sync/' . $filename;
+    self::assertFileExists($path);
+
+    $configuration = Yaml::parseFile($path);
+    self::assertIsArray($configuration);
+
+    return $configuration;
+  }
+
+  /**
+   * Determines whether the criteria restrict the pattern to Article nodes.
+   */
+  private function hasArticleBundleCriterion(array $criteria): bool {
+    foreach ($criteria as $criterion) {
+      if (($criterion['id'] ?? NULL) === 'entity_bundle:node'
+        && ($criterion['bundles']['article'] ?? NULL) === 'article') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Determines whether a language criterion exists, optionally for one locale.
+   */
+  private function hasLanguageCriterion(array $criteria, ?string $language = NULL): bool {
+    foreach ($criteria as $criterion) {
+      if (($criterion['id'] ?? NULL) !== 'language') {
+        continue;
+      }
+
+      if ($language === NULL) {
+        return TRUE;
+      }
+
+      return ($criterion['langcodes'][$language] ?? NULL) === $language;
+    }
+
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
Closes #393

## Scope

Finalise le SEO technique du Blog #355 après #356 et #391.

## Changements

- remplace les trois patterns Pathauto Article historiques (`/actualites/...`, `/news/...`, fallback `/actualites/...`) par le pattern neutre `/blog/[node:title]` ;
- conserve les critères de langue FR/EN et le fallback Article existants ;
- ajoute l’image principale Article à Open Graph (`og:image`) et Twitter (`twitter:image`) via le token natif prouvé `[node:field_feature_image:entity:url]` ;
- passe Twitter Card à `summary_large_image` ;
- ajoute `BlogSeoConfigTest` pour verrouiller aliases, critères de langue, canonical et métadonnées sociales ;
- ne modifie aucun autre bundle, menu, contenu, homepage ou workflow.

## Validation GitHub

- HEAD exact : `4372d6d72dc73695818e5784d69ac7a5168d50b3` ;
- CI #701 / run `31850946596` : **SUCCESS** ;
- quality scripts : GREEN ;
- suite PHPUnit custom : GREEN, `BlogSeoConfigTest` compris ;
- PR mergeable ;
- 0 commit derrière `main` ;
- aucun review ni thread ouvert ;
- diff final : 5 fichiers strictement dans le scope.

## Validation DDEV réelle

Configuration :

- `ddev drush config:status` : aucune différence DB/sync ;
- `git status --short` : propre ;
- les trois patterns actifs retournent `/blog/[node:title]`.

Article1 / nid 37 / FR :

- régénération bornée via `pathauto.generator->updateEntityAlias()` ;
- alias interne : `/blog/article1` ;
- URL publique validée : `/fr/blog/article1` ;
- ancienne URL `/fr/actualites/article1` : **301** vers `/fr/blog/article1` ;
- canonical : `/fr/blog/article1` ;
- hreflang FR : `/fr/blog/article1` ;
- `og:image` : URL absolue de `field_feature_image` ;
- `twitter:card` : `summary_large_image` ;
- `twitter:image` : URL absolue de `field_feature_image`.

Simple Sitemap :

- `/sitemap.xml` est l’index et pointe vers `/default/sitemap.xml` ;
- `/default/sitemap.xml` contient `https://emergingdigital.be/fr/blog/article1` et son hreflang FR ;
- réglages actifs `node:article` : `index=true`, priorité `0.5`, `changefreq=daily`, `include_images=true`.

## Multilingue EN

La base DDEV de validation ne contient actuellement qu’une traduction FR d’Article1. La preuve runtime EN n’est donc pas artificiellement créée dans ce ticket. Le pattern EN `/blog/[node:title]` et son critère `langcodes.en = en` sont couverts par le test automatisé de configuration ; la fondation de traduction Article a déjà été validée dans #356.

## Hors périmètre respecté

- aucun menu ;
- aucune homepage ;
- aucun Content Sync ;
- aucune IA ;
- aucun tracking ;
- aucun déploiement.
