### PR TITLE
Issue #493: make Governed Content the canonical CLI facade

### DIFF
--- a/docs/governed-content-facade.md
+++ b/docs/governed-content-facade.md
@@ -1,6 +1,6 @@
 # Governed Content — façade et dette custom après migration
 
-Statut : **façade Governed Content prouvée ; adoption production #491**  
+Statut : **façade Governed Content canonique ; compatibilité Content Sync conservée**  
 Date : **2026-08-18**  
 Parent : **#442**
 
@@ -21,29 +21,34 @@ web/modules/custom/emerging_digital_content/content_sync/catalog.yml
 Drupal\emerging_digital_content\ContentSync\Policy\GovernedContentPolicy
 ```
 
-Le moteur PHP historique conserve encore ses noms internes `ContentSync`, mais
-son rôle runtime courant est la matérialisation déterministe du petit catalogue
-Governed Content.
+Le moteur PHP historique conserve ses noms internes `ContentSync`, mais son rôle
+runtime courant est la matérialisation déterministe du petit catalogue Governed
+Content. Aucun renommage interne n'est requis pour obtenir cette garantie.
 
-## 2. Façade CLI
+## 2. Façade CLI canonique
 
-#481/#482 ont introduit deux aliases sans wrapper ni duplication de logique :
+La façade publique/CLI canonique est :
 
 ```text
 emerging:governed-content
--> alias de emerging:content-sync
-
 emerging:governed-content:validate
--> alias de emerging:content-sync:validate
 ```
 
-Les anciens noms restent disponibles comme compatibilité. Ils ne sont pas
-supprimés par #442 tant qu'une fenêtre de dépréciation/retrait n'a pas été
-explicitement décidée et prouvée.
+Les anciens noms sont conservés comme aliases de compatibilité :
 
-Aucun nouvel alias Governed Content n'est ajouté à `release` ou `readmit`. Ces
-commandes appartiennent au lifecycle historique de migration/rollback et restent
-classées `RETIRE-LATER`.
+```text
+emerging:content-sync
+emerging:content-sync:validate
+```
+
+Les anciens noms sont considérés comme **compatibilité dépréciée**, sans date de
+suppression sous #442. Aucun retrait n'est autorisé avant un ticket explicite,
+une nouvelle preuve de compatibilité et une décision liée notamment à la future
+migration des commandes Drush annotées vers Symfony Console.
+
+Aucun alias Governed Content n'est ajouté à `release` ou `readmit`. Ces commandes
+appartiennent au lifecycle historique de migration/rollback et restent classées
+`RETIRE-LATER`.
 
 ## 3. Admission policy durable
 
@@ -56,9 +61,9 @@ catalogue IDs == GovernedContentPolicy::GOVERNED_CONTENT_IDS
 LEGACY_RELEASE_PENDING_IDS == []
 ```
 
-Toute nouvelle entrée de catalogue doit être explicitement admise comme Governed
-Content dans la policy. Il n'existe plus de file grandfathered permettant de
-réintroduire du contenu marketing ou éditorial ordinaire.
+Toute nouvelle entrée de catalogue doit donc être explicitement admise comme
+Governed Content dans la policy. Il n'existe plus de file grandfathered pouvant
+servir à réintroduire du contenu marketing ou éditorial ordinaire.
 
 ## 4. Preuve runtime de parité — #483
 
@@ -89,14 +94,13 @@ Les diffs de sortie `validate`/`dry-run` et les quatre diffs d'état gouverné
 
 ## 5. Preuve d'apply réel — #487
 
-Après #487/#488, le workflow trusted a remplacé uniquement son apply historique
-par :
+Après #487/#488, le workflow trusted a appliqué le catalogue via :
 
 ```text
 ddev drush emerging:governed-content --all
 ```
 
-La preuve a été rejouée sur `main@5b65d6af002eec08eb34b8d3ff6fb8955e39c123` :
+Preuve sur `main@5b65d6af002eec08eb34b8d3ff6fb8955e39c123` :
 
 ```text
 gateway: 32120328538 / SUCCESS
@@ -119,21 +123,18 @@ Résultat de l'apply :
 - 0 erreur console, page, réseau ou HTTP inattendue ;
 - cleanup runner PASS.
 
-La nouvelle façade est donc prouvée en lecture, dry-run et écriture réelle.
+La façade Governed Content est donc prouvée en lecture, dry-run et écriture
+réelle.
 
 ## 6. Adoption production — #491
 
-Après la preuve #487, le consommateur repository-owned
-`scripts/deploy-production.sh` peut utiliser :
+#491/#492 ont basculé `scripts/deploy-production.sh` vers :
 
 ```text
 emerging:governed-content --all
 ```
 
-tout en conservant `emerging:content-sync --all` comme compatibilité au niveau
-Drush.
-
-#491 ne change ni l'ordre du déploiement ni ses protections :
+sans changer l'ordre ni les protections du déploiement :
 
 ```text
 updb
