### PR TITLE
Issue #476: discover governed proof run ids without advancing main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Discover governed proof run ids for issue 476
+        shell: bash
+        env:
+          DISPATCH_SHA: c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+
+          echo "=== GATEWAY_RUNS_FOR_DISPATCH_SHA ==="
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "User-Agent: agency-proof-observer" \
+            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=20" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'
+
+          echo "=== RECENT_GOVERNED_PROOF_RUNS ==="
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "User-Agent: agency-proof-observer" \
+            "${api}/actions/runs?event=workflow_dispatch&per_page=50" \
+            | jq -c '.workflow_runs[]
+              | select(.name == "Agency governed content transition proof")
+              | {
+                  id,
+                  name,
+                  run_number,
+                  event,
+                  head_sha,
+                  created_at,
+                  updated_at,
+                  status,
+                  conclusion,
+                  html_url
+                }'
+
       - name: Validate governed transition proof shell syntax and profiles
         run: |
           set -euo pipefail

--- a/.github/workflows/ops-discover-proof-runs.yml
+++ b/.github/workflows/ops-discover-proof-runs.yml
@@ -1,0 +1,60 @@
+name: Ops discover governed proof runs
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover proof run ids
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query public GitHub Actions metadata
+        shell: bash
+        env:
+          DISPATCH_SHA: c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c
+        run: |
+          set -euo pipefail
+
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+          headers=(
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+            -H "User-Agent: agency-proof-observer"
+          )
+
+          echo "=== GATEWAY_RUNS_FOR_DISPATCH_SHA ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=20" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'
+
+          echo "=== RECENT_GOVERNED_PROOF_RUNS ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?event=workflow_dispatch&per_page=50" \
+            | jq -c '.workflow_runs[]
+              | select(.name == "Agency governed content transition proof")
+              | {
+                  id,
+                  name,
+                  run_number,
+                  event,
+                  head_sha,
+                  created_at,
+                  updated_at,
+                  status,
+                  conclusion,
+                  html_url
+                }'


### PR DESCRIPTION
## Diagnostic éphémère — NE PAS FUSIONNER

Ajoute uniquement un workflow `pull_request` GitHub-hosted qui interroge en lecture seule l’API publique GitHub Actions pour retrouver :

- le gateway associé au commit de dispatch `c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c` ;
- les derniers runs `Agency governed content transition proof` en `workflow_dispatch`.

Aucun token n’est envoyé à l’API, aucune écriture, aucun runner self-hosted, aucun code/config Drupal.

Cette PR sera fermée sans merge dès que les IDs auront été récupérés.

Refs #476 #474 #441