### PR TITLE
Issue #395: add Blog to main navigation

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -76,7 +76,7 @@ function emerging_digital_content_update_11003(array &$sandbox): string {
 }
 
 /**
- * Ensures one Blog link immediately precedes Contact without reweighting others.
+ * Ensures Blog immediately precedes Contact without reweighting other links.
  */
 function _emerging_digital_content_ensure_blog_navigation_position(): int {
   $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
@@ -213,7 +213,7 @@ function _emerging_digital_content_sync_mapping_schema(): array {
         'default' => '',
       ],
       'catalog_hash' => [
-        'description' => 'Hash of the catalog definition used during the latest sync.',
+        'description' => 'Hash of the catalog definition used during the last sync.',
         'type' => 'varchar',
         'length' => 64,
         'not null' => TRUE,

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -160,7 +160,7 @@ function _emerging_digital_content_sync_mapping_schema(): array {
         'unsigned' => TRUE,
       ],
       'entity_uuid' => [
-        'description' => 'Drupal entity UUID managed by Content Sync.',
+        'description' => 'Drupal entity UUID.',
         'type' => 'varchar',
         'length' => 128,
       ],

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -59,7 +59,48 @@ function emerging_digital_content_update_11001(array &$sandbox): string {
 function emerging_digital_content_update_11002(array &$sandbox): string {
   unset($sandbox);
 
+  $changed = _emerging_digital_content_ensure_blog_navigation_position();
+
+  return sprintf('%d main navigation values were created or updated for Blog.', $changed);
+}
+
+/**
+ * Normalizes Blog and Contact weights relative to the existing navigation.
+ */
+function emerging_digital_content_update_11003(array &$sandbox): string {
+  unset($sandbox);
+
+  $changed = _emerging_digital_content_ensure_blog_navigation_position();
+
+  return sprintf('%d Blog navigation values were normalized.', $changed);
+}
+
+/**
+ * Ensures one Blog link immediately precedes Contact without reweighting others.
+ */
+function _emerging_digital_content_ensure_blog_navigation_position(): int {
   $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+  $all_ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'main')
+    ->execute();
+  $all_links = $storage->loadMultiple($all_ids);
+
+  $max_other_weight = NULL;
+  foreach ($all_links as $link) {
+    $title = (string) $link->label();
+    if (in_array($title, ['Blog', 'Contact'], TRUE)) {
+      continue;
+    }
+
+    $weight = (int) $link->get('weight')->value;
+    $max_other_weight = $max_other_weight === NULL
+      ? $weight
+      : max($max_other_weight, $weight);
+  }
+
+  $blog_weight = ($max_other_weight ?? -1) + 1;
+  $contact_weight = $blog_weight + 1;
   $changed = 0;
 
   $blog_ids = \Drupal::entityQuery('menu_link_content')
@@ -83,8 +124,8 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
         $blog->set('enabled', TRUE);
         $changed++;
       }
-      if ((int) $blog->get('weight')->value !== 4) {
-        $blog->set('weight', 4);
+      if ((int) $blog->get('weight')->value !== $blog_weight) {
+        $blog->set('weight', $blog_weight);
         $changed++;
       }
       $blog->save();
@@ -102,7 +143,7 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
       'link' => ['uri' => 'internal:/blog'],
       'expanded' => FALSE,
       'enabled' => TRUE,
-      'weight' => 4,
+      'weight' => $blog_weight,
     ])->save();
     $changed++;
   }
