### PR TITLE
Issue #491: use Governed Content CLI in production deploy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,19 +102,22 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - `GovernedContentCatalogPolicyTest`, la policy runtime et les tests de release
   protegent l'admission durable et empechent la readmission accidentelle des
   contenus ordinaires deja RELEASED.
-- La prochaine etape est #442 : converger la facade, la terminologie et la dette
-  custom Content Sync vers son role reel de Governed Content, sans rupture de
-  compatibilite production.
+- #442 fait converger la facade et la terminologie sans dupliquer le moteur.
+  `emerging:governed-content` et `emerging:governed-content:validate` sont les
+  noms operationnels a privilegier ; `emerging:content-sync` et
+  `emerging:content-sync:validate` restent des noms de compatibilite.
 - Valider avant toute application :
-  `ddev drush emerging:content-sync:validate`.
+  `ddev drush emerging:governed-content:validate`.
 - Toujours tester en lecture seule avant ecriture :
-  `ddev drush emerging:content-sync --all --dry-run`.
-- Application globale : `ddev drush emerging:content-sync --all`.
+  `ddev drush emerging:governed-content --all --dry-run`.
+- Application globale : `ddev drush emerging:governed-content --all`.
 - Application ciblee :
-  `ddev drush emerging:content-sync <content-id> --dry-run`, puis sans
+  `ddev drush emerging:governed-content <content-id> --dry-run`, puis sans
   `--dry-run` lorsque le ticket l'autorise.
-- Content Sync doit rester idempotent, lisible en dry-run et prudent en
-  production.
+- La facade historique `emerging:content-sync*` doit rester fonctionnelle tant
+  que #442 n'a pas defini et prouve une fenetre de deprecation/retrait.
+- Le moteur Governed Content doit rester idempotent, lisible en dry-run et
+  prudent en production.
 - Ne pas recycler les `legacy_uuid`, mappings ou identifiants metier existants.
 - Governed Content ne doit jamais contenir de secret, token, mot de passe, cle
   privee ou credential ; les references a Drupal Key restent des references.
@@ -152,7 +155,7 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
   `/contact` et les pages services pertinentes.
 - Les pages services doivent contenir 2 a 4 liens internes utiles.
 - Ne pas ajouter de liens artificiels ou redondants.
-- Verifier les URL FR/EN apres Content Sync.
+- Verifier les URL FR/EN apres Governed Content.
 
 ## 8. Promotions homepage/services
 
@@ -169,7 +172,7 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - Les menus sont hors perimetre de Content Sync.
 - Ne pas creer, modifier, traduire, reordonner ou supprimer de liens de menus
   dans un ticket de contenu ou SEO, sauf demande explicite.
-- Une commande `emerging:content-sync` doit laisser les entites
+- Une commande `emerging:governed-content` doit laisser les entites
   `menu_link_content` intactes.
 
 ## 10. `system.site:page.front`
@@ -240,8 +243,8 @@ preuves visuelles publiees.
 - Limiter les changements au perimetre exact du ticket.
 - Preferer les patterns existants aux nouvelles abstractions.
 - Ne jamais reformater ou refactoriser hors necessite.
-- Pour les changements Content Sync, toujours lire la trajectoire Governed
-  Content, valider le catalogue et faire un dry-run.
+- Pour les changements Governed Content, toujours lire la trajectoire, valider
+  le catalogue et faire un dry-run avant toute ecriture.
 - Pour les changements frontend, verifier le rendu public concerne.
 - Mentionner clairement les validations lancees et leurs resultats.
 
@@ -267,6 +270,6 @@ preuves visuelles publiees.
 - Ne pas modifier les content types sans ticket dedie.
 - Ne pas modifier les contenus YAML hors ticket de contenu explicite.
 - Ne pas modifier les aliases hors ticket SEO/contenu explicite.
-- Ne pas casser Content Sync ni son idempotence.
+- Ne pas casser le moteur Governed Content ni la compatibilite Content Sync.
 - Ne pas modifier la logique metier existante hors demande explicite.
 - Ne jamais commiter de secret, token, cle ou fichier local sensible.

--- a/docs/governed-content-facade.md
+++ b/docs/governed-content-facade.md
@@ -1,10 +1,10 @@
 # Governed Content — façade et dette custom après migration
 
-Statut : **phase de compatibilité #481**  
+Statut : **façade Governed Content prouvée ; adoption production #491**  
 Date : **2026-08-18**  
 Parent : **#442**
 
-## 1. État de départ
+## 1. État courant
 
 La migration des contenus ordinaires est terminée :
 
