### PR TITLE
Issue #400: restore scaffolded robots file during runner cleanup

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -258,6 +258,7 @@ jobs:
           set +e
           ddev delete --omit-snapshot --yes
           rm -f .ddev/config.gate-browser-ci.yaml
+          git restore --worktree -- web/robots.txt
           if [[ "$LOCKFILE_WAS_PRESENT" == "false" ]]; then
             rm -f package-lock.json
           fi


### PR DESCRIPTION
Relates to #400.

Le premier rebuild trusted a montré que `ddev composer install` réécrit le fichier tracked `web/robots.txt` via Drupal Composer Scaffold. Le cleanup supprimait correctement DDEV mais échouait ensuite sur cette mutation déterministe.

Cette PR ajoute uniquement :

```bash
git restore --worktree -- web/robots.txt
```

après suppression de la configuration DDEV temporaire et avant le contrôle final `git status --porcelain`.

Le cleanup reste fail-closed pour toute autre mutation inattendue. Aucun reset générique, aucun nettoyage large, aucune permission supplémentaire.