@@ -143,9 +144,27 @@ updb
 -> cr
 ```
 
-La CI doit verrouiller cette séquence. Après merge, le `Deploy Production` du
-même SHA doit fournir la preuve finale que le nouvel alias fonctionne sur la
-surface production réelle.
+Preuve post-merge sur `main@f77de43b587b42968405ced2ba1715dfcae0f8bc` :
+
+```text
+CI #884: 32121371583 / SUCCESS
+Deploy Production #185: 32121371710 / SUCCESS
+```
+
+Les logs production confirment :
+
+- release clonée sur le SHA exact ;
+- backup DB et maintenance mode opérationnels ;
+- `updb`, `cim` et Config Split réussis ;
+- étape `[deploy] Governed Content` exécutée ;
+- trois contenus gouvernés valides ;
+- 22 actions, 0 warning, 0 erreur ;
+- `blocking_errors=false` ;
+- `writes_attempted=true` ;
+- `menus_touched=false` ;
+- maintenance OFF et fin `[deploy] SUCCESS`.
+
+La production ne dépend donc plus du nom historique `emerging:content-sync`.
 
 ## 7. Revalidation Drupal/contrib
 
@@ -177,9 +196,9 @@ repository -> environnements des contenus Governed Content.
 
 ### Drush
 
-Agency utilise Drush 13.7.x. Les aliases de `#[CLI\Command]` permettent la
-convergence additive actuelle. La migration vers Symfony Console est un chantier
-distinct et ne doit pas être mélangée à #442.
+Agency utilise Drush 13.7.x. Les aliases de `#[CLI\Command]` permettent de
+conserver les anciens noms sans wrapper. La migration vers Symfony Console est
+un chantier distinct et ne doit pas être mélangée à #442.
 
 ## 8. Matrice KEEP / CONVERGE / RETIRE-LATER
 
@@ -188,28 +207,35 @@ distinct et ne doit pas être mélangée à #442.
 | catalogue YAML + loader/validator | KEEP | source versionnée des 3 contenus gouvernés |
 | mapping repository | KEEP | identité locale, audit et protections lifecycle |
 | `ContentSyncManager` | KEEP | matérialisation, dry-run, traductions, aliases et prune guards |
-| `emerging:governed-content` | PREFERRED | façade prouvée en lecture et écriture |
-| `emerging:governed-content:validate` | PREFERRED | façade prouvée, même moteur |
-| `emerging:content-sync` | COMPATIBILITY | ancien nom conservé temporairement |
-| `emerging:content-sync:validate` | COMPATIBILITY | ancien nom conservé temporairement |
+| `emerging:governed-content` | CANONICAL | façade publique prouvée en lecture, écriture et production |
+| `emerging:governed-content:validate` | CANONICAL | façade publique de validation |
+| `emerging:content-sync` | DEPRECATED COMPATIBILITY | alias conservé sans date de retrait sous #442 |
+| `emerging:content-sync:validate` | DEPRECATED COMPATIBILITY | alias conservé sans date de retrait sous #442 |
 | `ContentSyncReleaseManager` | RETIRE-LATER | plus de pending ; historique/rollback |
 | `content-sync:release` | RETIRE-LATER | aucun nouveau lot ordinaire attendu |
-| `content-sync:readmit` | RETIRE-LATER | conserver jusqu'à décision de fenêtre de rollback |
+| `content-sync:readmit` | RETIRE-LATER | conserver jusqu'à décision explicite de rollback |
 | scripts de preuve de transition #440/#441 | RETIRE-LATER | preuves historiques ; ne plus étendre sans besoin |
-| `scripts/deploy-production.sh` | CONVERGE #491 | bascule après preuves #483/#487 |
+| `scripts/deploy-production.sh` | CONVERGED | utilise Governed Content en production |
 | services DI `content_sync_*` | KEEP | renommage interne sans gain de garantie métier |
+| classes/namespaces `ContentSync*` | KEEP | dette nominale interne, pas de bénéfice runtime à renommer |
 | Default Content / DCD / Workspaces | EVALUATE LATER | aucune parité démontrée justifiant une migration |
 
-## 9. Convergence restante sous #442
+## 9. Politique de compatibilité après #442
 
-Après la preuve production de #491 :
+#442 ne supprime aucun ancien nom et ne retire aucune primitive de rollback.
 
