### PR TITLE
Issue #468: add trusted medium pages transition proof profile

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -81,7 +81,7 @@ jobs:
           for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
               if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
                   raise SystemExit(f'{name} must be a lowercase 40-character SHA')
-          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441', 'services-general-441'}:
+          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441', 'services-general-441', 'pages-medium-441'}:
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
             test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
           '
 
+          PROOF_PROFILE=pages-medium-441 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "3"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "equipe"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "6"
+          '
+
           if PROOF_PROFILE=unsupported-profile bash -c '
             set -euo pipefail
             source scripts/runner/governed-content-transition-profiles.sh

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -128,6 +128,14 @@ jobs:
               )
               release_policy_must_change="no"
               ;;
+            pages-medium-441)
+              target_ids=(
+                "cas-clients"
+                "equipe"
+                "ia-drupal"
+              )
+              release_policy_must_change="no"
+              ;;
             *)
               echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
               exit 1

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -280,6 +280,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    pages-medium-441)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "equipe")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Medium page mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Medium page node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #441 medium pages");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-medium-pages-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-medium-pages-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 

--- a/scripts/runner/governed-content-transition-profiles.sh
+++ b/scripts/runner/governed-content-transition-profiles.sh
@@ -125,6 +125,25 @@ case "$PROOF_PROFILE" in
     PROOF_EDITORIAL_MARKER="[proof-441-services-general-editorial-survives]"
     ;;
 
+  pages-medium-441)
+    PROOF_CONTENT_IDS=(
+      "cas-clients"
+      "equipe"
+      "ia-drupal"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/cas-clients"
+      "/en/case-studies"
+      "/fr/equipe"
+      "/en/team"
+      "/fr/ia-drupal"
+      "/en/ai-drupal"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="equipe"
+    PROOF_EDITORIAL_PATH="/fr/equipe"
+    PROOF_EDITORIAL_MARKER="[proof-441-medium-pages-editorial-survives]"
+    ;;
+
   *)
     echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
     return 1 2>/dev/null || exit 1

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -303,6 +303,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    pages-medium-441)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "equipe")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Medium page mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Medium page node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #441 medium pages");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-medium-pages-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-medium-pages-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 


### PR DESCRIPTION
## Résumé

Ajoute un cinquième profil fermé à la route self-hosted Governed Content existante :

`pages-medium-441`

Le profil couvre exactement les 3 pages ordinaires à impact moyen restantes avant le lot final :

- `cas-clients`
- `equipe`
- `ia-drupal`

## Garanties conservées

- les profils `case-studies-440`, `ai-features-441`, `services-drupal-441` et `services-general-441` restent disponibles ;
- aucun ID/alias n'est fourni librement par la requête ;
- 6 URLs FR/EN sont codées côté trusted ;
- `equipe` est la cible bornée de persistance éditoriale ;
- marqueur : `[proof-441-medium-pages-editorial-survives]` ;
- futur release candidate attendu : strictement `catalog.yml + 3 payloads`, policy inchangée ;
- futur HEAD final : retrait des 3 IDs de la policy, soit 6 -> 3 pending ;
- mêmes contrôles same-repo, OPEN/main, exact-head, ancestry, trusted-path refusal, DDEV/Playwright/rollback ;
- profil inconnu toujours refusé ;
- `homepage`, `services` et `contact` restent hors périmètre et réservés au lot final ;
- aucun contenu, catalogue, policy ou configuration Drupal n'est modifié par cette PR.

## Diff

6 fichiers trusted uniquement :

- `.github/workflows/agent-governed-content-transition-dispatch.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/self-hosted-governed-content-transition-proof.yml`
- `scripts/runner/governed-content-transition-profiles.sh`
- `scripts/runner/run-governed-content-transition-proof.sh`
- `scripts/runner/finalize-governed-content-transition-proof.sh`

Closes #468
Refs #441