### PR TITLE
Issue #462: add trusted general services transition proof profile

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -81,7 +81,7 @@ jobs:
           for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
               if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
                   raise SystemExit(f'{name} must be a lowercase 40-character SHA')
-          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441'}:
+          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441', 'services-general-441'}:
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
             test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
           '
 
+          PROOF_PROFILE=services-general-441 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "7"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "creation-site-web-professionnel"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
+          '
+
           if PROOF_PROFILE=unsupported-profile bash -c '
             set -euo pipefail
             source scripts/runner/governed-content-transition-profiles.sh

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -116,6 +116,18 @@ jobs:
               )
               release_policy_must_change="no"
               ;;
+            services-general-441)
+              target_ids=(
+                "agence-web-belgique"
+                "agence-web-liege"
+                "creation-site-web-professionnel"
+                "refonte-site-internet"
+                "site-web-pme"
+                "ia-integree"
+                "ia-pour-pme"
+              )
+              release_policy_must_change="no"
+              ;;
             *)
               echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
               exit 1

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -255,6 +255,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    services-general-441)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "creation-site-web-professionnel")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("General service mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("General service node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #441 services general");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-services-general-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-services-general-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 

--- a/scripts/runner/governed-content-transition-profiles.sh
+++ b/scripts/runner/governed-content-transition-profiles.sh
@@ -94,6 +94,37 @@ case "$PROOF_PROFILE" in
     PROOF_EDITORIAL_MARKER="[proof-441-services-drupal-editorial-survives]"
     ;;
 
+  services-general-441)
+    PROOF_CONTENT_IDS=(
+      "agence-web-belgique"
+      "agence-web-liege"
+      "creation-site-web-professionnel"
+      "refonte-site-internet"
+      "site-web-pme"
+      "ia-integree"
+      "ia-pour-pme"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/agence-web-belgique"
+      "/en/web-agency-belgium"
+      "/fr/agence-web-liege"
+      "/en/web-agency-liege"
+      "/fr/creation-site-web-professionnel"
+      "/en/professional-website-creation"
+      "/fr/refonte-site-internet"
+      "/en/website-redesign"
+      "/fr/site-web-pme"
+      "/en/sme-website"
+      "/fr/ia-integree"
+      "/en/integrated-ai"
+      "/fr/ia-pour-pme"
+      "/en/ai-for-smes"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="creation-site-web-professionnel"
+    PROOF_EDITORIAL_PATH="/fr/creation-site-web-professionnel"
+    PROOF_EDITORIAL_MARKER="[proof-441-services-general-editorial-survives]"
+    ;;
+
   *)
     echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
     return 1 2>/dev/null || exit 1

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -278,6 +278,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    services-general-441)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "creation-site-web-professionnel")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("General service mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("General service node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #441 services general");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-services-general-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-services-general-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 


### PR DESCRIPTION
## Résumé

Ajoute un quatrième profil fermé à la route self-hosted Governed Content existante :

`services-general-441`

Le profil couvre exactement les 7 services ordinaires encore pending :

- `agence-web-belgique`
- `agence-web-liege`
- `creation-site-web-professionnel`
- `refonte-site-internet`
- `site-web-pme`
- `ia-integree`
- `ia-pour-pme`

## Garanties conservées

- les profils `case-studies-440`, `ai-features-441` et `services-drupal-441` restent disponibles ;
- aucun ID/alias n’est fourni librement par la requête ;
- 14 URLs FR/EN sont codées côté trusted ;
- `creation-site-web-professionnel` est la cible bornée de persistance éditoriale ;
- marqueur : `[proof-441-services-general-editorial-survives]` ;
- futur release candidate attendu : strictement `catalog.yml + 7 payloads`, policy inchangée ;
- futur HEAD final : retrait des 7 IDs de la policy ;
- mêmes contrôles same-repo, OPEN/main, exact-head, ancestry, trusted-path refusal, DDEV/Playwright/rollback ;
- profil inconnu toujours refusé ;
- aucun contenu, catalogue, policy ou configuration Drupal n’est modifié par cette PR.

## Diff

6 fichiers trusted uniquement :

- `.github/workflows/agent-governed-content-transition-dispatch.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/self-hosted-governed-content-transition-proof.yml`
- `scripts/runner/governed-content-transition-profiles.sh`
- `scripts/runner/run-governed-content-transition-proof.sh`
- `scripts/runner/finalize-governed-content-transition-proof.sh`

Closes #462
Refs #441