### PR TITLE
Issue #445: réaligner l’inventaire Governed Content documenté

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,26 +75,34 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - Le catalogue actuel est en **migration controlee** d'un bootstrap massif vers
   un petit ensemble Governed Content ; il ne doit plus servir de precedent pour
   versionner tout nouveau contenu marketing/editorial.
-- Source versionnee de transition :
-  `web/modules/custom/emerging_digital_content/content_sync/catalog.yml`.
+- Les sources machine autoritatives de la transition sont le catalogue
+  `web/modules/custom/emerging_digital_content/content_sync/catalog.yml` et la
+  policy `Drupal\emerging_digital_content\ContentSync\Policy\GovernedContentPolicy`.
+  La documentation explique cet etat mais ne constitue pas une seconde liste
+  d'admission.
 - Fichiers de contenu de transition :
   `web/modules/custom/emerging_digital_content/content_sync/node/*.yml`.
 - Trois IDs sont explicitement Governed Content : `mentions-legales`,
   `politique-confidentialite`, `politique-cookies`.
-- Les 33 autres IDs actuels sont grandfathered `LEGACY_RELEASE_PENDING` : aucun
-  nouvel ID ne peut etre ajoute a cette classe et leur retrait doit suivre la
-  procedure de liberation documentee.
+- Depuis le pilote #440, **30** autres IDs sont encore grandfathered
+  `LEGACY_RELEASE_PENDING`. Aucun nouvel ID ne peut etre ajoute a cette classe
+  et leur retrait doit suivre la procedure de liberation documentee.
+- Les trois cas clients pilotes `cas-client-refonte-drupal-institutionnelle`,
+  `cas-client-migration-drupal-11` et `cas-client-integration-ia-editoriale`
+  sont `RELEASED` depuis #440 et ne doivent pas etre readmis par inadvertance.
 - Ne jamais ajouter un Article ou un nouveau contenu marketing/editorial
   ordinaire au catalogue. Une nouvelle admission exige un ticket, une classe
   gouvernee justifiee, une identite stable, une procedure de review/promotion et
   un rollback explicite.
 - Ne jamais retirer un ID grandfathered du catalogue avant qu'un etat de mapping
-  `released` ignore par le prune soit implemente et prouve en staging/preprod.
-  Retirer de la gouvernance Git ne signifie jamais supprimer/depublier Drupal.
+  `released` ignore par le prune soit applique et prouve sur l'environnement de
+  transition concerne. Retirer de la gouvernance Git ne signifie jamais
+  supprimer/depublier Drupal.
 - Apres liberation, le contenu ordinaire devient editor-owned dans Drupal et ne
   doit plus etre ecrase par Content Sync lors des deploiements suivants.
-- Le test `GovernedContentCatalogPolicyTest` est la barriere CI de transition :
-  toute admission ou liberation doit mettre a jour explicitement cette policy.
+- `GovernedContentCatalogPolicyTest` et la policy runtime sont les barrieres CI
+  de transition : toute admission ou liberation doit mettre a jour explicitement
+  `LEGACY_RELEASE_PENDING_IDS`.
 - Valider avant toute application :
   `ddev drush emerging:content-sync:validate`.
 - Toujours tester en lecture seule avant ecriture :

--- a/docs/governed-content-trajectory.md
+++ b/docs/governed-content-trajectory.md
@@ -1,13 +1,16 @@
 # Governed Content — trajectoire de convergence de Content Sync
 
-Statut : **architecture de transition approuvable, runtime inchangé**  
+Statut : **transition active — pilote #440 terminé**  
 Date : **2026-08-16**  
-Ticket : **#385**  
+Ticket d'origine : **#385**  
+Mise à jour d'inventaire : **#445**  
 Parent : **#60**
 
 ## 1. Décision
 
-Le Content Sync Agency a correctement rempli son rôle de bootstrap et de promotion déterministe du contenu initial. Il ne doit toutefois plus devenir la source de vérité Git de tout le contenu éditorial courant.
+Le Content Sync Agency a correctement rempli son rôle de bootstrap et de
+promotion déterministe du contenu initial. Il ne doit toutefois plus devenir la
+source de vérité Git de tout le contenu éditorial courant.
 
 La cible est :
 