@@ -21,18 +21,13 @@ web/modules/custom/emerging_digital_content/content_sync/catalog.yml
 Drupal\emerging_digital_content\ContentSync\Policy\GovernedContentPolicy
 ```
 
-Le moteur historique porte encore le nom `ContentSync`, mais son rôle runtime
-courant est désormais la matérialisation déterministe du petit catalogue
+Le moteur PHP historique conserve encore ses noms internes `ContentSync`, mais
+son rôle runtime courant est la matérialisation déterministe du petit catalogue
 Governed Content.
 
-## 2. Décision de façade
+## 2. Façade CLI
 
-La convergence commence de façon additive.
-
-Les commandes historiques restent canoniques pendant cette phase parce que la
-production appelle encore directement `emerging:content-sync --all`.
-
-Deux aliases Governed Content sont introduits sans wrapper ni duplication :
+#481/#482 ont introduit deux aliases sans wrapper ni duplication de logique :
 
 ```text
 emerging:governed-content
@@ -42,30 +37,117 @@ emerging:governed-content:validate
 -> alias de emerging:content-sync:validate
 ```
 
-Les deux noms appellent donc exactement les mêmes méthodes, services, options,
-dry-run, validations et rapports.
+Les anciens noms restent disponibles comme compatibilité. Ils ne sont pas
+supprimés par #442 tant qu'une fenêtre de dépréciation/retrait n'a pas été
+explicitement décidée et prouvée.
 
-Aucun alias Governed Content n'est ajouté à `release` ou `readmit` dans cette
-phase. Ces commandes appartiennent au lifecycle historique de migration et de
-rollback ; leur retrait éventuel exige une décision distincte sur la fenêtre de
-compatibilité et les procédures de rollback encore supportées.
+Aucun nouvel alias Governed Content n'est ajouté à `release` ou `readmit`. Ces
+commandes appartiennent au lifecycle historique de migration/rollback et restent
+classées `RETIRE-LATER`.
 
 ## 3. Admission policy durable
 
 Après #441, le catalogue ne combine plus deux classes d'admission.
 
-L'invariant durable devient :
+L'invariant durable est :
 
 ```text
 catalogue IDs == GovernedContentPolicy::GOVERNED_CONTENT_IDS
 LEGACY_RELEASE_PENDING_IDS == []
 ```
 
-Toute nouvelle entrée de catalogue doit donc être explicitement admise comme
-Governed Content dans la policy. Il n'existe plus de file grandfathered pouvant
-servir à introduire du contenu marketing ou éditorial ordinaire.
+Toute nouvelle entrée de catalogue doit être explicitement admise comme Governed
+Content dans la policy. Il n'existe plus de file grandfathered permettant de
+réintroduire du contenu marketing ou éditorial ordinaire.
 
-## 4. Revalidation Drupal/contrib
+## 4. Preuve runtime de parité — #483
+
+La Browser Validation trusted a reconstruit un Drupal complet dans DDEV sur le
+`main` exact `d016a60c5b0b0a689dd45e5c27eeb9f9ca36764f`.
+
+```text
+gateway: 32119292743 / SUCCESS
+browser validation: 32119304420 / SUCCESS
+artifact id: 9318031275
+artifact sha256: 95d04f6ed24ef56a5838a969a903c2071c4c49d8f87ac4f0bd0211b4b307d0eb
+```
+
+Le proof repository-owned a vérifié :
+
+```text
+old/new sync help status = 0/0
+old/new validate help status = 0/0
+old/new validate status = 0/0
+validate outputs_equal = true
+old/new --all --dry-run status = 0/0
+dry-run outputs_equal = true
+governed_state_unchanged = true
+```
+
+Les diffs de sortie `validate`/`dry-run` et les quatre diffs d'état gouverné
+étaient vides.
+
+## 5. Preuve d'apply réel — #487
+
+Après #487/#488, le workflow trusted a remplacé uniquement son apply historique
+par :
+
+```text
+ddev drush emerging:governed-content --all
+```
+
+La preuve a été rejouée sur `main@5b65d6af002eec08eb34b8d3ff6fb8955e39c123` :
+
+```text
+gateway: 32120328538 / SUCCESS
+browser validation: 32120339996 / SUCCESS
+artifact id: 9318375593
+artifact sha256: 2ac5523c693bbff85c2d489f2b7525317ec73d41043cfdc5d30e9e7ddaadad48
+```
+
+Résultat de l'apply :
+
+- trois contenus légaux créés/mappés ;
+- traductions FR/EN enregistrées ;
+- `writes_attempted=true` ;
+- `blocking_errors=false` ;
+- 0 warning ;
+- 0 erreur ;
+- menus intacts ;
+- configuration active/sync sans drift après apply ;
+- Browser Validation desktop/mobile PASS ;
+- 0 erreur console, page, réseau ou HTTP inattendue ;
+- cleanup runner PASS.
+
+La nouvelle façade est donc prouvée en lecture, dry-run et écriture réelle.
+
+## 6. Adoption production — #491
+
+Après la preuve #487, le consommateur repository-owned
+`scripts/deploy-production.sh` peut utiliser :
+
+```text
+emerging:governed-content --all
+```
+
+tout en conservant `emerging:content-sync --all` comme compatibilité au niveau
+Drush.
+
+#491 ne change ni l'ordre du déploiement ni ses protections :
+
+```text
+updb
+-> cim
+-> production Config Split
+-> Governed Content
+-> cr
+```
+
+La CI doit verrouiller cette séquence. Après merge, le `Deploy Production` du
+même SHA doit fournir la preuve finale que le nouvel alias fonctionne sur la
+surface production réelle.
+
+## 7. Revalidation Drupal/contrib
 
 Revalidation effectuée le 18 août 2026 à partir des sources officielles Drupal
 et Drush.
@@ -73,80 +155,61 @@ et Drush.
 ### Drupal Core Default Content
 
 Drupal 11 expose `Drupal\Core\DefaultContent`, avec import/export YAML et des
-primitives utiles. L'API est toutefois encore marquée **expérimentale**. Elle
-n'est donc pas utilisée ici comme remplacement immédiat d'une surface production
-qui possède déjà mapping, dry-run, audit et rollback éprouvés.
+primitives utiles. L'API reste expérimentale ; elle ne remplace pas une surface
+production qui possède déjà mapping, dry-run, audit et rollback éprouvés.
 
 ### `drupal/default_content`
 
-La branche 2.x propose notamment YAML, traductions, fichiers et références, mais
-le projet indique encore cette branche comme expérimentale et ne présente pas de
-release stable supportée au moment de la revalidation.
-
-Décision : **pas de nouvelle dépendance**.
+La branche 2.x reste expérimentale et n'apporte pas aujourd'hui de motif de
+migration justifiant une nouvelle dépendance.
 
 ### `drupal/default_content_deploy`
 
-Une release stable 2.1.4 couverte par la Security Team existe pour Drupal 11.
-Le projet possède cependant sa propre sémantique d'import/mise à jour, et la
-branche 2.2 documente un problème critique HAL affectant les références.
-Aucune parité n'est démontrée aujourd'hui avec les garanties Agency : mapping
-local, release/readmission fail-closed, prune guard, exact dry-run, identité et
-promotion déjà prouvés.
+Une stable 2.1.4 existe, mais aucune parité n'est démontrée avec les garanties
+Agency et la branche 2.2 a documenté un problème critique HAL sur les références.
 
-Décision : **évaluer plus tard seulement sur preuve de parité**, ne pas installer
-pour #481.
+Décision : **évaluer plus tard seulement sur preuve de parité**.
 
 ### Workspaces
 
-Core Workspaces sert à préparer et publier des changements de contenu dans un
-site Drupal. Cette responsabilité est différente de la matérialisation
-repository -> environnements utilisée pour les trois contenus Governed Content.
-
-Décision : **complément possible, pas remplacement du moteur**.
+Workspaces répond au staging intra-site, pas à la matérialisation
+repository -> environnements des contenus Governed Content.
 
 ### Drush
 
-Agency utilise Drush 13.7.x. Les attributs `#[CLI\Command]` supportent les
-aliases, ce qui permet une façade additive sans changer les méthodes exécutées.
-La famille des commandes annotées est elle-même dépréciée au profit de Symfony
-Console dans les versions récentes de Drush 13/14.
+Agency utilise Drush 13.7.x. Les aliases de `#[CLI\Command]` permettent la
+convergence additive actuelle. La migration vers Symfony Console est un chantier
+distinct et ne doit pas être mélangée à #442.
 
