### PR TITLE
Issue #501: add durable reporting to trusted AI Playwright evaluation

### DIFF
--- a/.github/workflows/self-hosted-ai-playwright-evaluation.yml
+++ b/.github/workflows/self-hosted-ai-playwright-evaluation.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: agency-ai-playwright-evaluation
@@ -20,6 +19,9 @@ jobs:
     name: Validate fixed AI Playwright pilot target
     if: ${{ github.event.pull_request.head.ref == 'feature/issue-499-ai-playwright-ddev-pilot' }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       head_sha: ${{ steps.validate.outputs.head_sha }}
       base_sha: ${{ steps.validate.outputs.base_sha }}
@@ -77,6 +79,13 @@ jobs:
     name: Run isolated provider-free DDEV evaluation
     needs: validate-target
     timeout-minutes: 45
+    permissions:
+      contents: read
+    outputs:
+      evidence_status: ${{ steps.summarize.outputs.evidence_status }}
+      failure_phase: ${{ steps.summarize.outputs.failure_phase }}
+      failure_message: ${{ steps.summarize.outputs.failure_message }}
+      artifact_name: ${{ steps.summarize.outputs.artifact_name }}
     runs-on:
       - self-hosted
       - linux
@@ -150,6 +159,32 @@ jobs:
           set -euo pipefail
           bash trusted/scripts/runner/run-ai-playwright-evaluation.sh
 
+      - name: Summarize bounded evaluation metadata
+        id: summarize
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file='target/artifacts/ai-playwright-evaluation/result.json'
+          evidence_status='MISSING'
+          failure_phase='n/a'
+          failure_message='result.json unavailable'
+
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            evidence_status="$(jq -r '.status // "UNKNOWN"' "$result_file")"
+            failure_phase="$(jq -r '.phase // "n/a"' "$result_file")"
+            failure_message="$(jq -r '.message // "n/a"' "$result_file")"
+          fi
+
+          failure_phase="$(printf '%s' "$failure_phase" | tr '\r\n' '  ' | cut -c1-80)"
+          failure_message="$(printf '%s' "$failure_message" | tr '\r\n' '  ' | cut -c1-200)"
+          artifact_name="agency-ai-playwright-evaluation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          echo "evidence_status=$evidence_status" >> "$GITHUB_OUTPUT"
+          echo "failure_phase=$failure_phase" >> "$GITHUB_OUTPUT"
+          echo "failure_message=$failure_message" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
       - name: Upload AI Playwright evaluation evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -172,3 +207,41 @@ jobs:
           fi
           cd "$GITHUB_WORKSPACE"
           rm -rf target trusted
+
+  report-result:
+    name: Report bounded evaluation result
+    needs:
+      - validate-target
+      - ai-playwright-evaluation
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish run locator and bounded outcome on pilot PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          JOB_RESULT: ${{ needs.ai-playwright-evaluation.result }}
+          EVIDENCE_STATUS: ${{ needs.ai-playwright-evaluation.outputs.evidence_status }}
+          FAILURE_PHASE: ${{ needs.ai-playwright-evaluation.outputs.failure_phase }}
+          FAILURE_MESSAGE: ${{ needs.ai-playwright-evaluation.outputs.failure_message }}
+          ARTIFACT_NAME: ${{ needs.ai-playwright-evaluation.outputs.artifact_name }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF
+          ### Trusted AI Playwright evaluation
+
+          - Run ID: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+          - Self-hosted job: \`${JOB_RESULT}\`
+          - Evidence status: \`${EVIDENCE_STATUS:-MISSING}\`
+          - Failure phase: \`${FAILURE_PHASE:-n/a}\`
+          - Failure message: \`${FAILURE_MESSAGE:-n/a}\`
+          - Artifact: \`${ARTIFACT_NAME:-agency-ai-playwright-evaluation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\`
+
+          This comment contains only bounded execution metadata. Inspect the artifact before any product decision.
+          EOF
+          )"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"


### PR DESCRIPTION
## Résumé

Rend le résultat du pilote #456 observable depuis GitHub connecté sans élargir les privilèges du job self-hosted.

### Séparation des privilèges

- `validate-target` : hosted, `contents: read` + `pull-requests: read` ;
- `ai-playwright-evaluation` : self-hosted, **`contents: read` uniquement** ;
- `report-result` : hosted, pas de checkout, `pull-requests: write` uniquement pour publier les métadonnées bornées.

Le job self-hosted expose uniquement : `PASS/FAIL/MISSING`, phase, message tronqué et nom d’artifact. Aucun contenu de page, cookie, URL de login, secret ou sortie brute n’est transmis au job report.

Le commentaire final contient run ID/attempt, résultat job, evidence status, failure phase/message bornés et nom d’artifact.

Après merge, PR #500 sera fermée/réouverte afin de déclencher un nouveau `pull_request_target` depuis le `main` mis à jour.

Closes #501
Refs #456 #499 #500