### PR TITLE
Issue #456: probe AI Playwright Composer compatibility without install

### DIFF
--- a/.github/workflows/issue-456-ai-playwright-dry-run.yml
+++ b/.github/workflows/issue-456-ai-playwright-dry-run.yml
@@ -1,0 +1,42 @@
+name: Issue 456 AI Playwright Composer dry-run
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/issue-456-ai-playwright-dry-run.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  composer-dry-run:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Validate current Composer state
+        run: composer validate --strict
+
+      - name: Probe AI Playwright dependency without modifying files
+        shell: bash
+        run: |
+          set -euo pipefail
+          before_composer="$(sha256sum composer.json | cut -d' ' -f1)"
+          before_lock="$(sha256sum composer.lock | cut -d' ' -f1)"
+
+          composer require 'drupal/ai_playwright:*@alpha' --dry-run --no-interaction --no-progress
+
+          after_composer="$(sha256sum composer.json | cut -d' ' -f1)"
+          after_lock="$(sha256sum composer.lock | cut -d' ' -f1)"
+          test "$before_composer" = "$after_composer"
+          test "$before_lock" = "$after_lock"


### PR DESCRIPTION
## Diagnostic éphémère — NE PAS FUSIONNER

Cette PR ajoute uniquement un workflow GitHub-hosted, read-only, pour exécuter le gate Phase 1 demandé par #456 :

```text
composer require 'drupal/ai_playwright:*@alpha' --dry-run
```

Le workflow :

- n’utilise aucun runner self-hosted ;
- ne possède que `contents: read` ;
- n’installe ni n’active `ai_playwright` dans le dépôt ;
- vérifie que `composer.json` et `composer.lock` restent byte-identiques après le dry-run ;
- sert uniquement à résoudre la release/contraintes Composer contre l’état réel de `main`.

Cette PR sera fermée sans merge dès lecture du résultat. Toute éventuelle évaluation DDEV sera matérialisée séparément seulement si Phase 1 le justifie.

Refs #456