### PR TITLE
Issue #400: fix trusted dispatch actor matching

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -42,13 +42,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          case "$GITHUB_ACTOR" in
-            E-merging-digital|github-actions[bot]) ;;
-            *)
-              echo "Refusing self-hosted dispatch actor: $GITHUB_ACTOR" >&2
-              exit 1
-              ;;
-          esac
+          if [[ "$GITHUB_ACTOR" != "E-merging-digital" && "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
+            echo "Refusing self-hosted dispatch actor: $GITHUB_ACTOR" >&2
+            exit 1
+          fi
 
           if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{8,80}$ ]]; then
             echo "Invalid request_id." >&2


### PR DESCRIPTION
Part of #400

Correction bornée du premier run gouverné du Browser Validation Executor.

Le gateway GitHub-hosted a bien dispatché le workflow trusted, mais le job de prévalidation a rejeté `github-actions[bot]` car le pattern Bash `github-actions[bot]` dans un `case` interprétait `[bot]` comme une classe de caractères.

Cette PR remplace ce pattern par une comparaison littérale explicite :

- `E-merging-digital` autorisé ;
- `github-actions[bot]` autorisé ;
- tout autre acteur refusé.

Aucun autre comportement du workflow n'est modifié.

Preuve du défaut : run self-hosted workflow #1 / run id `31876899468`, échec dans `Validate dispatch actor and target` avec `Refusing self-hosted dispatch actor: github-actions[bot]` avant tout job self-hosted.