### PR TITLE
Issue #380: enable guarded AI CKEditor for Article authoring

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -4,6 +4,7 @@ module:
   admin_toolbar: 0
   agency_ai_translation: 0
   ai: 0
+  ai_ckeditor: 0
   ai_provider_openai: 0
   announcements_feed: 0
   automated_cron: 0

--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.basic_html
   module:
+    - ai_ckeditor
     - ckeditor5
 _core:
   default_config_hash: JrKgrmvARpUBMILom2cUF4pz3mwrBnCYSlHjGwsKZ64
@@ -27,8 +28,46 @@ settings:
       - heading
       - code
       - '|'
+      - aickeditor
       - sourceEditing
   plugins:
+    ai_ckeditor_ai:
+      dialog:
+        autoresize: 'min-width: 600px'
+        height: '750'
+        width: '900'
+        dialog_class: ai-ckeditor-modal
+      plugins:
+        ai_ckeditor_completion:
+          enabled: true
+          provider: ''
+        ai_ckeditor_help:
+          enabled: false
+        ai_ckeditor_modify_prompt:
+          enabled: true
+          provider: ''
+        ai_ckeditor_reformat_html:
+          enabled: false
+          provider: ''
+        ai_ckeditor_spellfix:
+          enabled: true
+          provider: ''
+        ai_ckeditor_summarize:
+          enabled: true
+          provider: ''
+        ai_ckeditor_tone:
+          enabled: false
+          provider: ''
+          autocreate: false
+          tone_vocabulary: tags
+          use_description: false
+        ai_ckeditor_translate:
+          enabled: false
+          provider: ''
+          language_source: lang
+          autocreate: false
+          translate_vocabulary: tags
+          use_description: false
     ckeditor5_heading:
       enabled_headings:
         - heading2

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -8,6 +8,7 @@ dependencies:
     - taxonomy.vocabulary.blog_categories
     - taxonomy.vocabulary.tags
   module:
+    - ai_ckeditor
     - comment
     - content_translation
     - contextual
@@ -48,6 +49,7 @@ permissions:
   - 'revert all revisions'
   - 'translate article node'
   - 'translate blog_categories taxonomy_term'
+  - 'use ai ckeditor'
   - 'view all revisions'
   - 'view own unpublished content'
   - 'view the administration theme'

