### PR TITLE
Issue #455: add trusted services Drupal transition proof profile

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -81,7 +81,7 @@ jobs:
           for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
               if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
                   raise SystemExit(f'{name} must be a lowercase 40-character SHA')
-          if proof_profile not in {'case-studies-440', 'ai-features-441'}:
+          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441'}:
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
             test "${#PROOF_PUBLIC_PATHS[@]}" = "20"
           '
 
+          PROOF_PROFILE=services-drupal-441 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "7"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "audit-drupal"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
+          '
+
           if PROOF_PROFILE=unsupported-profile bash -c '
             set -euo pipefail
             source scripts/runner/governed-content-transition-profiles.sh

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -104,6 +104,18 @@ jobs:
               )
               release_policy_must_change="no"
               ;;
+            services-drupal-441)
+              target_ids=(
+                "agence-drupal-belgique"
+                "creation-site-drupal"
+                "maintenance-drupal"
+                "migration-drupal"
+                "refonte-site-drupal"
+                "audit-drupal"
+                "accessibilite-seo-optimisation"
+              )
+              release_policy_must_change="no"
+              ;;
             *)
               echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
               exit 1

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -230,6 +230,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    services-drupal-441)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "audit-drupal")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Drupal service mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Drupal service node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #441 services Drupal");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-services-drupal-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-services-drupal-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 

--- a/scripts/runner/governed-content-transition-profiles.sh
+++ b/scripts/runner/governed-content-transition-profiles.sh
@@ -63,6 +63,37 @@ case "$PROOF_PROFILE" in
     PROOF_EDITORIAL_MARKER="[proof-441-ai-features-editorial-survives]"
     ;;
 
+  services-drupal-441)
+    PROOF_CONTENT_IDS=(
+      "agence-drupal-belgique"
+      "creation-site-drupal"
+      "maintenance-drupal"
+      "migration-drupal"
+      "refonte-site-drupal"
+      "audit-drupal"
+      "accessibilite-seo-optimisation"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/agence-drupal-belgique"
+      "/en/drupal-agency-belgium"
+      "/fr/creation-site-drupal"
+      "/en/drupal-website-creation"
+      "/fr/maintenance-drupal"
+      "/en/drupal-maintenance"
+      "/fr/migration-drupal"
+      "/en/drupal-migration"
+      "/fr/refonte-site-drupal"
+      "/en/drupal-website-redesign"
+      "/fr/audit-drupal"
+      "/en/drupal-audit"
+      "/fr/accessibilite-seo-optimisation"
+      "/en/ai-accessibility-seo-optimization"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="audit-drupal"
+    PROOF_EDITORIAL_PATH="/fr/audit-drupal"
+    PROOF_EDITORIAL_MARKER="[proof-441-services-drupal-editorial-survives]"
+    ;;
+
   *)
     echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
     return 1 2>/dev/null || exit 1

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -253,6 +253,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    services-drupal-441)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "audit-drupal")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Drupal service mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Drupal service node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #441 services Drupal");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-services-drupal-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-services-drupal-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 


### PR DESCRIPTION
## Résumé

Ajoute un troisième profil fermé à la route self-hosted Governed Content existante :

`services-drupal-441`

Le profil couvre exactement 7 landing pages Drupal/qualité :

- `agence-drupal-belgique`
- `creation-site-drupal`
- `maintenance-drupal`
- `migration-drupal`
- `refonte-site-drupal`
- `audit-drupal`
- `accessibilite-seo-optimisation`

## Garanties conservées

- les profils `case-studies-440` et `ai-features-441` restent disponibles ;
- aucun ID/alias n'est fourni librement par la requête ;
- 14 URLs FR/EN sont codées côté trusted ;
- `audit-drupal` est la cible bornée de preuve de persistance éditoriale ;
- le release candidate attendu reste strictement `catalog.yml + 7 payloads`, avec policy inchangée ;
- le HEAD final doit retirer les 7 IDs de la policy ;
- mêmes contrôles same-repo, OPEN/main, exact-head, ancestry, trusted-path refusal, DDEV/Playwright/rollback ;
- aucun contenu, catalogue, policy ou configuration Drupal n'est modifié par cette PR.

## Diff

6 fichiers trusted uniquement :

- `.github/workflows/agent-governed-content-transition-dispatch.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/self-hosted-governed-content-transition-proof.yml`
- `scripts/runner/governed-content-transition-profiles.sh`
- `scripts/runner/run-governed-content-transition-proof.sh`
- `scripts/runner/finalize-governed-content-transition-proof.sh`

Closes #455
Refs #441