### PR TITLE
Issue #479: align Governed Content docs after pending reaches zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,60 +68,51 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - La PR doit cibler `main` et referencer le ticket avec `Closes #X`.
 - Aucun changement hors perimetre du ticket.
 
-## 4. Governed Content / Content Sync de transition
+## 4. Governed Content / Content Sync
 
 - Lire `docs/governed-content-trajectory.md` avant toute modification du
   catalogue Content Sync.
-- Le catalogue actuel est en **migration controlee** d'un bootstrap massif vers
-  un petit ensemble Governed Content ; il ne doit plus servir de precedent pour
-  versionner tout nouveau contenu marketing/editorial.
-- Les sources machine autoritatives de la transition sont le catalogue
+- La migration controlee des contenus ordinaires est **terminee depuis #441**.
+  Le catalogue ne doit plus servir de precedent pour versionner du nouveau
+  contenu marketing/editorial.
+- Les sources machine autoritatives sont le catalogue
   `web/modules/custom/emerging_digital_content/content_sync/catalog.yml` et la
   policy `Drupal\emerging_digital_content\ContentSync\Policy\GovernedContentPolicy`.
   La documentation explique cet etat mais ne constitue pas une seconde liste
   d'admission.
-- Fichiers de contenu de transition :
-  `web/modules/custom/emerging_digital_content/content_sync/node/*.yml`.
-- Trois IDs sont explicitement Governed Content : `mentions-legales`,
-  `politique-confidentialite`, `politique-cookies`.
-- Apres le pilote #440, le lot `ai_feature` #451 et les deux lots services #458
-  et #464, **6** IDs sont encore grandfathered `LEGACY_RELEASE_PENDING`. Aucun
-  nouvel ID ne peut etre ajoute a cette classe et leur retrait doit suivre la
-  procedure de liberation documentee.
-- Les trois cas clients pilotes `cas-client-refonte-drupal-institutionnelle`,
-  `cas-client-migration-drupal-11` et `cas-client-integration-ia-editoriale`
-  sont `RELEASED` depuis #440 et ne doivent pas etre readmis par inadvertance.
-- Les 10 contenus `ai_feature` du lot #451 sont egalement `RELEASED`.
-- Les 14 contenus `service` liberes par #458 puis #464 sont egalement
-  `RELEASED`; le catalogue de transition ne contient plus aucun bundle
-  `service`.
-- Au total, 27 contenus ordinaires ont maintenant ete liberes et prouves. Il
-  reste uniquement 6 pages ordinaires pending. La liste machine autoritative
-  reste exclusivement `GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS`.
-- Les pages ordinaires a impact moyen doivent etre traitees avant les pages a
-  fort impact `homepage`, `services` et `contact`, qui restent reservees aux
-  derniers lots avec browser gates dedies.
-- Ne jamais ajouter un Article ou un nouveau contenu marketing/editorial
-  ordinaire au catalogue. Une nouvelle admission exige un ticket, une classe
-  gouvernee justifiee, une identite stable, une procedure de review/promotion et
-  un rollback explicite.
-- Ne jamais retirer un ID grandfathered du catalogue avant qu'un etat de mapping
-  `released` ignore par le prune soit applique et prouve sur l'environnement de
-  transition concerne. Retirer de la gouvernance Git ne signifie jamais
-  supprimer/depublier Drupal.
-- Apres liberation, le contenu ordinaire devient editor-owned dans Drupal et ne
-  doit plus etre ecrase par Content Sync lors des deploiements suivants.
-- `GovernedContentCatalogPolicyTest` et la policy runtime sont les barrieres CI
-  de transition : toute admission ou liberation doit mettre a jour explicitement
-  `LEGACY_RELEASE_PENDING_IDS`.
+- Le catalogue contient uniquement trois contenus explicitement Governed
+  Content : `mentions-legales`, `politique-confidentialite`,
+  `politique-cookies`.
+- `GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS` est vide. Aucun contenu
+  ordinaire ne doit etre ajoute ou readmis dans cette classe.
+- Les 33 contenus ordinaires historiquement pilotes par Content Sync ont ete
+  liberes et prouves : 3 cas clients du pilote #440, puis 30 contenus sous
+  #441 (10 `ai_feature`, 14 `service` et 6 `page`). Ils sont editor-owned dans
+  Drupal et ne doivent pas etre repris par Content Sync lors des deploiements.
+- Les anciens payloads ordinaires RELEASED ne doivent pas etre recrees dans
+  `content_sync/node/` par habitude. Toute nouvelle admission exige un ticket,
+  une classe gouvernee justifiee, une identite stable, une procedure de
+  review/promotion et un rollback explicite.
+- Retirer de la gouvernance Git n'a jamais signifie supprimer ou depublier
+  Drupal. Les preuves #440/#441 ont conserve node IDs, UUID, traductions,
+  aliases et revisions pendant les releases et les rollbacks.
+- Les commandes `emerging:content-sync:release` et `:readmit` restent des
+  primitives de transition/rollback auditees ; elles ne definissent plus un
+  backlog ordinaire a liberer.
+- `GovernedContentCatalogPolicyTest`, la policy runtime et les tests de release
+  protegent l'admission durable et empechent la readmission accidentelle des
+  contenus ordinaires deja RELEASED.
+- La prochaine etape est #442 : converger la facade, la terminologie et la dette
+  custom Content Sync vers son role reel de Governed Content, sans rupture de
+  compatibilite production.
 - Valider avant toute application :
   `ddev drush emerging:content-sync:validate`.
 - Toujours tester en lecture seule avant ecriture :
   `ddev drush emerging:content-sync --all --dry-run`.
