### PR TITLE
Issue #449: add trusted ai_feature transition proof profile

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -81,7 +81,7 @@ jobs:
           for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
               if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
                   raise SystemExit(f'{name} must be a lowercase 40-character SHA')
-          if proof_profile != 'case-studies-440':
+          if proof_profile not in {'case-studies-440', 'ai-features-441'}:
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Validate governed transition proof shell syntax
+      - name: Validate governed transition proof shell syntax and profiles
         run: |
+          set -euo pipefail
+          bash -n scripts/runner/governed-content-transition-profiles.sh
           bash -n scripts/runner/run-governed-content-transition-proof.sh
           bash -n scripts/runner/finalize-governed-content-transition-proof.sh
+
+          PROOF_PROFILE=case-studies-440 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "3"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "cas-client-migration-drupal-11"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "6"
+          '
+
+          PROOF_PROFILE=ai-features-441 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "10"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "ai-redaction-assistee"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "20"
+          '
+
+          if PROOF_PROFILE=unsupported-profile bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+          '; then
+            echo "Unsupported proof profile was accepted." >&2
+            exit 1
+          fi
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -43,6 +43,7 @@ jobs:
       head_sha: ${{ steps.validate.outputs.head_sha }}
       pr_number: ${{ steps.validate.outputs.pr_number }}
       request_id: ${{ steps.validate.outputs.request_id }}
+      proof_profile: ${{ steps.validate.outputs.proof_profile }}
     steps:
       - name: Validate dispatch actor, profile and live PR
         id: validate
@@ -78,10 +79,36 @@ jobs:
             echo "release_sha must be an exact lowercase 40-character SHA." >&2
             exit 1
           fi
-          if [[ "$PROOF_PROFILE" != "case-studies-440" ]]; then
-            echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
-            exit 1
-          fi
+
+          case "$PROOF_PROFILE" in
+            case-studies-440)
+              target_ids=(
+                "cas-client-refonte-drupal-institutionnelle"
+                "cas-client-migration-drupal-11"
+                "cas-client-integration-ia-editoriale"
+              )
+              release_policy_must_change="yes"
+              ;;
+            ai-features-441)
+              target_ids=(
+                "ai-automatisation-contenu-drupal"
+                "ai-generation-multilingue"
+                "ai-chatbot-qualification"
+                "ai-audit-intelligent"
+                "ai-redaction-assistee"
+                "ai-correction-editoriale"
+                "ai-traduction-fr-en"
+                "ai-resumes-tags-structure"
+                "ai-seo-liens-internes"
+                "ai-gouvernance-validation"
+              )
+              release_policy_must_change="no"
+              ;;
+            *)
+              echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
+              exit 1
+              ;;
+          esac
 
           pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           state="$(jq -r '.state' <<<"$pr_json")"
@@ -114,16 +141,17 @@ jobs:
             exit 1
           fi
 
-          required_target_paths=(
-            "web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
-            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
-            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
-            "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
-            "web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
-          )
+          catalog_path="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
+          policy_path="web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
+          required_target_paths=("$catalog_path" "$policy_path")
+          for content_id in "${target_ids[@]}"; do
+            required_target_paths+=(
+              "web/modules/custom/emerging_digital_content/content_sync/node/${content_id}.yml"
+            )
+          done
           for required_path in "${required_target_paths[@]}"; do
             grep -Fxq "$required_path" <<<"$changed_files" || {
-              echo "Pilot #440 transition proof requires changed path: $required_path" >&2
+              echo "Transition profile ${PROOF_PROFILE} requires changed path: $required_path" >&2
               exit 1
             }
           done
@@ -136,19 +164,21 @@ jobs:
             exit 1
           fi
 
+          expected_release_paths=("$catalog_path")
+          for content_id in "${target_ids[@]}"; do
+            expected_release_paths+=(
+              "web/modules/custom/emerging_digital_content/content_sync/node/${content_id}.yml"
+            )
+          done
+          if [[ "$release_policy_must_change" == "yes" ]]; then
+            expected_release_paths+=("$policy_path")
+          fi
+
           release_changed="$(jq -r '.files[].filename' <<<"$release_compare" | sort)"
