### PR TITLE
Issue #472: add trusted final pages transition proof profile

### DIFF
--- a/.github/workflows/agent-governed-content-transition-dispatch.yml
+++ b/.github/workflows/agent-governed-content-transition-dispatch.yml
@@ -81,7 +81,7 @@ jobs:
           for name, value in [('head_sha', head_sha), ('release_sha', release_sha)]:
               if not isinstance(value, str) or not re.fullmatch(r'[0-9a-f]{40}', value):
                   raise SystemExit(f'{name} must be a lowercase 40-character SHA')
-          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441', 'services-general-441', 'pages-medium-441'}:
+          if proof_profile not in {'case-studies-440', 'ai-features-441', 'services-drupal-441', 'services-general-441', 'pages-medium-441', 'pages-final-441'}:
               raise SystemExit(f'Unsupported proof_profile: {proof_profile}')
 
           print(f'REQUEST_ID={request_id}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
             test "$PROOF_MAPPING_COUNT" = "3"
             test "$PROOF_EDITORIAL_CONTENT_ID" = "cas-client-migration-drupal-11"
             test "${#PROOF_PUBLIC_PATHS[@]}" = "6"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "0"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "0"
           '
 
           PROOF_PROFILE=ai-features-441 bash -c '
@@ -40,6 +42,8 @@ jobs:
             test "$PROOF_MAPPING_COUNT" = "10"
             test "$PROOF_EDITORIAL_CONTENT_ID" = "ai-redaction-assistee"
             test "${#PROOF_PUBLIC_PATHS[@]}" = "20"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "0"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "0"
           '
 
           PROOF_PROFILE=services-drupal-441 bash -c '
@@ -48,6 +52,8 @@ jobs:
             test "$PROOF_MAPPING_COUNT" = "7"
             test "$PROOF_EDITORIAL_CONTENT_ID" = "audit-drupal"
             test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "0"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "0"
           '
 
           PROOF_PROFILE=services-general-441 bash -c '
@@ -56,6 +62,8 @@ jobs:
             test "$PROOF_MAPPING_COUNT" = "7"
             test "$PROOF_EDITORIAL_CONTENT_ID" = "creation-site-web-professionnel"
             test "${#PROOF_PUBLIC_PATHS[@]}" = "14"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "0"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "0"
           '
 
           PROOF_PROFILE=pages-medium-441 bash -c '
@@ -64,6 +72,23 @@ jobs:
             test "$PROOF_MAPPING_COUNT" = "3"
             test "$PROOF_EDITORIAL_CONTENT_ID" = "equipe"
             test "${#PROOF_PUBLIC_PATHS[@]}" = "6"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "0"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "0"
+          '
+
+          PROOF_PROFILE=pages-final-441 bash -c '
+            set -euo pipefail
+            source scripts/runner/governed-content-transition-profiles.sh
+            test "$PROOF_MAPPING_COUNT" = "3"
+            test "$PROOF_EDITORIAL_CONTENT_ID" = "services"
+            test "$PROOF_EDITORIAL_MARKER" = "[proof-441-final-pages-editorial-survives]"
+            test "${#PROOF_PUBLIC_PATHS[@]}" = "6"
+            test "${#PROOF_BROWSER_ONLY_PATHS[@]}" = "2"
+            test "${PROOF_BROWSER_ONLY_PATHS[0]}" = "/fr/"
+            test "${PROOF_BROWSER_ONLY_PATHS[1]}" = "/en/"
+            test "${#PROOF_CONTACT_FORM_PATHS[@]}" = "2"
+            test "${PROOF_CONTACT_FORM_PATHS[0]}" = "/fr/contact"
+            test "${PROOF_CONTACT_FORM_PATHS[1]}" = "/en/contact"
           '
 
           if PROOF_PROFILE=unsupported-profile bash -c '

--- a/.github/workflows/self-hosted-governed-content-transition-proof.yml
+++ b/.github/workflows/self-hosted-governed-content-transition-proof.yml
@@ -136,6 +136,14 @@ jobs:
               )
               release_policy_must_change="no"
               ;;