-- Application globale de transition : `ddev drush emerging:content-sync --all`.
+- Application globale : `ddev drush emerging:content-sync --all`.
 - Application ciblee :
   `ddev drush emerging:content-sync <content-id> --dry-run`, puis sans
-  `--dry-run`.
+  `--dry-run` lorsque le ticket l'autorise.
 - Content Sync doit rester idempotent, lisible en dry-run et prudent en
   production.
 - Ne pas recycler les `legacy_uuid`, mappings ou identifiants metier existants.

--- a/docs/governed-content-trajectory.md
+++ b/docs/governed-content-trajectory.md
@@ -1,16 +1,16 @@
 # Governed Content — trajectoire de convergence de Content Sync
 
-Statut : **transition active — pilote #440, lot `ai_feature` #451 et deux lots services #458/#464 terminés**  
-Date : **2026-08-17**  
+Statut : **migration des contenus ordinaires terminée — #441 CLOSED ; convergence de façade #442 READY**  
+Date : **2026-08-18**  
 Ticket d'origine : **#385**  
-Mises à jour d'inventaire : **#445, #453, #460, #466**  
+Migration contrôlée : **#439, #440, #441**  
 Parent : **#60**
 
 ## 1. Décision
 
 Le Content Sync Agency a correctement rempli son rôle de bootstrap et de
-promotion déterministe du contenu initial. Il ne doit toutefois plus devenir la
-source de vérité Git de tout le contenu éditorial courant.
+promotion déterministe du contenu initial. Il ne doit plus être la source de
+vérité Git du contenu éditorial ordinaire.
 
 La cible est :
 
@@ -25,18 +25,19 @@ contenu marketing / éditorial ordinaire
 -> Drupal
 -> workflow éditeur normal
 -> révisions / traductions / permissions Drupal
--> pas d'écrasement par Git après libération contrôlée
+-> pas d'écrasement par Git
 ```
 
-La migration est progressive :
+La migration des contenus ordinaires est désormais achevée :
 
 - #439 a introduit le lifecycle `released`, la release/readmission explicite et
   les protections fail-closed ;
 - #440 a libéré et prouvé les trois cas clients pilotes ;
-- #451 a libéré et prouvé le lot complet des dix contenus `ai_feature` ;
-- #458 a libéré et prouvé un premier lot de sept services Drupal/qualité ;
-- #464 a libéré et prouvé les sept derniers services ordinaires ;
-- #441 poursuit maintenant les six pages ordinaires restantes par lots bornés.
+- #451 a libéré les dix contenus `ai_feature` ;
+- #458 puis #464 ont libéré les quatorze contenus `service` ;
+- #470 a libéré trois pages ordinaires à impact moyen ;
+- #474 a libéré le lot final `homepage`, `services`, `contact` ;
+- #441 est fermé avec `LEGACY_RELEASE_PENDING_IDS = []`.
 
 ## 2. Sources de vérité
 
@@ -57,47 +58,43 @@ GOVERNED_CONTENT_IDS
 LEGACY_RELEASE_PENDING_IDS
 ```
 
-La documentation explique la trajectoire, les invariants et les étapes. Elle ne
-doit jamais devenir une seconde allowlist copiée à la main.
+La documentation explique les invariants, l'historique de migration et la cible.
+Elle ne doit jamais devenir une seconde allowlist copiée à la main.
 
-## 3. Inventaire courant après #464
+## 3. Inventaire courant après #474/#475
 
 Inventaire recalculé depuis le catalogue et la policy versionnés sur `main`