-          expected_release_changed="$(
-            printf '%s\n' \
-              "web/modules/custom/emerging_digital_content/content_sync/catalog.yml" \
-              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml" \
-              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml" \
-              "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml" \
-              "web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php" \
-              | sort
-          )"
+          expected_release_changed="$(printf '%s\n' "${expected_release_paths[@]}" | sort)"
           if [[ "$release_changed" != "$expected_release_changed" ]]; then
-            echo "Release candidate must contain exactly the reviewed #440 transition paths." >&2
-            printf 'Observed:\n%s\n' "$release_changed" >&2
+            echo "Release candidate does not contain exactly the trusted ${PROOF_PROFILE} transition paths." >&2
+            printf 'Observed:\n%s\nExpected:\n%s\n' "$release_changed" "$expected_release_changed" >&2
             exit 1
           fi
 
@@ -159,9 +189,6 @@ jobs:
             echo "Release candidate must be an ancestor of the live PR HEAD." >&2
             exit 1
           fi
-
-          policy_path="web/modules/custom/emerging_digital_content/src/ContentSync/Policy/GovernedContentPolicy.php"
-          catalog_path="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
 
           release_policy="$(
             gh api "repos/$GITHUB_REPOSITORY/contents/$policy_path?ref=$REQUESTED_RELEASE_SHA" --jq '.content' \
@@ -180,34 +207,31 @@ jobs:
               | base64 --decode
           )"
 
-          for content_id in \
-            cas-client-refonte-drupal-institutionnelle \
-            cas-client-migration-drupal-11 \
-            cas-client-integration-ia-editoriale; do
+          for content_id in "${target_ids[@]}"; do
             grep -Fq "'${content_id}'" <<<"$release_policy" || {
-              echo "Release candidate policy does not admit pilot content: $content_id" >&2
+              echo "Release candidate policy does not admit transition content: $content_id" >&2
               exit 1
             }
             if grep -Fq "id: ${content_id}" <<<"$release_catalog"; then
-              echo "Release candidate still contains pilot catalog entry: $content_id" >&2
+              echo "Release candidate still contains catalog entry: $content_id" >&2
               exit 1
             fi
             if grep -Fq "'${content_id}'" <<<"$final_policy"; then
-              echo "Final policy still admits already released pilot content: $content_id" >&2
+              echo "Final policy still admits already released content: $content_id" >&2
               exit 1
             fi
             if grep -Fq "id: ${content_id}" <<<"$final_catalog"; then
-              echo "Final HEAD contains released pilot catalog entry: $content_id" >&2
+              echo "Final HEAD contains released catalog entry: $content_id" >&2
               exit 1
             fi
 
             payload_path="web/modules/custom/emerging_digital_content/content_sync/node/${content_id}.yml"
             if gh api "repos/$GITHUB_REPOSITORY/contents/$payload_path?ref=$REQUESTED_RELEASE_SHA" >/dev/null 2>&1; then
-              echo "Release candidate still contains pilot payload: $payload_path" >&2
+              echo "Release candidate still contains payload: $payload_path" >&2
               exit 1
             fi
             if gh api "repos/$GITHUB_REPOSITORY/contents/$payload_path?ref=$head_sha" >/dev/null 2>&1; then
-              echo "Final HEAD still contains pilot payload: $payload_path" >&2
+              echo "Final HEAD still contains payload: $payload_path" >&2
               exit 1
             fi
           done
@@ -217,6 +241,7 @@ jobs:
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
           echo "release_sha=$REQUESTED_RELEASE_SHA" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "proof_profile=$PROOF_PROFILE" >> "$GITHUB_OUTPUT"
 
   transition-proof:
     name: Prove base, release candidate and exact final HEAD
@@ -263,10 +288,13 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN_SHA"
+          test -f scripts/runner/governed-content-transition-profiles.sh
           test -f scripts/runner/run-governed-content-transition-proof.sh
           test -f scripts/runner/finalize-governed-content-transition-proof.sh
           test -f package-lock.json
           git diff --check
+          cp scripts/runner/governed-content-transition-profiles.sh \
+            "/tmp/agency-governed-transition-profiles-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           cp scripts/runner/run-governed-content-transition-proof.sh \
             "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           cp scripts/runner/finalize-governed-content-transition-proof.sh \
