### PR TITLE
Issue #489: temporary hosted observer for #442 Actions runs

### DIFF
--- a/.github/workflows/ops-observe-convergence-runs.yml
+++ b/.github/workflows/ops-observe-convergence-runs.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Query public GitHub Actions metadata
         shell: bash
         env:
-          DISPATCH_SHA: a0775822d29c50fff5f99ea3522ebcbc00771860
-          TARGET_SHA: 277ded0efd763d38a67a2a016737535e36c05b15
+          DISPATCH_SHA: 614bddae9316f522f4b0311d623682c87d8b3931
+          TARGET_SHA: 614bddae9316f522f4b0311d623682c87d8b3931
         run: |
           set -euo pipefail
 

--- a/.github/workflows/ops-observe-convergence-runs.yml
+++ b/.github/workflows/ops-observe-convergence-runs.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Query public GitHub Actions metadata
         shell: bash
         env:
-          DISPATCH_SHA: bed1efb7ce70bec5a6a726d66f6091bea3b5b826
-          TARGET_SHA: 5b65d6af002eec08eb34b8d3ff6fb8955e39c123
+          DISPATCH_SHA: f77de43b587b42968405ced2ba1715dfcae0f8bc
+          TARGET_SHA: f77de43b587b42968405ced2ba1715dfcae0f8bc
         run: |
           set -euo pipefail
 

--- a/.github/workflows/ops-observe-convergence-runs.yml
+++ b/.github/workflows/ops-observe-convergence-runs.yml
@@ -1,0 +1,61 @@
+name: Ops observe convergence runs
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  observe:
+    name: Observe convergence run ids
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query public GitHub Actions metadata
+        shell: bash
+        env:
+          DISPATCH_SHA: bed1efb7ce70bec5a6a726d66f6091bea3b5b826
+          TARGET_SHA: 5b65d6af002eec08eb34b8d3ff6fb8955e39c123
+        run: |
+          set -euo pipefail
+
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+          headers=(
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+            -H "User-Agent: agency-convergence-observer"
+          )
+
+          echo "=== RUNS_FOR_DISPATCH_SHA ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?head_sha=${DISPATCH_SHA}&per_page=30" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_branch,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'
+
+          echo "=== RUNS_FOR_TARGET_SHA ==="
+          curl -fsSL "${headers[@]}" \
+            "${api}/actions/runs?head_sha=${TARGET_SHA}&per_page=50" \
+            | jq -c '.workflow_runs[] | {
+                id,
+                name,
+                run_number,
+                event,
+                head_branch,
+                head_sha,
+                created_at,
+                updated_at,
+                status,
+                conclusion,
+                html_url
+              }'

--- a/.github/workflows/ops-observe-convergence-runs.yml
+++ b/.github/workflows/ops-observe-convergence-runs.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Query public GitHub Actions metadata
         shell: bash
         env:
-          DISPATCH_SHA: f77de43b587b42968405ced2ba1715dfcae0f8bc
-          TARGET_SHA: f77de43b587b42968405ced2ba1715dfcae0f8bc
+          DISPATCH_SHA: a0775822d29c50fff5f99ea3522ebcbc00771860
+          TARGET_SHA: 277ded0efd763d38a67a2a016737535e36c05b15
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Surface opérateur temporaire — NE PAS FUSIONNER

Cette PR existe uniquement parce que le cockpit courant ne sait pas énumérer les runs Actions `push/workflow_dispatch`.

Le workflow ajouté :

- tourne uniquement sur GitHub-hosted ;
- interroge l’API GitHub Actions publique sans token ;
- imprime les runs attachés à un `DISPATCH_SHA` et un `TARGET_SHA` ;
- ne possède aucune permission d’écriture ;
- sera mis à jour pendant #442 puis fermé sans merge.

Premier usage : observer le browser apply proof #487 sur `main@5b65d6af002eec08eb34b8d3ff6fb8955e39c123` déclenché depuis `bed1efb7ce70bec5a6a726d66f6091bea3b5b826`.

NE PAS FUSIONNER.

Refs #489 #442 #487