@@ -114,16 +155,16 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
     ->execute();
 
   foreach ($storage->loadMultiple($contact_ids) as $contact) {
-    if ((int) $contact->get('weight')->value === 5) {
+    if ((int) $contact->get('weight')->value === $contact_weight) {
       continue;
     }
 
-    $contact->set('weight', 5);
+    $contact->set('weight', $contact_weight);
     $contact->save();
     $changed++;
   }
 
-  return sprintf('%d main navigation values were created or updated for Blog.', $changed);
+  return $changed;
 }
 
 /**
@@ -172,7 +213,7 @@ function _emerging_digital_content_sync_mapping_schema(): array {
         'default' => '',
       ],
       'catalog_hash' => [
-        'description' => 'Hash of the catalog definition used during the last sync.',
+        'description' => 'Hash of the catalog definition used during the latest sync.',
         'type' => 'varchar',
         'length' => 64,
         'not null' => TRUE,

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -69,7 +69,9 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
     ->execute();
 
   if ($blog_ids) {
-    $blog = reset($storage->loadMultiple($blog_ids));
+    $blogs = array_values($storage->loadMultiple($blog_ids));
+    $blog = array_shift($blogs);
+
     if ($blog instanceof MenuLinkContent) {
       $link_item = $blog->get('link')->first();
       $uri = $link_item ? ($link_item->getValue()['uri'] ?? '') : '';
@@ -77,7 +79,7 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
         $blog->set('link', ['uri' => 'internal:/blog']);
         $changed++;
       }
-      if (!$blog->isEnabled()) {
+      if (!(bool) $blog->get('enabled')->value) {
         $blog->set('enabled', TRUE);
         $changed++;
       }
@@ -86,6 +88,11 @@ function emerging_digital_content_update_11002(array &$sandbox): string {
         $changed++;
       }
       $blog->save();
+    }
+
+    foreach ($blogs as $duplicate) {
+      $duplicate->delete();
+      $changed++;
     }
   }
   else {
@@ -153,7 +160,7 @@ function _emerging_digital_content_sync_mapping_schema(): array {
         'unsigned' => TRUE,
       ],
       'entity_uuid' => [
-        'description' => 'Drupal entity UUID.',
+        'description' => 'Drupal entity UUID managed by Content Sync.',
         'type' => 'varchar',
         'length' => 128,
       ],

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\emerging_digital_content\MainNavigationManager;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 
 /**
  * Implements hook_schema().
@@ -50,6 +51,72 @@ function emerging_digital_content_update_11001(array &$sandbox): string {
   }
 
   return 'Content Sync mapping table already exists.';
+}
+
+/**
+ * Adds Blog to the main navigation without rewriting unrelated links.
+ */
+function emerging_digital_content_update_11002(array &$sandbox): string {
+  unset($sandbox);
+
+  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+  $changed = 0;
+
+  $blog_ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'main')
+    ->condition('title', 'Blog')
+    ->execute();
+
+  if ($blog_ids) {
+    $blog = reset($storage->loadMultiple($blog_ids));
+    if ($blog instanceof MenuLinkContent) {
+      $link_item = $blog->get('link')->first();
+      $uri = $link_item ? ($link_item->getValue()['uri'] ?? '') : '';
+      if ($uri !== 'internal:/blog') {
+        $blog->set('link', ['uri' => 'internal:/blog']);
+        $changed++;
+      }
+      if (!$blog->isEnabled()) {
+        $blog->set('enabled', TRUE);
+        $changed++;
+      }
+      if ((int) $blog->get('weight')->value !== 4) {
+        $blog->set('weight', 4);
+        $changed++;
+      }
+      $blog->save();
+    }
+  }
+  else {
+    MenuLinkContent::create([
+      'title' => 'Blog',
+      'menu_name' => 'main',
+      'link' => ['uri' => 'internal:/blog'],
+      'expanded' => FALSE,
+      'enabled' => TRUE,
+      'weight' => 4,
+    ])->save();
+    $changed++;
+  }
+
+  $contact_ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'main')
+    ->condition('title', 'Contact')
+    ->execute();
+
+  foreach ($storage->loadMultiple($contact_ids) as $contact) {
+    if ((int) $contact->get('weight')->value === 5) {
+      continue;
+    }
+
+    $contact->set('weight', 5);
+    $contact->save();
+    $changed++;
+  }
+
+  return sprintf('%d main navigation values were created or updated for Blog.', $changed);
 }
 
 /**

--- a/web/modules/custom/emerging_digital_content/src/MainNavigationManager.php
+++ b/web/modules/custom/emerging_digital_content/src/MainNavigationManager.php
@@ -22,7 +22,8 @@ final class MainNavigationManager {
       ['title' => 'Services', 'uri' => 'internal:/services', 'weight' => 1],
       ['title' => 'IA & Drupal', 'uri' => 'internal:/ia-drupal', 'weight' => 2],
       ['title' => 'Cas clients', 'uri' => 'internal:/cas-clients', 'weight' => 3],
-      ['title' => 'Contact', 'uri' => 'internal:/contact', 'weight' => 4],
+      ['title' => 'Blog', 'uri' => 'internal:/blog', 'weight' => 4],
+      ['title' => 'Contact', 'uri' => 'internal:/contact', 'weight' => 5],
     ];
 
     $created_or_updated = 0;


### PR DESCRIPTION
Closes #395

## Scope

Ajoute le Blog à la navigation principale après finalisation du Blog V1 et de son SEO technique.

## Changements

- ajoute `Blog -> internal:/blog` au `MainNavigationManager` pour les installations neuves ;
- ajoute les updates `11002`/`11003` pour les environnements existants ;
- positionne Blog immédiatement avant Contact en calculant les poids relativement à la navigation existante au lieu d’imposer des poids absolus ;
- préserve l’ordre et les poids des autres liens (`Accueil`, `Services`, `IA & Drupal`, `Cas clients`, `Équipe`, etc.) ;
- supprime d’éventuels doublons `Blog` dans le menu `main` ;
- n’appelle pas le manager complet dans les updates existants afin de ne pas réécrire des liens historiques hors scope.

## Validation GitHub

- HEAD exact : `41592f393b6dbbc7b77f8b5319fb0c09d083ee88` ;
- CI #705 / run `31852228120` : **SUCCESS** ;
- quality scripts : GREEN ;
- suite PHPUnit custom : GREEN ;
- branche 0 commit derrière `main` ;
- diff final : 2 fichiers uniquement ;
- aucun changement homepage, Content Sync éditorial, IA, tracking ou déploiement.

## Validation DDEV réelle

Après `11002` puis `11003` sur l’environnement existant :

```text
Accueil      weight=-50
Services     weight=-48
IA & Drupal  weight=-47
Cas clients  weight=-46
Équipe       weight=-45
Blog         weight=-44  uri=internal:/blog  enabled=1
Contact      weight=-43  uri=internal:/contact enabled=1
```

Preuves complémentaires :

- exactement un lien Blog ;
- rendu FR validé visuellement sur `/fr/blog` ;
- état actif du lien Blog validé ;
- `ddev drush config:status` : aucune différence DB/sync ;
- `git status --short` : propre.

## Dernier contrôle avant merge

- confirmer que `/en/blog` affiche également le lien `Blog` vers le Blog anglais.