@@ -292,6 +320,8 @@ jobs:
           TARGET_SHA: ${{ needs.validate-request.outputs.release_sha }}
           PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
           REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
+          PROOF_PROFILE: ${{ needs.validate-request.outputs.proof_profile }}
+          PROOF_PROFILE_HELPER: /tmp/agency-governed-transition-profiles-${{ github.run_id }}-${{ github.run_attempt }}.sh
         run: |
           set -euo pipefail
           bash "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
@@ -304,6 +334,8 @@ jobs:
           TARGET_SHA: ${{ needs.validate-request.outputs.head_sha }}
           PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
           REQUEST_ID: ${{ needs.validate-request.outputs.request_id }}
+          PROOF_PROFILE: ${{ needs.validate-request.outputs.proof_profile }}
+          PROOF_PROFILE_HELPER: /tmp/agency-governed-transition-profiles-${{ github.run_id }}-${{ github.run_attempt }}.sh
         run: |
           set -euo pipefail
           mkdir -p artifacts/governed-content-transition/browser/release-candidate
@@ -334,6 +366,7 @@ jobs:
           ddev delete --omit-snapshot --yes
           rm -f .ddev/config.gate-governed-content-proof.yaml
           rm -f tests/browser/governed-content-transition-proof.spec.mjs
+          rm -f "/tmp/agency-governed-transition-profiles-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           rm -f "/tmp/agency-governed-transition-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           rm -f "/tmp/agency-governed-transition-finalize-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sh"
           git reset --hard "$TRUSTED_MAIN_SHA"

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -6,30 +6,36 @@ set -euo pipefail
 : "${TARGET_SHA:?TARGET_SHA is required}"
 : "${PR_NUMBER:?PR_NUMBER is required}"
 : "${REQUEST_ID:?REQUEST_ID is required}"
+: "${PROOF_PROFILE:?PROOF_PROFILE is required}"
+: "${PROOF_PROFILE_HELPER:?PROOF_PROFILE_HELPER is required}"
+
+# The helper is copied from trusted main by the workflow before any target SHA is
+# checked out. Do not source profile data from the PR under proof.
+# shellcheck source=/dev/null
+source "$PROOF_PROFILE_HELPER"
 
 ARTIFACT_ROOT="artifacts/governed-content-transition"
 SNAPSHOT_ROOT="$ARTIFACT_ROOT/snapshots"
 LOG_ROOT="$ARTIFACT_ROOT/logs"
 RESULT_PATH="$ARTIFACT_ROOT/final-result.json"
-EDITORIAL_MARKER="[proof-440-editorial-survives]"
+EDITORIAL_MARKER="$PROOF_EDITORIAL_MARKER"
 CATALOG_PATH="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