+            pages-final-441)
+              target_ids=(
+                "homepage"
+                "services"
+                "contact"
+              )
+              release_policy_must_change="no"
+              ;;
             *)
               echo "Unsupported governed transition proof profile: $PROOF_PROFILE" >&2
               exit 1

--- a/scripts/runner/finalize-governed-content-transition-proof.sh
+++ b/scripts/runner/finalize-governed-content-transition-proof.sh
@@ -24,6 +24,8 @@ SQL_IDS="$PROOF_SQL_IDS"
 PILOT_IDS=("${PROOF_CONTENT_IDS[@]}")
 PILOT_PAYLOADS=("${PROOF_PAYLOADS[@]}")
 EXPECTED_ALIASES=("${PROOF_PUBLIC_PATHS[@]}")
+EXPECTED_BROWSER_ONLY_PATHS=("${PROOF_BROWSER_ONLY_PATHS[@]}")
+CONTACT_FORM_PATHS=("${PROOF_CONTACT_FORM_PATHS[@]}")
 EXPECTED_MAPPING_COUNT="$PROOF_MAPPING_COUNT"
 EDITORIAL_CONTENT_ID="$PROOF_EDITORIAL_CONTENT_ID"
 EDITORIAL_PATH="$PROOF_EDITORIAL_PATH"
@@ -305,6 +307,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    pages-final-441)
+      ddev drush php:eval '
+        $nid = \Drupal::database()
+          ->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "services")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Final services page mapping not found.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Final services page node not found.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content exact-head proof #441 final pages");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-final-pages-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-final-pages-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 
@@ -348,10 +375,34 @@ print(url.rstrip("/"))
 '
 }
 
+path_is_contact_form() {
+  local candidate="$1"
+  local path
+  for path in "${CONTACT_FORM_PATHS[@]}"; do
+    [[ "$candidate" == "$path" ]] && return 0
+  done
+  return 1
+}
+
 browser_pages_json() {
-  printf '%s\n' "${EXPECTED_ALIASES[@]}" \
-    | jq -R -s --arg editorial "$EDITORIAL_PATH" \
-      'split("\n")[:-1] | map([., . == $editorial])'
+  local path
+  local contact
+  {
+    for path in "${EXPECTED_ALIASES[@]}"; do
+      contact=false
+      if path_is_contact_form "$path"; then
+        contact=true
+      fi
+      jq -nc \
+        --arg path "$path" \
+        --arg editorial "$EDITORIAL_PATH" \
+        --argjson contact "$contact" \
+        '[$path, $path == $editorial, $contact]'
+    done
+    for path in "${EXPECTED_BROWSER_ONLY_PATHS[@]}"; do
+      jq -nc --arg path "$path" '[$path, false, false]'
+    done
+  } | jq -s '.'
 }
 
 proof_phase="replay-release-candidate"

--- a/scripts/runner/governed-content-transition-profiles.sh
+++ b/scripts/runner/governed-content-transition-profiles.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 : "${PROOF_PROFILE:?PROOF_PROFILE is required}"
 
+PROOF_BROWSER_ONLY_PATHS=()
+PROOF_CONTACT_FORM_PATHS=()
+
 case "$PROOF_PROFILE" in
   case-studies-440)
     PROOF_CONTENT_IDS=(
@@ -142,6 +145,33 @@ case "$PROOF_PROFILE" in
     PROOF_EDITORIAL_CONTENT_ID="equipe"
     PROOF_EDITORIAL_PATH="/fr/equipe"
     PROOF_EDITORIAL_MARKER="[proof-441-medium-pages-editorial-survives]"
+    ;;
+
+  pages-final-441)
+    PROOF_CONTENT_IDS=(
+      "homepage"
+      "services"
+      "contact"
+    )
+    PROOF_PUBLIC_PATHS=(
+      "/fr/accueil"
+      "/en/home"
+      "/fr/services"
+      "/en/services"
+      "/fr/contact"
+      "/en/contact"
+    )
+    PROOF_BROWSER_ONLY_PATHS=(
+      "/fr/"
+      "/en/"
+    )
+    PROOF_CONTACT_FORM_PATHS=(
+      "/fr/contact"
+      "/en/contact"
+    )
+    PROOF_EDITORIAL_CONTENT_ID="services"
+    PROOF_EDITORIAL_PATH="/fr/services"
+    PROOF_EDITORIAL_MARKER="[proof-441-final-pages-editorial-survives]"
     ;;
 
   *)

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -22,6 +22,8 @@ EDITORIAL_MARKER="$PROOF_EDITORIAL_MARKER"
 PILOT_IDS=("${PROOF_CONTENT_IDS[@]}")
 PILOT_PAYLOADS=("${PROOF_PAYLOADS[@]}")
 EXPECTED_ALIASES=("${PROOF_PUBLIC_PATHS[@]}")
