### PR TITLE
Issue #446: add governed Content transition proof route

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -1,0 +1,120 @@
+name: Agent governed content transition dispatch
+
+on:
+  push:
+    branches:
+      - agency/governed-content-transition-dispatch-control
+    paths:
+      - .agency/governed-content-transition-request.json
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Validate governed transition request and dispatch trusted workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout control branch history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate control mutation
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_ACTOR" != "E-merging-digital" ]]; then
+            echo "Unauthorized control actor: $GITHUB_ACTOR" >&2
+            exit 1
+          fi
+
+          changed="$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")"
+          if [[ "$changed" != ".agency/governed-content-transition-request.json" ]]; then
+            echo "Control branch mutations must change exactly the governed transition request." >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+      - name: Validate request schema and live target
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' > /tmp/governed-transition-request.env
+          import json
+          import re
+          from pathlib import Path
+
+          path = Path('.agency/governed-content-transition-request.json')
+          data = json.loads(path.read_text(encoding='utf-8'))
+          expected = {'request_id', 'pr_number', 'head_sha', 'proof_profile'}
+          if set(data) != expected:
+              raise SystemExit(f'Expected exactly {sorted(expected)}, got {sorted(data)}')
+
+          request_id = data['request_id']
+          pr_number = data['pr_number']
+          head_sha = data['head_sha']
+          proof_profile = data['proof_profile']
+
+          if not isinstance(request_id, str) or not re.fullmatch(r'[A-Za-z0-9._-]{8,80}', request_id):
+              raise SystemExit('Invalid request_id')
+          if not isinstance(pr_number, int) or pr_number < 1:
+              raise SystemExit('pr_number must be a positive integer')
+          if not isinstance(head_sha, str) or not re.fullmatch(r'[0-9a-f]{40}', head_sha):
+              raise SystemExit('head_sha must be a lowercase 40-character SHA')
+          if proof_profile != 'case-studies-440':
+              raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
+
+          print(f'REQUEST_ID={request_id}')
+          print(f'PR_NUMBER={pr_number}')
+          print(f'HEAD_SHA={head_sha}')
+          print(f'PROOF_PROFILE={proof_profile}')
+          PY
+
+          source /tmp/governed-transition-request.env
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+
+          test "$(jq -r '.state' <<<"$pr_json")" = "open"
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = "main"
+          test "$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")" = "$GITHUB_REPOSITORY" || {
+            echo "Fork PRs are not dispatchable." >&2
+            exit 1
+          }
+          test "$(jq -r '.head.sha' <<<"$pr_json")" = "$HEAD_SHA" || {
+            echo "Requested PR SHA is stale." >&2
+            exit 1
+          }
+
+          echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "proof_profile=$PROOF_PROFILE" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch trusted governed transition proof
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+          PR_NUMBER: ${{ steps.request.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          PROOF_PROFILE: ${{ steps.request.outputs.proof_profile }}
+        run: |
+          set -euo pipefail
+          gh workflow run self-hosted-governed-content-transition-proof.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f "request_id=$REQUEST_ID" \
+            -f "pr_number=$PR_NUMBER" \
+            -f "head_sha=$HEAD_SHA" \
+            -f "proof_profile=$PROOF_PROFILE"

--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -58,27 +58,36 @@ jobs:
 
           path = Path('.agency/governed-content-transition-request.json')
           data = json.loads(path.read_text(encoding='utf-8'))
-          expected = {'request_id', 'pr_number', 'head_sha', 'proof_profile'}
+          expected = {
+              'request_id',
+              'pr_number',
+              'head_sha',
+              'release_sha',
+              'proof_profile',
+          }
           if set(data) != expected:
               raise SystemExit(f'Expected exactly {sorted(expected)}, got {sorted(data)}')
 
           request_id = data['request_id']
           pr_number = data['pr_number']
           head_sha = data['head_sha']
+          release_sha = data['release_sha']
           proof_profile = data['proof_profile']
 
           if not isinstance(request_id, str) or not re.fullmatch(r'[A-Za-z0-9._-]{8,80}', request_id):
               raise SystemExit('Invalid request_id')
           if not isinstance(pr_number, int) or pr_number < 1:
               raise SystemExit('pr_number must be a positive integer')
-          if not isinstance(head_sha, str) or not re.fullmatch(r'[0-9a-f]{40}', head_sha):
-              raise SystemExit('head_sha must be a lowercase 40-character SHA')
+          for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
+              if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
+                  raise SystemExit(f'{name} must be a lowercase 40-character SHA')
           if proof_profile != 'case-studies-440':
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')
           print(f'PR_NUMBER={pr_number}')
           print(f'HEAD_SHA={head_sha}')
+          print(f'RELEASE_SHA={release_sha}')
           print(f'PROOF_PROFILE={proof_profile}')
           PY
 
@@ -99,6 +108,7 @@ jobs:
           echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
           echo "proof_profile=$PROOF_PROFILE" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch trusted governed transition proof
@@ -108,6 +118,7 @@ jobs:
           REQUEST_ID: ${{ steps.request.outputs.request_id }}
           PR_NUMBER: ${{ steps.request.outputs.pr_number }}
           HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          RELEASE_SHA: ${{ steps.request.outputs.release_sha }}
           PROOF_PROFILE: ${{ steps.request.outputs.proof_profile }}
         run: |
           set -euo pipefail
@@ -117,4 +128,5 @@ jobs:
             -f "request_id=$REQUEST_ID" \
             -f "pr_number=$PR_NUMBER" \
             -f "head_sha=$HEAD_SHA" \
+            -f "release_sha=$RELEASE_SHA" \
             -f "proof_profile=$PROOF_PROFILE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Validate governed transition proof shell syntax
+        run: bash -n scripts/runner/run-governed-content-transition-proof.sh
+
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Validate governed transition proof shell syntax
-        run: bash -n scripts/runner/run-governed-content-transition-proof.sh
+        run: |
+          bash -n scripts/runner/run-governed-content-transition-proof.sh
+          bash -n scripts/runner/finalize-governed-content-transition-proof.sh
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -1,0 +1,233 @@
+name: Agency governed content transition proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      request_id:
+        description: Auditable request identifier
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number to prove
+        required: true
+        type: string
+      head_sha:
+        description: Exact 40-character PR HEAD SHA
+        required: true
+        type: string
+      proof_profile:
+        description: Trusted transition proof profile
+        required: true
+        default: case-studies-440
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: agency-governed-content-transition-proof
+  cancel-in-progress: false
+
+jobs:
+  validate-request:
+    name: Validate governed transition target
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.validate.outputs.base_sha }}
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+      pr_number: ${{ steps.validate.outputs.pr_number }}
+      request_id: ${{ steps.validate.outputs.request_id }}
+    steps:
+      - name: Validate dispatch actor, profile and live PR
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ inputs.request_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REQUESTED_HEAD_SHA: ${{ inputs.head_sha }}
+          PROOF_PROFILE: ${{ inputs.proof_profile }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_ACTOR" != "E-merging-digital" && "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
+            echo "Refusing self-hosted transition dispatch actor: $GITHUB_ACTOR" >&2
+            exit 1
+          fi
+
+          if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{8,80}$ ]]; then
+            echo "Invalid request_id." >&2
+            exit 1
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "pr_number must identify a pull request." >&2
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "head_sha must be an exact lowercase 40-character SHA." >&2
+            exit 1
+          fi
+          if [[ "$PROOF_PROFILE" != "case-studies-440" ]]; then
+            echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
+            exit 1
+          fi
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -r '.state' <<<"$pr_json")"
+          base_ref="$(jq -r '.base.ref' <<<"$pr_json")"
+          base_sha="$(jq -r '.base.sha' <<<"$pr_json")"
+          head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+
+          if [[ "$state" != "open" || "$base_ref" != "main" ]]; then
+            echo "Transition proof target must be an OPEN PR based on main." >&2
+            exit 1
+          fi
+          if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+            echo "Fork PRs are never allowed on the self-hosted transition runner." >&2
+            exit 1
+          fi
+          if [[ "$head_sha" != "$REQUESTED_HEAD_SHA" ]]; then
+            echo "Requested SHA is not the live PR HEAD." >&2
+            exit 1
+          fi
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Live PR base SHA is invalid." >&2
+            exit 1
+          fi
+
+          changed_files="$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')"
+          if grep -Eq '^(\.github/|\.ddev/|\.agency/|scripts/runner/|tests/browser/|package\.json$|package-lock\.json$|playwright\.config\.mjs$)' <<<"$changed_files"; then
+            echo "Target PR changes trusted runner/browser infrastructure and cannot execute on this proof route." >&2
+            printf '%s\n' "$changed_files" >&2
+            exit 1
+          fi
+
+          required_paths=(
+            "web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
+            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
+            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
+            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
+            "web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
+          )
+          for required_path in "${required_paths[@]}"; do
+            grep -Fxq "$required_path" <<<"$changed_files" || {
+              echo "Pilot #440 transition proof requires changed path: $required_path" >&2
+              exit 1
+            }
+          done
+
+          echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+  transition-proof:
+    name: Prove base to released target on persistent DDEV database
+    needs: validate-request
+    timeout-minutes: 60
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+
+    steps:
+      - name: Verify runner identity and trusted toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+          jq --version
+          command -v python3
+          python3 --version
+
+      - name: Checkout trusted proof implementation from main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify trusted proof implementation
+        shell: bash
+        env:
+          TRUSTED_MAIN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN_SHA"
+          test -f scripts/runner/run-governed-content-transition-proof.sh
+          test -f package-lock.json
+          git diff --check
+          cp scripts/runner/run-governed-content-transition-proof.sh \
+            "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install trusted browser dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install chromium
+
+      - name: Run governed content transition proof
+        shell: bash
+        env:
+          BASE_SHA: ${{ needs.validate-request.outputs.base_sha }}
+          TARGET_SHA: ${{ needs.validate-request.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
+          REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          bash "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+
+      - name: Upload governed transition evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-governed-content-transition-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/governed-content-transition
+            test-results
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Clean DDEV and verify trusted workspace
+        if: ${{ always() }}
+        shell: bash
+        env:
+          TRUSTED_MAIN_SHA: ${{ github.sha }}
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-governed-content-proof.yaml
+          rm -f tests/browser/governed-content-transition-proof.spec.mjs
+          rm -f "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+          git reset --hard "$TRUSTED_MAIN_SHA"
+          git clean -fd -- .ddev tests/browser
+          rm -rf artifacts/governed-content-transition test-results
+          rmdir artifacts 2>/dev/null || true
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -175,6 +175,10 @@ jobs:
             gh api "repos/$GITHUB_REPOSITORY/contents/$policy_path?ref=$head_sha" --jq '.content' \
               | base64 --decode
           )"
+          final_catalog="$(
+            gh api "repos/$GITHUB_REPOSITORY/contents/$catalog_path?ref=$head_sha" --jq '.content' \
+              | base64 --decode
+          )"
 
           for content_id in \
             cas-client-refonte-drupal-institutionnelle \