@@ -25,11 +28,131 @@ contenu marketing / éditorial ordinaire
 -> pas d'écrasement par Git après libération contrôlée
 ```
 
-La migration est progressive. **Aucune des 33 entrées ordinaires actuelles n'est retirée du catalogue dans #385.** Le déploiement production continue donc à exécuter le Content Sync actuel tant que le mécanisme de libération des mappings n'est pas implémenté et prouvé.
+La migration est progressive. #439 a introduit le lifecycle `released` et les
+commandes de release/readmission. #440 a ensuite libéré un premier lot de trois
+cas clients sans perte d'identité, de traduction, d'alias ou de persistance
+éditoriale.
 
-## 2. Pourquoi la migration ne doit pas être brutale
+## 2. Sources de vérité
 
-Le déploiement production appelle actuellement :
+L'inventaire n'est **pas** maintenu manuellement dans cette documentation.
+
+Les deux sources machine autoritatives sont :
+
+```text
+web/modules/custom/emerging_digital_content/content_sync/catalog.yml
+Drupal\emerging_digital_content\ContentSync\Policy\GovernedContentPolicy
+```
+
+Le catalogue décrit les contenus encore sous contrôle Content Sync. La policy
+distingue explicitement :
+
+```text
+GOVERNED_CONTENT_IDS
+LEGACY_RELEASE_PENDING_IDS
+```
+
+La documentation explique la trajectoire, les invariants et les étapes. Elle ne
+doit jamais devenir une seconde allowlist copiée à la main.
+
+## 3. Inventaire courant après #440
+
+Inventaire recalculé depuis le catalogue versionné sur `main` après le merge de
+#440 :
+
+```text
+CATALOG_VERSION=1
+CATALOG_COUNT=33
+BUNDLE_COUNTS={"ai_feature":10,"page":9,"service":14}
+MISSING_REFERENCED_FILES=[]
+UNREFERENCED_NODE_FILES=[]
+DUPLICATE_IDS=[]
+ALL_HAVE_FR_EN=true
+LEGACY_UUID_COUNT=8
+```
+
+`LEGACY_UUID_COUNT` compte uniquement les entrées du catalogue portant encore
+explicitement la clé top-level `legacy_uuid`. Il ne faut pas l'assimiler au
+nombre total d'entrées du catalogue.
+
+La policy runtime contient :
+
+```text
+3 IDs = GOVERNED
+30 IDs = LEGACY_RELEASE_PENDING
+```
+
+Donc :
+
+```text
+33 entrées cataloguées
+= 3 Governed Content
++ 30 contenus ordinaires encore en transition
+```
+
+### 3.1 Governed Content conservé sous Git
+
+Les trois contenus actuellement admis durablement sont :
+
+| Source ID | Bundle | Classification | Motif |
+|---|---|---|---|
+| `mentions-legales` | `page` | `GOVERNED` | contenu légal |
+| `politique-confidentialite` | `page` | `GOVERNED` | politique de confidentialité |
+| `politique-cookies` | `page` | `GOVERNED` | politique cookies |
+
+Ces contenus restent canoniques dans le repository jusqu'à décision contraire
+explicite.
+
+### 3.2 Contenu ordinaire encore pending
+
+La liste exacte des 30 contenus encore `LEGACY_RELEASE_PENDING` appartient à
+`GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS` et ne doit pas être recopiée
+ici.
+
+Répartition actuelle, dérivée du catalogue :
+
+```text
+service: 14
+ai_feature: 10
+page ordinaire pending: 6
+```
+
+Les pages ordinaires à fort impact (`homepage`, `services`, `contact`) doivent
+rester parmi les derniers lots et conserver des browser gates dédiés.
+
+### 3.3 Lot pilote déjà RELEASED
+
+#440 a libéré les trois vrais cas clients historiques :
+
+```text
+cas-client-refonte-drupal-institutionnelle
+cas-client-migration-drupal-11
+cas-client-integration-ia-editoriale
+```
+
+Leur bundle historique est `case_client`.
+
+Ils sont désormais :
+
+```text
+RELEASED
+absents du catalogue
+absents de LEGACY_RELEASE_PENDING_IDS
+editor-owned dans Drupal
+```
+
+Les identifiants suivants n'ont jamais constitué les IDs autoritatifs du
+catalogue et ne doivent plus être utilisés comme inventaire :
+
+```text
+cas-clients/refonte-drupal-b2b
+cas-clients/plateforme-contenus-api-first
+cas-clients/industrie-site-haute-disponibilite
+```
+
+## 4. Pourquoi la migration ne doit pas être brutale
+
+Le déploiement production appelle :
 
 ```text
 emerging:content-sync:validate