-après le merge de #464 :
+après le merge `7511588f9b23366e4132b773236366ed57e6159c` :
 
 ```text
 CATALOG_VERSION=1
-CATALOG_COUNT=9
-BUNDLE_COUNTS={"page":9}
+CATALOG_COUNT=3
+BUNDLE_COUNTS={"page":3}
 MISSING_REFERENCED_FILES=[]
 UNREFERENCED_NODE_FILES=[]
 DUPLICATE_IDS=[]
 ALL_HAVE_FR_EN=true
-LEGACY_UUID_COUNT=8
+LEGACY_UUID_COUNT=3
 ```
-
-`LEGACY_UUID_COUNT` compte uniquement les entrées du catalogue portant encore
-explicitement la clé top-level `legacy_uuid`. Il ne faut pas l'assimiler au
-nombre total d'entrées du catalogue.
 
 La policy runtime contient :
 
 ```text
 3 IDs = GOVERNED
-6 IDs = LEGACY_RELEASE_PENDING
+0 ID = LEGACY_RELEASE_PENDING
 ```
 
 Donc :
 
 ```text
-9 entrées cataloguées
-= 3 Governed Content
-+ 6 pages ordinaires encore en transition
+3 entrées cataloguées
+= 3 Governed Content légaux
++ 0 contenu ordinaire en transition
 ```
 
 ### 3.1 Governed Content conservé sous Git
 
-Les trois contenus actuellement admis durablement sont :
+Les trois contenus durablement admis sont :
 
 | Source ID | Bundle | Classification | Motif |
 |---|---|---|---|
@@ -106,65 +103,51 @@ Les trois contenus actuellement admis durablement sont :
 | `politique-cookies` | `page` | `GOVERNED` | politique cookies |
 
 Ces contenus restent canoniques dans le repository jusqu'à décision contraire
-explicite.
+explicite et revue.
 
-### 3.2 Contenu ordinaire encore pending
+### 3.2 Contenu ordinaire pending
 
-La liste exacte des 6 contenus encore `LEGACY_RELEASE_PENDING` appartient à
-`GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS` et ne doit pas être recopiée
-ici.
-
-Répartition actuelle, dérivée du catalogue :
+Il n'existe plus de contenu ordinaire `LEGACY_RELEASE_PENDING`.
 
 ```text
 service pending: 0
-page ordinaire pending: 6
+page ordinaire pending: 0
 ```
 
-Les trois pages ordinaires à impact moyen doivent être libérées avant les pages
-à fort impact (`homepage`, `services`, `contact`), qui restent réservées au lot
-final avec browser gates dédiés.
+`GovernedContentPolicy::LEGACY_RELEASE_PENDING_IDS` est vide et ne doit pas être
+réutilisé comme file d'attente pour de nouveaux contenus marketing.
 
-### 3.3 Lots déjà RELEASED
+### 3.3 Contenus ordinaires RELEASED
 
-#### Pilote case clients — #440
-
-Les trois vrais cas clients historiques ont été libérés :
+La trajectoire complète a libéré **33 contenus ordinaires** :
 
 ```text
-cas-client-refonte-drupal-institutionnelle
-cas-client-migration-drupal-11
-cas-client-integration-ia-editoriale
+3 case studies du pilote #440
++ 10 ai_feature sous #441
++ 14 service sous #441
++ 6 page sous #441
+= 33 contenus RELEASED
 ```
 
-Leur bundle historique est `case_client`.
+#441 représentait les 30 contenus restant après le pilote #440 ; il est désormais
+terminé.
 
-Les anciens identifiants documentaires suivants n'ont jamais constitué les IDs
-autoritatifs du catalogue et ne doivent pas être réintroduits :
+## 4. Preuves de migration
 
-```text
-cas-clients/refonte-drupal-b2b
-cas-clients/plateforme-contenus-api-first
-cas-clients/industrie-site-haute-disponibilite
-```
-
-#### Lot `ai_feature` — #451
-
-Les dix contenus `ai_feature` historiquement Content Sync ont été libérés en un
-lot homogène et gouverné.
-
-La preuve self-hosted a validé successivement :
+Chaque lot réel a utilisé le même principe :
 
 ```text
 base active
--> release candidate released
--> HEAD final released
+-> release candidate reviewed
+-> mapping released
+-> Content Sync sans réadmission implicite
 -> modification éditoriale Drupal persistante
--> Browser Validation FR/EN desktop/mobile
--> rollback/readmission active
+-> HEAD final exact toujours released
+-> Browser Validation lorsque nécessaire
+-> rollback/readmission active avec identité conservée
 ```
 