@@ -190,6 +194,10 @@ jobs:
             fi
             if grep -Fq "'${content_id}'" <<<"$final_policy"; then
               echo "Final policy still admits already released pilot content: $content_id" >&2
+              exit 1
+            fi
+            if grep -Fq "id: ${content_id}" <<<"$final_catalog"; then
+              echo "Final HEAD contains released pilot catalog entry: $content_id" >&2
               exit 1
             fi
 
@@ -298,6 +306,10 @@ jobs:
           REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
         run: |
           set -euo pipefail
+          mkdir -p artifacts/governed-content-transition/browser/release-candidate
+          find artifacts/governed-content-transition/browser \
+            -maxdepth 1 -type f -name '*.png' \
+            -exec mv -t artifacts/governed-content-transition/browser/release-candidate {} +
           git fetch --no-tags origin "$BASE_SHA" "$RELEASE_SHA" "$TARGET_SHA"
           bash "/tmp/agency-governed-transition-finalize-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
 
@@ -308,6 +320,7 @@ jobs:
           name: agency-governed-content-transition-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             artifacts/governed-content-transition
+            artifacts/browser-validation
           if-no-files-found: warn
           retention-days: 14
 
@@ -326,6 +339,8 @@ jobs:
           git reset --hard "$TRUSTED_MAIN_SHA"
           git clean -fd -- .ddev tests/browser
           rm -rf artifacts/governed-content-transition
+          rm -rf artifacts/browser-validation
+          rm -rf test-results playwright-report
           rmdir artifacts 2>/dev/null || true
 
           git diff --check

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       release_sha:
-        description: Reviewed prerelease SHA that admits the pilot IDs before removal
+        description: Reviewed release-candidate SHA before final policy removal
         required: true
         type: string
       proof_profile:
@@ -114,56 +114,94 @@ jobs:
             exit 1
           fi
 
-          required_paths=(
+          required_target_paths=(
             "web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
             "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
             "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
             "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
             "web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
           )
-          for required_path in "${required_paths[@]}"; do
+          for required_path in "${required_target_paths[@]}"; do
             grep -Fxq "$required_path" <<<"$changed_files" || {
               echo "Pilot #440 transition proof requires changed path: $required_path" >&2
               exit 1
             }
           done
 
-          release_json="$(gh api "repos/$GITHUB_REPOSITORY/commits/$REQUESTED_RELEASE_SHA")"
-          parent_count="$(jq '.parents | length' <<<"$release_json")"
-          release_parent="$(jq -r '.parents[0].sha // ""' <<<"$release_json")"
-          release_files="$(jq -r '.files[].filename' <<<"$release_json")"
+          release_compare="$(gh api "repos/$GITHUB_REPOSITORY/compare/$base_sha...$REQUESTED_RELEASE_SHA")"
+          release_status="$(jq -r '.status' <<<"$release_compare")"
+          release_merge_base="$(jq -r '.merge_base_commit.sha' <<<"$release_compare")"
+          if [[ "$release_status" != "ahead" || "$release_merge_base" != "$base_sha" ]]; then
+            echo "Release candidate must be a descendant of the live PR base SHA." >&2
+            exit 1
+          fi
+
+          release_changed="$(jq -r '.files[].filename' <<<"$release_compare" | sort)"
+          expected_release_changed="$(
+            printf '%s\n' \
+              "web/modules/custom/emerging_digital_content/content_sync/catalog.yml" \
+              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml" \
+              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml" \
+              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml" \
+              "web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php" \
+              | sort
+          )"
+          if [[ "$release_changed" != "$expected_release_changed" ]]; then
+            echo "Release candidate must contain exactly the reviewed #440 transition paths." >&2
+            printf 'Observed:\n%s\n' "$release_changed" >&2
+            exit 1
+          fi
+
+          target_compare="$(gh api "repos/$GITHUB_REPOSITORY/compare/$REQUESTED_RELEASE_SHA...$head_sha")"
+          target_status="$(jq -r '.status' <<<"$target_compare")"
+          target_merge_base="$(jq -r '.merge_base_commit.sha' <<<"$target_compare")"
+          if [[ "$target_status" != "ahead" || "$target_merge_base" != "$REQUESTED_RELEASE_SHA" ]]; then
+            echo "Release candidate must be an ancestor of the live PR HEAD." >&2
+            exit 1
+          fi
+
           policy_path="web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
+          catalog_path="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
 
-          if [[ "$parent_count" != "1" || "$release_parent" != "$base_sha" ]]; then
-            echo "Prerelease SHA must be a single-parent direct child of the PR base SHA." >&2
-            exit 1
-          fi
-          if [[ "$release_files" != "$policy_path" ]]; then
-            echo "Prerelease SHA must change exactly GovernedContentPolicy.php." >&2
-            printf '%s\n' "$release_files" >&2
-            exit 1
-          fi
-
-          compare_json="$(gh api "repos/$GITHUB_REPOSITORY/compare/$REQUESTED_RELEASE_SHA...$head_sha")"
-          compare_status="$(jq -r '.status' <<<"$compare_json")"
-          merge_base="$(jq -r '.merge_base_commit.sha' <<<"$compare_json")"
-          if [[ "$compare_status" != "ahead" || "$merge_base" != "$REQUESTED_RELEASE_SHA" ]]; then
-            echo "Prerelease SHA must be an ancestor of the live PR HEAD." >&2
-            exit 1
-          fi
-
-          policy_content="$(
+          release_policy="$(
             gh api "repos/$GITHUB_REPOSITORY/contents/$policy_path?ref=$REQUESTED_RELEASE_SHA" --jq '.content' \
               | base64 --decode
           )"
+          release_catalog="$(
+            gh api "repos/$GITHUB_REPOSITORY/contents/$catalog_path?ref=$REQUESTED_RELEASE_SHA" --jq '.content' \
+              | base64 --decode
+          )"
+          final_policy="$(
+            gh api "repos/$GITHUB_REPOSITORY/contents/$policy_path?ref=$head_sha" --jq '.content' \
+              | base64 --decode
+          )"
+
           for content_id in \
             cas-client-refonte-drupal-institutionnelle \
             cas-client-migration-drupal-11 \
             cas-client-integration-ia-editoriale; do