@@ -38,129 +161,33 @@ emerging:content-sync --all
 emerging:content-sync:report --severity=error
 ```
 
-Le chemin normal n'active pas `--prune`. Le prune `unpublish` possède par ailleurs un garde-fou production explicite.
+Le chemin normal n'active pas `--prune`. Le prune `unpublish` possède un
+garde-fou production explicite.
 
-C'est une bonne base de sécurité, mais elle ne suffit pas pour retirer immédiatement des éléments ordinaires du catalogue : la table de mapping continue à mémoriser les contenus historiquement gérés et le prune considère aujourd'hui comme candidats les mappings absents du catalogue tant qu'ils ne sont pas déjà `pruned`.
-
-Le besoin de transition est donc :
+Invariant fondamental :
 
 ```text
 retirer un contenu de la gouvernance Git
 != supprimer ou dépublier son entité Drupal
 ```
 
-Avant toute réduction du catalogue, le runtime doit savoir représenter explicitement un mapping **released** que le prune ignore.
+Le lifecycle `released` implémenté dans #439 garantit précisément cette
+séparation : un mapping released est ignoré par le prune et ne peut pas être
+repris implicitement par un Content Sync normal.
 
-## 3. Inventaire autoritatif au 16 août 2026
+## 5. Taxonomie de gouvernance cible
 
-Une preuve machine a inventorié le catalogue exact :
+Un contenu n'entre dans le futur catalogue Governed Content que s'il appartient
+explicitement à une classe approuvée.
 
-```text
-CATALOG_VERSION=1
-CATALOG_COUNT=36
-BUNDLE_COUNTS={"ai_feature":10,"case_study":3,"page":9,"service":14}
-MISSING_REFERENCED_FILES=[]
-UNREFERENCED_NODE_FILES=[]
-DUPLICATE_IDS=[]
-ALL_HAVE_FR_EN=true
-LEGACY_UUID_COUNT=36
-```
+### 5.1 Légal et réglementaire
 
-Le catalogue actuel est donc techniquement cohérent : tous les fichiers sont référencés, tous les contenus possèdent FR/EN, aucun ID source n'est dupliqué et les 36 entrées portent encore un `legacy_uuid` de migration.
-
-### 3.1 Contenu conservé sous gouvernance Git
-
-Trois entrées correspondent directement au besoin de Governed Content actuel :
-
-| Source ID | Bundle | Classification | Motif |
-|---|---|---|---|
-| `mentions-legales` | `page` | `GOVERNED` | contenu légal |
-| `politique-confidentialite` | `page` | `GOVERNED` | politique de confidentialité |
-| `politique-cookies` | `page` | `GOVERNED` | politique cookies |
-
-Ces contenus restent canoniques dans le repository jusqu'à décision contraire explicite.
-
-### 3.2 Contenu ordinaire grandfathered pendant la transition
-
-Les 33 entrées suivantes ne sont **pas** des candidats naturels au Governed Content cible. Elles restent néanmoins temporairement dans le catalogue afin d'éviter toute perte, dépublication ou reprise de contrôle involontaire pendant la migration.
-
-#### Services — 14
-
-```text
-services/drupal
-services/web
-services/architecture
-services/securite
-services/communication
-services/hebergement
-services/sauvegardes
-services/migration
-services/formation
-services/infogerance
-services/support
-services/seo
-services/contenus
-services/ia-drupal
-```
-
-#### AI features — 10
-
-```text
-ai-features/brief-wizard
-ai-features/rewrite-blocks
-ai-features/seo-assistant
-ai-features/content-assistant
-ai-features/semantic-search
-ai-features/document-search
-ai-features/chatbot
-ai-features/agent-workflows
-ai-features/privacy-guardrails
-ai-features/observability
-```
-
-#### Cas clients — 3
-
-```text
-cas-clients/refonte-drupal-b2b
-cas-clients/plateforme-contenus-api-first
-cas-clients/industrie-site-haute-disponibilite
-```
-
-#### Pages ordinaires — 6
-
-```text
-services
-ia-drupal
-cas-clients
-equipe
-contact
-homepage
-```
-
-État de transition :
-
-```text
-33 IDs = LEGACY_RELEASE_PENDING
-```
-
-Ils ne doivent plus servir de précédent pour admettre de nouveaux contenus marketing dans Content Sync.
-
-## 4. Taxonomie de gouvernance cible
-
-Un contenu n'entre dans le futur catalogue Governed Content que s'il appartient explicitement à une classe approuvée.
-
-### 4.1 Légal et réglementaire
-
-Exemples :
-
-- mentions légales ;
-- confidentialité ;
-- cookies ;
-- notices réglementaires réellement requises.
+Exemples : mentions légales, confidentialité, cookies et notices réglementaires
+réellement requises.
 
 C'est le seul groupe actuellement matérialisé dans le catalogue.
 
-### 4.2 Prompts système approuvés
+### 5.2 Prompts système approuvés
 
 Un prompt système peut être gouverné seulement si :
 
@@ -170,23 +197,20 @@ Un prompt système peut être gouverné seulement si :
 - il possède une identité stable et une destination runtime définie ;
 - le mécanisme de matérialisation est explicite.
 
-Les prompts de configuration existants ne doivent pas être déplacés artificiellement dans Content Sync uniquement pour remplir cette catégorie. Cette classe reste une **capacité future**, pas un prétexte pour créer de nouveaux payloads.
+Cette classe reste une capacité future, pas un prétexte pour créer de nouveaux
+payloads.
 
-### 4.3 Contrats et métadonnées contrôlées
+### 5.3 Contrats, métadonnées contrôlées et ressources critiques
 
-Éligibles uniquement lorsque l'artefact doit être identique entre environnements et que l'historique Git/review apporte une garantie métier concrète.
+Éligibles uniquement lorsque l'artefact doit être identique entre environnements
+et que l'historique Git/review apporte une garantie métier concrète.
 
-Le contenu business configurable ne doit jamais être placé dans `config/sync` pour cette raison : configuration Drupal et Governed Content restent deux responsabilités distinctes.
+Une ressource n'est pas « critique » simplement parce qu'elle est pratique à
+versionner. Toute nouvelle admission exige un ticket et une justification.
 
-### 4.4 Ressources critiques
+## 6. États de cycle de vie
 
-Exemples possibles : ressources de référence, manifests ou textes approuvés dont l'intégrité inter-environnements est une exigence produit.
-
-Une ressource n'est pas « critique » parce qu'elle est pratique à versionner. L'admission doit être justifiée dans le ticket qui l'introduit.
-
-## 5. États de cycle de vie
-
-La trajectoire utilise quatre états conceptuels :
+La trajectoire utilise quatre états :
 
 ```text
 GOVERNED
