### PR TITLE
Issue #431: clean browser evidence after upload

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -294,6 +294,17 @@ jobs:
           if [[ "$LOCKFILE_WAS_PRESENT" == "false" ]]; then
             rm -f package-lock.json
           fi
+
+          # Evidence has already been uploaded above. Remove only workflow-owned
+          # runtime output so PASS and fail-closed paths end on the same clean
+          # repository workspace without deleting any versioned file.
+          rm -rf \
+            artifacts/browser-validation \
+            artifacts/config-canonicalization \
+            playwright-report \
+            test-results
+          rmdir artifacts 2>/dev/null || true
+
           git diff --check
           status="$(git status --porcelain)"
           if [[ -n "$status" ]]; then


### PR DESCRIPTION
Closes #431

## Correctif

Le workflow self-hosted upload déjà correctement les preuves browser/config avant son cleanup. Sur un chemin fail-closed de configuration, `artifacts/config-canonicalization` restait ensuite non suivi et faisait échouer secondairement le contrôle final du workspace.

Le correctif supprime **après l'upload** et uniquement les sorties runtime possédées par le workflow :

- `artifacts/browser-validation` ;
- `artifacts/config-canonicalization` ;
- `playwright-report` ;
- `test-results`.

Puis `artifacts/` est supprimé seulement s'il est vide (`rmdir ... || true`).

Aucun fichier versionné n'est ciblé. Le `git status --porcelain` final reste inchangé et continue à faire échouer le cleanup si un autre drift subsiste.

## Propriétés préservées

- upload des preuves avant nettoyage ;
- DDEV toujours supprimé via le step `always()` ;
- restauration de `web/robots.txt` et `config/sync` conservée ;
- fail-closed primaire non masqué ;
- aucun changement Drupal, DDEV, contenu ou production.

## Validation

Le diff touche `.github/` : conformément au trust boundary du workflow, aucune exécution self-hosted du code non fusionné n'est autorisée. Le plan de preuve est donc :

1. CI standard exact-head sur cette PR ;
2. merge si green ;
3. dispatch du workflow **depuis le `main` trusted exact** ;
4. vérification que l'upload des preuves précède le cleanup et que le cleanup termine avec un workspace Git propre.

Diff final : 1 fichier, +11 lignes.