### PR TITLE
Issue #513: publish self-hosted browser validation run status

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -97,10 +97,40 @@ jobs:
 
           echo "head_sha=$REQUESTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
 
+  report-start:
+    name: Publish browser validation run locator
+    needs: validate-request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Publish pending commit status
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate-request.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          description="Browser validation pending - run ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$TARGET_SHA" \
+            -f state='pending' \
+            -f context='agency/browser-validation' \
+            -f description="$description" \
+            -f target_url="$target_url" >/dev/null
+
   browser-validation:
     name: Rebuild Agency and run real browser validation
-    needs: validate-request
+    needs:
+      - validate-request
+      - report-start
     timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on:
       - self-hosted
       - linux
@@ -313,3 +343,37 @@ jobs:
             printf '%s\n' "$status" >&2
             exit 1
           fi
+
+  report-result:
+    name: Publish browser validation result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - report-start
+      - browser-validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Publish final commit status
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate-request.outputs.head_sha }}
+          BROWSER_RESULT: ${{ needs.browser-validation.result }}
+        run: |
+          set -euo pipefail
+          state='failure'
+          if [[ "$BROWSER_RESULT" == 'success' ]]; then
+            state='success'
+          fi
+          target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          description="Browser validation ${BROWSER_RESULT} - run ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$TARGET_SHA" \
+            -f state="$state" \
+            -f context='agency/browser-validation' \
+            -f description="$description" \
+            -f target_url="$target_url" >/dev/null


### PR DESCRIPTION
## Résumé

Rend les runs self-hosted de Browser Validation durablement retrouvables depuis le SHA validé, sans élargir les privilèges du job self-hosted.

### Diff exact

Un seul fichier modifié :

- `.github/workflows/self-hosted-browser-validation.yml`

### Reporting

Après `validate-request` :

- job GitHub-hosted `report-start` ;
- aucun checkout ;
- `statuses: write` uniquement ;
- status context `agency/browser-validation` sur le SHA exact ;
- état `pending` + Run ID/attempt + target URL Actions.

Après le self-hosted :

- job GitHub-hosted `report-result`, `if: always()` ;
- même context ;
- `success` si le job browser est success, sinon `failure` ;
- Run ID/attempt dans la description.

### Séparation de privilèges

Le job `browser-validation` rend ses permissions explicites : `contents: read`, `pull-requests: read`. Il ne reçoit aucun token `statuses: write`.

La validation du target, les checkouts exacts, DDEV, Playwright, artifacts et cleanup sont inchangés.

Après CI et merge, une nouvelle Browser Validation sera dispatchée sur le nouveau `main` trusted contenant le spec externe #511/#512. `get_commit_combined_status` devra alors fournir le Run ID exact pour inspection de l’artifact et comparaison finale #456.

Closes #513
Refs #456 #511 #512