@@ -197,32 +221,26 @@ RETIRED
 
 ### `GOVERNED`
 
-Le payload versionné est canonique. Drupal est une matérialisation runtime. Les changements suivent PR -> revue -> promotion.
+Le payload versionné est canonique. Drupal est une matérialisation runtime. Les
+changements suivent PR -> revue -> promotion.
 
 ### `LEGACY_RELEASE_PENDING`
 
-Contenu historiquement versionné par le bootstrap Content Sync, mais destiné à revenir au workflow éditorial Drupal. Tant que la libération n'est pas prouvée, le comportement historique reste intact.
+Contenu historiquement versionné par le bootstrap Content Sync mais destiné à
+revenir au workflow éditorial Drupal.
 
 ### `RELEASED`
 
-Le contenu n'est plus piloté par Git. L'entité Drupal existante, ses traductions, aliases et révisions restent en place et deviennent la source éditoriale runtime. Le déploiement ne doit plus l'écraser ni le considérer comme un orphan à pruner.
+Le contenu n'est plus piloté par Git. L'entité Drupal existante, ses
+traductions, aliases et révisions restent en place et deviennent la source
+éditoriale runtime.
 
 ### `RETIRED`
 
-Utilisé uniquement lorsqu'un contenu gouverné doit réellement être retiré. La suppression ou dépublication reste une opération distincte, explicite et auditable ; elle ne découle jamais implicitement d'un simple changement de classification.
+Retrait réellement voulu d'un contenu gouverné. La suppression ou dépublication
+reste une opération distincte, explicite et auditable.
 
-## 6. Source de vérité par classe
-
-| Classe | Source canonique | Runtime | Écriture normale |
-|---|---|---|---|
-| `GOVERNED` | payload versionné Git | entité/artefact Drupal matérialisé | PR + promotion |
-| `LEGACY_RELEASE_PENDING` | Git temporairement | entité Drupal | pas de nouveaux edits durables avant libération |
-| `RELEASED` | entité Drupal de l'environnement éditorial | entité Drupal | UI/workflow éditeur Drupal |
-| `RETIRED` | décision/revision Git + audit | absent/non publié selon décision | opération dédiée |
-
-Le statut `RELEASED` ne signifie pas que chaque environnement Drupal devient une source indépendante sans processus. La production reste alimentée par le processus éditorial/déploiement retenu pour le site ; ce que l'on retire est uniquement **l'écrasement automatique par le catalogue Git de bootstrap**.
-
-## 7. Identité, UUID et mapping inter-environnements
+## 7. Identité, UUID et mapping
 
 L'identité métier existante reste la clé de convergence :
 
@@ -237,21 +255,20 @@ Règles :
 - le `source_id` reste stable tant que l'élément est gouverné ou en transition ;
 - le mapping est propre à chaque environnement ;
 - `target_id` et `target_uuid` identifient l'entité runtime locale ;
-- `legacy_uuid` reste une graine/héritage de migration et ne doit pas être recyclé ;
-- la destination n'est jamais directement couplée à un UUID provenant d'un autre environnement comme seule identité métier ;
-- le passage `released` conserve l'identité de l'entité existante ; il ne recrée pas le node.
+- `legacy_uuid` reste une graine/héritage de migration et ne doit pas être
+  recyclé ;
+- le passage `released` conserve l'identité de l'entité existante ;
+- une release ne recrée jamais le node.
 
 ## 8. Révisions, traductions et aliases
 