-Résultat de preuve :
+### 4.1 Lot `ai_feature` — #451
 
 ```text
 workflow run: 31951005179
@@ -173,36 +156,10 @@ release candidate: bf6d3aaaaa5e697ecd3a319001c4800e611f9ddb
 exact HEAD: 960b16d3a041846bd65adcc31a3100d8f5d144c9
 result: PASS
 browser: 40/40 release candidate + 40/40 exact HEAD
+artifact sha256: 36dcb51eba0ca2146b68214c91e9b3ed07df5e43fd9f72607c040d1a40218aca
 ```
 
-L'artefact de preuve du run porte le digest :
-
-```text
-sha256:36dcb51eba0ca2146b68214c91e9b3ed07df5e43fd9f72607c040d1a40218aca
-```
-
-Les dix mappings conservent la même identité node/UUID/hash pendant la release,
-restent `released` au HEAD exact et retrouvent `active` pendant le rollback.
-Les diffs d'identité et d'état node de la preuve sont vides.
-
-#### Premier lot services Drupal/qualité — #458
-
-Sept landing pages de service ont ensuite été libérées avec le profil trusted
-`services-drupal-441`.
-
-La preuve a couvert la même séquence complète :
-
-```text
-base active
--> release candidate released
--> Content Sync sans réadmission
--> modification éditoriale Drupal persistante
--> HEAD final exact released
--> Browser Validation FR/EN desktop/mobile
--> rollback/readmission active
-```
-
-Résultat de preuve :
+### 4.2 Premier lot services — #458
 
 ```text
 workflow run: 31953623538
@@ -211,40 +168,10 @@ release candidate: 0b40245817d3781046e5d596a1febee3323eed4e
 exact HEAD: feff40159e973ecd242d2b7041bf38833c86d8ab
 result: PASS
 browser: 28/28 release candidate + 28/28 exact HEAD
+artifact sha256: f0e03f4846a40201ff838a52a71d0e71d7d70361a1564122a7d6b677b8b2b5eb
 ```
 
-L'artefact de preuve du run porte le digest :
-
-```text
-sha256:f0e03f4846a40201ff838a52a71d0e71d7d70361a1564122a7d6b677b8b2b5eb
-```
-
-Les sept mappings conservent exactement leurs node IDs, UUID et catalog hashes
-pendant la release et au HEAD final. Tous les diffs d'identité et d'état node
-sont vides. La modification éditoriale de `audit-drupal` crée une nouvelle
-révision et survit à un Content Sync complet. Les 28 captures du HEAD final sont
-bit-à-bit identiques aux 28 captures du release candidate. Le rollback remet
-les sept mappings à `active` avec la même identité.
-
-#### Second lot services ordinaires — #464
-
-Les sept derniers contenus de bundle `service` ont été libérés avec le profil
-trusted `services-general-441`. Le catalogue de transition ne contient donc
-plus aucun service.
-
-La preuve a validé :
-
-```text
-base active
--> release candidate released
--> Content Sync sans réadmission
--> modification éditoriale Drupal persistante
--> HEAD final exact released
--> Browser Validation FR/EN desktop/mobile
--> rollback/readmission active
-```
-
-Résultat de preuve :
+### 4.3 Second lot services — #464
 
 ```text
 workflow run: 32067198176
@@ -253,64 +180,96 @@ release candidate: 295b1c8fb5afba2b0db93f13dcf6f07d73be6846
 exact HEAD: c235264ed3c490b8defd359921cab5a857d9cb77
 result: PASS
 browser: 28/28 release candidate + 28/28 exact HEAD
+artifact sha256: 87d2128494142f6602fc25b58515f1370a99b128797fa2c08316abd92fd91849
 ```
 
-L'artefact de preuve du run porte le digest :
+### 4.4 Pages à impact moyen — #470
 
 ```text
-sha256:87d2128494142f6602fc25b58515f1370a99b128797fa2c08316abd92fd91849
+workflow run: 32070506061
+profile: pages-medium-441
+release candidate: edf8b8e5208cfc6fb7d5f3a79dc8c0babb72d586
+exact HEAD: a3097178391830c2df1690bdc3387f4f5fbc2407
+result: PASS
 ```
 
-Les sept mappings conservent exactement leurs node IDs, UUID et catalog hashes.
-Tous les diffs d'identité et d'état node sont vides. La modification éditoriale
-de `creation-site-web-professionnel` crée une deuxième révision et survit au
-Content Sync. Les 28 captures du HEAD final sont bit-à-bit identiques aux 28
-captures du release candidate. Le rollback remet les sept mappings à `active`
-avec la même identité.
+Le lot a libéré `cas-clients`, `equipe` et `ia-drupal` avant les pages à fort
+impact.
 