+EXPECTED_BROWSER_ONLY_PATHS=("${PROOF_BROWSER_ONLY_PATHS[@]}")
+CONTACT_FORM_PATHS=("${PROOF_CONTACT_FORM_PATHS[@]}")
 EXPECTED_MAPPING_COUNT="$PROOF_MAPPING_COUNT"
 EDITORIAL_CONTENT_ID="$PROOF_EDITORIAL_CONTENT_ID"
 EDITORIAL_PATH="$PROOF_EDITORIAL_PATH"
@@ -103,7 +105,7 @@ snapshot_nodes() {
            nfd.title, COALESCE(pa.alias, '')
       FROM emerging_digital_content_sync_mapping m
       JOIN node n ON n.nid = m.entity_id
-      JOIN node_field_data nfd ON nfd.nid = n.nid
+      JOIN node_field_data nfd ON nfd.nid = m.entity_id
       LEFT JOIN path_alias pa
         ON pa.path = CONCAT('/node/', n.nid)
        AND pa.langcode = nfd.langcode
@@ -328,6 +330,31 @@ apply_editorial_edit() {
         $node->save();
       '
       ;;
+
+    pages-final-441)
+      ddev drush php:eval '
+        $database = \Drupal::database();
+        $nid = $database->select("emerging_digital_content_sync_mapping", "m")
+          ->fields("m", ["entity_id"])
+          ->condition("content_id", "services")
+          ->execute()
+          ->fetchField();
+        if (!$nid) {
+          throw new \RuntimeException("Final services page mapping not found for editorial proof.");
+        }
+        $node = \Drupal\node\Entity\Node::load((int) $nid);
+        if (!$node) {
+          throw new \RuntimeException("Final services page node not found for editorial proof.");
+        }
+        $node->setNewRevision(TRUE);
+        $node->setRevisionLogMessage("Governed Content transition proof #441 final pages");
+        $translation = $node->hasTranslation("fr") ? $node->getTranslation("fr") : $node;
+        if (!str_contains((string) $translation->label(), "[proof-441-final-pages-editorial-survives]")) {
+          $translation->setTitle($translation->label() . " [proof-441-final-pages-editorial-survives]");
+        }
+        $node->save();
+      '
+      ;;
   esac
 }
 
@@ -373,10 +400,34 @@ print(url.rstrip("/"))
 '
 }
 