-Décision : **ne pas mélanger la migration Symfony Console avec #481**. Ce sera un
-chantier de compatibilité Drush séparé si nécessaire.
-
-## 5. Matrice KEEP / CONVERGE / RETIRE-LATER
+## 8. Matrice KEEP / CONVERGE / RETIRE-LATER
 
 | Surface | Décision | Motif |
 |---|---|---|
 | catalogue YAML + loader/validator | KEEP | source versionnée des 3 contenus gouvernés |
 | mapping repository | KEEP | identité locale, audit et protections lifecycle |
 | `ContentSyncManager` | KEEP | matérialisation, dry-run, traductions, aliases et prune guards |
-| `emerging:content-sync` | CONVERGE | encore utilisé en production ; garder compatible |
-| `emerging:content-sync:validate` | CONVERGE | même moteur, nouveau vocabulaire disponible en alias |
-| `emerging:governed-content` | ADDITIVE | façade de vocabulaire, zéro logique dupliquée |
-| `emerging:governed-content:validate` | ADDITIVE | façade de vocabulaire, zéro logique dupliquée |
-| `ContentSyncReleaseManager` | RETIRE-LATER | plus de pending ; encore utile pour historique/rollback |
+| `emerging:governed-content` | PREFERRED | façade prouvée en lecture et écriture |
+| `emerging:governed-content:validate` | PREFERRED | façade prouvée, même moteur |
+| `emerging:content-sync` | COMPATIBILITY | ancien nom conservé temporairement |
+| `emerging:content-sync:validate` | COMPATIBILITY | ancien nom conservé temporairement |
+| `ContentSyncReleaseManager` | RETIRE-LATER | plus de pending ; historique/rollback |
 | `content-sync:release` | RETIRE-LATER | aucun nouveau lot ordinaire attendu |
 | `content-sync:readmit` | RETIRE-LATER | conserver jusqu'à décision de fenêtre de rollback |