-Les pages sont revisionables (`new_revision: true` pour le type `page`). La transition doit préserver cette propriété.
-
 Avant libération d'un ID ordinaire :
 
-- vérifier que les traductions FR/EN runtime correspondent au contenu attendu ;
+- vérifier les traductions FR/EN runtime ;
 - vérifier les aliases FR/EN ;
 - conserver le node existant et son UUID ;
-- créer ou conserver une révision récupérable avant la bascule ;
-- enregistrer le checksum/mapping final de la dernière version gouvernée.
+- conserver une révision récupérable ;
+- enregistrer l'état final du mapping et son checksum.
 
 Après libération :
 
@@ -263,8 +280,6 @@ Après libération :
 ## 9. Promotion et revue
 
 ### 9.1 Governed Content
-
-Le chemin cible est :
 
 ```text
 changement payload
@@ -278,72 +293,46 @@ changement payload
 -> validation post-déploiement
 ```
 
-Le même contenu versionné et le même commit doivent être promus ; la production ne doit pas recevoir une copie manuelle réécrite après validation.
-
 ### 9.2 Contenu ordinaire libéré
 
-Le contenu éditorial ordinaire suit le workflow Drupal normal : permissions, révisions, traduction et validation humaine. Il n'est pas réexporté automatiquement vers `content_sync/`.
+Le contenu suit le workflow Drupal normal : permissions, révisions, traduction
+et validation humaine. Il n'est pas réexporté automatiquement vers
+`content_sync/`.
 
-Si un futur besoin exige une promotion éditoriale structurée de staging vers production, il devra être traité par un mécanisme dédié et évalué séparément ; il ne justifie pas de conserver tout le marketing sous Git par défaut.
-
-## 10. Positionnement des primitives Drupal/contrib
+## 10. Positionnement des primitives
 
 ### Content Sync custom actuel — `KEEP -> CONVERGE`
 
-À conserver pendant la transition pour :
+À conserver pendant la transition pour : parsing du catalogue, validation,
+mapping, idempotence/checksums, traductions/aliases, matérialisation
+déterministe, rapports et dry-run.
 
-- parsing du catalogue ;
-- validation ;
-- mapping ;
-- idempotence/checksums ;
-- traductions/aliases ;
-- matérialisation déterministe ;
-- rapports et dry-run.
+Le but est de réduire son domaine à ce qui mérite réellement la gouvernance Git,
+pas de construire une nouvelle plateforme custom.
 
-Il ne faut pas le réécrire en une nouvelle « plateforme de gouvernance » custom. Le but est de **réduire son domaine** à ce qui mérite réellement la gouvernance Git.
+### Core Workspaces
 
-### Core Workspaces — responsabilité différente
-
-Workspaces est pertinent pour des scénarios de staging de contenu dans un même site Drupal. Il ne remplace pas, à lui seul, le besoin Agency de promotion déterministe d'un artefact gouverné entre environnements.
-
-Il pourra être réévalué si le workflow éditorial du site adopte un besoin de staging de révisions, mais ne doit pas être détourné en mécanisme cross-environment ad hoc dans #385.
+Responsabilité différente : staging de contenu/révisions dans Drupal. Il ne
+remplace pas à lui seul la promotion déterministe inter-environnements de
+Governed Content.
 
 ### Default Content Deploy — `EVALUATE LATER`
 
-Une solution contrib d'export/import peut être réévaluée plus tard si elle remplace réellement une partie du materializer/mapping custom avec :
+À réévaluer seulement si une solution contrib remplace réellement une partie du
+materializer/mapping custom avec des garanties au moins équivalentes.
 
-- identité stable ;
-- traductions ;
-- aliases ;
-- dry-run/review ;
-- promotion reproductible ;
-- sécurité et rollback au moins équivalents.
+## 11. Admission policy
 
-Aucune nouvelle dépendance n'est introduite dans #385.
-
-### `default_content` historique — migration uniquement
-
-Le legacy/default content reste une source de migration historique, pas un second runtime de gouvernance en parallèle.
-
-## 11. Admission policy — empêcher le retour du bootstrap massif
-
-Pendant la migration, un test CI contient deux allowlists explicites :
+Pendant la migration, la policy runtime contient deux ensembles explicites :
 
 ```text
 GOVERNED_CONTENT_IDS = 3 IDs légaux
-LEGACY_ORDINARY_CONTENT_IDS = 33 IDs grandfathered
+LEGACY_RELEASE_PENDING_IDS = 30 IDs grandfathered
 ```
 
-Le test échoue si :
+La liste pending ne peut que diminuer.
 