-1. décider si le nom canonique Drush doit devenir `emerging:governed-content`
-   avec l'ancien nom rétrogradé en alias, ou si la compatibilité actuelle suffit ;
-2. documenter une fenêtre explicite avant tout retrait de `release/readmit` ;
-3. décider du devenir des scripts trusted de transition #440/#441 ;
-4. ne renommer les services/classes internes que si un gain concret est démontré ;
-5. fermer la surface opérateur temporaire #489/#490 lorsque #442 est terminé.
+Règles de sortie :
+
+1. `emerging:governed-content*` est le vocabulaire à utiliser dans toute nouvelle
+   documentation, automatisation et opération ;
+2. `emerging:content-sync` et `:validate` restent fonctionnels comme aliases ;
+3. leur retrait éventuel exige un ticket futur explicite et une preuve que plus
+   aucun consommateur supporté n'en dépend ;
+4. `release/readmit` restent disponibles pour historique/rollback tant qu'une
+   politique de rétention dédiée n'a pas été décidée ;
+5. les scripts trusted de transition #440/#441 ne sont plus étendus et pourront
+   être archivés/simplifiés dans un chantier futur distinct ;
+6. les services/classes internes ne sont pas renommés par cosmétique.
 
 Invariant :
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedContentCliFacadeCiTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedContentCliFacadeCiTest.php
@@ -17,19 +17,19 @@ use PHPUnit\Framework\TestCase;
 final class GovernedContentCliFacadeCiTest extends TestCase {
 
   /**
-   * Runtime sync and validation expose additive Governed Content aliases.
+   * Governed Content is canonical and Content Sync remains compatible.
    */
-  public function testGovernedContentRuntimeAliasesAreAdditive(): void {
+  public function testGovernedContentRuntimeNamesAreCanonical(): void {
     $this->loadCommandClass();
 
     $sync = $this->commandAttribute('sync');
-    self::assertSame('emerging:content-sync', $sync->name);
-    self::assertSame(['emerging:governed-content'], $sync->aliases);
+    self::assertSame('emerging:governed-content', $sync->name);
+    self::assertSame(['emerging:content-sync'], $sync->aliases);
 
     $validate = $this->commandAttribute('validate');
-    self::assertSame('emerging:content-sync:validate', $validate->name);
+    self::assertSame('emerging:governed-content:validate', $validate->name);
     self::assertSame(
-      ['emerging:governed-content:validate'],
+      ['emerging:content-sync:validate'],
       $validate->aliases,
     );
   }

--- a/web/modules/custom/emerging_digital_content/src/Drush/Commands/ContentSyncCommands.php
+++ b/web/modules/custom/emerging_digital_content/src/Drush/Commands/ContentSyncCommands.php
@@ -12,7 +12,7 @@ use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
- * Drush commands for Content Sync catalog checks and writes.
+ * Drush commands for Governed Content catalog checks and writes.
  */
 final class ContentSyncCommands extends DrushCommands {
 
@@ -28,15 +28,15 @@ final class ContentSyncCommands extends DrushCommands {
   }
 
   /**
-   * Validates the versioned Content Sync catalog.
+   * Validates the versioned Governed Content catalog.
    */
   #[CLI\Command(
-    name: 'emerging:content-sync:validate',
-    aliases: ['emerging:governed-content:validate'],
+    name: 'emerging:governed-content:validate',
+    aliases: ['emerging:content-sync:validate'],
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync:validate',
-    description: 'Validate the Content Sync catalog without writing entities.',
+    name: 'drush emerging:governed-content:validate',
+    description: 'Validate the Governed Content catalog without writing entities.',
   )]
   public function validate(): int {
     try {
@@ -47,45 +47,45 @@ final class ContentSyncCommands extends DrushCommands {
       return self::EXIT_FAILURE;
     }
 
-    $this->printReport($report, 'Content Sync catalog validation');
+    $this->printReport($report, 'Governed Content catalog validation');
 
     return $this->reportList($report, 'errors') === [] ? self::EXIT_SUCCESS : self::EXIT_FAILURE;
   }
 
   /**
-   * Synchronizes versioned content by business identifier or full catalog.
+   * Synchronizes governed content by business identifier or full catalog.
    */
   #[CLI\Command(
-    name: 'emerging:content-sync',
-    aliases: ['emerging:governed-content'],
+    name: 'emerging:governed-content',
+    aliases: ['emerging:content-sync'],
   )]