-SQL_IDS="'cas-client-refonte-drupal-institutionnelle','cas-client-migration-drupal-11','cas-client-integration-ia-editoriale'"
-PILOT_IDS=(
-  "cas-client-refonte-drupal-institutionnelle"
-  "cas-client-migration-drupal-11"
-  "cas-client-integration-ia-editoriale"
-)
-PILOT_PAYLOADS=(
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
-)
+SQL_IDS="$PROOF_SQL_IDS"
+PILOT_IDS=("${PROOF_CONTENT_IDS[@]}")
+PILOT_PAYLOADS=("${PROOF_PAYLOADS[@]}")
+EXPECTED_ALIASES=("${PROOF_PUBLIC_PATHS[@]}")
+EXPECTED_MAPPING_COUNT="$PROOF_MAPPING_COUNT"
+EDITORIAL_CONTENT_ID="$PROOF_EDITORIAL_CONTENT_ID"
+EDITORIAL_PATH="$PROOF_EDITORIAL_PATH"
 
 proof_status="FAIL"
 proof_phase="finalize-bootstrap"
 
 write_result() {
   local exit_code="$1"
+  local pilot_ids_json
+  pilot_ids_json="$(printf '%s\n' "${PILOT_IDS[@]}" | jq -R -s 'split("\n")[:-1]')"
+
   jq -n \
     --arg result "$proof_status" \
     --arg phase "$proof_phase" \
@@ -38,6 +44,8 @@ write_result() {
     --arg base_sha "$BASE_SHA" \
     --arg release_sha "$RELEASE_SHA" \
     --arg target_sha "$TARGET_SHA" \
+    --arg proof_profile "$PROOF_PROFILE" \
+    --argjson pilot_content_ids "$pilot_ids_json" \
     --argjson exit_code "$exit_code" \
     '{
       result: $result,
@@ -47,6 +55,8 @@ write_result() {
       base_sha: $base_sha,
       release_sha: $release_sha,
       target_sha: $target_sha,
+      proof_profile: $proof_profile,
+      pilot_content_ids: $pilot_content_ids,
       exit_code: $exit_code
     }' > "$RESULT_PATH"
 }
@@ -96,9 +106,19 @@ mapping_identity() {
 assert_mapping_status() {
   local snapshot="$1"
   local expected="$2"
-  [[ "$(wc -l < "$snapshot" | tr -d ' ')" == "3" ]]
+  local count
+
+  count="$(wc -l < "$snapshot" | tr -d ' ')"
+  [[ "$count" == "$EXPECTED_MAPPING_COUNT" ]] || {
+    echo "Expected exactly ${EXPECTED_MAPPING_COUNT} proof mappings, found ${count}." >&2
+    return 1
+  }
+
   awk -F '\t' -v expected="$expected" '
-    $4 != expected { bad = 1 }
+    $4 != expected {
+      printf "Unexpected mapping status for %s: %s (expected %s)\n", $1, $4, expected > "/dev/stderr"
+      bad = 1
+    }
     END { exit bad }
   ' "$snapshot"
 }
@@ -106,18 +126,23 @@ assert_mapping_status() {
 assert_aliases_and_publication() {
   local snapshot="$1"
   local alias
-  local expected_aliases=(
-    "/cas-clients/refonte-drupal-institutionnelle"
-    "/case-studies/institutional-drupal-redesign"
-    "/cas-clients/migration-drupal-11"
-    "/case-studies/drupal-11-migration"
-    "/cas-clients/integration-ia-editoriale"
-    "/case-studies/editorial-ai-integration"
-  )
-  for alias in "${expected_aliases[@]}"; do
-    grep -Fq $'\t'"${alias}" "$snapshot"
+
+  for alias in "${EXPECTED_ALIASES[@]}"; do
+    alias="${alias#/fr}"
+    alias="${alias#/en}"
+    grep -Fq $'\t'"${alias}" "$snapshot" || {
+      echo "Expected alias missing from runtime snapshot: ${alias}" >&2
+      return 1
+    }
   done
-  awk -F '\t' '$5 != "1" { bad = 1 } END { exit bad }' "$snapshot"
+
+  awk -F '\t' '
+    $5 != "1" {
+      printf "Proof node %s translation %s is not published.\n", $1, $4 > "/dev/stderr"
+      bad = 1
+    }
+    END { exit bad }
+  ' "$snapshot"
 }
 
 release_pilot() {
@@ -148,32 +173,64 @@ verify_config_clean() {
   local status
   status="$(ddev drush config:status 2>&1)"
   printf '%s\n' "$status" | tee "$LOG_ROOT/final-config-status-${label}.txt"
-  grep -Fq 'No differences' <<<"$status"
+  grep -Fq 'No differences' <<<"$status" || {
+    echo "Configuration drift detected during ${label}." >&2
+    return 1
+  }
 }
 
 apply_editorial_edit() {
-  ddev drush php:eval '
-    $nid = \Drupal::database()
-      ->select("emerging_digital_content_sync_mapping", "m")
-      ->fields("m", ["entity_id"])
-      ->condition("content_id", "cas-client-migration-drupal-11")
-      ->execute()
-      ->fetchField();
-    if (!$nid) {
-      throw new \RuntimeException("Pilot mapping not found.");
-    }
-    $node = \Drupal\node\Entity\Node::load((int) $nid);
-    if (!$node) {
-      throw new \RuntimeException("Pilot node not found.");
-    }
-    $node->setNewRevision(TRUE);
-    $node->setRevisionLogMessage("Governed Content exact-head proof #440");
-    $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
-    if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
-      $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
-    }
-    $node->save();
-  '
+  case "$PROOF_PROFILE" in
+    case-studies-440)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "cas-client-migration-drupal-11")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Pilot mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Pilot node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #440");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
+
+    ai-features-441)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "ai-redaction-assistee")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("AI feature mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("AI feature node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #441 ai_feature");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-ai-features-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-ai-features-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
+  esac
 }
 
 assert_editorial_marker() {
@@ -183,7 +240,7 @@ assert_editorial_marker() {
       JOIN node_field_data nfd
         ON nfd.nid = m.entity_id
        AND nfd.langcode = 'fr'
-     WHERE m.content_id = 'cas-client-migration-drupal-11';
+     WHERE m.content_id = '${EDITORIAL_CONTENT_ID}';
   " | grep -Fq "$EDITORIAL_MARKER"
 }
 
@@ -214,6 +271,12 @@ if not url:
     raise SystemExit("No DDEV URL found")
 print(url.rstrip("/"))
 '
+}
+
+browser_pages_json() {
+  printf '%s\n' "${EXPECTED_ALIASES[@]}" \
+    | jq -R -s --arg editorial "$EDITORIAL_PATH" \
+      'split("\n")[:-1] | map([., . == $editorial])'
 }
 
 proof_phase="replay-release-candidate"