-- une entrée inconnue est ajoutée ;
-- une entrée est retirée sans mettre à jour la politique ;
-- un Article éditorial est introduit dans le catalogue ;
-- un des trois contenus légaux perd sa classification structurelle attendue.
-
-Cette duplication est **volontaire et temporaire** : elle transforme l'inventaire actuel en contrat de migration auditable.
-
-Règle d'admission :
+Règle :
 
 ```text
 nouvel ID ordinaire marketing/editorial
@@ -353,46 +342,47 @@ nouvel ID Governed Content
 -> ticket dédié
 -> justification de classe gouvernée
 -> identité + destination + review + rollback documentés
--> mise à jour explicite du test/policy
+-> mise à jour explicite de la policy
 ```
 
-Aucun nouvel ID ne doit être ajouté à `LEGACY_ORDINARY_CONTENT_IDS`. Cette liste ne peut que diminuer au fil des libérations prouvées.
+`GovernedContentCatalogPolicyTest` vérifie que le catalogue et la policy restent
+alignés.
 
-## 12. Libération contrôlée d'un contenu ordinaire
+## 12. Libération contrôlée
 
-Le mécanisme de libération n'est **pas** implémenté dans #385. Sa spécification minimale est :
+La primitive a été implémentée par #439. La procédure opérationnelle détaillée
+est documentée dans `docs/governed-content-release.md`.
 
-1. sélectionner l'ID `LEGACY_RELEASE_PENDING` ;
-2. valider le catalogue et exécuter un dry-run actuel ;
-3. vérifier node, UUID, traductions, aliases et révision de secours ;
-4. sauvegarder/rapporter l'état final et le mapping ;
-5. passer explicitement le mapping au statut `released` ;
-6. prouver que le prune ignore `released` ;
-7. retirer l'ID du catalogue et son payload dans le même changement gouverné ;
-8. déployer en staging/preprod ;
-9. modifier le contenu via Drupal pour produire une preuve éditoriale ;
-10. relancer le déploiement/Content Sync et prouver que cette modification n'est pas écrasée ;
-11. valider le rendu/traductions/aliases ;
-12. promouvoir le même changement en production.
+Séquence minimale :
+
+1. sélectionner un ID encore `LEGACY_RELEASE_PENDING` ;
+2. valider le catalogue et lancer le dry-run global ;
+3. vérifier node, UUID, traductions, aliases et révision ;
+4. lancer `emerging:content-sync:release <id> --dry-run` ;
+5. lancer `emerging:content-sync:release <id> --apply` ;
+6. vérifier le mapping `released` et l'entité inchangée ;
+7. retirer l'ID/payload du catalogue et de la policy dans le même changement
+   gouverné ;
+8. déployer/rejouer Content Sync ;
+9. prouver une modification éditoriale persistante ;
+10. valider rendu, traductions, aliases et rollback.
 
 Invariant :
 
 ```text
 catalogue removal
 MUST NOT happen
-before released mapping semantics are implemented and proven
+before released mapping semantics are applied and proven
 ```
 
 ## 13. Prune
 
-Le prune reste une primitive de retrait volontaire, pas un outil de migration vers l'édition Drupal.
+Le prune reste une primitive de retrait volontaire, pas un outil de migration
+vers l'édition Drupal.
 
-Règles futures :
-
-- `managed` absent du catalogue peut être candidat au prune selon la politique existante ;
-- `released` absent du catalogue doit être **ignoré** par le prune ;
+- `active` absent du catalogue peut être candidat au prune selon la policy ;
+- `released` absent du catalogue est ignoré ;
 - `pruned` reste terminal pour l'action historique correspondante ;
-- aucun `released` ne doit être repassé en `managed` implicitement par `--all` ;
 - la réadmission d'un contenu released exige une décision explicite.
 
 Le garde-fou production de `--prune=unpublish` reste obligatoire.
@@ -401,8 +391,6 @@ Le garde-fou production de `--prune=unpublish` reste obligatoire.
 
 ### Governed Content
 
-Rollback normal :
-
 ```text
 commit/payload précédent approuvé
 -> promotion
@@ -410,157 +398,82 @@ commit/payload précédent approuvé
 -> vérification runtime
 ```
 
-Les révisions Drupal et backups restent une protection supplémentaire, pas la source de vérité principale.
-
 ### Libération de mapping
 
-Avant promotion production, le rollback de transition doit permettre :
+Le rollback doit permettre de réintroduire explicitement l'ID/payload, exécuter
+la readmission, préserver l'identité du node et vérifier traductions/aliases.
 
