### PR TITLE
Issue #417: restore fresh-install main navigation bootstrap

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
@@ -6,6 +6,7 @@ package: Custom
 dependencies:
   - drupal:default_content
   - drupal:language
+  - drupal:menu_link_content
   - drupal:node
   - drupal:path
   - drupal:path_alias


### PR DESCRIPTION
## Résumé

- déclare `drupal:menu_link_content` comme dépendance explicite de `emerging_digital_content` ;
- garantit l'ordre d'installation requis avant l'appel à `MainNavigationManager::ensureMainNavigationLinks()` dans `hook_install()` ;
- ne modifie ni Content Sync ni les définitions de menu existantes.

## Pourquoi

La reconstruction self-hosted de #399 (run `31879662365`) installe Drupal depuis `--existing-config` avec succès mais obtient un menu principal vide. Le module appelait directement l'API `menu_link_content` sans la déclarer comme dépendance.

## Validation attendue

- CI standard du dépôt ;
- après fusion, nouvelle preuve clean-install self-hosted via #399/#400 pour confirmer `Services` et `Blog` en desktop/mobile et `menus_touched: false`.

Closes #417