-            grep -Fq "'${content_id}'" <<<"$policy_content" || {
-              echo "Prerelease policy does not admit pilot content: $content_id" >&2
+            grep -Fq "'${content_id}'" <<<"$release_policy" || {
+              echo "Release candidate policy does not admit pilot content: $content_id" >&2
               exit 1
             }
+            if grep -Fq "id: ${content_id}" <<<"$release_catalog"; then
+              echo "Release candidate still contains pilot catalog entry: $content_id" >&2
+              exit 1
+            fi
+            if grep -Fq "'${content_id}'" <<<"$final_policy"; then
+              echo "Final policy still admits already released pilot content: $content_id" >&2
+              exit 1
+            fi
+
+            payload_path="web/modules/custom/emerging_digital_content/content_sync/node/${content_id}.yml"
+            if gh api "repos/$GITHUB_REPOSITORY/contents/$payload_path?ref=$REQUESTED_RELEASE_SHA" >/dev/null 2>&1; then
+              echo "Release candidate still contains pilot payload: $payload_path" >&2
+              exit 1
+            fi
+            if gh api "repos/$GITHUB_REPOSITORY/contents/$payload_path?ref=$head_sha" >/dev/null 2>&1; then
+              echo "Final HEAD still contains pilot payload: $payload_path" >&2
+              exit 1
+            fi
           done
 
           echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
@@ -173,9 +211,9 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
   transition-proof:
-    name: Prove base to released target on persistent DDEV database
+    name: Prove base, release candidate and exact final HEAD
     needs: validate-request
-    timeout-minutes: 60
+    timeout-minutes: 75
     runs-on:
       - self-hosted
       - linux
@@ -210,7 +248,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Verify trusted proof implementation
+      - name: Verify and preserve trusted proof implementation
         shell: bash
         env:
           TRUSTED_MAIN_SHA: ${{ github.sha }}
@@ -218,10 +256,13 @@ jobs:
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN_SHA"
           test -f scripts/runner/run-governed-content-transition-proof.sh
+          test -f scripts/runner/finalize-governed-content-transition-proof.sh
           test -f package-lock.json
           git diff --check
           cp scripts/runner/run-governed-content-transition-proof.sh \
             "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+          cp scripts/runner/finalize-governed-content-transition-proof.sh \
+            "/tmp/agency-governed-transition-finalize-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
 
       - name: Setup Node 24
         uses: actions/setup-node@v6
@@ -236,7 +277,18 @@ jobs:
           npm ci
           npx playwright install chromium
 
-      - name: Run governed content transition proof
+      - name: Prove base to reviewed release candidate
+        shell: bash
+        env:
+          BASE_SHA: ${{ needs.validate-request.outputs.base_sha }}
+          TARGET_SHA: ${{ needs.validate-request.outputs.release_sha }}
+          PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
+          REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          bash "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+
+      - name: Prove reviewed release candidate to exact final HEAD
         shell: bash
         env:
           BASE_SHA: ${{ needs.validate-request.outputs.base_sha }}
@@ -246,7 +298,8 @@ jobs:
           REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
         run: |
           set -euo pipefail
-          bash "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+          git fetch --no-tags origin "$BASE_SHA" "$RELEASE_SHA" "$TARGET_SHA"
+          bash "/tmp/agency-governed-transition-finalize-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
 
       - name: Upload governed transition evidence
         if: ${{ always() }}
@@ -269,6 +322,7 @@ jobs:
           rm -f .ddev/config.gate-governed-content-proof.yaml
           rm -f tests/browser/governed-content-transition-proof.spec.mjs
           rm -f "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
+          rm -f "/tmp/agency-governed-transition-finalize-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           git reset --hard "$TRUSTED_MAIN_SHA"
           git clean -fd -- .ddev tests/browser
           rm -rf artifacts/governed-content-transition

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -15,6 +15,10 @@ on:
         description: Exact 40-character PR HEAD SHA
         required: true
         type: string
+      release_sha:
+        description: Reviewed prerelease SHA that admits the pilot IDs before removal
+        required: true
+        type: string
       proof_profile:
         description: Trusted transition proof profile
         required: true
@@ -35,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.validate.outputs.base_sha }}
+      release_sha: ${{ steps.validate.outputs.release_sha }}
       head_sha: ${{ steps.validate.outputs.head_sha }}
       pr_number: ${{ steps.validate.outputs.pr_number }}
       request_id: ${{ steps.validate.outputs.request_id }}
@@ -47,6 +52,7 @@ jobs:
           REQUEST_ID: ${{ inputs.request_id }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REQUESTED_HEAD_SHA: ${{ inputs.head_sha }}
+          REQUESTED_RELEASE_SHA: ${{ inputs.release_sha }}
           PROOF_PROFILE: ${{ inputs.proof_profile }}
         run: |
           set -euo pipefail
@@ -66,6 +72,10 @@ jobs:
           fi
           if [[ ! "$REQUESTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "head_sha must be an exact lowercase 40-character SHA." >&2
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release_sha must be an exact lowercase 40-character SHA." >&2
             exit 1
           fi
           if [[ "$PROOF_PROFILE" != "case-studies-440" ]]; then
@@ -118,9 +128,48 @@ jobs:
             }
           done
 
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/commits/$REQUESTED_RELEASE_SHA")"
+          parent_count="$(jq '.parents | length' <<<"$release_json")"
+          release_parent="$(jq -r '.parents[0].sha // ""' <<<"$release_json")"
+          release_files="$(jq -r '.files[].filename' <<<"$release_json")"
+          policy_path="web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
+
+          if [[ "$parent_count" != "1" || "$release_parent" != "$base_sha" ]]; then
+            echo "Prerelease SHA must be a single-parent direct child of the PR base SHA." >&2
+            exit 1
+          fi
+          if [[ "$release_files" != "$policy_path" ]]; then
+            echo "Prerelease SHA must change exactly GovernedContentPolicy.php." >&2
+            printf '%s\n' "$release_files" >&2
+            exit 1
+          fi
+
+          compare_json="$(gh api "repos/$GITHUB_REPOSITORY/compare/$REQUESTED_RELEASE_SHA...$head_sha")"
+          compare_status="$(jq -r '.status' <<<"$compare_json")"
+          merge_base="$(jq -r '.merge_base_commit.sha' <<<"$compare_json")"
+          if [[ "$compare_status" != "ahead" || "$merge_base" != "$REQUESTED_RELEASE_SHA" ]]; then
+            echo "Prerelease SHA must be an ancestor of the live PR HEAD." >&2
+            exit 1
+          fi
+
+          policy_content="$(
+            gh api "repos/$GITHUB_REPOSITORY/contents/$policy_path?ref=$REQUESTED_RELEASE_SHA" --jq '.content' \
+              | base64 --decode
+          )"
+          for content_id in \
+            cas-client-refonte-drupal-institutionnelle \
+            cas-client-migration-drupal-11 \
+            cas-client-integration-ia-editoriale; do
+            grep -Fq "'${content_id}'" <<<"$policy_content" || {
+              echo "Prerelease policy does not admit pilot content: $content_id" >&2
+              exit 1
+            }
+          done
+
           echo "request_id=$REQUEST_ID" >> "$GITHUB_OUTPUT"
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$REQUESTED_RELEASE_SHA" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
   transition-proof:
@@ -191,6 +240,7 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ needs.validate-request.outputs.base_sha }}
+          RELEASE_SHA: ${{ needs.validate-request.outputs.release_sha }}
           TARGET_SHA: ${{ needs.validate-request.outputs.head_sha }}
           PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
           REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
@@ -205,7 +255,6 @@ jobs:
           name: agency-governed-content-transition-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             artifacts/governed-content-transition
-            test-results
           if-no-files-found: warn
           retention-days: 14
 
@@ -222,7 +271,7 @@ jobs:
           rm -f "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           git reset --hard "$TRUSTED_MAIN_SHA"
           git clean -fd -- .ddev tests/browser
-          rm -rf artifacts/governed-content-transition test-results
+          rm -rf artifacts/governed-content-transition
           rmdir artifacts 2>/dev/null || true
 
           git diff --check

--- a/docs/operations/execution-capabilities.md
+++ b/docs/operations/execution-capabilities.md
@@ -3,7 +3,7 @@
 Status: **AUTHORITATIVE CAPABILITY REGISTRY**  
 Repository: `E-merging-digital/agency-website-drupal`  
 Owner issue: #421  
-Last materialized: 2026-08-15
+Last materialized: 2026-08-16
 
 ## 1. Purpose
 
@@ -124,6 +124,41 @@ The implementation is documented in:
 
 ```text
 docs/operations/agency-self-hosted-browser-runner.md
+```
+
+### Governed Content transition proof route
+
+Issue #446 adds a second trusted-dispatch route for migrations that must preserve
+the **same Drupal database** while repository governance changes across commits.
+It is not interchangeable with the fresh-install browser route.
+
+The transition route is:
+
+```text
+agency/governed-content-transition-dispatch-control
+-> strict JSON request
+-> GitHub-hosted validation of PR / base / release candidate / exact HEAD
+-> trusted workflow on main
+-> agency-browser-runner-01
+-> one isolated DDEV database
+-> base state + active mappings
+-> reviewed release candidate + explicit release
+-> exact final HEAD + Content Sync persistence proof
+-> browser evidence
+-> controlled rollback / readmission
+-> artifact
+-> cleanup always()
+```
+
+For the #440 pilot the profile is fixed to `case-studies-440`; callers may not
+supply arbitrary content IDs or shell commands. The request carries an exact PR
+HEAD and a reviewed `release_sha`, and the trusted gateway proves the ancestry
+and expected path set before the self-hosted runner is allocated.
+
+The implementation and artifact contract are documented in:
+
+```text
+docs/operations/governed-content-transition-proof.md
 ```
 
 ## 5. What the agent can verify visually today