-- réadmettre explicitement l'ID ;
-- restaurer son état de mapping `managed` ;
-- rematérialiser le payload connu ;
-- conserver l'UUID du node lorsque possible ;
-- vérifier traductions et aliases.
-
-Aucun rollback ne doit supprimer silencieusement des modifications éditoriales réalisées après une libération déjà acceptée en production. Si ce cas survient, une décision humaine sur la version de contenu à conserver est requise.
-
-### Contenu ordinaire après libération
-
-Rollback par :
-
-- révision Drupal ;
-- backup DB ;
-- mécanisme éditorial/déploiement du contenu ordinaire retenu.
-
-Ne jamais restaurer automatiquement l'ancien YAML Content Sync comme raccourci.
+Aucun rollback ne doit écraser silencieusement des modifications éditoriales
+réalisées après une libération déjà acceptée.
 
 ## 15. Données sensibles
 
 Governed Content n'est pas un coffre-fort.
 
-Interdit dans les payloads :
+Interdit dans les payloads : secrets provider, tokens, mots de passe, clés
+privées, credentials, variables sensibles ou dumps arbitraires contenant des
+secrets.
 
-- secrets provider ;
-- tokens ;
-- mots de passe ;
-- clés privées ;
-- credentials ;
-- variables d'environnement sensibles ;
-- dumps arbitraires de configuration contenant des secrets.
+## 16. Backlog de migration
 
-Pour les prompts ou métadonnées contrôlées, les références à des secrets restent des identifiants de Key/configuration locale, jamais les valeurs elles-mêmes.
+### GC-1 — mapping `released` et commandes de transition — **TERMINÉ (#439)**
 
-## 16. Backlog de migration borné
+La release/readmission explicite, le fail-closed et l'exclusion du prune sont
+implémentés et testés.
 
-### GC-1 — mapping `released` et commande de libération
+### GC-2 — pilote de libération — **TERMINÉ (#440)**
 
-Ajouter une primitive de mapping explicite :
+Les trois cas clients réels ont été libérés, vérifiés sur l'environnement de
+preuve, validés au navigateur et leur rollback a été prouvé avant merge.
 
-```text
-emerging:content-sync:release <content-id> --dry-run
-```
+### GC-3 — libération par lots — **PROCHAINE ÉTAPE (#441)**
 
-ou équivalent cohérent avec les patterns existants.
-
-DoD minimal :
-
-- uniquement ID grandfathered ;
-- dry-run lisible ;
-- apply explicite ;
-- mapping devient `released` ;
-- prune ignore `released` ;
-- `--all` ne reprend pas possession après retrait du catalogue ;
-- tests unit/kernel selon la couche concernée ;
-- audit/log clair ;
-- aucun delete/unpublish implicite.
-
-### GC-2 — pilote de libération staging/preprod
-
-Choisir un petit groupe à faible risque, de préférence les **3 cas clients**, puis prouver :
-
-- mapping released ;
-- retrait catalogue sans retrait Drupal ;
-- FR/EN + aliases + UUID conservés ;
-- modification éditoriale Drupal persistante ;
-- déploiement suivant sans overwrite ;
-- browser validation ;
-- rollback documenté et testé avant production.
-
-### GC-3 — libération par lots des contenus ordinaires
-
-Après le pilote :
+Ordre recommandé :
 
 ```text
-case_study
--> ai_feature
--> services/pages ordinaires par lots maîtrisés
+ai_feature
+-> services détaillés par lots bornés
+-> pages/services ordinaires à impact moyen
+-> homepage / services / contact en dernier
 ```
 
-Chaque lot doit réduire `LEGACY_ORDINARY_CONTENT_IDS`. Aucun lot ne doit ajouter de nouvel ID grandfathered.
+Chaque lot doit réduire `LEGACY_RELEASE_PENDING_IDS`. Aucun lot ne peut ajouter
+un nouvel ID grandfathered.
 
-Les pages à fort impact (`homepage`, `services`, `contact`) passent en dernier avec browser validation dédiée.
-
-### GC-4 — convergence nominale finale
+### GC-4 — convergence nominale finale — **#442**
 
 Lorsque le catalogue ne contient plus que le Governed Content :
 
-- renommer/documenter la surface comme Governed Content ;
-- garder éventuellement `emerging:content-sync` comme alias déprécié temporaire ;
-- simplifier le test d'admission ;
-- mettre à jour les scripts de déploiement/documentation ;
-- supprimer la terminologie bootstrap ambiguë ;
-- réévaluer le volume de code custom restant face aux primitives contrib stables du moment.
+- converger la terminologie et la façade ;
+- conserver si nécessaire un alias de compatibilité temporaire ;
+- simplifier l'admission policy ;
+- réévaluer le volume de code custom restant.
 
-### GC-5 — export éditorial vers Git, seulement si besoin réel
+## 17. Preuves et historique
 
-Si un jour les contenus gouvernés doivent être édités depuis Drupal staging :
+La preuve d'inventaire #385 correspond à l'état **avant** les corrections
+matérialisées par #439/#440. Elle reste historique et ne doit pas être utilisée
+comme inventaire courant.
 
