### PR TITLE
Issue #487: apply Governed Content through the trusted CLI facade

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -254,7 +254,7 @@ jobs:
           verify_config_clean
 
           bash scripts/runner/prove-governed-content-cli-facade.sh
-          ddev drush emerging:content-sync --all
+          ddev drush emerging:governed-content --all
           ddev drush cr
           ddev drush status
           verify_config_clean


### PR DESCRIPTION
## Résumé

Fait une seule évolution fonctionnelle dans la Browser Validation trusted :

```diff
-ddev drush emerging:content-sync --all
+ddev drush emerging:governed-content --all
```

Le proof pré-apply de #483 reste inchangé et continue de vérifier discovery, `validate`, `--all --dry-run`, parité old/new et absence d’écriture avant l’apply.

## Hors périmètre

- gateway/inputs inchangés ;
- runner/DDEV inchangés ;
- aucun catalogue, policy, contenu, Composer ou service DI ;
- `scripts/deploy-production.sh` inchangé ;
- ancien nom toujours disponible.

Après CI hosted GREEN et merge exact-head, la Browser Validation sera dispatchée sur le nouveau `main` afin de prouver l’apply réel via `emerging:governed-content --all`, puis le browser proof et le cleanup.

Closes #487
Refs #442 #483