-## 4. Pourquoi la migration ne doit pas être brutale
+### 4.5 Lot final — #474/#475
 
-Le déploiement production appelle :
+Le lot final a libéré exactement `homepage`, `services` et `contact` avec le
+profil trusted `pages-final-441`.
 
 ```text
-emerging:content-sync:validate
-emerging:content-sync --all --dry-run
-emerging:content-sync --all
-emerging:content-sync:report --severity=error
+CI exact-head: 32089079390 / #867 / SUCCESS
+gateway: 32089390437 / #7 / SUCCESS
+proof: 32089398559 / #6 / SUCCESS
+release candidate: 9d9d615679d345ddacbd11a3c4fcdbba35580fb5
+exact HEAD: 6c420c65403ee036c3f5773f2157c5a99ac5dac2
+merge main: 7511588f9b23366e4132b773236366ed57e6159c
+result: PASS
+artifact id: 9308024782
+artifact sha256: caef27d7dd696c28e7470e05bad68ea193534eec3715db08f5bc040a1a42bd39
 ```
 
-Le chemin normal n'active pas `--prune`. Le prune `unpublish` possède un
-garde-fou production explicite.
+La preuve a confirmé :
 
-Invariant fondamental :
+- les trois mappings `active -> released -> released` ;
+- conservation des node IDs, UUID et catalog hashes ;
+- diffs d'identité et de node state vides ;
+- `services` passé de révision 1 à 2 pendant l'edit proof ;
+- marqueur `[proof-441-final-pages-editorial-survives]` conservé après resync ;
+- 16/16 Playwright au release candidate et 16/16 au HEAD final ;
+- six aliases FR/EN plus les fronts `/fr/` et `/en/` ;
+- formulaire contact FR/EN visible avec les champs attendus et submit, sans
+  soumission ;
+- 16 captures release candidate et 16 captures HEAD final, paires correspondantes
+  identiques ;
+- rollback/readmission des trois mappings vers `active` avec identité conservée.
+
+Post-merge :
+
+```text
+CI #870: 32116483748 / SUCCESS
+Deploy Production #180: 32116483785 / SUCCESS
+```
+
+## 5. Invariant de release
 
 ```text
 retirer un contenu de la gouvernance Git
-!= supprimer ou dépublier son entité Drupal
+!= supprimer Drupal
+!= dépublier Drupal
+!= recréer Drupal
 ```
 
-Le lifecycle `released` implémenté dans #439 garantit précisément cette
-séparation : un mapping released est ignoré par le prune et ne peut pas être
-repris implicitement par un Content Sync normal.
+Le lifecycle `released` implémenté dans #439 garantit cette séparation : un
+mapping released est ignoré par le prune et ne peut pas être repris implicitement
+par un Content Sync normal.
 
-## 5. Taxonomie de gouvernance cible
+La commande de release a été la primitive de migration. Maintenant que pending=0,
+elle reste une capacité d'audit/compatibilité et non un mécanisme de gestion du
+contenu éditorial courant.
+
+## 6. Taxonomie de gouvernance cible
 
 Un contenu n'entre dans le futur catalogue Governed Content que s'il appartient
 explicitement à une classe approuvée.
 
-### 5.1 Légal et réglementaire
+### 6.1 Légal et réglementaire
 
 Exemples : mentions légales, confidentialité, cookies et notices réglementaires
 réellement requises.
 
 C'est le seul groupe actuellement matérialisé dans le catalogue.
 
-### 5.2 Prompts système approuvés
+### 6.2 Prompts système approuvés
 
 Un prompt système peut être gouverné seulement si :
 
 - il est réellement un artefact métier versionnable ;
-- sa revue humaine avant promotion est requise ;
+- sa revue avant promotion est requise ;
 - il ne contient aucun secret, token ou credential ;
 - il possède une identité stable et une destination runtime définie ;
 - le mécanisme de matérialisation est explicite.
@@ -318,7 +277,7 @@ Un prompt système peut être gouverné seulement si :
 Cette classe reste une capacité future, pas un prétexte pour créer de nouveaux
 payloads.
 
-### 5.3 Contrats, métadonnées contrôlées et ressources critiques
+### 6.3 Contrats, métadonnées contrôlées et ressources critiques
 
 Éligibles uniquement lorsque l'artefact doit être identique entre environnements
 et que l'historique Git/review apporte une garantie métier concrète.
@@ -326,9 +285,9 @@ et que l'historique Git/review apporte une garantie métier concrète.
 Une ressource n'est pas « critique » simplement parce qu'elle est pratique à
 versionner. Toute nouvelle admission exige un ticket et une justification.
 
