### PR TITLE
Issue #476: verify post-merge CI and deploy without advancing main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Discover governed proof run ids for issue 476
+        shell: bash
+        env:
+          DISPATCH_SHA: c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+
+          echo "=== GATEWAY_RUNS_FOR_DISPATCH_SHA ==="
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "User-Agent: agency-proof-observer" \
+            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=20" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'
+
+          echo "=== RECENT_GOVERNED_PROOF_RUNS ==="
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "User-Agent: agency-proof-observer" \
+            "${api}/actions/runs?event=workflow_dispatch&per_page=50" \
+            | jq -c '.workflow_runs[]
+              | select(.name == "Agency governed content transition proof")
+              | {
+                  id,
+                  name,
+                  run_number,
+                  event,
+                  head_sha,
+                  created_at,
+                  updated_at,
+                  status,
+                  conclusion,
+                  html_url
+                }'
+
       - name: Validate governed transition proof shell syntax and profiles
         run: |
           set -euo pipefail

--- a/.github/workflows/ops-discover-proof-runs.yml
+++ b/.github/workflows/ops-discover-proof-runs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Query public GitHub Actions metadata
         shell: bash
         env:
-          DISPATCH_SHA: c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c
+          POST_MERGE_SHA: 7511588f9b23366e4132b773236366ed57e6159c
         run: |
           set -euo pipefail
 
@@ -25,14 +25,15 @@ jobs:
             -H "User-Agent: agency-proof-observer"
           )
 
-          echo "=== GATEWAY_RUNS_FOR_DISPATCH_SHA ==="
+          echo "=== RUNS_FOR_POST_MERGE_SHA ==="
           curl -fsSL "${headers[@]}" \
-            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=20" \
+            "${api}/actions/runs?head_sha=${POST_MERGE_SHA}&per_page=30" \
             | jq -c '.workflow_runs[] | {
                 id,
                 name,
                 run_number,
                 event,
+                head_branch,
                 head_sha,
                 created_at,
                 updated_at,
@@ -41,16 +42,17 @@ jobs:
                 html_url
               }'
 
-          echo "=== RECENT_GOVERNED_PROOF_RUNS ==="
+          echo "=== RECENT_DEPLOY_PRODUCTION_RUNS ==="
           curl -fsSL "${headers[@]}" \
-            "${api}/actions/runs?event=workflow_dispatch&per_page=50" \
+            "${api}/actions/runs?per_page=50" \
             | jq -c '.workflow_runs[]
-              | select(.name == "Agency governed content transition proof")
+              | select(.name == "Deploy Production")
               | {
                   id,
                   name,
                   run_number,
                   event,
+                  head_branch,
                   head_sha,
                   created_at,
                   updated_at,

--- a/.github/workflows/ops-discover-proof-runs.yml
+++ b/.github/workflows/ops-discover-proof-runs.yml
@@ -1,0 +1,60 @@
+name: Ops discover governed proof runs
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover proof run ids
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query public GitHub Actions metadata
+        shell: bash
+        env:
+          DISPATCH_SHA: c2d7d80233f88c6fcb5936a5ce786a2bdac43b0c
+        run: |
+          set -euo pipefail
+
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+          headers=(
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+            -H "User-Agent: agency-proof-observer"
+          )
+
+          echo "=== GATEWAY_RUNS_FOR_DISPATCH_SHA ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=20" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'
+
+          echo "=== RECENT_GOVERNED_PROOF_RUNS ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?event=workflow_dispatch&per_page=50" \
+            | jq -c '.workflow_runs[]
+              | select(.name == "Agency governed content transition proof")
+              | {
+                  id,
+                  name,
+                  run_number,
+                  event,
+                  head_sha,
+                  created_at,
+                  updated_at,
+                  status,
+                  conclusion,
+                  html_url
+                }'


### PR DESCRIPTION
## Diagnostic éphémère — NE PAS FUSIONNER

Réutilise la branche hosted-only de #476 pour retrouver les runs post-merge associés à :

`main@7511588f9b23366e4132b773236366ed57e6159c`

Objectif : confirmer CI `main` puis `Deploy Production` après merge de #475.

Aucune écriture API, aucun runner self-hosted, aucun changement Drupal/Composer/production. Cette PR sera fermée sans merge immédiatement après lecture des IDs.

Refs #476 #474 #441