### PR TITLE
Issue #400: add governed self-hosted browser executor

### DIFF
--- a/.github/workflows/agent-browser-validation-dispatch.yml
+++ b/.github/workflows/agent-browser-validation-dispatch.yml
@@ -1,0 +1,121 @@
+name: Agent browser validation dispatch
+
+on:
+  push:
+    branches:
+      - agency/browser-validation-dispatch-control
+    paths:
+      - .agency/browser-validation-request.json
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Validate governed request and dispatch trusted workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout control branch history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate control mutation
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_ACTOR" != "E-merging-digital" ]]; then
+            echo "Unauthorized control actor: $GITHUB_ACTOR" >&2
+            exit 1
+          fi
+
+          changed="$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")"
+          if [[ "$changed" != ".agency/browser-validation-request.json" ]]; then
+            echo "Control branch mutations must change exactly .agency/browser-validation-request.json" >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+      - name: Validate request schema and live target
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' > /tmp/browser-request.env
+          import json
+          import re
+          from pathlib import Path
+
+          path = Path('.agency/browser-validation-request.json')
+          data = json.loads(path.read_text(encoding='utf-8'))
+          expected = {'request_id', 'pr_number', 'head_sha'}
+          if set(data) != expected:
+              raise SystemExit(f'Expected exactly {sorted(expected)}, got {sorted(data)}')
+
+          request_id = data['request_id']
+          pr_number = data['pr_number']
+          head_sha = data['head_sha']
+
+          if not isinstance(request_id, str) or not re.fullmatch(r'[A-Za-z0-9._-]{8,80}', request_id):
+              raise SystemExit('Invalid request_id')
+          if not isinstance(pr_number, int) or pr_number < 0:
+              raise SystemExit('pr_number must be a non-negative integer')
+          if not isinstance(head_sha, str) or not re.fullmatch(r'[0-9a-f]{40}', head_sha):
+              raise SystemExit('head_sha must be a lowercase 40-character SHA')
+
+          print(f'REQUEST_ID={request_id}')
+          print(f'PR_NUMBER={pr_number}')
+          print(f'HEAD_SHA={head_sha}')
+          PY
+
+          source /tmp/browser-request.env
+
+          if [[ "$PR_NUMBER" == "0" ]]; then
+            live_main="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')"
+            test "$HEAD_SHA" = "$live_main" || {
+              echo "Requested main SHA is stale." >&2
+              exit 1
+            }
+          else
+            pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+            test "$(jq -r '.state' <<<"$pr_json")" = "open"
+            test "$(jq -r '.base.ref' <<<"$pr_json")" = "main"
+            test "$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")" = "$GITHUB_REPOSITORY" || {
+              echo "Fork PRs are not dispatchable." >&2
+              exit 1
+            }
+            test "$(jq -r '.head.sha' <<<"$pr_json")" = "$HEAD_SHA" || {
+              echo "Requested PR SHA is stale." >&2
+              exit 1
+            }
+          fi
+
+          echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch trusted self-hosted validation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+          PR_NUMBER: ${{ steps.request.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh workflow run self-hosted-browser-validation.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f "request_id=$REQUEST_ID" \
+            -f "pr_number=$PR_NUMBER" \
+            -f "head_sha=$HEAD_SHA"

--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -149,18 +149,19 @@ jobs:
           test -f scripts/run-browser-validation.mjs
           git diff --check
 
-      - name: Setup Node 22
+      - name: Setup Node 24
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
 
-      - name: Install Node dependencies
+      - name: Install Node dependencies and Chromium
         shell: bash
         run: |
           set -euo pipefail
+          node --version
+          npm --version
           npm ci
-          npx playwright install-deps chromium --dry-run
           npx playwright install chromium
 
       - name: Isolate DDEV project for this run

--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -1,0 +1,225 @@
+name: Agency self-hosted browser validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      request_id:
+        description: Auditable request identifier
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number, or 0 to validate current main
+        required: true
+        type: string
+      head_sha:
+        description: Exact 40-character commit SHA to validate
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: agency-self-hosted-browser-validation
+  cancel-in-progress: false
+
+jobs:
+  validate-request:
+    name: Validate trusted target before self-hosted execution
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+    steps:
+      - name: Validate dispatch actor and target
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ inputs.request_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REQUESTED_HEAD_SHA: ${{ inputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          case "$GITHUB_ACTOR" in
+            E-merging-digital|github-actions[bot]) ;;
+            *)
+              echo "Refusing self-hosted dispatch actor: $GITHUB_ACTOR" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{8,80}$ ]]; then
+            echo "Invalid request_id." >&2
+            exit 1
+          fi
+
+          if [[ ! "$REQUESTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "head_sha must be an exact lowercase 40-character SHA." >&2
+            exit 1
+          fi
+
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "pr_number must be numeric." >&2
+            exit 1
+          fi
+
+          if [[ "$PR_NUMBER" == "0" ]]; then
+            main_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')"
+            if [[ "$REQUESTED_HEAD_SHA" != "$main_sha" ]]; then
+              echo "Main validation requires the live main SHA." >&2
+              exit 1
+            fi
+          else
+            pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+            state="$(jq -r '.state' <<<"$pr_json")"
+            base_ref="$(jq -r '.base.ref' <<<"$pr_json")"
+            head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
+            head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+
+            if [[ "$state" != "open" || "$base_ref" != "main" ]]; then
+              echo "Target must be an OPEN PR based on main." >&2
+              exit 1
+            fi
+            if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+              echo "Fork PRs are never allowed on the self-hosted runner." >&2
+              exit 1
+            fi
+            if [[ "$head_sha" != "$REQUESTED_HEAD_SHA" ]]; then
+              echo "Requested SHA is not the live PR HEAD." >&2
+              exit 1
+            fi
+
+            changed_files="$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')"
+            if grep -Eq '^(\.github/|\.ddev/|\.agency/|scripts/runner/)' <<<"$changed_files"; then
+              echo "Runner/workflow/DDEV infrastructure changes require a trusted main merge before execution." >&2
+              exit 1
+            fi
+          fi
+
+          echo "head_sha=$REQUESTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+  browser-validation:
+    name: Rebuild Agency and run real browser validation
+    needs: validate-request
+    timeout-minutes: 45
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          docker info --format 'ServerVersion={{.ServerVersion}} Driver={{.Driver}}'
+          command -v ddev
+          ddev version
+
+      - name: Checkout exact trusted target
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable infrastructure
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-request.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -f AGENTS.md
+          test -f .ddev/config.yaml
+          test -f package.json
+          test -f package-lock.json
+          test -f scripts/run-browser-validation.mjs
+          git diff --check
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install Node dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install-deps chromium --dry-run
+          npx playwright install chromium
+
+      - name: Isolate DDEV project for this run
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-browser-ci.yaml <<EOF
+          name: agency-browser-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-browser-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned state
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush emerging:content-sync:validate
+          ddev drush emerging:content-sync --all --dry-run
+          ddev drush emerging:content-sync --all
+          ddev drush cr
+          ddev drush status
+          ddev drush config:status
+
+      - name: Run unattended real-browser validation
+        shell: bash
+        env:
+          CI: 'true'
+        run: |
+          set -euo pipefail
+          npm run browser:validate
+
+      - name: Upload browser evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-browser-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/browser-validation
+            playwright-report
+            test-results
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-browser-ci.yaml
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi

--- a/docs/operations/agency-self-hosted-browser-runner.md
+++ b/docs/operations/agency-self-hosted-browser-runner.md
@@ -119,6 +119,10 @@ runs-on:
   - browser
 ```
 
+Node n'est pas un prérequis global de la VM. Le job utilise
+`actions/setup-node@v6` avec Node 24, puis `npm ci` et installe uniquement le
+Chromium correspondant au lockfile/Playwright du projet.
+
 ## 4. État Drupal reproductible
 
 Aucun dump local n'est utilisé.
@@ -127,6 +131,7 @@ Chaque run crée un nom DDEV éphémère avec un `config.*.yaml` local, puis :
 
 ```text
 checkout exact
+-> actions/setup-node Node 24
 -> npm ci
 -> Chromium Playwright
 -> ddev start
@@ -198,12 +203,16 @@ Retention initiale : 14 jours.
 La machine cible est `preflight-runner-01`, déjà prouvée pour Docker et DDEV.
 Le bootstrap vérifie aussi :
 
-- `curl`, `tar`, `sha256sum` ;
+- Ubuntu 24.04 exact ;
+- `apt-get`, `curl`, `tar`, `sha256sum` ;
 - Docker fonctionnel ;
 - DDEV fonctionnel ;
-- Node.js >= 20 et npm ;
-- accès réseau à GitHub/npm ;
+- accès réseau à GitHub ;
 - droits root pour l'installation one-shot.
+
+**Node/npm ne sont pas requis sur l'hôte.** La version Node est apportée par
+`actions/setup-node@v6` dans chaque job, ce qui évite un runtime Node global
+mutable sur la VM.
 
 Le script :
 
@@ -224,9 +233,11 @@ runner = agency-browser-runner-01
 labels = agency,ddev,browser (+ labels GitHub par défaut)
 ```
 
-Il ajoute uniquement `agency-runner` au groupe Docker et installe une fois les
-dépendances système Chromium requises par Playwright. Aucun `sudo` n'est donné
-au compte runner pour les jobs ordinaires.
+Il ajoute uniquement `agency-runner` au groupe Docker et installe une fois, via
+`apt-get`, les groupes `tools + chromium` déclarés par Playwright 1.62.1 pour
+`ubuntu24.04-x64`. Aucun `sudo` n'est donné au compte runner pour les jobs
+ordinaires. Les binaires Chromium sont téléchargés sous le compte runner par le
+workflow et restent indépendants du bootstrap système.
 
 ### Seul gate humain de provisioning
 
@@ -291,7 +302,7 @@ workflow GitHub-hosted vérifie et déclenche la browser validation.
 
 ## 9. Première preuve unattended
 
-Une fois #399 et #400 présents sur `main` :
+Une fois #399 et les workflows #400 présents sur `main` :
 
 1. créer/mettre à jour la requête de contrôle avec `pr_number=0` et le SHA exact
    de `main` ;
@@ -309,13 +320,18 @@ Ce run constitue la preuve DoD « unattended Agency réel ».
 
 MCP est optionnel et ne participe jamais au verdict CI.
 
-Sur la machine Agency, la voie préférée pour un agent local est **stdio** :
+Sur la machine Agency, la voie préférée pour un agent local est **stdio**. Node
+sera fourni explicitement à la session d'agent (ou par un runtime gouverné) avant
+d'enregistrer le serveur MCP ; le runner système n'a pas besoin de Node global.
 
-```bash
-codex mcp add playwright npx "@playwright/mcp@latest"
+Configuration cible conceptuelle :
+
+```text
+Codex CLI local
+-> Playwright MCP en stdio
+-> Chromium
+-> Agency DDEV
 ```
-
-ou configuration Codex équivalente.
 
 Le serveur Playwright MCP officiel utilise localhost par défaut lorsqu'un
 transport réseau est demandé. Agency interdit :

--- a/docs/operations/agency-self-hosted-browser-runner.md
+++ b/docs/operations/agency-self-hosted-browser-runner.md
@@ -1,0 +1,373 @@
+# Agency self-hosted browser validation runner
+
+Status: **PROVISIONING**  
+Issue: #400  
+Repository: `E-merging-digital/agency-website-drupal`
+
+## 1. Architecture retenue
+
+Agency réutilise la machine déjà éprouvée `preflight-runner-01`, mais **pas** le
+runner GitHub Preflight lui-même.
+
+La machine héberge deux runners repository-scoped distincts :
+
+```text
+preflight-runner-01
+|
++-- runner Preflight existant
+|   account: preflight-runner
+|   labels: self-hosted, linux, x64, preflight, ddev
+|
++-- runner Agency Browser
+    account: agency-runner
+    name: agency-browser-runner-01
+    labels: self-hosted, linux, x64, agency, ddev, browser
+```
+
+Le compte, le répertoire d'installation, le workdir et le service systemd du
+runner Agency sont séparés de Preflight. #400 n'autorise aucune modification du
+runner/service Preflight.
+
+## 2. Pourquoi le runner n'est jamais déclenché directement par une PR
+
+Le dépôt Agency est public. Un self-hosted runner ne doit pas exécuter du code
+d'une fork PR ou d'un workflow modifiable par un contributeur non fiable.
+
+La browser validation self-hosted est donc **trusted dispatch only** :
+
+```text
+agent / opérateur autorisé
+        |
+        v
+branche de contrôle dédiée
+        |
+        v
+workflow GitHub-hosted de validation/dispatch
+        |
+        v
+validation cible same-repository + exact HEAD
+        |
+        v
+workflow trusted sur main
+        |
+        v
+runner Agency self-hosted
+```
+
+Le workflow self-hosted n'a aucun trigger `pull_request` ou `push`.
+
+## 3. Workflows
+
+### `.github/workflows/agent-browser-validation-dispatch.yml`
+
+Surface de contrôle GitHub-hosted. Elle observe uniquement :
+
+```text
+branch = agency/browser-validation-dispatch-control
+file = .agency/browser-validation-request.json
+```
+
+Elle exige :
+
+- acteur `E-merging-digital` ;
+- exactement un fichier modifié ;
+- schéma JSON strict ;
+- `request_id` borné ;
+- SHA exact ;
+- soit `pr_number=0` et SHA égal au `main` live ;
+- soit PR `OPEN`, base `main`, same-repository et HEAD exact.
+
+Le job ne reçoit aucun secret externe. Son `GITHUB_TOKEN` est limité à
+`actions: write`, `contents: read`, `pull-requests: read` et sert uniquement à
+dispatcher le workflow allowlisté.
+
+Format de requête :
+
+```json
+{
+  "request_id": "agency-browser-20260815-001",
+  "pr_number": 0,
+  "head_sha": "40-character-lowercase-sha"
+}
+```
+
+`pr_number=0` sert à la preuve bootstrap sur `main`. Pour une PR normale,
+`pr_number` doit porter le numéro exact de la PR et `head_sha` son HEAD live.
+
+### `.github/workflows/self-hosted-browser-validation.yml`
+
+Workflow trusted, `workflow_dispatch` uniquement.
+
+Avant qu'un job atteigne la machine self-hosted, un job GitHub-hosted valide :
+
+- acteur autorisé (`E-merging-digital` ou `github-actions[bot]`) ;
+- request id ;
+- SHA exact ;
+- PR same-repository / base `main` / OPEN ;
+- absence de changement de l'infrastructure `.github/`, `.ddev/`, `.agency/`
+  ou `scripts/runner/` sur une cible PR.
+
+Le job self-hosted cible uniquement :
+
+```yaml
+runs-on:
+  - self-hosted
+  - linux
+  - x64
+  - agency
+  - ddev
+  - browser
+```
+
+## 4. État Drupal reproductible
+
+Aucun dump local n'est utilisé.
+
+Chaque run crée un nom DDEV éphémère avec un `config.*.yaml` local, puis :
+
+```text
+checkout exact
+-> npm ci
+-> Chromium Playwright
+-> ddev start
+-> composer install
+-> drush site:install --existing-config
+-> emerging:content-sync:validate
+-> emerging:content-sync --all --dry-run
+-> emerging:content-sync --all
+-> drush cr/status/config:status
+-> npm run browser:validate
+```
+
+Le vertical slice `/fr/blog` n'exige pas l'Article1 local : il vérifie la page
+Blog, le DOM, la navigation `Services -> Blog`, console/réseau et les rendus
+mobile/desktop. La config versionnée + Content Sync constituent donc la source
+de données de validation.
+
+## 5. DDEV isolation et nettoyage
+
+Le fichier créé par le workflow :
+
+```text
+.ddev/config.gate-browser-ci.yaml
+```
+
+porte un nom :
+
+```text
+agency-browser-<run_id>-<attempt>
+```
+
+Les `config.*.yaml` sont des overrides DDEV supportés. Le run finit par :
+
+```bash
+ddev delete --omit-snapshot --yes
+rm -f .ddev/config.gate-browser-ci.yaml
+git diff --check
+git status --porcelain
+```
+
+La suppression omet volontairement le snapshot : la base est une fixture
+reconstructible, pas une donnée à conserver.
+
+## 6. Preuves publiées
+
+Le workflow upload avec `actions/upload-artifact` :
+
+```text
+artifacts/browser-validation/
+playwright-report/
+test-results/
+```
+
+La preuve principale reste :
+
+```text
+artifacts/browser-validation/result.json
+```
+
+et les screenshots desktop/mobile. Les traces ne sont attendues qu'en cas de
+besoin/échec selon la configuration Playwright.
+
+Retention initiale : 14 jours.
+
+## 7. Provisioning du runner Agency
+
+### Prérequis hôte
+
+La machine cible est `preflight-runner-01`, déjà prouvée pour Docker et DDEV.
+Le bootstrap vérifie aussi :
+
+- `curl`, `tar`, `sha256sum` ;
+- Docker fonctionnel ;
+- DDEV fonctionnel ;
+- Node.js >= 20 et npm ;
+- accès réseau à GitHub/npm ;
+- droits root pour l'installation one-shot.
+
+Le script :
+
+```text
+scripts/runner/bootstrap-agency-browser-runner.sh
+```
+
+utilise actuellement le runner GitHub officiel `2.336.0` et vérifie le SHA-256
+de l'archive Linux x64 avant extraction.
+
+Il crée :
+
+```text
+account = agency-runner
+dir = /opt/actions-runner-agency
+workdir = /opt/actions-runner-agency/_work
+runner = agency-browser-runner-01
+labels = agency,ddev,browser (+ labels GitHub par défaut)
+```
+
+Il ajoute uniquement `agency-runner` au groupe Docker et installe une fois les
+dépendances système Chromium requises par Playwright. Aucun `sudo` n'est donné
+au compte runner pour les jobs ordinaires.
+
+### Seul gate humain de provisioning
+
+L'intégration GitHub utilisée par l'agent ne possède pas la permission
+`Self-hosted runners`; elle ne peut donc pas obtenir le token éphémère
+d'enregistrement.
+
+Dans GitHub :
+
+```text
+Agency repository
+-> Settings
+-> Actions
+-> Runners
+-> New self-hosted runner
+-> Linux / x64
+```
+
+Copier uniquement le **registration token** éphémère. Ne jamais le committer.
+
+Sur `preflight-runner-01`, depuis un checkout de la branche #400 ou après merge :
+
+```bash
+sudo bash scripts/runner/bootstrap-agency-browser-runner.sh
+```
+
+Le script demande le token sans écho. Variante non interactive :
+
+```bash
+sudo env AGENCY_RUNNER_REGISTRATION_TOKEN='...' \
+  bash scripts/runner/bootstrap-agency-browser-runner.sh
+```
+
+Éviter de mettre ce token dans l'historique shell. La saisie interactive est
+préférée.
+
+Après exécution, vérifier dans GitHub que :
+
+```text
+agency-browser-runner-01 = Idle/Online
+labels = self-hosted, Linux, X64, agency, ddev, browser
+```
+
+## 8. Bootstrap de la branche de contrôle
+
+À faire seulement une fois les workflows #400 fusionnés sur `main` :
+
+```text
+branch = agency/browser-validation-dispatch-control
+base = main exact
+```
+
+Aucun fichier métier ne vit sur cette branche. Les requêtes successives ne
+modifient que :
+
+```text
+.agency/browser-validation-request.json
+```
+
+L'agent GitHub peut ensuite produire un commit de requête sans clic humain ; le
+workflow GitHub-hosted vérifie et déclenche la browser validation.
+
+## 9. Première preuve unattended
+
+Une fois #399 et #400 présents sur `main` :
+
+1. créer/mettre à jour la requête de contrôle avec `pr_number=0` et le SHA exact
+   de `main` ;
+2. observer le gateway GitHub-hosted ;
+3. observer le run self-hosted ;
+4. exiger `result.json = PASS` ;
+5. vérifier les screenshots desktop/mobile ;
+6. vérifier console/network sans erreurs inattendues ;
+7. vérifier l'artifact GitHub ;
+8. vérifier cleanup DDEV + workspace propre.
+
+Ce run constitue la preuve DoD « unattended Agency réel ».
+
+## 10. Playwright MCP
+
+MCP est optionnel et ne participe jamais au verdict CI.
+
+Sur la machine Agency, la voie préférée pour un agent local est **stdio** :
+
+```bash
+codex mcp add playwright npx "@playwright/mcp@latest"
+```
+
+ou configuration Codex équivalente.
+
+Le serveur Playwright MCP officiel utilise localhost par défaut lorsqu'un
+transport réseau est demandé. Agency interdit :
+
+```text
+--host 0.0.0.0
+exposition Internet
+port forwarding public
+profil navigateur contenant des credentials persistants non maîtrisés
+```
+
+Un futur transport HTTP, s'il devient nécessaire, doit rester `127.0.0.1` et
+être atteint par une route privée/gouvernée. Le simple fait que MCP soit installé
+ne prouve pas qu'un control plane distant peut l'atteindre.
+
+## 11. Authentification Drupal future
+
+Les scénarios authentifiés ne sont pas nécessaires à #400.
+
+La stratégie cible reste `storageState` Playwright sous :
+
+```text
+tests/browser/.auth/
+```
+
+Ce répertoire doit rester ignoré. Aucun mot de passe, cookie ou état de session
+n'est uploadé comme artifact par défaut.
+
+Avant d'ajouter un rôle Drupal :
+
+- créer un ticket/use case réel ;
+- fournir le secret au runtime via une surface sécurisée ;
+- créer la session pendant le job ;
+- exclure auth state, pages privées et secrets des screenshots/logs/artifacts.
+
+## 12. Merge gate
+
+La browser validation ne devient **pas** un required check dans #400.
+
+Séquence :
+
+```text
+runner provisionné
+-> première preuve unattended PASS
+-> quelques runs réels stables
+-> seulement ensuite décision séparée sur un merge gate
+```
+
+## 13. Sources techniques
+
+- GitHub self-hosted runners / labels / accès : documentation GitHub Actions.
+- DDEV `config.*.yaml` et `ddev delete --omit-snapshot --yes` : documentation DDEV.
+- Drush `site:install --existing-config` : documentation Drush.
+- Playwright CI / Chromium : documentation Playwright.
+- Playwright MCP : dépôt officiel `microsoft/playwright-mcp`.

--- a/scripts/runner/bootstrap-agency-browser-runner.sh
+++ b/scripts/runner/bootstrap-agency-browser-runner.sh
@@ -20,23 +20,25 @@ RUNNER_HOME="/home/${RUNNER_USER}"
 RUNNER_DIR="/opt/actions-runner-agency"
 RUNNER_NAME="${AGENCY_RUNNER_NAME:-agency-browser-runner-01}"
 RUNNER_LABELS="agency,ddev,browser"
-PLAYWRIGHT_VERSION="1.62.1"
 
-for command in curl tar sha256sum docker ddev node npm runuser openssl; do
+for command in apt-get curl tar sha256sum docker ddev runuser openssl; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "Missing prerequisite on host: $command" >&2
     exit 1
   fi
 done
 
-docker info >/dev/null
-ddev version
-node_version="$(node -p 'process.versions.node')"
-node_major="${node_version%%.*}"
-if (( node_major < 20 )); then
-  echo "Node.js >=20 is required on the host; found ${node_version}." >&2
+# Playwright 1.62.1 declares a concrete Ubuntu 24.04 dependency set.
+# Keep this bootstrap fail-closed rather than silently installing packages for a
+# different distribution/version.
+source /etc/os-release
+if [[ "${ID:-}" != "ubuntu" || "${VERSION_ID:-}" != "24.04" ]]; then
+  echo "Expected Ubuntu 24.04, found ${ID:-unknown} ${VERSION_ID:-unknown}." >&2
   exit 1
 fi
+
+docker info >/dev/null
+ddev version
 
 if [[ -z "${AGENCY_RUNNER_REGISTRATION_TOKEN:-}" ]]; then
   if [[ ! -t 0 ]]; then
@@ -63,18 +65,48 @@ else
   exit 1
 fi
 
-# Install browser OS dependencies once at host level. Browser binaries themselves
-# are installed per workflow under the runner account.
-playwright_tmp="$(mktemp -d)"
-cleanup_tmp() {
-  rm -rf "$playwright_tmp"
-}
-trap cleanup_tmp EXIT
-pushd "$playwright_tmp" >/dev/null
-npm init -y >/dev/null 2>&1
-npm install --no-audit --no-fund --silent --save-dev "@playwright/test@${PLAYWRIGHT_VERSION}"
-npx playwright install-deps chromium
-popd >/dev/null
+# One-time browser runtime dependencies, copied from the Playwright 1.62.1
+# ubuntu24.04-x64 tools + chromium dependency groups. Node itself is intentionally
+# not installed globally: actions/setup-node@v6 provisions Node 24 per workflow.
+playwright_packages=(
+  xvfb
+  fonts-noto-color-emoji
+  fonts-unifont
+  libfontconfig1
+  libfreetype6
+  xfonts-cyrillic
+  xfonts-scalable
+  fonts-liberation
+  fonts-ipafont-gothic
+  fonts-wqy-zenhei
+  fonts-tlwg-loma-otf
+  fonts-freefont-ttf
+  libasound2t64
+  libatk-bridge2.0-0t64
+  libatk1.0-0t64
+  libatspi2.0-0t64
+  libcairo2
+  libcups2t64
+  libdbus-1-3
+  libdrm2
+  libgbm1
+  libglib2.0-0t64
+  libnspr4
+  libnss3
+  libpango-1.0-0
+  libx11-6
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxkbcommon0
+  libxrandr2
+)
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends "${playwright_packages[@]}"
 
 if [[ -e "$RUNNER_DIR/.runner" ]]; then
   echo "Agency runner already appears configured at $RUNNER_DIR; refusing replacement." >&2
@@ -82,7 +114,13 @@ if [[ -e "$RUNNER_DIR/.runner" ]]; then
 fi
 
 mkdir -p "$RUNNER_DIR"
-archive_path="${playwright_tmp}/${RUNNER_ARCHIVE}"
+bootstrap_tmp="$(mktemp -d)"
+cleanup_tmp() {
+  rm -rf "$bootstrap_tmp"
+}
+trap cleanup_tmp EXIT
+archive_path="${bootstrap_tmp}/${RUNNER_ARCHIVE}"
+
 curl --fail --location --silent --show-error "$RUNNER_URL" --output "$archive_path"
 printf '%s  %s\n' "$RUNNER_SHA256" "$archive_path" | sha256sum --check --status || {
   echo "GitHub Actions runner archive checksum mismatch." >&2
@@ -112,18 +150,18 @@ unset AGENCY_RUNNER_REGISTRATION_TOKEN
 ./svc.sh status
 popd >/dev/null
 
-# A new login/session is needed for docker-group membership to be reflected.
+# A new login/session is represented by runuser; docker-group membership must be
+# effective and DDEV must remain available to the isolated Agency account.
 runuser -u "$RUNNER_USER" -- env HOME="$RUNNER_HOME" bash -lc '
   set -euo pipefail
   id
   docker info --format "ServerVersion={{.ServerVersion}} Driver={{.Driver}}"
   ddev version
-  node --version
-  npm --version
 '
 
 echo
 printf 'Agency runner provisioned: %s\n' "$RUNNER_NAME"
 printf 'Labels: self-hosted, linux, x64, %s\n' "$RUNNER_LABELS"
 printf 'Repository: %s\n' "$REPOSITORY_URL"
+printf 'Node is provisioned per job by actions/setup-node@v6; no host Node install is required.\n'
 printf 'Existing Preflight runner was not modified.\n'

--- a/scripts/runner/bootstrap-agency-browser-runner.sh
+++ b/scripts/runner/bootstrap-agency-browser-runner.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time bootstrap for a repository-scoped Agency browser validation runner.
+# Run as root on the already-proven preflight-runner-01 host.
+# This script never modifies the existing Preflight runner installation/service.
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run this script as root (for example: sudo bash ...)." >&2
+  exit 1
+fi
+
+RUNNER_VERSION="2.336.0"
+RUNNER_ARCHIVE="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+RUNNER_SHA256="04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d"
+RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_ARCHIVE}"
+REPOSITORY_URL="https://github.com/E-merging-digital/agency-website-drupal"
+RUNNER_USER="agency-runner"
+RUNNER_HOME="/home/${RUNNER_USER}"
+RUNNER_DIR="/opt/actions-runner-agency"
+RUNNER_NAME="${AGENCY_RUNNER_NAME:-agency-browser-runner-01}"
+RUNNER_LABELS="agency,ddev,browser"
+PLAYWRIGHT_VERSION="1.62.1"
+
+for command in curl tar sha256sum docker ddev node npm runuser openssl; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing prerequisite on host: $command" >&2
+    exit 1
+  fi
+done
+
+docker info >/dev/null
+ddev version
+node_version="$(node -p 'process.versions.node')"
+node_major="${node_version%%.*}"
+if (( node_major < 20 )); then
+  echo "Node.js >=20 is required on the host; found ${node_version}." >&2
+  exit 1
+fi
+
+if [[ -z "${AGENCY_RUNNER_REGISTRATION_TOKEN:-}" ]]; then
+  if [[ ! -t 0 ]]; then
+    echo "Set AGENCY_RUNNER_REGISTRATION_TOKEN or run interactively." >&2
+    exit 1
+  fi
+  read -r -s -p "Agency GitHub runner registration token: " AGENCY_RUNNER_REGISTRATION_TOKEN
+  echo
+fi
+
+if [[ -z "$AGENCY_RUNNER_REGISTRATION_TOKEN" ]]; then
+  echo "Registration token is required." >&2
+  exit 1
+fi
+
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+  useradd --create-home --home-dir "$RUNNER_HOME" --shell /bin/bash "$RUNNER_USER"
+fi
+
+if getent group docker >/dev/null 2>&1; then
+  usermod -aG docker "$RUNNER_USER"
+else
+  echo "Docker group is missing; refusing to alter Docker installation." >&2
+  exit 1
+fi
+
+# Install browser OS dependencies once at host level. Browser binaries themselves
+# are installed per workflow under the runner account.
+playwright_tmp="$(mktemp -d)"
+cleanup_tmp() {
+  rm -rf "$playwright_tmp"
+}
+trap cleanup_tmp EXIT
+pushd "$playwright_tmp" >/dev/null
+npm init -y >/dev/null 2>&1
+npm install --no-audit --no-fund --silent --save-dev "@playwright/test@${PLAYWRIGHT_VERSION}"
+npx playwright install-deps chromium
+popd >/dev/null
+
+if [[ -e "$RUNNER_DIR/.runner" ]]; then
+  echo "Agency runner already appears configured at $RUNNER_DIR; refusing replacement." >&2
+  exit 1
+fi
+
+mkdir -p "$RUNNER_DIR"
+archive_path="${playwright_tmp}/${RUNNER_ARCHIVE}"
+curl --fail --location --silent --show-error "$RUNNER_URL" --output "$archive_path"
+printf '%s  %s\n' "$RUNNER_SHA256" "$archive_path" | sha256sum --check --status || {
+  echo "GitHub Actions runner archive checksum mismatch." >&2
+  exit 1
+}
+
+tar -xzf "$archive_path" -C "$RUNNER_DIR"
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR" "$RUNNER_HOME"
+
+pushd "$RUNNER_DIR" >/dev/null
+./bin/installdependencies.sh
+
+runuser -u "$RUNNER_USER" -- env \
+  HOME="$RUNNER_HOME" \
+  ./config.sh \
+    --unattended \
+    --url "$REPOSITORY_URL" \
+    --token "$AGENCY_RUNNER_REGISTRATION_TOKEN" \
+    --name "$RUNNER_NAME" \
+    --labels "$RUNNER_LABELS" \
+    --work _work
+
+unset AGENCY_RUNNER_REGISTRATION_TOKEN
+
+./svc.sh install "$RUNNER_USER"
+./svc.sh start
+./svc.sh status
+popd >/dev/null
+
+# A new login/session is needed for docker-group membership to be reflected.
+runuser -u "$RUNNER_USER" -- env HOME="$RUNNER_HOME" bash -lc '
+  set -euo pipefail
+  id
+  docker info --format "ServerVersion={{.ServerVersion}} Driver={{.Driver}}"
+  ddev version
+  node --version
+  npm --version
+'
+
+echo
+printf 'Agency runner provisioned: %s\n' "$RUNNER_NAME"
+printf 'Labels: self-hosted, linux, x64, %s\n' "$RUNNER_LABELS"
+printf 'Repository: %s\n' "$REPOSITORY_URL"
+printf 'Existing Preflight runner was not modified.\n'

--- a/scripts/runner/bootstrap-agency-browser-runner.sh
+++ b/scripts/runner/bootstrap-agency-browser-runner.sh
@@ -21,7 +21,7 @@ RUNNER_DIR="/opt/actions-runner-agency"
 RUNNER_NAME="${AGENCY_RUNNER_NAME:-agency-browser-runner-01}"
 RUNNER_LABELS="agency,ddev,browser"
 
-for command in apt-get curl tar sha256sum docker ddev runuser openssl; do
+for command in apt-get curl tar sha256sum docker ddev runuser openssl getent; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "Missing prerequisite on host: $command" >&2
     exit 1
@@ -38,7 +38,25 @@ if [[ "${ID:-}" != "ubuntu" || "${VERSION_ID:-}" != "24.04" ]]; then
 fi
 
 docker info >/dev/null
-ddev version
+
+# DDEV deliberately refuses to run as root. Validate it under the sudo caller
+# before making any host mutation, then validate it again under agency-runner at
+# the end of the bootstrap.
+DDEV_CHECK_USER="${SUDO_USER:-}"
+if [[ -z "$DDEV_CHECK_USER" || "$DDEV_CHECK_USER" == "root" ]]; then
+  echo "Run this script through sudo from a non-root account so DDEV can be validated safely." >&2
+  exit 1
+fi
+if ! id "$DDEV_CHECK_USER" >/dev/null 2>&1; then
+  echo "Unable to resolve sudo caller for DDEV validation: $DDEV_CHECK_USER" >&2
+  exit 1
+fi
+DDEV_CHECK_HOME="$(getent passwd "$DDEV_CHECK_USER" | cut -d: -f6)"
+if [[ -z "$DDEV_CHECK_HOME" ]]; then
+  echo "Unable to resolve home directory for DDEV validation user: $DDEV_CHECK_USER" >&2
+  exit 1
+fi
+runuser -u "$DDEV_CHECK_USER" -- env HOME="$DDEV_CHECK_HOME" ddev version
 
 if [[ -z "${AGENCY_RUNNER_REGISTRATION_TOKEN:-}" ]]; then
   if [[ ! -t 0 ]]; then


### PR DESCRIPTION
Part of #400

## Objectif

Ajouter l’infrastructure repository-owned d’un exécuteur Browser Validation Agency auto-hébergé, sans exposer le runner public aux PR de forks et sans dépendre de Playwright MCP pour la preuve reproductible.

## Architecture

Réutilise la machine déjà prouvée `preflight-runner-01`, mais avec un **second runner repository-scoped distinct** :

- account `agency-runner` ;
- runner `agency-browser-runner-01` ;
- labels `self-hosted, linux, x64, agency, ddev, browser` ;
- installation/workdir/service séparés du runner Preflight.

Agency étant un dépôt public, **aucun trigger `pull_request` ou `push` n’atteint directement le runner self-hosted**.

## Dispatch gouverné

- branche de contrôle future : `agency/browser-validation-dispatch-control` ;
- fichier unique : `.agency/browser-validation-request.json` ;
- gateway sur `ubuntu-latest` ;
- acteur autorisé `E-merging-digital` ;
- PR same-repository, OPEN, base main, HEAD exact ;
- forks refusées ;
- changements `.github/`, `.ddev/`, `.agency/`, `scripts/runner/` refusés avant self-hosted execution ;
- dispatch vers un seul workflow trusted présent sur `main`.

`pr_number=0` permet une première preuve exacte sur le `main` live.

## Reconstruction Agency

Pas de dump local :

1. checkout exact ;
2. `actions/setup-node@v6` fournit Node 24 ;
3. `npm ci` + Chromium ;
4. DDEV isolé par run ;
5. Composer ;
6. `drush site:install --existing-config` ;
7. Content Sync validate/dry-run/apply ;
8. `npm run browser:validate` ;
9. artifacts result/screenshots/traces ;
10. `ddev delete --omit-snapshot --yes` + workspace clean.

Le contrat Blog n’exige aucun article local non versionné.

## Provisioning

`scripts/runner/bootstrap-agency-browser-runner.sh` :

- exige Ubuntu 24.04 ;
- vérifie Docker/DDEV ;
- ne requiert **pas** Node/npm sur l’hôte ;
- crée le compte Agency séparé ;
- installe les dépendances système `tools + chromium` déclarées par Playwright 1.62.1 pour Ubuntu 24.04 ;
- télécharge GitHub Actions runner officiel 2.336.0 ;
- vérifie SHA-256 Linux x64 ;
- configure le runner repository-scoped et son service.

Le seul gate humain unavoidable est le **registration token éphémère GitHub**, l’intégration actuelle n’ayant pas la permission Self-hosted runners.

## MCP

Playwright MCP reste optionnel. Cible : stdio local avec Codex CLI ; aucune exposition `0.0.0.0`, aucun port public, aucune dépendance du verdict CI.

## État actuel

- base `main` = `19689457bf5f05caea911c3eb819766a27638582` ;
- HEAD actuel = `3fc0cd49599ab0be2ebb49c26e59c2c78763a0d7` ;
- diff = 4 nouveaux fichiers ;
- aucun changement Drupal métier/provider/secret.

## Pourquoi cette PR ne ferme pas encore #400

Le workflow `workflow_dispatch` doit être présent sur la branche par défaut avant la première preuve unattended. Cette PR matérialise donc l’infrastructure bootstrap. #400 restera ouverte jusqu’à la preuve réelle : runner Online/Idle, premier run complet PASS, artifacts disponibles et cleanup prouvé.

## Gates restant

- CI exact-head ;
- provisionner le runner Agency réel ;
- vérifier Online/Idle + labels ;
- merger cette infrastructure sur `main` sans fermer #400 ;
- #399 présent sur `main` avec lockfile ;
- première requête gouvernée sur `main` ;
- run self-hosted complet PASS ;
- artifacts disponibles ;
- cleanup/workspace propre ;
- confirmer que le runner Preflight reste unaffected ;
- clôturer #400 seulement après cette preuve.