-## 6. États de cycle de vie
+## 7. États de cycle de vie
 
-La trajectoire utilise quatre états :
+La terminologie historique utilise :
 
 ```text
 GOVERNED
@@ -337,30 +296,21 @@ RELEASED
 RETIRED
 ```
 
-### `GOVERNED`
+État courant :
 
-Le payload versionné est canonique. Drupal est une matérialisation runtime. Les
-changements suivent PR -> revue -> promotion.
+- `GOVERNED` : trois contenus légaux ;
+- `LEGACY_RELEASE_PENDING` : ensemble vide ;
+- `RELEASED` : contenus ordinaires désormais editor-owned dans Drupal ;
+- `RETIRED` : retrait volontaire d'un contenu gouverné, opération distincte et
+  explicite.
 
-### `LEGACY_RELEASE_PENDING`
+#442 doit maintenant déterminer quelles notions de transition restent utiles
+dans la façade publique du module et lesquelles peuvent être renommées,
+dépréciées ou confinées sans casser les garanties runtime.
 
-Contenu historiquement versionné par le bootstrap Content Sync mais destiné à
-revenir au workflow éditorial Drupal.
+## 8. Identité, révisions, traductions et aliases
 
-### `RELEASED`
-
-Le contenu n'est plus piloté par Git. L'entité Drupal existante, ses
-traductions, aliases et révisions restent en place et deviennent la source
-éditoriale runtime.
-
-### `RETIRED`
-
-Retrait réellement voulu d'un contenu gouverné. La suppression ou dépublication
-reste une opération distincte, explicite et auditable.
-
-## 7. Identité, UUID et mapping
-
-L'identité métier existante reste la clé de convergence :
+L'identité métier reste :
 
 ```text
 source/business ID
@@ -368,87 +318,45 @@ source/business ID
 -> target entity ID / UUID
 ```
 
-Règles :
+Règles conservées :
 
-- le `source_id` reste stable tant que l'élément est gouverné ou en transition ;
-- le mapping est propre à chaque environnement ;
-- `target_id` et `target_uuid` identifient l'entité runtime locale ;
-- `legacy_uuid` reste une graine/héritage de migration et ne doit pas être
-  recyclé ;
-- le passage `released` conserve l'identité de l'entité existante ;
-- une release ne recrée jamais le node.
-
-## 8. Révisions, traductions et aliases
-
-Avant libération d'un ID ordinaire :
-
-- vérifier les traductions FR/EN runtime ;
-- vérifier les aliases FR/EN ;
-- conserver le node existant et son UUID ;
-- conserver une révision récupérable ;
-- enregistrer l'état final du mapping et son checksum.
-
-Après libération :
-
-- les traductions deviennent éditables via Drupal ;
-- les aliases ne sont plus réappliqués depuis le payload Git ;
-- un déploiement Content Sync normal ne doit plus toucher le contenu ;
-- un ancien commit Git ne doit pas reprendre automatiquement possession du node.
+- ne jamais recycler un `source_id`, `legacy_uuid` ou mapping historique ;
+- une release ne recrée jamais le node ;
+- traductions FR/EN et aliases doivent rester stables pendant une transition ;
+- les contenus RELEASED sont éditables via Drupal et ne sont plus réappliqués
+  depuis un payload Git ;
+- un ancien commit ne doit pas reprendre automatiquement possession d'un node.
 
 ## 9. Promotion et revue
 
-### 9.1 Governed Content
+### Governed Content
 
 ```text
 changement payload
 -> PR
 -> validation schéma/politique
--> matérialisation staging/preprod
--> validation fonctionnelle + rendu si applicable
--> revue humaine
+-> matérialisation staging/preprod si nécessaire
+-> validation fonctionnelle + rendu
+-> revue
 -> merge du même commit
 -> promotion production
 -> validation post-déploiement
 ```
 
-### 9.2 Contenu ordinaire libéré
+### Contenu ordinaire RELEASED
 
 Le contenu suit le workflow Drupal normal : permissions, révisions, traduction
 et validation humaine. Il n'est pas réexporté automatiquement vers
 `content_sync/`.
 
-## 10. Positionnement des primitives
+## 10. Admission policy après migration
 