-  #[CLI\Argument(name: 'content_id', description: 'Optional stable business identifier, for example agence-drupal-belgique.')]
+  #[CLI\Argument(name: 'content_id', description: 'Optional stable business identifier, for example mentions-legales.')]
   #[CLI\Option(name: 'all', description: 'Synchronize every content item declared in the catalog.')]
   #[CLI\Option(name: 'dry-run', description: 'Read and report only without writing entities or mappings.')]
   #[CLI\Option(name: 'prune', description: 'Prune mode for --all. Supported value: unpublish.')]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync --all --dry-run',
+    name: 'drush emerging:governed-content --all --dry-run',
     description: 'Preview every catalog content item without saving content.',
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync --all',
-    description: 'Create or update every managed content item declared in the catalog.',
+    name: 'drush emerging:governed-content --all',
+    description: 'Create or update every governed content item declared in the catalog.',
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync --all --prune=unpublish --dry-run',
+    name: 'drush emerging:governed-content --all --prune=unpublish --dry-run',
     description: 'Preview managed nodes absent from the catalog that would be unpublished.',
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync --all --prune=unpublish',
+    name: 'drush emerging:governed-content --all --prune=unpublish',
     description: 'Unpublish managed nodes absent from the catalog after applying the catalog.',
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync agence-drupal-belgique --dry-run',
+    name: 'drush emerging:governed-content mentions-legales --dry-run',
     description: 'Preview catalog reading without saving content.',
   )]
   #[CLI\Usage(
-    name: 'drush emerging:content-sync agence-drupal-belgique',
-    description: 'Create or update the targeted managed content item.',
+    name: 'drush emerging:governed-content mentions-legales',
+    description: 'Create or update the targeted governed content item.',
   )]
   public function sync(
     string $content_id = '',
@@ -200,17 +200,17 @@ final class ContentSyncCommands extends DrushCommands {
   private function reportTitle(bool $dry_run, bool $all, string $prune): string {
     if ($prune !== '') {
       return $dry_run
-        ? 'Content Sync prune unpublish read-only dry-run'
-        : 'Content Sync prune unpublish apply';
+        ? 'Governed Content prune unpublish read-only dry-run'
+        : 'Governed Content prune unpublish apply';
     }
 
     if ($dry_run) {
       return $all
-        ? 'Content Sync full catalog read-only dry-run'
-        : 'Content Sync catalog read-only dry-run';
+        ? 'Governed Content full catalog read-only dry-run'
+        : 'Governed Content catalog read-only dry-run';
     }
 
-    return $all ? 'Content Sync full catalog apply' : 'Content Sync targeted apply';
+    return $all ? 'Governed Content full catalog apply' : 'Governed Content targeted apply';
   }
 
   /**


### PR DESCRIPTION
## Résumé

Dernier basculement sémantique de #442 : Governed Content devient le nom canonique Drush, tandis que Content Sync reste un alias de compatibilité.

### Commandes runtime

```text
CANONICAL: emerging:governed-content
ALIAS:     emerging:content-sync

CANONICAL: emerging:governed-content:validate
ALIAS:     emerging:content-sync:validate
```

Les mêmes méthodes `sync()` / `validate()` et les mêmes services sont utilisés ; aucune logique métier n'est dupliquée.

Les usages et titres CLI runtime sont alignés sur Governed Content. Les exemples ciblés utilisent désormais le contenu réellement gouverné `mentions-legales` plutôt qu'un ancien contenu ordinaire released.

### Compatibilité

- `release/readmit` restent strictement inchangés et sans nouvel alias ;
- les anciens noms `content-sync` / `:validate` sont documentés comme compatibilité dépréciée ;
- aucune date de suppression sous #442 : retrait futur uniquement via ticket explicite + preuve de non-dépendance + décision liée à la migration Drush/Symfony Console.

### Tests/docs

- `GovernedContentCliFacadeCiTest` exige les nouveaux noms canoniques et anciens aliases ;
- `docs/governed-content-facade.md` fixe la matrice finale KEEP/CANONICAL/DEPRECATED COMPATIBILITY/RETIRE-LATER et intègre la preuve production #491.

## Hors périmètre

- aucun renommage de classe/service/namespace `ContentSync*` ;
- aucun workflow/runner ;
- aucun déploiement script ;
- aucun catalogue/policy/contenu/config/Composer ;
- aucune suppression de commande.

## Gates

- CI exact-head ;
- Browser Validation gouvernée sur cette PR exacte : discovery old/new, validate old/new, dry-run old/new, state unchanged, apply via nouveau nom et Playwright ;
- merge exact-head seulement après artifact inspecté ;
- post-merge CI + Deploy Production sur le même SHA.

Closes #493
Refs #442 #481 #483 #487 #491