### PR TITLE
Issue #427: export canonical config drift evidence

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -220,7 +220,22 @@ jobs:
             local config_status
             config_status="$(ddev drush config:status 2>&1)"
             printf '%s\n' "$config_status"
-            grep -Fq 'No differences' <<<"$config_status"
+            if grep -Fq 'No differences' <<<"$config_status"; then
+              return 0
+            fi
+
+            mkdir -p artifacts/config-canonicalization
+            printf '%s\n' "$config_status" > artifacts/config-canonicalization/config-status.txt
+
+            # Materialize the exact canonical export produced by the freshly
+            # rebuilt Drupal runtime so maintainers can review a deterministic
+            # patch instead of guessing which YAML normalization is required.
+            ddev drush cex -y
+            git status --short config/sync > artifacts/config-canonicalization/git-status.txt
+            git diff --binary -- config/sync > artifacts/config-canonicalization/canonical-config.patch
+
+            echo "Canonical configuration drift detected; exported patch evidence." >&2
+            return 1
           }
 
           ddev start -y
@@ -252,13 +267,14 @@ jobs:
           set -euo pipefail
           npm run browser:validate
 
-      - name: Upload browser evidence
+      - name: Upload browser and config evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: agency-browser-validation-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             artifacts/browser-validation
+            artifacts/config-canonicalization
             playwright-report
             test-results
           if-no-files-found: warn
@@ -273,7 +289,8 @@ jobs:
           set +e
           ddev delete --omit-snapshot --yes
           rm -f .ddev/config.gate-browser-ci.yaml
-          git restore --worktree -- web/robots.txt
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
           if [[ "$LOCKFILE_WAS_PRESENT" == "false" ]]; then
             rm -f package-lock.json
           fi


### PR DESCRIPTION
Reopens and continues #427 after the first fail-closed main proof.

## Why

Trusted main run `31884421063` correctly failed before Playwright because `config:status` still reported residual drift after `cim`. The gate is working; the repository configuration needs canonicalization.

## Change

When `config:status` is not clean, the trusted runner now:

- records the exact `config:status` output;
- runs `drush cex -y` against the freshly rebuilt Drupal runtime;
- captures `git status --short config/sync`;
- captures an exact `git diff --binary -- config/sync` patch;
- uploads this as governed artifact evidence;
- still fails closed;
- restores/cleans `config/sync` during runner cleanup so the workspace remains pristine.

No drift allowlist is introduced. The goal is to materialize and review Drupal's exact canonical export, then version only the legitimate neutral normalizations.