-### Content Sync custom actuel — `KEEP -> CONVERGE`
-
-À conserver pendant la transition pour : parsing du catalogue, validation,
-mapping, idempotence/checksums, traductions/aliases, matérialisation
-déterministe, rapports et dry-run.
-
-Le but est de réduire son domaine à ce qui mérite réellement la gouvernance Git,
-pas de construire une nouvelle plateforme custom.
-
-### Core Workspaces
-
-Responsabilité différente : staging de contenu/révisions dans Drupal. Il ne
-remplace pas à lui seul la promotion déterministe inter-environnements de
-Governed Content.
-
-### Default Content Deploy — `EVALUATE LATER`
-
-À réévaluer seulement si une solution contrib remplace réellement une partie du
-materializer/mapping custom avec des garanties au moins équivalentes.
-
-## 11. Admission policy
-
-Pendant la migration, la policy runtime contient deux ensembles explicites :
+État machine :
 
 ```text
 GOVERNED_CONTENT_IDS = 3 IDs légaux
-LEGACY_RELEASE_PENDING_IDS = 6 IDs grandfathered
+LEGACY_RELEASE_PENDING_IDS = []
 ```
-
-La liste pending ne peut que diminuer.
 
 Règle :
 
@@ -466,161 +374,46 @@ nouvel ID Governed Content
 `GovernedContentCatalogPolicyTest` vérifie que le catalogue et la policy restent
 alignés.
 
-## 12. Libération contrôlée
+## 11. Rollback et readmission
 
-La primitive a été implémentée par #439. La procédure opérationnelle détaillée
-est documentée dans `docs/governed-content-release.md`.
+La primitive `emerging:content-sync:readmit` reste une capacité explicite de
+rollback pour un mapping `released`. Elle ne doit jamais devenir une reprise de
+contrôle implicite.
 
-Séquence minimale :
+Ordre de rollback :
 
-1. sélectionner un lot d'IDs encore `LEGACY_RELEASE_PENDING` ;
-2. valider le catalogue et lancer le dry-run global ;
-3. vérifier node, UUID, traductions, aliases et révisions ;
-4. construire un release candidate borné ;
-5. exécuter `emerging:content-sync:release <id> --dry-run` puis `--apply` dans
-   l'environnement de preuve ;
-6. vérifier les mappings `released` et les entités inchangées ;
-7. appliquer le HEAD final qui réduit explicitement la policy ;
-8. rejouer Content Sync ;
-9. prouver une modification éditoriale persistante ;
-10. valider rendu FR/EN desktop/mobile et rollback ;
-11. fusionner uniquement le HEAD exact prouvé.
+1. restaurer explicitement l'ID et son payload dans un checkout gouverné ;
+2. `readmit --dry-run` ;
+3. `readmit --apply` ;
+4. vérifier la même identité node/UUID ;
+5. resynchroniser explicitement ;
+6. vérifier FR/EN, aliases, publication et rendu.
 
-Invariant :
+`--prune=unpublish` n'est pas un mécanisme de rollback de release.
 
-```text
-catalogue removal
-MUST NOT happen
-before released mapping semantics are applied and proven
-```
+## 12. Prochaine convergence — #442
 
-## 13. Prune
+La migration étant terminée, le chantier suivant n'est **pas** un nouveau lot de
+contenu. #442 doit converger la façade `emerging_digital_content` vers son rôle
+réel de Governed Content.
 
-Le prune reste une primitive de retrait volontaire, pas un outil de migration
-vers l'édition Drupal.
+Ordre recommandé :
 
-- `active` absent du catalogue peut être candidat au prune selon la policy ;
-- `released` absent du catalogue est ignoré ;
-- `pruned` reste terminal pour l'action historique correspondante ;
-- la réadmission d'un contenu released exige une décision explicite.
+1. inventorier les APIs, commandes et services encore nommés comme bootstrap
+   générique ;
+2. distinguer ce qui reste nécessaire aux trois contenus gouvernés de ce qui
+   n'était utile qu'à la migration legacy ;
+3. définir les alias/dépréciations nécessaires avant tout renommage ;
+4. préserver idempotence, dry-run, mapping, rollback, prune guards et production ;
+5. réduire la dette custom seulement après preuve de compatibilité ;
+6. mettre à jour `docs/governed-content-release.md`, commandes et exemples une
+   fois la décision de façade matérialisée.
 
-Le garde-fou production de `--prune=unpublish` reste obligatoire.
-
-## 14. Rollback
-
-### Governed Content
+Invariant de #442 :
 
 ```text
-commit/payload précédent approuvé
--> promotion
--> sync ciblé
--> vérification runtime
+migration terminée
+!= autorisation de casser les primitives éprouvées
 ```
 