--- a/docs/operations/governed-content-transition-proof.md
+++ b/docs/operations/governed-content-transition-proof.md
@@ -1,0 +1,100 @@
+# Governed Content — preuve de transition DDEV
+
+Statut : route d’exécution gouvernée pour le pilote `#440`.
+
+Cette capacité complète la Browser Validation générale. Elle sert lorsqu’une preuve doit conserver la même base Drupal entre un état de départ encore géré par Content Sync et le HEAD exact d’une PR qui libère des contenus.
+
+## Modèle de confiance
+
+Le dépôt étant public, aucune PR ne déclenche directement le runner self-hosted.
+
+Le chemin autorisé est :
+
+```text
+branche de contrôle dédiée
+-> .agency/governed-content-transition-request.json
+-> gateway GitHub-hosted
+-> revalidation live de la PR et du SHA
+-> workflow trusted depuis main
+-> runner agency-browser-runner-01
+-> DDEV isolé
+-> artifact de preuve
+-> cleanup always()
+```
+
+La branche de contrôle est :
+
+```text
+agency/governed-content-transition-dispatch-control
+```
+
+La mutation autorisée sur cette branche est limitée à :
+
+```text
+.agency/governed-content-transition-request.json
+```
+
+Le schéma du pilote est strict :
+
+```json
+{
+  "request_id": "agency-governed-pr444-proof-001",
+  "pr_number": 444,
+  "head_sha": "<sha exact sur 40 caractères>",
+  "proof_profile": "case-studies-440"
+}
+```
+
+Le gateway refuse notamment un acteur de contrôle autre que `E-merging-digital`, une PR fermée, une base autre que `main`, un fork ou un SHA devenu obsolète.
+
+Le workflow trusted revalide ces invariants avant toute allocation self-hosted. Il refuse également les PR qui modifient les surfaces d’exécution de confiance : `.github/`, `.ddev/`, `.agency/`, `scripts/runner/`, `tests/browser/`, `package.json`, `package-lock.json` et `playwright.config.mjs`.
+
+## Profil `case-studies-440`
+
+Le profil courant est volontairement borné aux trois IDs réellement présents dans le catalogue :
+
+```text
+cas-client-refonte-drupal-institutionnelle
+cas-client-migration-drupal-11
+cas-client-integration-ia-editoriale
+```
+
+La preuve exécute :
+
+1. checkout du SHA de base de la PR ;
+2. installation DDEV depuis `--existing-config` ;
+3. Content Sync complet pour matérialiser les mappings `active` ;
+4. snapshot mappings, IDs/UUID, statuts, FR/EN, aliases, titres et révisions ;
+5. checkout du HEAD exact de la PR sans détruire la base DDEV ;
+6. `updb`, `cim` et cache rebuild, sans Content Sync préalable ;
+7. release dry-run puis apply des trois mappings avec le code du candidat ;
+8. vérification de conservation d’identité, publication, traductions et aliases ;
+9. Content Sync complet après retrait du catalogue ;
+10. modification éditoriale bornée d’un cas client, avec nouvelle révision ;
+11. nouveau Content Sync et preuve que l’édition Drupal survit ;
+12. validation Chromium desktop et mobile des six aliases FR/EN avec captures ;
+13. rollback par restauration contrôlée des trois payloads/catalogue depuis le SHA de base, readmission explicite et resynchronisation ;
+14. preuve que l’identité et le contenu canonique sont récupérés ;
+15. upload des snapshots/logs/captures/résultat JSON ;
+16. destruction de l’environnement DDEV et vérification d’un workspace propre.
+
+## Limites
+
+Cette route n’effectue aucune mutation de production et ne consomme aucun secret provider. La modification éditoriale de preuve reste confinée à la base DDEV éphémère du run.
+
+Le profil `case-studies-440` est fixe. Les futurs lots `#441` doivent réutiliser le même modèle de contrôle mais ajouter un profil trusted explicitement revu ; ils ne doivent pas transmettre une liste d’IDs ou une commande shell arbitraire depuis la branche de contrôle.
+
+## Lecture de l’artifact
+
+L’artifact `agency-governed-content-transition-<run>-<attempt>` contient notamment :
+
+- `result.json` : verdict machine lisible et SHAs exacts ;
+- `snapshots/base-*` : état avant release ;
+- `snapshots/released-*` : état immédiatement après release ;
+- `snapshots/post-deploy-*` : état après Content Sync du candidat ;
+- `snapshots/after-editorial-*` : preuve de persistance éditoriale ;
+- `snapshots/rollback-*` : état après readmission/resync ;
+- `browser/*.png` : captures des six aliases, desktop et mobile ;
+- `logs/*.txt` : sorties des commandes de release, sync, readmit et Playwright.
+
+Un PASS n’est valide que pour le couple `base_sha` / `target_sha` enregistré dans `result.json`. Un nouveau commit sur la PR impose un nouveau run.

--- a/docs/operations/governed-content-transition-proof.md
+++ b/docs/operations/governed-content-transition-proof.md
@@ -2,7 +2,7 @@
 
 Statut : route d’exécution gouvernée pour le pilote `#440`.
 
-Cette capacité complète la Browser Validation générale. Elle sert lorsqu’une preuve doit conserver la même base Drupal entre un état de départ encore géré par Content Sync et le HEAD exact d’une PR qui libère des contenus.
+Cette capacité complète la Browser Validation générale. Elle sert lorsqu’une preuve doit conserver la même base Drupal entre un état de départ encore géré par Content Sync, un commit de release contrôlée et le HEAD exact d’une PR qui retire ensuite les contenus de la gouvernance Git.
 
 ## Modèle de confiance
 
@@ -14,10 +14,10 @@ Le chemin autorisé est :
 branche de contrôle dédiée
 -> .agency/governed-content-transition-request.json
 -> gateway GitHub-hosted
--> revalidation live de la PR et du SHA
+-> revalidation live de la PR, du release candidate et du HEAD exact
 -> workflow trusted depuis main
 -> runner agency-browser-runner-01
--> DDEV isolé
+-> même base DDEV sur toute la transition
 -> artifact de preuve
 -> cleanup always()
 ```
@@ -40,18 +40,21 @@ Le schéma du pilote est strict :
 {
   "request_id": "agency-governed-pr444-proof-001",
   "pr_number": 444,
-  "head_sha": "<sha exact sur 40 caractères>",
+  "head_sha": "<HEAD exact de la PR sur 40 caractères>",
+  "release_sha": "<release candidate revu sur 40 caractères>",
   "proof_profile": "case-studies-440"
 }
 ```
 
-Le gateway refuse notamment un acteur de contrôle autre que `E-merging-digital`, une PR fermée, une base autre que `main`, un fork ou un SHA devenu obsolète.
+Le gateway refuse notamment un acteur de contrôle autre que `E-merging-digital`, une PR fermée, une base autre que `main`, un fork ou un HEAD devenu obsolète.
 
 Le workflow trusted revalide ces invariants avant toute allocation self-hosted. Il refuse également les PR qui modifient les surfaces d’exécution de confiance : `.github/`, `.ddev/`, `.agency/`, `scripts/runner/`, `tests/browser/`, `package.json`, `package-lock.json` et `playwright.config.mjs`.
 
+Le `release_sha` n’est pas une commande ni un ref arbitraire accepté tel quel. Pour le profil `case-studies-440`, le gateway trusted prouve qu’il est un descendant du SHA de base et un ancêtre du HEAD exact, que le diff base -> release candidate contient exactement la policy, le catalogue et les trois payloads du pilote, que les trois IDs restent autorisés par la policy à ce stade et qu’ils ont déjà été retirés du catalogue et des payloads. Le HEAD final doit, lui, avoir retiré ces IDs de l’allowlist de release.
+
 ## Profil `case-studies-440`
 
-Le profil courant est volontairement borné aux trois IDs réellement présents dans le catalogue :
+Le profil courant est volontairement borné aux trois IDs réellement présents dans le catalogue de départ :
 
 ```text
 cas-client-refonte-drupal-institutionnelle
@@ -59,28 +62,43 @@ cas-client-migration-drupal-11
 cas-client-integration-ia-editoriale
 ```
 
