### PR TITLE
Issue #507: trigger trusted AI Playwright pilot from bounded PR comment

### DIFF
--- a/.github/workflows/self-hosted-ai-playwright-evaluation.yml
+++ b/.github/workflows/self-hosted-ai-playwright-evaluation.yml
@@ -1,23 +1,17 @@
 name: Agency trusted AI Playwright evaluation
 
 on:
-  pull_request_target:
+  issue_comment:
     types:
-      - opened
-      - synchronize
-      - reopened
+      - created
 
 permissions:
   contents: read
 
-concurrency:
-  group: agency-ai-playwright-evaluation-${{ github.event.pull_request.base.sha }}
-  cancel-in-progress: false
-
 jobs:
   validate-target:
     name: Validate fixed AI Playwright pilot target
-    if: ${{ github.event.pull_request.head.ref == 'feature/issue-499-ai-playwright-ddev-pilot' }}
+    if: ${{ github.event.issue.pull_request && github.event.issue.number == 500 && github.event.comment.body == '/agency-ai-playwright-evaluate-456' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -26,24 +20,27 @@ jobs:
       head_sha: ${{ steps.validate.outputs.head_sha }}
       base_sha: ${{ steps.validate.outputs.base_sha }}
     steps:
-      - name: Validate same-repo exact-head inert pilot marker
+      - name: Validate bounded comment and exact inert pilot target
         id: validate
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+
+          [[ "$PR_NUMBER" == "500" ]]
+          [[ "$TRIGGER_COMMENT" == "/agency-ai-playwright-evaluate-456" ]]
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
 
           if [[ "$GITHUB_ACTOR" != "E-merging-digital" && "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
             echo "Refusing pilot actor: $GITHUB_ACTOR" >&2
             exit 1
           fi
-
-          [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$EVENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
 
           pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           state="$(jq -r '.state' <<<"$pr_json")"
@@ -57,8 +54,8 @@ jobs:
           [[ "$base_ref" == "main" ]]
           [[ "$head_ref" == "feature/issue-499-ai-playwright-ddev-pilot" ]]
           [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
-          [[ "$head_sha" == "$EVENT_HEAD_SHA" ]]
-          [[ "$base_sha" == "$EVENT_BASE_SHA" ]]
+          [[ "$base_sha" == "$EVENT_DEFAULT_SHA" ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
 
           mapfile -t changed_files < <(
             gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename'
@@ -87,7 +84,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
           VALIDATED_BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
           VALIDATED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
         run: |
@@ -112,6 +109,9 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+    concurrency:
+      group: agency-ai-playwright-evaluation-${{ needs.validate-target.outputs.head_sha }}
+      cancel-in-progress: false
     outputs:
       evidence_status: ${{ steps.summarize.outputs.evidence_status }}
       failure_phase: ${{ steps.summarize.outputs.failure_phase }}
@@ -254,7 +254,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
           JOB_RESULT: ${{ needs.ai-playwright-evaluation.result }}
           EVIDENCE_STATUS: ${{ needs.ai-playwright-evaluation.outputs.evidence_status }}
           FAILURE_PHASE: ${{ needs.ai-playwright-evaluation.outputs.failure_phase }}


### PR DESCRIPTION
## Résumé

Remplace le déclencheur `pull_request_target` devenu non observable pour le pilote #456 par un événement `issue_comment` borné et chargé depuis la branche par défaut trusted.

### Déclencheur exact

Sur la PR #500 uniquement :

```text
/agency-ai-playwright-evaluate-456
```

### Gate hosted avant tout checkout

Le workflow vérifie :

- objet = pull request et numéro = `500` ;
- commentaire exact ;
- actor autorisé (`E-merging-digital` ou `github-actions[bot]`) et auteur cohérent ;
- PR OPEN / base `main` / same-repo ;
- branche pilote exacte `feature/issue-499-ai-playwright-ddev-pilot` ;
- base SHA live identique au `github.sha` de l'événement default-branch ;
- HEAD figé ;
- diff = exactement le marqueur inerte ;
- contenu exact du marqueur.

### Concurrence et privilèges

- suppression de la concurrence au niveau workflow : `validate-target` et `report-start` restent toujours observables ;
- concurrence déplacée uniquement sur le job self-hosted, par HEAD pilote ;
- self-hosted : `contents: read` uniquement ;
- reporting : GitHub-hosted, aucun checkout de la branche pilote ;
- aucune dépendance alpha persistée dans Git ;
- aucun secret/provider ;
- aucun accès production.

### Diff

Un seul fichier trusted modifié :

- `.github/workflows/self-hosted-ai-playwright-evaluation.yml`

20 ajouts / 20 suppressions. Aucun changement Composer, Drupal, script runner ou pilote.

Après merge, le commentaire exact sera posté sur #500 via GitHub connecté. Le `report-start` devra alors publier immédiatement le Run ID, permettant l'inspection Actions et de l'artifact sans dépendre de l'UI.

Closes #507
Refs #456 #499 #500 #503 #505