-- export allowlisté de champs ;
-- production d'un diff/PR ;
-- aucune écriture directe Git depuis production ;
-- aucune exportation de secret ;
-- identité et schéma versionnés ;
-- revue humaine avant promotion.
-
-Ce besoin n'est pas requis pour la trajectoire actuelle.
-
-## 17. Ce que #385 ne change pas
-
-Dans cette tâche :
-
-- aucun payload Content Sync n'est supprimé ;
-- aucun mapping runtime n'est modifié ;
-- aucun node n'est recréé, dépublié ou supprimé ;
-- `scripts/deploy-production.sh` reste inchangé ;
-- les commandes Drush restent inchangées ;
-- aucune dépendance Drupal/contrib n'est ajoutée ;
-- aucune configuration Drupal n'est modifiée ;
-- aucune donnée de production n'est requise.
-
-Le seul changement exécutable est un **test de politique CI** destiné à empêcher une dérive du catalogue pendant la transition.
-
-## 18. Preuve d'inventaire #385
-
-Workflow d'inspection jetable :
+La preuve autoritative actuelle est le couple :
 
 ```text
-run 31937823780
+catalog.yml
+GovernedContentPolicy.php
 ```
 
-Artefact :
+Le merge #440 a également ajouté une barrière projet qui vérifie :
 
 ```text
-issue-385-content-sync-inventory-31937823780
-sha256:5bd01c33df172d5037fbe331ea1b068d830d61c233035479282d735da08d9c56
+GOVERNED count = 3
+LEGACY_RELEASE_PENDING count = 30
+catalog count = 33
+3 vrais case_client pilotes absents du catalogue
 ```
 
-Le workflow temporaire n'appartient pas au candidat final ; il sert uniquement de preuve d'inventaire reproductible.
-
-## 19. Conclusion
+## 18. Conclusion
 
 La cible n'est ni « tout Git » ni « tout Drupal ».
-
-La séparation voulue est :
 
 ```text
 Git
@@ -572,6 +485,15 @@ Drupal
 -> permissions/révisions/traductions/workflow humain
 ```
 
-Le Content Sync existant reste utile comme materializer fiable pendant la transition, mais son domaine doit progressivement se réduire de **36 entrées** à un noyau Governed Content justifié.
+La trajectoire réelle est désormais :
 
-#385 crée la barrière qui manquait : un inventaire explicite, une admission policy, des règles d'identité/promotion/rollback et un chemin de libération qui évite toute perte ou overwrite avant de toucher au catalogue runtime.
+```text
+bootstrap historique : 36 entrées
+après pilote #440 : 33 entrées au catalogue
+                    3 GOV + 30 pending
+cible :             noyau Governed Content justifié
+```
+
+#439 a fourni la primitive de release sûre, #440 a prouvé le premier lot réel,
+et #441 poursuit désormais la diminution progressive des 30 contenus ordinaires
+restants.


### PR DESCRIPTION
## Résumé

- corrige `AGENTS.md` après le pilote #440 : 3 contenus `GOVERNED` + 30 `LEGACY_RELEASE_PENDING` ;
- rend explicitement `catalog.yml` + `GovernedContentPolicy` autoritatifs pour l’inventaire machine ;
- remplace dans `docs/governed-content-trajectory.md` l’ancien inventaire recopié et erroné par un état dérivé du catalogue/policy ;
- documente les trois vrais contenus pilotes libérés par #440 et leur bundle historique `case_client` ;
- corrige les métriques courantes : catalogue 33, bundles 14 `service` + 10 `ai_feature` + 9 `page`, `LEGACY_UUID_COUNT=8` ;
- marque #439/#440 comme étapes terminées et #441 comme prochaine phase de libération par lots.

## Pourquoi

La revalidation de #440 a montré que la documentation historique avait dérivé du catalogue réel : faux IDs de cas clients, mauvais bundle et métriques recopiées incorrectement. Cette PR supprime la duplication de la liste des 30 IDs pending afin que la documentation ne puisse plus devenir une seconde allowlist divergente.

## Vérifications effectuées

- `main` rechargé sur `d7dd382f0692977a22a16c90c3138ab7b3a0db5d` ;
- catalogue courant relu : 33 entrées ;
- `GovernedContentPolicy::GOVERNED_CONTENT_IDS` : 3 ;
- `GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS` : 30 ;
- commit #440 relu pour confirmer les trois vrais IDs pilotes et le bundle `case_client` ;
- `docs/governed-content-release.md` vérifié : ses mentions de 33 IDs sont explicitement historiques au scope #439 et aucun faux ID n’y est recopié ;
- comparaison de branche : uniquement `AGENTS.md` et `docs/governed-content-trajectory.md`.

Aucun changement de catalogue, payload, mapping, contenu Drupal, alias, menu, workflow ou runtime.

Closes #445