@@ -266,8 +329,10 @@ assert_editorial_marker
 
 proof_phase="exact-head-browser"
 base_url="$(detect_ddev_url)"
+pages_json="$(browser_pages_json)"
 PLAYWRIGHT_BASE_URL="$base_url" \
 PROOF_EDITORIAL_MARKER="$EDITORIAL_MARKER" \
+PROOF_PAGES_JSON="$pages_json" \
   npx playwright test tests/browser/governed-content-transition-proof.spec.mjs \
     --output="$ARTIFACT_ROOT/final-playwright-test-results" \
     | tee "$LOG_ROOT/final-playwright.txt"

--- a/scripts/runner/governed-content-transition-profiles.sh
+++ b/scripts/runner/governed-content-transition-profiles.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PROOF_PROFILE:?PROOF_PROFILE is required}"
+
+case "$PROOF_PROFILE" in
+  case-studies-440)
+    PROOF_CONTENT_IDS=(
+      "cas-client-refonte-drupal-institutionnelle"
+      "cas-client-migration-drupal-11"
+      "cas-client-integration-ia-editoriale"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/cas-clients/refonte-drupal-institutionnelle"
+      "/en/case-studies/institutional-drupal-redesign"
+      "/fr/cas-clients/migration-drupal-11"
+      "/en/case-studies/drupal-11-migration"
+      "/fr/cas-clients/integration-ia-editoriale"
+      "/en/case-studies/editorial-ai-integration"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="cas-client-migration-drupal-11"
+    PROOF_EDITORIAL_PATH="/fr/cas-clients/migration-drupal-11"
+    PROOF_EDITORIAL_MARKER="[proof-440-editorial-survives]"
+    ;;
+
+  ai-features-441)
+    PROOF_CONTENT_IDS=(
+      "ai-automatisation-contenu-drupal"
+      "ai-generation-multilingue"
+      "ai-chatbot-qualification"
+      "ai-audit-intelligent"
+      "ai-redaction-assistee"
+      "ai-correction-editoriale"
+      "ai-traduction-fr-en"
+      "ai-resumes-tags-structure"
+      "ai-seo-liens-internes"
+      "ai-gouvernance-validation"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/ia-drupal/automatisation-contenu-drupal"
+      "/en/ai-drupal/drupal-content-automation"
+      "/fr/ia-drupal/generation-multilingue"
+      "/en/ai-drupal/multilingual-generation"
+      "/fr/ia-drupal/chatbot-qualification"
+      "/en/ai-drupal/qualification-chatbot"
+      "/fr/ia-drupal/audit-intelligent"
+      "/en/ai-drupal/intelligent-audit"
+      "/fr/ia-drupal/redaction-assistee"
+      "/en/ai-drupal/assisted-writing"
+      "/fr/ia-drupal/correction-editoriale"
+      "/en/ai-drupal/editorial-review"
+      "/fr/ia-drupal/traduction-fr-en"
+      "/en/ai-drupal/fr-en-translation"
+      "/fr/ia-drupal/resumes-tags-structure"
+      "/en/ai-drupal/summaries-tags-structure"
+      "/fr/ia-drupal/seo-liens-internes"
+      "/en/ai-drupal/seo-internal-links"
+      "/fr/ia-drupal/gouvernance-validation"
+      "/en/ai-drupal/governance-approval"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="ai-redaction-assistee"
+    PROOF_EDITORIAL_PATH="/fr/ia-drupal/redaction-assistee"
+    PROOF_EDITORIAL_MARKER="[proof-441-ai-features-editorial-survives]"
+    ;;
+
+  *)
+    echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
+    return 1 2>/dev/null || exit 1
+    ;;
+esac
+
+PROOF_PAYLOADS=()
+for content_id in "${PROOF_CONTENT_IDS[@]}"; do
+  PROOF_PAYLOADS+=(
+    "web/modules/custom/emerging_digital_content/content_sync/node/${content_id}.yml"
+  )
+done
+
+PROOF_MAPPING_COUNT="${#PROOF_CONTENT_IDS[@]}"
+PROOF_SQL_IDS="$(printf "'%s'," "${PROOF_CONTENT_IDS[@]}")"
+PROOF_SQL_IDS="${PROOF_SQL_IDS%,}"

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -5,28 +5,28 @@ set -euo pipefail
 : "${TARGET_SHA:?TARGET_SHA is required}"
 : "${PR_NUMBER:?PR_NUMBER is required}"
 : "${REQUEST_ID:?REQUEST_ID is required}"
