### PR TITLE
Issue #505: scope trusted AI Playwright concurrency to base SHA

### DIFF
--- a/.github/workflows/self-hosted-ai-playwright-evaluation.yml
+++ b/.github/workflows/self-hosted-ai-playwright-evaluation.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: agency-ai-playwright-evaluation
+  group: agency-ai-playwright-evaluation-${{ github.event.pull_request.base.sha }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Résumé

Corrige le blocage d'observabilité du pilote #456 sans annuler brutalement les anciens runs.

Diff exact : **1 ligne remplacée** dans `.github/workflows/self-hosted-ai-playwright-evaluation.yml`.

Avant :

```yaml
group: agency-ai-playwright-evaluation
```

Après :

```yaml
group: agency-ai-playwright-evaluation-${{ github.event.pull_request.base.sha }}
```

`cancel-in-progress:false` reste inchangé.

Conséquence : les relances contre le même base SHA restent sérialisées, tandis qu'une nouvelle version trusted de `main` n'est plus bloquée par un run appartenant à un ancien base SHA. Cela permet au `report-start` mergé via #503/#504 de publier le nouveau Run ID avant l'attente self-hosted.

Aucun changement Composer, Drupal, script runner, permission, secret ou production.

Closes #505
Refs #456 #499 #500 #503