+La preuve suit trois états distincts :
+
+```text
+base main avec mappings active
+-> release candidate : payloads/catalogue retirés, IDs encore autorisés à release
+-> HEAD final : IDs retirés de l’allowlist après release
+```
+
+Cette séparation est obligatoire : lancer `release` directement sur le HEAD final serait incorrect puisque ce HEAD ne doit plus autoriser une nouvelle release de ces IDs.
+
 La preuve exécute :
 
 1. checkout du SHA de base de la PR ;
 2. installation DDEV depuis `--existing-config` ;
 3. Content Sync complet pour matérialiser les mappings `active` ;
 4. snapshot mappings, IDs/UUID, statuts, FR/EN, aliases, titres et révisions ;
-5. checkout du HEAD exact de la PR sans détruire la base DDEV ;
-6. `updb`, `cim` et cache rebuild, sans Content Sync préalable ;
-7. release dry-run puis apply des trois mappings avec le code du candidat ;
-8. vérification de conservation d’identité, publication, traductions et aliases ;
-9. Content Sync complet après retrait du catalogue ;
-10. modification éditoriale bornée d’un cas client, avec nouvelle révision ;
-11. nouveau Content Sync et preuve que l’édition Drupal survit ;
-12. validation Chromium desktop et mobile des six aliases FR/EN avec captures ;
-13. rollback par restauration contrôlée des trois payloads/catalogue depuis le SHA de base, readmission explicite et resynchronisation ;
-14. preuve que l’identité et le contenu canonique sont récupérés ;
-15. upload des snapshots/logs/captures/résultat JSON ;
-16. destruction de l’environnement DDEV et vérification d’un workspace propre.
+5. checkout du `release_sha` sans détruire la base DDEV ;
+6. release dry-run puis apply des trois mappings avant tout Content Sync du catalogue réduit ;
+7. vérification de conservation d’identité, publication, traductions et aliases ;
+8. Content Sync complet avec les trois contenus absents du catalogue ;
+9. modification éditoriale bornée d’un cas client, puis nouveau Content Sync prouvant que l’édition Drupal survit ;
+10. validation Chromium desktop et mobile des six aliases FR/EN avec captures ;
+11. rollback contrôlé vers les payloads/catalogue de base et readmission explicite ;
+12. replay de la release sur le même DDEV afin de préparer la vérification du HEAD final ;
+13. checkout du `head_sha` exact sans détruire la base ;
+14. `updb`, `cim`, Content Sync et cache rebuild sur le HEAD final ;
+15. preuve que les mappings restent `released`, que les IDs/UUID, publication, FR/EN et aliases sont préservés ;
+16. nouvelle modification éditoriale bornée, nouveau Content Sync et preuve de persistance au HEAD exact ;
+17. seconde validation Chromium desktop/mobile des six aliases ;
+18. rollback final par restauration contrôlée des trois payloads/catalogue depuis le SHA de base, readmission explicite et resynchronisation ;
+19. preuve que l’identité et le contenu canonique sont récupérés ;
+20. upload des snapshots/logs/captures et des deux résultats JSON ;
+21. destruction de l’environnement DDEV et vérification d’un workspace propre.
 
 ## Limites
 
-Cette route n’effectue aucune mutation de production et ne consomme aucun secret provider. La modification éditoriale de preuve reste confinée à la base DDEV éphémère du run.
+Cette route n’effectue aucune mutation de production et ne consomme aucun secret provider. Les modifications éditoriales de preuve restent confinées à la base DDEV éphémère du run.
 
 Le profil `case-studies-440` est fixe. Les futurs lots `#441` doivent réutiliser le même modèle de contrôle mais ajouter un profil trusted explicitement revu ; ils ne doivent pas transmettre une liste d’IDs ou une commande shell arbitraire depuis la branche de contrôle.
 
@@ -88,13 +106,13 @@ Le profil `case-studies-440` est fixe. Les futurs lots `#441` doivent réutilise
 
 L’artifact `agency-governed-content-transition-<run>-<attempt>` contient notamment :
 
-- `result.json` : verdict machine lisible et SHAs exacts ;
+- `result.json` : verdict de la première transition base -> release candidate ;
+- `final-result.json` : verdict du replay release candidate -> HEAD exact ;
 - `snapshots/base-*` : état avant release ;
-- `snapshots/released-*` : état immédiatement après release ;
-- `snapshots/post-deploy-*` : état après Content Sync du candidat ;
-- `snapshots/after-editorial-*` : preuve de persistance éditoriale ;
-- `snapshots/rollback-*` : état après readmission/resync ;
+- `snapshots/released-*` et `post-deploy-*` : état du release candidate ;
+- `snapshots/after-editorial-*` : première preuve de persistance éditoriale ;
+- `snapshots/final-*` : état et rollback du HEAD exact ;
 - `browser/*.png` : captures des six aliases, desktop et mobile ;
 - `logs/*.txt` : sorties des commandes de release, sync, readmit et Playwright.
 