+: "${PROOF_PROFILE:?PROOF_PROFILE is required}"
+: "${PROOF_PROFILE_HELPER:?PROOF_PROFILE_HELPER is required}"
+
+# The helper is copied from trusted main by the workflow before any target SHA is
+# checked out. Do not source profile data from the PR under proof.
+# shellcheck source=/dev/null
+source "$PROOF_PROFILE_HELPER"
 
 ARTIFACT_ROOT="artifacts/governed-content-transition"
 SNAPSHOT_ROOT="$ARTIFACT_ROOT/snapshots"
 BROWSER_ROOT="$ARTIFACT_ROOT/browser"
 LOG_ROOT="$ARTIFACT_ROOT/logs"
 RESULT_PATH="$ARTIFACT_ROOT/result.json"
-EDITORIAL_MARKER="[proof-440-editorial-survives]"
-
-PILOT_IDS=(
-  "cas-client-refonte-drupal-institutionnelle"
-  "cas-client-migration-drupal-11"
-  "cas-client-integration-ia-editoriale"
-)
-
-PILOT_PAYLOADS=(
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-refonte-drupal-institutionnelle.yml"
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-migration-drupal-11.yml"
-  "web/modules/custom/emerging_digital_content/content_sync/node/cas-client-integration-ia-editoriale.yml"
-)
-
+EDITORIAL_MARKER="$PROOF_EDITORIAL_MARKER"
+PILOT_IDS=("${PROOF_CONTENT_IDS[@]}")
+PILOT_PAYLOADS=("${PROOF_PAYLOADS[@]}")
+EXPECTED_ALIASES=("${PROOF_PUBLIC_PATHS[@]}")
+EXPECTED_MAPPING_COUNT="$PROOF_MAPPING_COUNT"
+EDITORIAL_CONTENT_ID="$PROOF_EDITORIAL_CONTENT_ID"
+EDITORIAL_PATH="$PROOF_EDITORIAL_PATH"
 CATALOG_PATH="web/modules/custom/emerging_digital_content/content_sync/catalog.yml"
-SQL_IDS="'cas-client-refonte-drupal-institutionnelle','cas-client-migration-drupal-11','cas-client-integration-ia-editoriale'"
+SQL_IDS="$PROOF_SQL_IDS"
 
 mkdir -p "$SNAPSHOT_ROOT" "$BROWSER_ROOT" "$LOG_ROOT"
 