+path_is_contact_form() {
+  local candidate="$1"
+  local path
+  for path in "${CONTACT_FORM_PATHS[@]}"; do
+    [[ "$candidate" == "$path" ]] && return 0
+  done
+  return 1
+}
+
 browser_pages_json() {
-  printf '%s\n' "${EXPECTED_ALIASES[@]}" \
-    | jq -R -s --arg editorial "$EDITORIAL_PATH" \
-      'split("\n")[:-1] | map([., . == $editorial])'
+  local path
+  local contact
+  {
+    for path in "${EXPECTED_ALIASES[@]}"; do
+      contact=false
+      if path_is_contact_form "$path"; then
+        contact=true
+      fi
+      jq -nc \
+        --arg path "$path" \
+        --arg editorial "$EDITORIAL_PATH" \
+        --argjson contact "$contact" \
+        '[$path, $path == $editorial, $contact]'
+    done
+    for path in "${EXPECTED_BROWSER_ONLY_PATHS[@]}"; do
+      jq -nc --arg path "$path" '[$path, false, false]'
+    done
+  } | jq -s '.'
 }
 
 run_browser_proof() {
@@ -391,7 +442,7 @@ import { mkdir } from 'node:fs/promises';
 
 const pages = JSON.parse(process.env.PROOF_PAGES_JSON);
 
-for (const [path, expectsMarker] of pages) {
+for (const [path, expectsMarker, expectsContactForm] of pages) {
   test(`released governed-content item remains public: ${path}`, async ({ page }, testInfo) => {
     const runtimeErrors = [];
     page.on('console', (message) => {
@@ -408,6 +459,15 @@ for (const [path, expectsMarker] of pages) {
 
     if (expectsMarker) {
       await expect(page.locator('body')).toContainText(process.env.PROOF_EDITORIAL_MARKER);
+    }
+
+    if (expectsContactForm) {
+      const form = page.locator('form').filter({ has: page.locator('[name="email"]') }).first();
+      await expect(form).toBeVisible();
+      for (const fieldName of ['name', 'email', 'subject', 'message', 'rgpd_consent']) {
+        await expect(form.locator(`[name="${fieldName}"]`), `Missing contact field ${fieldName} on ${path}`).toBeVisible();
+      }
+      await expect(form.locator('button[type="submit"], input[type="submit"]').first()).toBeVisible();
     }
 
     expect(runtimeErrors, `Browser runtime errors for ${path}`).toEqual([]);

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -59,7 +59,7 @@ write_result() {
       base_sha: $base_sha,
       target_sha: $target_sha,
       proof_profile: $proof_profile,
-      pilot_content_ids: $pilot_ids_json,
+      pilot_content_ids: $pilot_content_ids,
       editorial_marker: $marker,
       exit_code: $exit_code
     }' > "$RESULT_PATH"

--- a/scripts/runner/run-governed-content-transition-proof.sh
+++ b/scripts/runner/run-governed-content-transition-proof.sh
@@ -59,7 +59,7 @@ write_result() {
       base_sha: $base_sha,
       target_sha: $target_sha,
       proof_profile: $proof_profile,
-      pilot_content_ids: $pilot_content_ids,
+      pilot_content_ids: $pilot_ids_json,
       editorial_marker: $marker,
       exit_code: $exit_code
     }' > "$RESULT_PATH"
@@ -105,7 +105,7 @@ snapshot_nodes() {
            nfd.title, COALESCE(pa.alias, '')
       FROM emerging_digital_content_sync_mapping m
       JOIN node n ON n.nid = m.entity_id
-      JOIN node_field_data nfd ON nfd.nid = m.entity_id
+      JOIN node_field_data nfd ON nfd.nid = n.nid
       LEFT JOIN path_alias pa
         ON pa.path = CONCAT('/node/', n.nid)
        AND pa.langcode = nfd.langcode


### PR DESCRIPTION
## Résumé

Ajoute le profil trusted final `pages-final-441` pour préparer la libération contrôlée de `homepage`, `services` et `contact` sous #441.

Le profil encode côté trusted :

- exactement 3 IDs : `homepage`, `services`, `contact` ;
- exactement 6 aliases FR/EN ;
- 2 chemins browser-only `/fr/` et `/en/`, distincts des aliases Content Sync ;
- `services` comme cible de persistance éditoriale ;
- marqueur `[proof-441-final-pages-editorial-survives]` ;
- contrôle Playwright réel du formulaire sur `/fr/contact` et `/en/contact` : champs `name`, `email`, `subject`, `message`, `rgpd_consent` et bouton submit, sans soumission.

## Garanties

- les cinq profils historiques restent disponibles ;
- aucun ID/alias/path libre n’est fourni par la requête ;
- même gateway same-repo / OPEN-main / exact-head / ancestry / trusted-path refusal ;
- futur release candidate strictement `catalog.yml + 3 payloads`, policy inchangée ;
- aucune libération de contenu dans cette PR ;
- aucun catalogue, payload métier, policy, node, alias, menu ou configuration Drupal modifié.

Cette PR est ouverte initialement en draft afin de servir de surface de revue du diff trusted avant le gate CI final.

Closes #472
Refs #441