### PR TITLE
Issue #418: normalize localized cookie policy links

### DIFF
--- a/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
+++ b/web/themes/custom/emerging_digital/emerging_digital.libraries.yml
@@ -11,5 +11,8 @@ global-styling:
     js/main.js:
       attributes:
         defer: true
+    js/cookie-policy-links.js:
+      attributes:
+        defer: true
   dependencies:
     - core/drupal

--- a/web/themes/custom/emerging_digital/js/cookie-policy-links.js
+++ b/web/themes/custom/emerging_digital/js/cookie-policy-links.js
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Keeps legacy theme-generated cookie policy links aligned with live aliases.
+ */
+
+(function () {
+  'use strict';
+
+  function getPolicyPath() {
+    var langcode = (document.documentElement.lang || 'fr').substring(0, 2);
+    return langcode === 'en'
+      ? '/en/cookie-policy'
+      : '/fr/politique-de-cookies';
+  }
+
+  function normalizeCookiePolicyLinks() {
+    var policyPath = getPolicyPath();
+    document.querySelectorAll('a[href="/cookies"]').forEach(function (link) {
+      link.setAttribute('href', policyPath);
+    });
+  }
+
+  normalizeCookiePolicyLinks();
+
+  var observer = new MutationObserver(normalizeCookiePolicyLinks);
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true
+  });
+})();


### PR DESCRIPTION
## Résumé

- ajoute un petit normaliseur dédié aux liens de politique de cookies hérités du thème ;
- remplace `/cookies` par `/fr/politique-de-cookies` en français et `/en/cookie-policy` en anglais ;
- observe les ajouts dynamiques afin de couvrir aussi la modale de préférences ;
- ne modifie pas la logique de consentement, le contenu ni les aliases.

## Cause

`main.js` injecte historiquement `/cookies` dans les surfaces cookies génériques, alors que les aliases Content Sync réels sont désormais localisés. La preuve self-hosted #399 signale donc deux 404, desktop et mobile.

## Validation

- CI standard du dépôt ;
- validation réelle finale par la reconstruction self-hosted #399/#400, qui doit ne plus observer de requête 4xx vers `/cookies`.

Closes #418