-Un PASS n’est valide que pour le couple `base_sha` / `target_sha` enregistré dans `result.json`. Un nouveau commit sur la PR impose un nouveau run.
+Un PASS n’est valide que pour le triplet `base_sha` / `release_sha` / `target_sha` enregistré dans les résultats. Un nouveau commit sur la PR impose un nouveau run.

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${TARGET_SHA:?TARGET_SHA is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${REQUEST_ID:?REQUEST_ID is required}"
+
+ARTIFACT_ROOT="artifacts/governed-content-transition"
+SNAPSHOT_ROOT="$ARTIFACT_ROOT/snapshots"
+LOG_ROOT="$ARTIFACT_ROOT/logs"
+RESULT_PATH="$ARTIFACT_ROOT/final-result.json"
+EDITORIAL_MARKER="[proof-440-editorial-survives]"
+CATALOG_PATH="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
+SQL_IDS="'cas-client-refonte-drupal-institutionnelle','cas-client-migration-drupal-11','cas-client-integration-ia-editoriale'"
+PILOT_IDS=(
+  "cas-client-refonte-drupal-institutionnelle"
+  "cas-client-migration-drupal-11"
+  "cas-client-integration-ia-editoriale"
+)
+PILOT_PAYLOADS=(
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
+)
+
+proof_status="FAIL"
+proof_phase="finalize-bootstrap"
+
+write_result() {
+  local exit_code="$1"
+  jq -n \
+    --arg result "$proof_status" \
+    --arg phase "$proof_phase" \
+    --arg request_id "$REQUEST_ID" \
+    --arg pr_number "$PR_NUMBER" \
+    --arg base_sha "$BASE_SHA" \
+    --arg release_sha "$RELEASE_SHA" \
+    --arg target_sha "$TARGET_SHA" \
+    --argjson exit_code "$exit_code" \
+    '{
+      result: $result,
+      phase: $phase,
+      request_id: $request_id,
+      pr_number: $pr_number,
+      base_sha: $base_sha,
+      release_sha: $release_sha,
+      target_sha: $target_sha,
+      exit_code: $exit_code
+    }' > "$RESULT_PATH"
+}
+
+on_exit() {
+  local exit_code=$?
+  if [[ "$exit_code" -eq 0 ]]; then
+    proof_status="PASS"
+    proof_phase="complete"
+  fi
+  write_result "$exit_code"
+}
+trap on_exit EXIT
+
+snapshot_mappings() {
+  local destination="$1"
+  ddev mysql -N -B -e "
+    SELECT content_id, entity_id, entity_uuid, status, catalog_hash,
+           COALESCE(last_synced, 0), last_action
+      FROM emerging_digital_content_sync_mapping
+     WHERE content_id IN (${SQL_IDS})
+     ORDER BY content_id;
+  " > "$destination"
+}
+
+snapshot_nodes() {
+  local destination="$1"
+  ddev mysql -N -B -e "
+    SELECT m.content_id, nfd.nid, n.uuid, nfd.langcode, nfd.status,
+           nfd.title, COALESCE(pa.alias, '')
+      FROM emerging_digital_content_sync_mapping m
+      JOIN node n ON n.nid = m.entity_id
+      JOIN node_field_data nfd ON nfd.nid = n.nid
+      LEFT JOIN path_alias pa
+        ON pa.path = CONCAT('/node/', n.nid)
+       AND pa.langcode = nfd.langcode
+       AND pa.status = 1
+     WHERE m.content_id IN (${SQL_IDS})
+     ORDER BY m.content_id, nfd.langcode, pa.alias;
+  " > "$destination"
+}
+
+mapping_identity() {
+  cut -f1,2,3,5 "$1"
+}
+
+assert_mapping_status() {
+  local snapshot="$1"
+  local expected="$2"
+  [[ "$(wc -l < "$snapshot" | tr -d ' ')" == "3" ]]
+  awk -F '\t' -v expected="$expected" '
+    $4 != expected { bad = 1 }
+    END { exit bad }
+  ' "$snapshot"
+}
+
+assert_aliases_and_publication() {
+  local snapshot="$1"
+  local alias
+  local expected_aliases=(
+    "/cas-clients/refonte-drupal-institutionnelle"
+    "/case-studies/institutional-drupal-redesign"
+    "/cas-clients/migration-drupal-11"
+    "/case-studies/drupal-11-migration"
+    "/cas-clients/integration-ia-editoriale"
+    "/case-studies/editorial-ai-integration"
+  )
+  for alias in "${expected_aliases[@]}"; do
+    grep -Fq $'\t'"${alias}" "$snapshot"
+  done
+  awk -F '\t' '$5 != "1" { bad = 1 } END { exit bad }' "$snapshot"
+}
+
+release_pilot() {
+  local content_id
+  for content_id in "${PILOT_IDS[@]}"; do
+    ddev drush emerging:content-sync:release "$content_id" --dry-run \
+      | tee "$LOG_ROOT/final-release-${content_id}-dry-run.txt"
+    ddev drush emerging:content-sync:release "$content_id" --apply \
+      | tee "$LOG_ROOT/final-release-${content_id}-apply.txt"
+  done
+}
+
+readmit_pilot() {
+  local content_id
+  for content_id in "${PILOT_IDS[@]}"; do
+    ddev drush emerging:content-sync:readmit "$content_id" --dry-run \
+      | tee "$LOG_ROOT/final-readmit-${content_id}-dry-run.txt"
+    ddev drush emerging:content-sync:readmit "$content_id" --apply \
+      | tee "$LOG_ROOT/final-readmit-${content_id}-apply.txt"
+    ddev drush emerging:content-sync "$content_id" \
+      | tee "$LOG_ROOT/final-readmit-${content_id}-resync.txt"
+  done
+  ddev drush cr
+}
+
+verify_config_clean() {
+  local label="$1"
+  local status
+  status="$(ddev drush config:status 2>&1)"
+  printf '%s\n' "$status" | tee "$LOG_ROOT/final-config-status-${label}.txt"
+  grep -Fq 'No differences' <<<"$status"
+}
+
+apply_editorial_edit() {
+  ddev drush php:eval '
+    $nid = \Drupal::database()
+      ->select("emerging_digital_content_sync_mapping", "m")
+      ->fields("m", ["entity_id"])
+      ->condition("content_id", "cas-client-migration-drupal-11")
+      ->execute()
+      ->fetchField();
+    if (!$nid) {
+      throw new \RuntimeException("Pilot mapping not found.");
+    }
+    $node = \Drupal\node\Entity\Node::load((int) $nid);
+    if (!$node) {
+      throw new \RuntimeException("Pilot node not found.");
+    }
+    $node->setNewRevision(TRUE);
+    $node->setRevisionLogMessage("Governed Content exact-head proof #440");
+    $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+    if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
+      $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
+    }
+    $node->save();
+  '
+}
+
+assert_editorial_marker() {
+  ddev mysql -N -B -e "
+    SELECT nfd.title
+      FROM emerging_digital_content_sync_mapping m
+      JOIN node_field_data nfd
+        ON nfd.nid = m.entity_id
+       AND nfd.langcode = 'fr'
+     WHERE m.content_id = 'cas-client-migration-drupal-11';
+  " | grep -Fq "$EDITORIAL_MARKER"
+}
+
+detect_ddev_url() {
+  ddev describe -j | python3 -c '
+import json, sys
+
+def find(value):
+    if isinstance(value, str):
+        return value if value.startswith(("https://", "http://")) else None
+    if isinstance(value, list):
+        found = [find(item) for item in value]
+        found = [item for item in found if item]
+        return next((item for item in found if item.startswith("https://")), found[0] if found else None)
+    if isinstance(value, dict):
+        for key, entry in value.items():
+            if key.lower().replace("-", "_") in {"primary_url", "primaryurl"}:
+                if isinstance(entry, str) and entry.startswith(("https://", "http://")):
+                    return entry
+        for entry in value.values():
+            result = find(entry)
+            if result:
+                return result
+    return None
+
+url = find(json.load(sys.stdin))
+if not url:
+    raise SystemExit("No DDEV URL found")
+print(url.rstrip("/"))
+'
+}
+
+proof_phase="replay-release-candidate"
+git reset --hard "$RELEASE_SHA"
+git clean -fd -- web/modules/custom/emerging_digital_content/content_sync
+ddev drush cr
+release_pilot
+snapshot_mappings "$SNAPSHOT_ROOT/final-prerelease-mappings.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/final-prerelease-mappings.tsv" "released"
+diff -u \
+  <(mapping_identity "$SNAPSHOT_ROOT/base-mappings.tsv") \
+  <(mapping_identity "$SNAPSHOT_ROOT/final-prerelease-mappings.tsv") \
+  | tee "$LOG_ROOT/final-prerelease-identity.diff"
+
+proof_phase="exact-head-deploy"
+git checkout --detach "$TARGET_SHA"
+git diff --check
+ddev composer install --no-interaction --no-progress --prefer-dist
+ddev drush updb -y
+ddev drush cim -y
+ddev drush cr
+verify_config_clean "before-sync"
+ddev drush emerging:content-sync:validate \
+  | tee "$LOG_ROOT/final-content-sync-validate.txt"
+ddev drush emerging:content-sync --all --dry-run \
+  | tee "$LOG_ROOT/final-content-sync-dry-run.txt"
+ddev drush emerging:content-sync --all \
+  | tee "$LOG_ROOT/final-content-sync-apply.txt"
+ddev drush cr
+verify_config_clean "after-sync"
+
+snapshot_mappings "$SNAPSHOT_ROOT/final-head-mappings.tsv"
+snapshot_nodes "$SNAPSHOT_ROOT/final-head-nodes.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/final-head-mappings.tsv" "released"
+assert_aliases_and_publication "$SNAPSHOT_ROOT/final-head-nodes.tsv"
+diff -u \
+  <(mapping_identity "$SNAPSHOT_ROOT/base-mappings.tsv") \
+  <(mapping_identity "$SNAPSHOT_ROOT/final-head-mappings.tsv") \
+  | tee "$LOG_ROOT/final-head-identity.diff"
+diff -u "$SNAPSHOT_ROOT/base-nodes.tsv" "$SNAPSHOT_ROOT/final-head-nodes.tsv" \
+  | tee "$LOG_ROOT/final-head-node-state.diff"
+
+proof_phase="exact-head-editorial-persistence"
+apply_editorial_edit
+assert_editorial_marker
+ddev drush emerging:content-sync --all \
+  | tee "$LOG_ROOT/final-content-sync-after-editorial-edit.txt"
+ddev drush cr
+assert_editorial_marker
+
+proof_phase="exact-head-browser"
+base_url="$(detect_ddev_url)"
+PLAYWRIGHT_BASE_URL="$base_url" \
+PROOF_EDITORIAL_MARKER="$EDITORIAL_MARKER" \
+  npx playwright test tests/browser/governed-content-transition-proof.spec.mjs \
+    --output="$ARTIFACT_ROOT/final-playwright-test-results" \
+    | tee "$LOG_ROOT/final-playwright.txt"
+
+proof_phase="final-rollback"
+git checkout "$BASE_SHA" -- "$CATALOG_PATH" "${PILOT_PAYLOADS[@]}"
+readmit_pilot
+snapshot_mappings "$SNAPSHOT_ROOT/final-rollback-mappings.tsv"
+snapshot_nodes "$SNAPSHOT_ROOT/final-rollback-nodes.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/final-rollback-mappings.tsv" "active"
+assert_aliases_and_publication "$SNAPSHOT_ROOT/final-rollback-nodes.tsv"
+diff -u \
+  <(mapping_identity "$SNAPSHOT_ROOT/base-mappings.tsv") \
+  <(mapping_identity "$SNAPSHOT_ROOT/final-rollback-mappings.tsv") \
+  | tee "$LOG_ROOT/final-rollback-identity.diff"
+diff -u "$SNAPSHOT_ROOT/base-nodes.tsv" "$SNAPSHOT_ROOT/final-rollback-nodes.tsv" \
+  | tee "$LOG_ROOT/final-rollback-node-state.diff"
+
+proof_status="PASS"
+proof_phase="complete"

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${TARGET_SHA:?TARGET_SHA is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${REQUEST_ID:?REQUEST_ID is required}"
+
+ARTIFACT_ROOT="artifacts/governed-content-transition"
+SNAPSHOT_ROOT="$ARTIFACT_ROOT/snapshots"
+BROWSER_ROOT="$ARTIFACT_ROOT/browser"
+LOG_ROOT="$ARTIFACT_ROOT/logs"
+RESULT_PATH="$ARTIFACT_ROOT/result.json"
+EDITORIAL_MARKER="[proof-440-editorial-survives]"
+
+PILOT_IDS=(
+  "cas-client-refonte-drupal-institutionnelle"
+  "cas-client-migration-drupal-11"
+  "cas-client-integration-ia-editoriale"
+)
+
+PILOT_PAYLOADS=(
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
+  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
+)
+
+CATALOG_PATH="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
+SQL_IDS="'cas-client-refonte-drupal-institutionnelle','cas-client-migration-drupal-11','cas-client-integration-ia-editoriale'"
+
+mkdir -p "$SNAPSHOT_ROOT" "$BROWSER_ROOT" "$LOG_ROOT"
+
+proof_status="FAIL"
+proof_phase="bootstrap"
+
+write_result() {
+  local exit_code="$1"
+  jq -n \
+    --arg result "$proof_status" \
+    --arg phase "$proof_phase" \
+    --arg request_id "$REQUEST_ID" \
+    --arg pr_number "$PR_NUMBER" \
+    --arg base_sha "$BASE_SHA" \
+    --arg target_sha "$TARGET_SHA" \
+    --arg marker "$EDITORIAL_MARKER" \
+    --argjson exit_code "$exit_code" \
+    '{
+      result: $result,
+      phase: $phase,
+      request_id: $request_id,
+      pr_number: $pr_number,
+      base_sha: $base_sha,
+      target_sha: $target_sha,
+      pilot_content_ids: [
+        "cas-client-refonte-drupal-institutionnelle",
+        "cas-client-migration-drupal-11",
+        "cas-client-integration-ia-editoriale"
+      ],
+      editorial_marker: $marker,
+      exit_code: $exit_code
+    }' > "$RESULT_PATH"
+}
+
+on_exit() {
+  local exit_code=$?
+  if [[ "$exit_code" -eq 0 ]]; then
+    proof_status="PASS"
+    proof_phase="complete"
+  fi
+  write_result "$exit_code"
+}
+trap on_exit EXIT
+
+verify_config_clean() {
+  local label="$1"
+  local config_status
+
+  config_status="$(ddev drush config:status 2>&1)"
+  printf '%s\n' "$config_status" | tee "$LOG_ROOT/config-status-${label}.txt"
+  grep -Fq 'No differences' <<<"$config_status" || {
+    echo "Configuration drift detected during ${label}." >&2
+    return 1
+  }
+}
+
+snapshot_mappings() {
+  local destination="$1"
+  ddev mysql -N -B -e "
+    SELECT content_id, entity_id, entity_uuid, status, catalog_hash,
+           COALESCE(last_synced, 0), last_action
+      FROM emerging_digital_content_sync_mapping
+     WHERE content_id IN (${SQL_IDS})
+     ORDER BY content_id;
+  " > "$destination"
+}
+
+snapshot_nodes() {
+  local destination="$1"
+  ddev mysql -N -B -e "
+    SELECT m.content_id, nfd.nid, n.uuid, nfd.langcode, nfd.status,
+           nfd.title, COALESCE(pa.alias, '')
+      FROM emerging_digital_content_sync_mapping m
+      JOIN node n ON n.nid = m.entity_id
+      JOIN node_field_data nfd ON nfd.nid = n.nid
+      LEFT JOIN path_alias pa
+        ON pa.path = CONCAT('/node/', n.nid)
+       AND pa.langcode = nfd.langcode
+       AND pa.status = 1
+     WHERE m.content_id IN (${SQL_IDS})
+     ORDER BY m.content_id, nfd.langcode, pa.alias;
+  " > "$destination"
+}
+
+snapshot_revisions() {
+  local destination="$1"
+  ddev mysql -N -B -e "
+    SELECT m.content_id, COUNT(DISTINCT nr.vid), MAX(nr.vid)
+      FROM emerging_digital_content_sync_mapping m
+      JOIN node_revision nr ON nr.nid = m.entity_id
+     WHERE m.content_id IN (${SQL_IDS})
+     GROUP BY m.content_id
+     ORDER BY m.content_id;
+  " > "$destination"
+}
+
+assert_mapping_status() {
+  local snapshot="$1"
+  local expected="$2"
+  local count
+
+  count="$(wc -l < "$snapshot" | tr -d ' ')"
+  [[ "$count" == "3" ]] || {
+    echo "Expected exactly 3 pilot mappings, found ${count}." >&2
+    return 1
+  }
+
+  awk -F '\t' -v expected="$expected" '
+    $4 != expected {
+      printf "Unexpected mapping status for %s: %s (expected %s)\n", $1, $4, expected > "/dev/stderr"
+      bad = 1
+    }
+    END { exit bad }
+  ' "$snapshot"
+}
+
+mapping_identity() {
+  cut -f1,2,3,5 "$1"
+}
+
+assert_public_aliases() {
+  local snapshot="$1"
+  local alias
+  local expected_aliases=(
+    "/cas-clients/refonte-drupal-institutionnelle"
+    "/case-studies/institutional-drupal-redesign"
+    "/cas-clients/migration-drupal-11"
+    "/case-studies/drupal-11-migration"
+    "/cas-clients/integration-ia-editoriale"
+    "/case-studies/editorial-ai-integration"
+  )
+
+  for alias in "${expected_aliases[@]}"; do
+    grep -Fq $'\t'"${alias}" "$snapshot" || {
+      echo "Expected alias missing from runtime snapshot: ${alias}" >&2
+      return 1
+    }
+  done
+
+  awk -F '\t' '
+    $5 != "1" {
+      printf "Pilot node %s translation %s is not published.\n", $1, $4 > "/dev/stderr"
+      bad = 1
+    }
+    END { exit bad }
+  ' "$snapshot"
+}
+
+sync_full_catalog() {
+  local label="$1"
+  ddev drush emerging:content-sync:validate | tee "$LOG_ROOT/content-sync-${label}-validate.txt"
+  ddev drush emerging:content-sync --all --dry-run | tee "$LOG_ROOT/content-sync-${label}-dry-run.txt"
+  ddev drush emerging:content-sync --all | tee "$LOG_ROOT/content-sync-${label}-apply.txt"
+  ddev drush cr
+}
+
+release_pilot() {
+  local content_id
+  for content_id in "${PILOT_IDS[@]}"; do
+    ddev drush emerging:content-sync:release "$content_id" --dry-run \
+      | tee "$LOG_ROOT/release-${content_id}-dry-run.txt"
+    ddev drush emerging:content-sync:release "$content_id" --apply \
+      | tee "$LOG_ROOT/release-${content_id}-apply.txt"
+  done
+}
+
+readmit_pilot() {
+  local content_id
+  for content_id in "${PILOT_IDS[@]}"; do
+    ddev drush emerging:content-sync:readmit "$content_id" --dry-run \
+      | tee "$LOG_ROOT/readmit-${content_id}-dry-run.txt"
+    ddev drush emerging:content-sync:readmit "$content_id" --apply \
+      | tee "$LOG_ROOT/readmit-${content_id}-apply.txt"
+    ddev drush emerging:content-sync "$content_id" \
+      | tee "$LOG_ROOT/readmit-${content_id}-resync.txt"
+  done
+  ddev drush cr
+}
+
+apply_editorial_edit() {
+  ddev drush php:eval '
+    $database = \Drupal::database();
+    $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+      ->fields("m", ["entity_id"])
+      ->condition("content_id", "cas-client-migration-drupal-11")
+      ->execute()
+      ->fetchField();
+    if (!$nid) {
+      throw new \RuntimeException("Pilot mapping not found for editorial proof.");
+    }
+    $node = \Drupal\node\Entity\Node::load((int) $nid);
+    if (!$node) {
+      throw new \RuntimeException("Pilot node not found for editorial proof.");
+    }
+    $node->setNewRevision(TRUE);
+    $node->setRevisionLogMessage("Governed Content transition proof #440");
+    $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+    if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
+      $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
+    }
+    $node->save();
+  '
+}
+
+assert_editorial_edit_survives() {
+  ddev mysql -N -B -e "
+    SELECT nfd.title
+      FROM emerging_digital_content_sync_mapping m
+      JOIN node_field_data nfd ON nfd.nid = m.entity_id AND nfd.langcode = 'fr'
+     WHERE m.content_id = 'cas-client-migration-drupal-11';
+  " | grep -Fq "$EDITORIAL_MARKER"
+}
+
+detect_ddev_url() {
+  ddev describe -j | python3 -c '
+import json
+import sys
+
+def find_url(value):
+    if isinstance(value, str):
+        return value if value.startswith(("https://", "http://")) else None
+    if isinstance(value, list):
+        urls = [find_url(item) for item in value]
+        urls = [url for url in urls if url]
+        return next((url for url in urls if url.startswith("https://")), urls[0] if urls else None)
+    if not isinstance(value, dict):
+        return None
+    for key, entry in value.items():
+        normalized = key.lower().replace("-", "_")
+        if normalized in {"primary_url", "primaryurl"} and isinstance(entry, str):
+            if entry.startswith(("https://", "http://")):
+                return entry
+    for entry in value.values():
+        found = find_url(entry)
+        if found:
+            return found
+    return None
+
+data = json.load(sys.stdin)
+url = find_url(data)
+if not url:
+    raise SystemExit("No DDEV primary URL found")
+print(url.rstrip("/"))
+'
+}
+
+run_browser_proof() {
+  local base_url
+  base_url="$(detect_ddev_url)"
+
+  cat > tests/browser/governed-content-transition-proof.spec.mjs <<'EOF'
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+
+const pages = [
+  ['/fr/cas-clients/refonte-drupal-institutionnelle', false],
+  ['/en/case-studies/institutional-drupal-redesign', false],
+  ['/fr/cas-clients/migration-drupal-11', true],
+  ['/en/case-studies/drupal-11-migration', false],
+  ['/fr/cas-clients/integration-ia-editoriale', false],
+  ['/en/case-studies/editorial-ai-integration', false],
+];
+
+for (const [path, expectsMarker] of pages) {
+  test(`released case study remains public: ${path}`, async ({ page }, testInfo) => {
+    const runtimeErrors = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        runtimeErrors.push(`console: ${message.text()}`);
+      }
+    });
+    page.on('pageerror', (error) => runtimeErrors.push(`pageerror: ${error.message}`));
+
+    const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(response, `No navigation response for ${path}`).not.toBeNull();
+    expect(response.status(), `Unexpected HTTP status for ${path}`).toBeLessThan(400);
+    await expect(page.locator('body')).not.toContainText('The website encountered an unexpected error.');
+
+    if (expectsMarker) {
+      await expect(page.locator('body')).toContainText(process.env.PROOF_EDITORIAL_MARKER);
+    }
+
+    expect(runtimeErrors, `Browser runtime errors for ${path}`).toEqual([]);
+
+    await mkdir('artifacts/governed-content-transition/browser', { recursive: true });
+    const slug = path.replace(/^\//, '').replaceAll('/', '--');
+    await page.screenshot({
+      path: `artifacts/governed-content-transition/browser/${slug}-${testInfo.project.name}.png`,
+      fullPage: true,
+    });
+  });
+}
+EOF
+
+  PLAYWRIGHT_BASE_URL="$base_url" \
+  PROOF_EDITORIAL_MARKER="$EDITORIAL_MARKER" \
+    npx playwright test tests/browser/governed-content-transition-proof.spec.mjs \
+      | tee "$LOG_ROOT/playwright.txt"
+}
+
+proof_phase="prepare-base"
+git fetch --no-tags origin "$BASE_SHA" "$TARGET_SHA"
+git checkout --detach "$BASE_SHA"
+git diff --check
+
+cat > .ddev/config.gate-governed-content-proof.yaml <<EOF
+name: agency-governed-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+EOF
+
+ddev start -y
+ddev composer install --no-interaction --no-progress --prefer-dist
+admin_pass="$(openssl rand -hex 24)"
+ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+unset admin_pass
+ddev drush cim -y
+ddev drush cr
+verify_config_clean "base-before-sync"
+sync_full_catalog "base"
+verify_config_clean "base-after-sync"
+
+snapshot_mappings "$SNAPSHOT_ROOT/base-mappings.tsv"
+snapshot_nodes "$SNAPSHOT_ROOT/base-nodes.tsv"
+snapshot_revisions "$SNAPSHOT_ROOT/base-revisions.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/base-mappings.tsv" "active"
+assert_public_aliases "$SNAPSHOT_ROOT/base-nodes.tsv"
+
+proof_phase="target-release"
+git checkout --detach "$TARGET_SHA"
+git diff --check
+ddev composer install --no-interaction --no-progress --prefer-dist
+ddev drush updb -y
+ddev drush cim -y
+ddev drush cr
+verify_config_clean "target-before-release"
+
+release_pilot
+snapshot_mappings "$SNAPSHOT_ROOT/released-mappings.tsv"
+snapshot_nodes "$SNAPSHOT_ROOT/released-nodes.tsv"
+snapshot_revisions "$SNAPSHOT_ROOT/released-revisions.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/released-mappings.tsv" "released"
+assert_public_aliases "$SNAPSHOT_ROOT/released-nodes.tsv"
+diff -u \
+  <(mapping_identity "$SNAPSHOT_ROOT/base-mappings.tsv") \
+  <(mapping_identity "$SNAPSHOT_ROOT/released-mappings.tsv") \
+  | tee "$LOG_ROOT/release-mapping-identity.diff"
+diff -u "$SNAPSHOT_ROOT/base-nodes.tsv" "$SNAPSHOT_ROOT/released-nodes.tsv" \
+  | tee "$LOG_ROOT/release-node-state.diff"
+
+sync_full_catalog "target-after-release"
+verify_config_clean "target-after-sync"
+snapshot_nodes "$SNAPSHOT_ROOT/post-deploy-nodes.tsv"
+diff -u "$SNAPSHOT_ROOT/base-nodes.tsv" "$SNAPSHOT_ROOT/post-deploy-nodes.tsv" \
+  | tee "$LOG_ROOT/post-deploy-node-state.diff"
+
+proof_phase="editorial-persistence"
+apply_editorial_edit
+assert_editorial_edit_survives
+snapshot_revisions "$SNAPSHOT_ROOT/after-editorial-edit-revisions.tsv"
+sync_full_catalog "target-after-editorial-edit"
+assert_editorial_edit_survives
+snapshot_nodes "$SNAPSHOT_ROOT/after-editorial-resync-nodes.tsv"
+snapshot_revisions "$SNAPSHOT_ROOT/after-editorial-resync-revisions.tsv"
+
+proof_phase="browser-proof"
+run_browser_proof
+
+proof_phase="rollback"
+git checkout "$BASE_SHA" -- "$CATALOG_PATH" "${PILOT_PAYLOADS[@]}"
+readmit_pilot
+snapshot_mappings "$SNAPSHOT_ROOT/rollback-mappings.tsv"
+snapshot_nodes "$SNAPSHOT_ROOT/rollback-nodes.tsv"
+snapshot_revisions "$SNAPSHOT_ROOT/rollback-revisions.tsv"
+assert_mapping_status "$SNAPSHOT_ROOT/rollback-mappings.tsv" "active"
+assert_public_aliases "$SNAPSHOT_ROOT/rollback-nodes.tsv"
+diff -u \
+  <(mapping_identity "$SNAPSHOT_ROOT/base-mappings.tsv") \
+  <(mapping_identity "$SNAPSHOT_ROOT/rollback-mappings.tsv") \
+  | tee "$LOG_ROOT/rollback-mapping-identity.diff"
+diff -u "$SNAPSHOT_ROOT/base-nodes.tsv" "$SNAPSHOT_ROOT/rollback-nodes.tsv" \
+  | tee "$LOG_ROOT/rollback-node-state.diff"
+
+proof_status="PASS"
+proof_phase="complete"