--- a/docs/drupal-ai-ckeditor.md
+++ b/docs/drupal-ai-ckeditor.md
@@ -1,0 +1,143 @@
+# Drupal AI CKEditor — governed Article authoring
+
+Status: initial guarded rollout  
+Owner issue: #380  
+Parent roadmap: #32
+
+## Purpose
+
+Agency uses the upstream `ai_ckeditor` submodule from Drupal AI to provide
+explicit, human-triggered writing assistance inside CKEditor 5.
+
+This feature assists the editor. It does not generate or publish Article content
+automatically.
+
+## Version baseline
+
+The project currently locks Drupal AI 1.4.6. On 2026-08-15 this is the latest
+stable, security-covered 1.4.x release compatible with Drupal 11.4.5. Drupal AI
+1.5 is still a release candidate and is not part of this rollout.
+
+No experimental/dev dependency is introduced by #380.
+
+## Scope
+
+The initial rollout uses the existing `basic_html` CKEditor 5 text format and
+adds the upstream `aickeditor` toolbar item immediately before Source Editing.
+
+Enabled tools:
+
+```text
+Completion / Generate fragment = enabled
+Modify with a prompt           = enabled
+Fix spelling                   = enabled
+Summarize                      = enabled
+Reformat HTML                  = disabled
+Tone                           = disabled
+Translate                      = disabled
+Help                           = disabled
+```
+
+Tone and Translate remain disabled so this ticket does not invent a `Tone of
+voice` or `Languages` taxonomy. CKEditor Translate is also not a substitute for
+Drupal entity translation; the FR/EN entity workflow belongs to #382.
+
+## Provider abstraction
+
+Every enabled AI CKEditor plugin is versioned with:
+
+```yaml
+provider: ''
+```
+
+This is deliberate. No provider name, model, API key or secret is encoded in the
+editor configuration. At runtime, Drupal AI resolves the configured/default Chat
+provider through its provider abstraction.
+
+If no provider is configured or the provider is unavailable, the AI action may
+fail, but normal Drupal authoring remains independent: editors can continue to
+edit and save content without invoking an AI action.
+
+Provider configuration and secrets remain environment-owned and must never be
+committed.
+
+## Guardrails
+
+#380 is downstream of #379. The global deterministic guardrail set
+`agency_editorial_baseline` applies to Drupal AI requests, including AI CKEditor
+requests that use the Drupal AI provider abstraction.
+
+Initial baseline:
+
+```text
+Input Length Limit = 20,000 characters
+latest message only
+pre-generate
+stop threshold = 1.0
+```
+
+No second LLM guardrail call is enabled by default.
+
+## Access control
+
+AI CKEditor has its own permission:
+
+```text
+use ai ckeditor
+```
+
+Agency grants it to `content_editor` only in this rollout. The generic
+`authenticated` role can still use the Basic HTML format but does **not** receive
+the AI permission.
+
+This distinction is intentional: access to a text format alone is not treated as
+permission to incur AI cost or send selected content to a provider.
+
+The ticket does not grant AI CKEditor administration privileges to editors.
+
+## Human-in-the-loop contract
+
+An AI request happens only after an editor explicitly chooses an AI action.
+Selected text or editor context may then be sent to the configured provider.
+
+The returned text remains an editable proposal inside the Article form. The
+editor chooses whether to apply it and whether to save the Article. No action in
+this rollout publishes content automatically.
+
+## Multilingual contract
+
+Article body remains translatable through Drupal. AI CKEditor Translate is
+explicitly disabled because translating a selected fragment is not equivalent to
+creating and governing a Drupal FR/EN entity translation.
+
+Entity translation remains a separate roadmap item (#382).
+
+## Failure behaviour
+
+The expected failure mode is bounded:
+
+```text
+provider absent/down
+-> requested AI action fails/degrades
+-> CKEditor/Drupal form remains usable
+-> existing text remains under editor control
+-> normal save path remains available
+```
+
+No provider call occurs merely because the edit form is loaded.
+
+## Validation gates
+
+Before merge #380 requires:
+
+1. standard CI green on the exact PR head;
+2. fresh DDEV `site:install --existing-config`;
+3. final `cim` and clean `config:status`;
+4. Content Sync validate/dry-run/apply;
+5. clean `config:status` after Content Sync;
+6. public Playwright regression PASS;
+7. evidence that the versioned CKEditor configuration imports canonically;
+8. no secret or provider-specific credential in the diff.
+
+A later provider-backed UI exercise may validate generation quality, but it must
+use a governed runtime secret and is not permission to commit provider secrets.

--- a/tests/browser/ai-ckeditor-article.spec.mjs
+++ b/tests/browser/ai-ckeditor-article.spec.mjs
@@ -84,7 +84,13 @@ async function logIn(page, username, password) {
   await page.locator('input[name="name"]').fill(username);
   await page.locator('input[name="pass"]').fill(password);
   await page.locator('#edit-submit').click();
-  await page.waitForLoadState('domcontentloaded');
+  await expect(
+    page.getByRole('heading', {
+      name: username,
+      level: 1,
+    }),
+    'A successful Drupal login must land on the authenticated user page.',
+  ).toBeVisible({ timeout: 15_000 });
 }
 
 async function openArticleForm(page) {
@@ -110,6 +116,7 @@ test.describe('Issue #380 authenticated AI CKEditor proof', () => {
     page,
     baseURL,
   }, testInfo) => {
+    test.setTimeout(90_000);
     test.skip(
       testInfo.project.name !== 'desktop',
       'The authenticated admin proof is intentionally desktop-only.',
@@ -209,7 +216,6 @@ test.describe('Issue #380 authenticated AI CKEditor proof', () => {
       await page.locator('input[name="title[0][value]"]').fill(title);
       await editable.fill('Contenu éditorial saisi sans provider AI configuré.');
       await page.locator('#edit-submit').click();
-      await page.waitForLoadState('domcontentloaded');
       await expect(
         page.getByRole('heading', {
           name: title,

--- a/tests/browser/ai-ckeditor-article.spec.mjs
+++ b/tests/browser/ai-ckeditor-article.spec.mjs
@@ -1,0 +1,274 @@
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { test, expect } from '@playwright/test';
+
+const editorUsername = 'agency_browser_editor';
+const plainEditorUsername = 'agency_browser_plain_editor';
+const plainEditorRole = 'agency_browser_plain_editor';
+const screenshotDirectory = path.resolve(
+  'artifacts/browser-validation/screenshots',
+);
+const evidenceDirectory = path.resolve(
+  'artifacts/browser-validation/evidence',
+);
+
+function phpString(value) {
+  return `'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`;
+}
+
+function runPhp(code) {
+  return execFileSync('ddev', ['drush', 'php:eval', code], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function deleteEphemeralFixtures() {
+  runPhp(`
+    $storage = \\Drupal::entityTypeManager()->getStorage('user');
+    foreach ([${phpString(editorUsername)}, ${phpString(plainEditorUsername)}] as $name) {
+      foreach ($storage->loadByProperties(['name' => $name]) as $user) {
+        $user->delete();
+      }
+    }
+    if ($role = \\Drupal\\user\\Entity\\Role::load(${phpString(plainEditorRole)})) {
+      $role->delete();
+    }
+  `);
+}
+
+function createEphemeralFixtures(editorPassword, plainEditorPassword) {
+  deleteEphemeralFixtures();
+
+  runPhp(`
+    $role = \\Drupal\\user\\Entity\\Role::create([
+      'id' => ${phpString(plainEditorRole)},
+      'label' => 'Agency browser plain editor',
+    ]);
+    $role->grantPermission('create article content');
+    $role->save();
+
+    $editor = \\Drupal\\user\\Entity\\User::create([
+      'name' => ${phpString(editorUsername)},
+      'mail' => 'agency-browser-editor@example.invalid',
+      'status' => 1,
+      'preferred_langcode' => 'fr',
+      'preferred_admin_langcode' => 'fr',
+    ]);
+    $editor->setPassword(${phpString(editorPassword)});
+    $editor->addRole('content_editor');
+    $editor->save();
+
+    $plain = \\Drupal\\user\\Entity\\User::create([
+      'name' => ${phpString(plainEditorUsername)},
+      'mail' => 'agency-browser-plain-editor@example.invalid',
+      'status' => 1,
+      'preferred_langcode' => 'fr',
+      'preferred_admin_langcode' => 'fr',
+    ]);
+    $plain->setPassword(${phpString(plainEditorPassword)});
+    $plain->addRole(${phpString(plainEditorRole)});
+    $plain->save();
+  `);
+}
+
+async function logIn(page, username, password) {
+  const response = await page.goto('/user/login', {
+    waitUntil: 'domcontentloaded',
+  });
+  expect(response, 'The login route must return a response.').not.toBeNull();
+  expect(response.status(), 'The login route must remain reachable.').toBeLessThan(400);
+
+  await page.locator('input[name="name"]').fill(username);
+  await page.locator('input[name="pass"]').fill(password);
+  await page.locator('#edit-submit').click();
+  await page.waitForLoadState('domcontentloaded');
+}
+
+async function openArticleForm(page) {
+  const response = await page.goto('/node/add/article', {
+    waitUntil: 'domcontentloaded',
+  });
+  expect(response, 'The Article form must return a response.').not.toBeNull();
+  expect(response.status(), 'The Article form must remain reachable.').toBeLessThan(400);
+
+  const editable = page.locator('.ck-editor__editable[contenteditable="true"]').first();
+  await expect(editable).toBeVisible({ timeout: 15_000 });
+  return editable;
+}
+
+function aiAssistantButton(page) {
+  return page.getByRole('button', {
+    name: /AI Assistant|Assistant IA/i,
+  }).first();
+}
+
+test.describe('Issue #380 authenticated AI CKEditor proof', () => {
+  test('Article exposes the guarded AI menu only to an authorized editor', async ({
+    page,
+    baseURL,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'desktop',
+      'The authenticated admin proof is intentionally desktop-only.',
+    );
+
+    if (!baseURL) {
+      throw new Error('Playwright baseURL is required.');
+    }
+
+    const editorPassword = randomBytes(24).toString('base64url');
+    const plainEditorPassword = randomBytes(24).toString('base64url');
+    const consoleErrors = [];
+    const pageErrors = [];
+    const http5xx = [];
+    const failedRequests = [];
+
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+    page.on('response', (response) => {
+      if (
+        new URL(response.url()).origin === new URL(baseURL).origin
+        && response.status() >= 500
+      ) {
+        http5xx.push({
+          status: response.status(),
+          method: response.request().method(),
+          url: response.url(),
+        });
+      }
+    });
+    page.on('requestfailed', (request) => {
+      if (new URL(request.url()).origin === new URL(baseURL).origin) {
+        failedRequests.push({
+          method: request.method(),
+          url: request.url(),
+          error: request.failure()?.errorText ?? 'Unknown request failure',
+        });
+      }
+    });
+
+    await mkdir(screenshotDirectory, { recursive: true });
+    await mkdir(evidenceDirectory, { recursive: true });
+
+    try {
+      createEphemeralFixtures(editorPassword, plainEditorPassword);
+
+      await logIn(page, plainEditorUsername, plainEditorPassword);
+      await openArticleForm(page);
+      await expect(aiAssistantButton(page)).toHaveCount(0);
+
+      const noPermissionScreenshot = path.join(
+        screenshotDirectory,
+        'ai-ckeditor-article-no-permission-desktop.png',
+      );
+      await page.screenshot({
+        path: noPermissionScreenshot,
+        fullPage: true,
+      });
+
+      await page.context().clearCookies();
+      await logIn(page, editorUsername, editorPassword);
+      const editable = await openArticleForm(page);
+
+      const aiButton = aiAssistantButton(page);
+      await expect(aiButton).toBeVisible();
+      await aiButton.click();
+
+      const panel = page.locator('.ck-dropdown__panel:visible').last();
+      await expect(panel).toBeVisible();
+      const menuText = await panel.innerText();
+
+      expect(menuText).toMatch(/Generate with AI|Génér.+IA/i);
+      expect(menuText).toMatch(/Modify with a prompt|Modifier.+(?:prompt|invite)/i);
+      expect(menuText).toMatch(/Fix spelling|Corriger.+orthograph/i);
+      expect(menuText).toMatch(/Summarize|Résum/i);
+      expect(menuText).not.toMatch(/Reformat HTML|Reformater HTML/i);
+      expect(menuText).not.toMatch(/(?:^|\n)\s*(?:Tone|Ton)\s*(?:\n|$)/i);
+      expect(menuText).not.toMatch(/(?:^|\n)\s*(?:Translate|Traduire)\s*(?:\n|$)/i);
+      expect(menuText).not.toMatch(/(?:^|\n)\s*(?:Help|Aide)\s*(?:\n|$)/i);
+
+      const menuScreenshot = path.join(
+        screenshotDirectory,
+        'ai-ckeditor-article-authorized-menu-desktop.png',
+      );
+      await page.screenshot({
+        path: menuScreenshot,
+        fullPage: true,
+      });
+
+      const title = `Agency AI CKEditor proof ${Date.now()}`;
+      await page.locator('input[name="title[0][value]"]').fill(title);
+      await editable.fill('Contenu éditorial saisi sans provider AI configuré.');
+      await page.locator('#edit-submit').click();
+      await page.waitForLoadState('domcontentloaded');
+      await expect(
+        page.getByRole('heading', {
+          name: title,
+          level: 1,
+        }),
+      ).toBeVisible({ timeout: 15_000 });
+
+      const savedScreenshot = path.join(
+        screenshotDirectory,
+        'ai-ckeditor-article-normal-save-desktop.png',
+      );
+      await page.screenshot({
+        path: savedScreenshot,
+        fullPage: true,
+      });
+
+      expect(consoleErrors, 'No browser console error is allowed.').toEqual([]);
+      expect(pageErrors, 'No uncaught browser page error is allowed.').toEqual([]);
+      expect(http5xx, 'No same-origin HTTP 5xx response is allowed.').toEqual([]);
+      expect(failedRequests, 'No same-origin browser request may fail.').toEqual([]);
+
+      const evidence = {
+        schema_version: 1,
+        contract: 'ai-ckeditor-article-authenticated',
+        issue: 380,
+        actor: 'ephemeral content_editor',
+        negative_actor: 'ephemeral editor without use ai ckeditor',
+        result: 'PASS',
+        checks: {
+          article_form: 'PASS',
+          ckeditor_loaded: 'PASS',
+          authorized_ai_button: 'PASS',
+          authorized_menu_subset: 'PASS',
+          unauthorized_ai_button_absent: 'PASS',
+          normal_save_without_provider: 'PASS',
+          console: 'PASS',
+          network: 'PASS',
+        },
+        screenshots: [
+          'screenshots/ai-ckeditor-article-no-permission-desktop.png',
+          'screenshots/ai-ckeditor-article-authorized-menu-desktop.png',
+          'screenshots/ai-ckeditor-article-normal-save-desktop.png',
+        ],
+        generated_at: new Date().toISOString(),
+      };
+
+      await writeFile(
+        path.join(evidenceDirectory, 'ai-ckeditor-authenticated.json'),
+        `${JSON.stringify(evidence, null, 2)}\n`,
+        'utf8',
+      );
+    }
+    finally {
+      try {
+        deleteEphemeralFixtures();
+      }
+      catch {
+        // The DDEV project is disposable and the runner cleanup remains authoritative.
+      }
+    }
+  });
+});

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorConfigTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorConfigTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Verifies the narrow, human-governed AI CKEditor configuration.
+ *
+ * @group agency_project_tests
+ * @group agency_ai
+ */
+#[Group('agency_ai')]
+final class AiCkeditorConfigTest extends TestCase {
+
+  /**
+   * Verifies AI CKEditor is enabled and scoped to the Basic HTML editor.
+   */
+  public function testAiCkeditorIsEnabledOnBasicHtmlOnly(): void {
+    $extensions = $this->loadConfiguration('core.extension.yml');
+    self::assertArrayHasKey('ai_ckeditor', $extensions['module'] ?? []);
+
+    $editor = $this->loadConfiguration('editor.editor.basic_html.yml');
+    self::assertContains('ai_ckeditor', $editor['dependencies']['module'] ?? []);
+    self::assertContains('aickeditor', $editor['settings']['toolbar']['items'] ?? []);
+
+    $source_index = array_search(
+      'sourceEditing',
+      $editor['settings']['toolbar']['items'] ?? [],
+      TRUE,
+    );
+    $ai_index = array_search(
+      'aickeditor',
+      $editor['settings']['toolbar']['items'] ?? [],
+      TRUE,
+    );
+    self::assertIsInt($source_index);
+    self::assertIsInt($ai_index);
+    self::assertSame($source_index - 1, $ai_index);
+  }
+
+  /**
+   * Verifies the deliberately narrow tool set and provider abstraction.
+   */
+  public function testEnabledToolsAreExplicitAndProviderAgnostic(): void {
+    $editor = $this->loadConfiguration('editor.editor.basic_html.yml');
+    $plugins = $editor['settings']['plugins']['ai_ckeditor_ai']['plugins'] ?? [];
+    self::assertIsArray($plugins);
+
+    $enabled = [];
+    foreach ($plugins as $plugin_id => $plugin) {
+      if (($plugin['enabled'] ?? FALSE) === TRUE) {
+        $enabled[] = $plugin_id;
+        if (array_key_exists('provider', $plugin)) {
+          self::assertSame('', $plugin['provider']);
+        }
+      }
+    }
+
+    self::assertSame([
+      'ai_ckeditor_completion',
+      'ai_ckeditor_modify_prompt',
+      'ai_ckeditor_spellfix',
+      'ai_ckeditor_summarize',
+    ], $enabled);
+    self::assertFalse($plugins['ai_ckeditor_tone']['enabled'] ?? TRUE);
+    self::assertFalse($plugins['ai_ckeditor_translate']['enabled'] ?? TRUE);
+  }
+
+  /**
+   * Verifies the AI tool permission is limited to the editorial role.
+   */
+  public function testAiCkeditorPermissionIsEditorialOnly(): void {
+    $content_editor = $this->loadConfiguration('user.role.content_editor.yml');
+    $authenticated = $this->loadConfiguration('user.role.authenticated.yml');
+
+    self::assertContains(
+      'use ai ckeditor',
+      $content_editor['permissions'] ?? [],
+    );
+    self::assertContains(
+      'ai_ckeditor',
+      $content_editor['dependencies']['module'] ?? [],
+    );
+    self::assertNotContains(
+      'use ai ckeditor',
+      $authenticated['permissions'] ?? [],
+    );
+  }
+
+  /**
+   * Verifies Article remains a normal human-edited rich-text field.
+   */
+  public function testArticleBodyRemainsHumanEditedAndTranslatable(): void {
+    $field = $this->loadConfiguration('field.field.node.article.body.yml');
+
+    self::assertTrue($field['translatable'] ?? FALSE);
+    self::assertSame('text_with_summary', $field['field_type'] ?? NULL);
+    self::assertSame([], $field['settings']['allowed_formats'] ?? []);
+  }
+
+  /**
+   * Loads one configuration file from the repository sync directory.
+   */
+  private function loadConfiguration(string $filename): array {
+    $path = dirname(DRUPAL_ROOT) . '/config/sync/' . $filename;
+    self::assertFileExists($path);
+
+    $configuration = Yaml::parseFile($path);
+    self::assertIsArray($configuration);
+
+    return $configuration;
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorProviderFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorProviderFailureTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\agency_project_tests\Functional;
 
 use Drupal\editor\Entity\Editor;
+use Drupal\node\Entity\NodeType;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Proves AI CKEditor does not make normal Article authoring provider-dependent.
@@ -15,6 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @group agency_ai
  */
 #[Group('agency_ai')]
+#[RunTestsInSeparateProcesses]
 final class AiCkeditorProviderFailureTest extends BrowserTestBase {
 
   /**
@@ -40,6 +43,13 @@ final class AiCkeditorProviderFailureTest extends BrowserTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    if (!NodeType::load('article')) {
+      $this->drupalCreateContentType([
+        'type' => 'article',
+        'name' => 'Article',
+      ]);
+    }
 
     $editor = Editor::load('basic_html');
     self::assertInstanceOf(Editor::class, $editor);

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorProviderFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AiCkeditorProviderFailureTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Proves AI CKEditor does not make normal Article authoring provider-dependent.
+ *
+ * @group agency_project_tests
+ * @group agency_ai
+ */
+#[Group('agency_ai')]
+final class AiCkeditorProviderFailureTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'ai',
+    'ai_ckeditor',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'standard';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $editor = Editor::load('basic_html');
+    self::assertInstanceOf(Editor::class, $editor);
+
+    $settings = $editor->getSettings();
+    $toolbar = $settings['toolbar']['items'] ?? [];
+    self::assertIsArray($toolbar);
+    if (!in_array('aickeditor', $toolbar, TRUE)) {
+      $toolbar[] = 'aickeditor';
+    }
+    $settings['toolbar']['items'] = $toolbar;
+    $settings['plugins']['ai_ckeditor_ai'] = [
+      'dialog' => [
+        'autoresize' => 'min-width: 600px',
+        'height' => '750',
+        'width' => '900',
+        'dialog_class' => 'ai-ckeditor-modal',
+      ],
+      'plugins' => [
+        'ai_ckeditor_completion' => [
+          'enabled' => TRUE,
+          'provider' => '',
+        ],
+        'ai_ckeditor_help' => ['enabled' => FALSE],
+        'ai_ckeditor_modify_prompt' => [
+          'enabled' => TRUE,
+          'provider' => '',
+        ],
+        'ai_ckeditor_reformat_html' => [
+          'enabled' => FALSE,
+          'provider' => '',
+        ],
+        'ai_ckeditor_spellfix' => [
+          'enabled' => TRUE,
+          'provider' => '',
+        ],
+        'ai_ckeditor_summarize' => [
+          'enabled' => TRUE,
+          'provider' => '',
+        ],
+        'ai_ckeditor_tone' => [
+          'enabled' => FALSE,
+          'provider' => '',
+          'autocreate' => FALSE,
+          'tone_vocabulary' => 'tags',
+          'use_description' => FALSE,
+        ],
+        'ai_ckeditor_translate' => [
+          'enabled' => FALSE,
+          'provider' => '',
+          'language_source' => 'lang',
+          'autocreate' => FALSE,
+          'translate_vocabulary' => 'tags',
+          'use_description' => FALSE,
+        ],
+      ],
+    ];
+    $editor->setSettings($settings)->save();
+
+    $account = $this->drupalCreateUser([
+      'create article content',
+      'use text format basic_html',
+      'use ai ckeditor',
+    ]);
+    self::assertNotFalse($account);
+    $this->drupalLogin($account);
+  }
+
+  /**
+   * Verifies an editor can save an Article with no AI provider configured.
+   */
+  public function testNormalArticleSaveWithoutProvider(): void {
+    self::assertSame([], $this->config('ai.settings')->get('default_providers') ?? []);
+
+    $this->drupalGet('node/add/article');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->submitForm([
+      'title[0][value]' => 'Human authored article without provider',
+      'body[0][value]' => '<p>This content is saved without invoking AI.</p>',
+    ], 'Save');
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Human authored article without provider');
+    $this->assertSession()->pageTextContains('has been created');
+  }
+
+}


### PR DESCRIPTION
Closes #380

## Objectif

Activer l’assistance éditoriale upstream AI CKEditor pour Article, de façon étroite, explicite et human-in-the-loop.

## Baseline upstream revalidée

- Drupal AI `1.4.6` est la dernière release stable/security-covered 1.4.x au 2026-08-15 ;
- `1.5.0-rc1` reste une RC, donc aucune montée de dépendance dans ce ticket ;
- `ai_ckeditor` est livré dans AI Core et expose la permission dédiée `use ai ckeditor` ;
- la structure `settings.plugins.ai_ckeditor_ai` et le bouton `aickeditor` suivent le pattern upstream/recipe Drupal AI.

## Changements

- active `ai_ckeditor` dans `core.extension` ;
- ajoute `aickeditor` au CKEditor 5 `basic_html`, immédiatement avant Source Editing ;
- active uniquement :
  - Completion / génération de fragment ;
  - Modify with a prompt / reformulation ;
  - SpellFix / correction ;
  - Summarize ;
- laisse Reformat HTML, Tone, Translate et Help désactivés ;
- aucune nouvelle taxonomie Tone/Languages ;
- aucun usage de CKEditor Translate pour les traductions d’entité FR/EN ;
- tous les tools actifs utilisent `provider: ''` : résolution via abstraction/default Chat provider Drupal AI, aucun provider/modèle/secret versionné ;
- accorde `use ai ckeditor` à `content_editor` seulement ; `authenticated` garde Basic HTML mais n’obtient pas la permission AI ;
- documente gouvernance, panne provider et relation aux Guardrails #379 ;
- ajoute un test de contrat du module, toolbar, sous-ensemble de tools, provider abstraction et permissions.

## Gouvernance

- action AI uniquement sur déclenchement explicite éditeur ;
- résultat relu/modifiable avant sauvegarde ;
- aucune auto-publication ;
- les Guardrails globaux #379 restent applicables ;
- panne/absence provider ne doit pas empêcher l’édition Drupal normale.

## Gates

1. CI standard exacte ;
2. fresh DDEV runner ;
3. `cim` + `config:status CLEAN` ;
4. Content Sync + second `config:status CLEAN` ;
5. Playwright public regression PASS ;
6. si Drupal normalise les configs AI CKEditor, matérialiser uniquement le `cex` exact et recommencer ;
7. aucune clé/secret dans le diff.

Références upstream : Drupal AI 1.4.6 + AI CKEditor recipe/meta #3566421 + permission issue history.