@@ -35,6 +35,9 @@ proof_phase="bootstrap"
 
 write_result() {
   local exit_code="$1"
+  local pilot_ids_json
+  pilot_ids_json="$(printf '%s\n' "${PILOT_IDS[@]}" | jq -R -s 'split("\n")[:-1]')"
+
   jq -n \
     --arg result "$proof_status" \
     --arg phase "$proof_phase" \
@@ -42,7 +45,9 @@ write_result() {
     --arg pr_number "$PR_NUMBER" \
     --arg base_sha "$BASE_SHA" \
     --arg target_sha "$TARGET_SHA" \
+    --arg proof_profile "$PROOF_PROFILE" \
     --arg marker "$EDITORIAL_MARKER" \
+    --argjson pilot_content_ids "$pilot_ids_json" \
     --argjson exit_code "$exit_code" \
     '{
       result: $result,
@@ -51,11 +56,8 @@ write_result() {
       pr_number: $pr_number,
       base_sha: $base_sha,
       target_sha: $target_sha,
-      pilot_content_ids: [
-        "cas-client-refonte-drupal-institutionnelle",
-        "cas-client-migration-drupal-11",
-        "cas-client-integration-ia-editoriale"
-      ],
+      proof_profile: $proof_profile,
+      pilot_content_ids: $pilot_content_ids,
       editorial_marker: $marker,
       exit_code: $exit_code
     }' > "$RESULT_PATH"
@@ -129,8 +131,8 @@ assert_mapping_status() {
   local count
 
   count="$(wc -l < "$snapshot" | tr -d ' ')"
-  [[ "$count" == "3" ]] || {
-    echo "Expected exactly 3 pilot mappings, found ${count}." >&2
+  [[ "$count" == "$EXPECTED_MAPPING_COUNT" ]] || {
+    echo "Expected exactly ${EXPECTED_MAPPING_COUNT} proof mappings, found ${count}." >&2
     return 1
   }
 
@@ -150,16 +152,10 @@ mapping_identity() {
 assert_public_aliases() {
   local snapshot="$1"
   local alias
-  local expected_aliases=(
-    "/cas-clients/refonte-drupal-institutionnelle"
-    "/case-studies/institutional-drupal-redesign"
-    "/cas-clients/migration-drupal-11"
-    "/case-studies/drupal-11-migration"
-    "/cas-clients/integration-ia-editoriale"
-    "/case-studies/editorial-ai-integration"
-  )
 
-  for alias in "${expected_aliases[@]}"; do
+  for alias in "${EXPECTED_ALIASES[@]}"; do
+    alias="${alias#/fr}"
+    alias="${alias#/en}"
     grep -Fq $'\t'"${alias}" "$snapshot" || {
       echo "Expected alias missing from runtime snapshot: ${alias}" >&2
       return 1
@@ -168,7 +164,7 @@ assert_public_aliases() {
 
   awk -F '\t' '
     $5 != "1" {
-      printf "Pilot node %s translation %s is not published.\n", $1, $4 > "/dev/stderr"
+      printf "Proof node %s translation %s is not published.\n", $1, $4 > "/dev/stderr"
       bad = 1
     }
     END { exit bad }
@@ -207,28 +203,57 @@ readmit_pilot() {
 }
 
 apply_editorial_edit() {
-  ddev drush php:eval '
-    $database = \Drupal::database();
-    $nid = $database->select("emerging_digital_content_sync_mapping", "m")
-      ->fields("m", ["entity_id"])
-      ->condition("content_id", "cas-client-migration-drupal-11")
-      ->execute()
-      ->fetchField();
-    if (!$nid) {
-      throw new \RuntimeException("Pilot mapping not found for editorial proof.");
-    }
-    $node = \Drupal\node\Entity\Node::load((int) $nid);
-    if (!$node) {
-      throw new \RuntimeException("Pilot node not found for editorial proof.");
-    }
-    $node->setNewRevision(TRUE);
-    $node->setRevisionLogMessage("Governed Content transition proof #440");
-    $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
-    if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
-      $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
-    }
-    $node->save();
-  '
+  case "$PROOF_PROFILE" in
+    case-studies-440)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "cas-client-migration-drupal-11")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Pilot mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Pilot node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #440");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-440-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-440-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
+
+    ai-features-441)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "ai-redaction-assistee")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("AI feature mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("AI feature node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #441 ai_feature");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-ai-features-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-ai-features-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
+  esac
 }
 
 assert_editorial_edit_survives() {
@@ -236,7 +261,7 @@ assert_editorial_edit_survives() {
     SELECT nfd.title
       FROM emerging_digital_content_sync_mapping m
       JOIN node_field_data nfd ON nfd.nid = m.entity_id AND nfd.langcode = 'fr'
-     WHERE m.content_id = 'cas-client-migration-drupal-11';
+     WHERE m.content_id = '${EDITORIAL_CONTENT_ID}';
   " | grep -Fq "$EDITORIAL_MARKER"
 }
 
@@ -273,25 +298,26 @@ print(url.rstrip("/"))
 '
 }
 
+browser_pages_json() {
+  printf '%s\n' "${EXPECTED_ALIASES[@]}" \
+    | jq -R -s --arg editorial "$EDITORIAL_PATH" \
+      'split("\n")[:-1] | map([., . == $editorial])'
+}
+
 run_browser_proof() {
   local base_url
+  local pages_json
   base_url="$(detect_ddev_url)"
+  pages_json="$(browser_pages_json)"
 
   cat > tests/browser/governed-content-transition-proof.spec.mjs <<'EOF'
 import { expect, test } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 
-const pages = [
-  ['/fr/cas-clients/refonte-drupal-institutionnelle', false],
-  ['/en/case-studies/institutional-drupal-redesign', false],
-  ['/fr/cas-clients/migration-drupal-11', true],
-  ['/en/case-studies/drupal-11-migration', false],
-  ['/fr/cas-clients/integration-ia-editoriale', false],
-  ['/en/case-studies/editorial-ai-integration', false],
-];
+const pages = JSON.parse(process.env.PROOF_PAGES_JSON);
 
 for (const [path, expectsMarker] of pages) {
-  test(`released case study remains public: ${path}`, async ({ page }, testInfo) => {
+  test(`released governed-content item remains public: ${path}`, async ({ page }, testInfo) => {
     const runtimeErrors = [];
     page.on('console', (message) => {
       if (message.type() === 'error') {
@@ -323,6 +349,7 @@ EOF
 
   PLAYWRIGHT_BASE_URL="$base_url" \
   PROOF_EDITORIAL_MARKER="$EDITORIAL_MARKER" \
+  PROOF_PAGES_JSON="$pages_json" \
     npx playwright test tests/browser/governed-content-transition-proof.spec.mjs \
       | tee "$LOG_ROOT/playwright.txt"
 }


### PR DESCRIPTION
## Résumé

Étend la route de preuve Governed Content introduite par #446/#447 avec un second profil trusted fermé :

- `case-studies-440` reste supporté pour audit/rerun ;
- `ai-features-441` couvre exactement les 10 contenus `ai_feature` encore `LEGACY_RELEASE_PENDING` ;
- aucun ID, alias ou commande arbitraire n'est fourni par l'appelant.

## Implémentation

- ajoute `scripts/runner/governed-content-transition-profiles.sh` comme registre trusted des IDs, payloads, URLs publiques et cible d'édition de chaque profil ;
- rend les scripts base->release et release->HEAD dépendants du profil trusted : compteur de mappings, SQL, aliases, browser pages, édition de persistance et rollback ;
- conserve les éditions de preuve explicitement codées par profil (`cas-client-migration-drupal-11` pour #440, `ai-redaction-assistee` pour #441) ;
- autorise le gateway uniquement pour `case-studies-440` et `ai-features-441` ;
- valide côté workflow les chemins exacts du release candidate selon le profil ;
- transmet le profil aux scripts via une copie `/tmp` provenant du `main` trusted, avant tout checkout du SHA cible ;
- renforce la CI avec `bash -n`, compteurs attendus 3/10, 6/20 URLs et refus explicite d'un profil inconnu.

## Invariants de sécurité conservés

- PR same-repository, OPEN, base `main`, HEAD exact ;
- release candidate descendant du base SHA et ancêtre du HEAD ;
- refus d'une PR cible modifiant `.github/`, `.ddev/`, `.agency/`, `scripts/runner/`, browser/npm/playwright trusted ;
- aucun secret, aucune production, aucun shell fourni par la requête ;
- les IDs et aliases admissibles restent versionnés dans le code trusted.

## Périmètre

Cette PR ne libère aucun contenu. Elle ne modifie ni catalogue, payload métier, policy Governed Content, node, alias, menu ni configuration Drupal.

Closes #449
Refs #441