### PR DESCRIPTION
Refs #446

## Objectif

Ajouter une route self-hosted gouvernée capable de prouver une transition Governed Content sur **la même base DDEV** entre trois états contrôlés d’une PR : base -> release candidate -> HEAD exact.

## Implémentation

- gateway dédié sur `agency/governed-content-transition-dispatch-control` ;
- requête JSON à schéma strict avec `head_sha`, `release_sha` et profil trusted `case-studies-440` ;
- double revalidation GitHub-hosted avant allocation du runner ;
- refus des forks, SHA obsolètes et modifications des surfaces runner/browser de confiance ;
- validation que le release candidate est descendant de la base, ancêtre du HEAD final et limité aux cinq chemins métier attendus ;
- validation que les trois IDs sont encore autorisés au release candidate mais déjà absents de son catalogue/payloads ;
- workflow self-hosted borné au runner `agency,ddev,browser` ;
- reconstruction depuis le base SHA, Content Sync complet et snapshots ;
- checkout du release candidate sans destruction de la DB, release dry-run/apply, sync, edit persistant et navigateur ;
- replay de la release puis checkout du HEAD exact, toujours sur la même DB ;
- preuve au HEAD exact des identités, publication, FR/EN, aliases et de la persistance d’une édition Drupal après Content Sync ;
- rollback/readmission contrôlés ;
- artifacts machine lisibles + captures Playwright desktop/mobile ;
- cleanup `always()` ;
- CI : syntax-check des deux scripts trusted.

## Sécurité

Aucun déclenchement direct depuis `pull_request`, aucun fork, aucun secret, aucune production, aucune commande arbitraire fournie par la requête. Le profil du pilote et les chemins admissibles sont codés côté trusted workflow.

## Validation attendue

La PR ne clôture pas automatiquement #446 : après merge de cette infrastructure trusted, la branche de contrôle sera matérialisée depuis `main` et la preuve exacte de #444 sera exécutée. #446 ne sera clôturée qu’après un run self-hosted PASS et inspection de l’artifact.