### PR TITLE
Issue #412: restore locked language configuration

### DIFF
--- a/config/sync/language.entity.und.yml
+++ b/config/sync/language.entity.und.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: und
+label: 'Not specified'
+direction: ltr
+weight: 2
+locked: true

--- a/config/sync/language.entity.zxx.yml
+++ b/config/sync/language.entity.zxx.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: zxx
+label: 'Not applicable'
+direction: ltr
+weight: 3
+locked: true


### PR DESCRIPTION
Closes #412.

## Contexte

La reconstruction fresh du runner Agency échoue sur `drush site:install --existing-config` dans `ConfigurableLanguageManager::updateLockedLanguageWeights()` parce que les deux langues verrouillées attendues par Drupal core sont absentes de `config/sync/`.

## Correction

Ajout exact des configurations fournies par Drupal core 11.4.5 :

- `language.entity.und.yml` (`Not specified`, locked, weight 2) ;
- `language.entity.zxx.yml` (`Not applicable`, locked, weight 3).

Aucun UUID ou metadata spécifique au site n'est inventé. Aucun code, workflow, DDEV ou configuration de langue `en`/`fr` n'est modifié.

## Validation attendue

- CI standard verte ;
- merge séparé ;
- resynchronisation de #399 sur `main` ;
- nouvelle preuve unattended du rebuild Drupal puis Playwright.