-### Libération de mapping
-
-Le rollback doit permettre de réintroduire explicitement l'ID/payload, exécuter
-la readmission, préserver l'identité du node et vérifier traductions/aliases.
-
-Aucun rollback ne doit écraser silencieusement des modifications éditoriales
-réalisées après une libération déjà acceptée.
-
-## 15. Données sensibles
-
-Governed Content n'est pas un coffre-fort.
-
-Interdit dans les payloads : secrets provider, tokens, mots de passe, clés
-privées, credentials, variables sensibles ou dumps arbitraires contenant des
-secrets.
-
-## 16. Backlog de migration
-
-### GC-1 — mapping `released` et commandes de transition — **TERMINÉ (#439)**
-
-La release/readmission explicite, le fail-closed et l'exclusion du prune sont
-implémentés et testés.
-
-### GC-2 — pilote de libération — **TERMINÉ (#440)**
-
-Les trois cas clients réels ont été libérés, validés au navigateur et leur
-rollback a été prouvé avant merge.
-
-### GC-3 — libération par lots — **EN COURS (#441)**
-
-Progression :
-
-```text
-case clients (3)              -> RELEASED #440
-ai_feature (10)               -> RELEASED #451
-services Drupal/qualité (7)   -> RELEASED #458
-services ordinaires (7)       -> RELEASED #464
-pages impact moyen (3)        -> NEXT, lot borné
-homepage / services / contact -> en dernier avec browser gates dédiés
-```
-
-Chaque lot doit réduire `LEGACY_RELEASE_PENDING_IDS`. Aucun lot ne peut ajouter
-un nouvel ID grandfathered.
-
-### GC-4 — convergence nominale finale — **#442**
-
-Lorsque le catalogue ne contient plus que le Governed Content :
-
-- converger la terminologie et la façade ;
-- conserver si nécessaire un alias de compatibilité temporaire ;
-- simplifier l'admission policy ;
-- réévaluer le volume de code custom restant.
-
-## 17. Preuves et historique
-
-La preuve d'inventaire #385 correspond à l'état initial de transition. Elle
-reste historique et ne doit pas être utilisée comme inventaire courant.
-
-Les preuves #440, #451, #458 et #464 démontrent successivement que la primitive
-de release peut être appliquée à plusieurs formes de contenu sans perte
-d'identité ni reprise de contrôle par Content Sync.
-
-La preuve autoritative de l'inventaire courant reste le couple :
-
-```text
-catalog.yml
-GovernedContentPolicy.php
-```
-
-Les tests projet/module vérifient désormais :
-
-```text
-GOVERNED count = 3
-LEGACY_RELEASE_PENDING count = 6
-catalog count = 9
-3 case_client + 10 ai_feature + 14 services libérés absents du catalogue/policy/payloads
-```
-
-## 18. Conclusion
-
-La cible n'est ni « tout Git » ni « tout Drupal ».
-
-```text
-Git
--> petit ensemble explicitement gouverné
--> review/promotion déterministe
-
-Drupal
--> contenu éditorial ordinaire
--> permissions/révisions/traductions/workflow humain
-```
-
-La trajectoire réelle est désormais :
-
-```text
-bootstrap historique : 36 entrées
-après pilote #440 :    33 entrées = 3 GOV + 30 pending
-après lot #451 :       23 entrées = 3 GOV + 20 pending
-après lot #458 :       16 entrées = 3 GOV + 13 pending
-après lot #464 :        9 entrées = 3 GOV + 6 pending
-cible :                 noyau Governed Content justifié
-```
-
-Le mécanisme de transition a maintenant été prouvé sur vingt-sept contenus
-ordinaires. #441 peut poursuivre les trois pages à impact moyen par un lot
-borné, puis terminer avec `homepage`, `services` et `contact`, en réutilisant les
-mêmes invariants de release, preuve exact-head, Browser Validation et rollback.
+La convergence doit simplifier la surface sans réduire les garanties.


### PR DESCRIPTION
## Résumé

Aligne la documentation dérivée sur l’état autoritatif après clôture de #441 et merge #475.

État documenté :

```text
catalogue = 3 contenus légaux GOVERNED
LEGACY_RELEASE_PENDING_IDS = []
33 contenus ordinaires RELEASED au total
#441 = completed
#442 = prochaine convergence
```

### Fichiers

- `AGENTS.md` : retire les chiffres/étapes intermédiaires 27 released / 6 pending et cadre la phase post-migration ;
- `docs/governed-content-trajectory.md` : remplace la trajectoire active obsolète par l’état final, les preuves des lots, la preuve finale #474/#475 et le passage de relais à #442.

### Hors périmètre

- aucun code ;
- aucun workflow ;
- aucune config Drupal ;
- aucun payload ;
- aucune commande renommée/supprimée ;
- `docs/governed-content-release.md` reste inchangé jusqu’à la décision de façade #442.

Closes #479
Refs #441 #442 #474