-| scripts de preuve de transition #440/#441 | RETIRE-LATER | preuves historiques utiles ; ne plus étendre sans nouveau besoin |
-| `scripts/deploy-production.sh` | KEEP UNCHANGED #481 | production prouvée sur ancien nom |
-| services DI `content_sync_*` | KEEP #481 | renommage interne n'apporte pas de garantie métier |
-| Default Content / DCD / Workspaces | EVALUATE LATER | aucune parité démontrée justifiant une migration maintenant |
+| scripts de preuve de transition #440/#441 | RETIRE-LATER | preuves historiques ; ne plus étendre sans besoin |
+| `scripts/deploy-production.sh` | CONVERGE #491 | bascule après preuves #483/#487 |
+| services DI `content_sync_*` | KEEP | renommage interne sans gain de garantie métier |
+| Default Content / DCD / Workspaces | EVALUATE LATER | aucune parité démontrée justifiant une migration |
 
-## 6. Ordre de convergence restant sous #442
+## 9. Convergence restante sous #442
 
-Après #481 :
+Après la preuve production de #491 :
 
-1. prouver sur une surface Drupal réelle que les deux nouveaux aliases sont
-   découverts et produisent la même validation/dry-run que les noms historiques ;
-2. décider si le prochain déploiement peut utiliser le nouvel alias tout en
-   conservant l'ancien ;
-3. seulement après plusieurs déploiements verts, décider du nom canonique ;
-4. fixer une fenêtre explicite avant tout retrait de `release/readmit` ou des
-   scripts de preuve de transition ;
-5. réévaluer les composants contrib lorsque leurs APIs/release lines apportent
-   une parité réelle et stable.
+1. décider si le nom canonique Drush doit devenir `emerging:governed-content`
+   avec l'ancien nom rétrogradé en alias, ou si la compatibilité actuelle suffit ;
+2. documenter une fenêtre explicite avant tout retrait de `release/readmit` ;
+3. décider du devenir des scripts trusted de transition #440/#441 ;
+4. ne renommer les services/classes internes que si un gain concret est démontré ;
+5. fermer la surface opérateur temporaire #489/#490 lorsque #442 est terminé.
 
 Invariant :
 

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -6,7 +6,7 @@ TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 
 PROJECT_ROOT="/var/www/agency"
 RELEASES_DIR="/var/www/agency/releases"
-SHARED_DIR="/var/www/agency/shared"
+SHARED_DIR="$PROJECT_ROOT/shared"
 BACKUPS_DIR="$SHARED_DIR/backups"
 LOG_FILE="$SHARED_DIR/deployments.log"
 REPO_URL="${REPO_URL:-git@github.com:E-merging-digital/agency-website-drupal.git}"
@@ -185,10 +185,10 @@ if [[ ! -d "$PRODUCTION_SPLIT_DIR" ]]; then
 fi
 log "[deploy] Production Config Split"
 "$CURRENT_LINK/vendor/bin/drush" config:import --source="$PRODUCTION_SPLIT_DIR" --partial -y
-log "[deploy] Content Sync"
-"$CURRENT_LINK/vendor/bin/drush" emerging:content-sync --all
+log "[deploy] Governed Content"
+"$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all
 "$CURRENT_LINK/vendor/bin/drush" cr
