### PR TITLE
Issue #423: ensure main navigation after bulk install

### DIFF
--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.module
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.module
@@ -8,7 +8,25 @@
 declare(strict_types=1);
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\emerging_digital_content\MainNavigationManager;
 use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_modules_installed().
+ *
+ * Drupal 11.2+ can install modules in bulk before the final installed state is
+ * available to hook_install(). Re-ensuring the idempotent content-entity menu
+ * links here guarantees the public navigation after the install batch finishes.
+ */
+function emerging_digital_content_modules_installed(array $modules, bool $is_syncing): void {
+  unset($is_syncing);
+
+  if (!in_array('emerging_digital_content', $modules, TRUE)) {
+    return;
+  }
+
+  MainNavigationManager::ensureMainNavigationLinks();
+}
 
 /**
  * Implements hook_form_alter().

--- a/web/modules/custom/emerging_digital_content/tests/src/Kernel/MainNavigationInstallTest.php
+++ b/web/modules/custom/emerging_digital_content/tests/src/Kernel/MainNavigationInstallTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emerging_digital_content\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the final main-navigation bootstrap after module installation.
+ *
+ * @group emerging_digital_content
+ */
+#[RunTestsInSeparateProcesses]
+final class MainNavigationInstallTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'link',
+    'menu_link_content',
+    'emerging_digital_content',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('menu_link_content');
+  }
+
+  /**
+   * Tests the hook is scoped to the module install batch and is idempotent.
+   */
+  public function testModulesInstalledEnsuresMainNavigationIdempotently(): void {
+    $module_handler = $this->container->get('module_handler');
+
+    $module_handler->invoke(
+      'emerging_digital_content',
+      'modules_installed',
+      [['system'], TRUE],
+    );
+    self::assertSame([], $this->loadMainNavigationLinks());
+
+    $module_handler->invoke(
+      'emerging_digital_content',
+      'modules_installed',
+      [['system', 'emerging_digital_content'], TRUE],
+    );
+
+    $expected = [
+      'Accueil' => ['uri' => 'internal:/accueil', 'weight' => 0],
+      'Services' => ['uri' => 'internal:/services', 'weight' => 1],
+      'IA & Drupal' => ['uri' => 'internal:/ia-drupal', 'weight' => 2],
+      'Cas clients' => ['uri' => 'internal:/cas-clients', 'weight' => 3],
+      'Blog' => ['uri' => 'internal:/blog', 'weight' => 4],
+      'Contact' => ['uri' => 'internal:/contact', 'weight' => 5],
+    ];
+
+    self::assertSame($expected, $this->loadMainNavigationLinks());
+
+    $module_handler->invoke(
+      'emerging_digital_content',
+      'modules_installed',
+      [['emerging_digital_content'], TRUE],
+    );
+    self::assertSame($expected, $this->loadMainNavigationLinks());
+  }
+
+  /**
+   * Loads the expected values keyed by menu-link title.
+   *
+   * @return array<string, array{uri: string, weight: int}>
+   *   Main navigation values.
+   */
+  private function loadMainNavigationLinks(): array {
+    $storage = $this->container->get('entity_type.manager')->getStorage('menu_link_content');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('menu_name', 'main')
+      ->sort('weight')
+      ->execute();
+
+    $actual = [];
+    foreach ($storage->loadMultiple($ids) as $link) {
+      self::assertTrue((bool) $link->get('enabled')->value);
+      $link_item = $link->get('link')->first();
+      self::assertNotNull($link_item);
+      $actual[(string) $link->label()] = [
+        'uri' => (string) ($link_item->getValue()['uri'] ?? ''),
+        'weight' => (int) $link->get('weight')->value,
+      ];
+    }
+
+    return $actual;
+  }
+
+}


### PR DESCRIPTION
Closes #423

## Résumé

- ajoute `hook_modules_installed()` dans `emerging_digital_content.module` ;
- borne la garantie finale au lot qui installe `emerging_digital_content` ;
- réutilise `MainNavigationManager::ensureMainNavigationLinks()` sans changer le contrat du menu ;
- conserve le `hook_install()` existant : la seconde passe est volontairement idempotente et garantit l’état final après l’installation en lot Drupal 11 ;
- ajoute un Kernel test vérifiant les six liens, leurs URI/poids, le scoping du hook et l’idempotence.

## Pourquoi

Le run self-hosted #8 `31881409021` reconstruit Drupal 11.4.5 avec `site:install --existing-config` sans erreur mais rend le menu principal vide. Drupal core documente le changement de timing des installations de modules en lot depuis 11.2 et `hook_modules_installed()` comme point post-install adapté lorsque `hook_install()` est trop tôt pour l’état final.

## Invariants

- Content Sync ne touche toujours pas les menus ;
- aucun titre/URI/poids modifié ;
- aucun changement de workflow, DDEV, contenu ou provider ;
- preuve finale exigée sur le runner Agency après merge et réconciliation de #399.