-log "Drupal update, config import, production config split import, content sync and cache rebuild completed."
+log "Drupal update, config import, production config split import, Governed Content and cache rebuild completed."
 
 log "[deploy] Maintenance OFF"
 "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -6,7 +6,7 @@ TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 
 PROJECT_ROOT="/var/www/agency"
 RELEASES_DIR="/var/www/agency/releases"
-SHARED_DIR="$PROJECT_ROOT/shared"
+SHARED_DIR="/var/www/agency/shared"
 BACKUPS_DIR="$SHARED_DIR/backups"
 LOG_FILE="$SHARED_DIR/deployments.log"
 REPO_URL="${REPO_URL:-git@github.com:E-merging-digital/agency-website-drupal.git}"

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/DeployProductionConfigSplitTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/DeployProductionConfigSplitTest.php
@@ -29,30 +29,34 @@ final class DeployProductionConfigSplitTest extends TestCase {
   }
 
   /**
-   * Vérifie que le split production est importé après le config import global.
+   * Vérifie que le split production est importé avant Governed Content.
    */
-  public function testProductionSplitIsImportedAfterGlobalConfigImport(): void {
+  public function testProductionSplitIsImportedBeforeGovernedContent(): void {
     $script = $this->loadDeployProductionScript();
     $global_import_command = '"$CURRENT_LINK/vendor/bin/drush" cim -y';
     $split_dir_command = 'PRODUCTION_SPLIT_DIR="$CURRENT_LINK/config/splits/production"';
     $split_import_command = '"$CURRENT_LINK/vendor/bin/drush" config:import'
       . ' --source="$PRODUCTION_SPLIT_DIR" --partial -y';
-    $content_sync_command = '"$CURRENT_LINK/vendor/bin/drush" emerging:content-sync --all';
+    $governed_content_command = '"$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all';
 
-    self::assertStringContainsString('"$CURRENT_LINK/vendor/bin/drush" cim -y', $script);
+    self::assertStringContainsString($global_import_command, $script);
     self::assertStringContainsString($split_dir_command, $script);
     self::assertStringContainsString($split_import_command, $script);
-    self::assertStringContainsString($content_sync_command, $script);
+    self::assertStringContainsString($governed_content_command, $script);
+    self::assertStringNotContainsString(
+      '"$CURRENT_LINK/vendor/bin/drush" emerging:content-sync --all',
+      $script,
+    );
 
     $global_import_position = strpos($script, $global_import_command);
     $split_import_position = strpos($script, $split_import_command);
-    $content_sync_position = strpos($script, $content_sync_command);
+    $governed_content_position = strpos($script, $governed_content_command);
 
     self::assertIsInt($global_import_position);
     self::assertIsInt($split_import_position);
-    self::assertIsInt($content_sync_position);
+    self::assertIsInt($governed_content_position);
     self::assertGreaterThan($global_import_position, $split_import_position);
-    self::assertGreaterThan($split_import_position, $content_sync_position);
+    self::assertGreaterThan($split_import_position, $governed_content_position);
   }
 
   /**


### PR DESCRIPTION
## Résumé

Bascule le dernier consommateur runtime repository-owned important vers la façade Governed Content, après les preuves DDEV #483 et #487.

### Déploiement production

`scripts/deploy-production.sh` ne change que trois lignes :

```diff
-[deploy] Content Sync
-emerging:content-sync --all
-... content sync ...
+[deploy] Governed Content
+emerging:governed-content --all
+... Governed Content ...
```

Aucun changement de séquence, maintenance, symlink, backup, Config Split ou rollback.

### Test

`DeployProductionConfigSplitTest` exige désormais :

- `cim` avant Config Split ;
- Config Split avant `emerging:governed-content --all` ;
- absence de l'ancien appel `emerging:content-sync --all` dans le script production.

### Documentation opérationnelle

- `AGENTS.md` préfère `emerging:governed-content` / `:validate` et conserve les anciens noms comme compatibilité ;
- `docs/governed-content-facade.md` documente les preuves #483/#487 et l'adoption production candidate #491.

## Preuves préalables

- #483 Browser Validation `32119304420` SUCCESS : old/new validate et dry-run équivalents, aucun write ;
- #487 Browser Validation `32120339996` SUCCESS : apply réel `emerging:governed-content --all`, 3 contenus gouvernés matérialisés, Browser Validation PASS.

## Hors périmètre

- aucune modification des commandes Drush ;
- ancien nom toujours disponible ;
- aucun catalogue, policy, contenu, config Drupal, Composer ou service DI ;
- aucun retrait `release/readmit` ;
- aucun workflow GitHub.

Après CI exact-head GREEN et merge, le `Deploy Production` du merge SHA doit confirmer l'exécution réelle du nouvel alias en production.

Closes #491
Refs #442 #483 #487