### PR TITLE
Issue #516: inspect AI Agent and AI Test contract

### DIFF
--- a/.github/workflows/issue-516-inspect-agent-test-contract.yml
+++ b/.github/workflows/issue-516-inspect-agent-test-contract.yml
@@ -31,38 +31,54 @@ jobs:
           out=/tmp/agent-contract.txt
           : > "$out"
           section() { printf '\n===== %s =====\n' "$1" | tee -a "$out"; }
+          dump_matches() {
+            local root="$1" pattern="$2" limit="$3"
+            local matches
+            matches="$(find "$root" -type f -iname "$pattern" 2>/dev/null | sort | head -n "$limit" || true)"
+            if [[ -z "$matches" ]]; then
+              printf 'No matches for %s under %s\n' "$pattern" "$root" | tee -a "$out"
+              return 0
+            fi
+            while IFS= read -r f; do
+              printf '\n--- %s ---\n' "$f" | tee -a "$out"
+              sed -n '1,360p' "$f" | tee -a "$out"
+            done <<< "$matches"
+          }
 
           section 'RESOLVED PACKAGES'
-          composer show drupal/ai drupal/ai_agents drupal/ai_playwright 2>&1 | tee -a "$out" || true
+          for p in drupal/ai drupal/ai_agents drupal/ai_playwright; do
+            composer show "$p" --format=json | jq '{name,versions}' | tee -a "$out"
+          done
 
           section 'AI AGENT ENTITY'
-          sed -n '1,320p' web/modules/contrib/ai_agents/src/Entity/AiAgent.php | tee -a "$out"
+          sed -n '1,360p' web/modules/contrib/ai_agents/src/Entity/AiAgent.php | tee -a "$out"
 
-          section 'AI AGENT MANAGER'
-          sed -n '1,280p' web/modules/contrib/ai_agents/src/AiAgentManager.php | tee -a "$out"
+          section 'AI AGENT MANAGER-LIKE SOURCES'
+          dump_matches web/modules/contrib/ai_agents/src '*AgentManager*.php' 10
+          dump_matches web/modules/contrib/ai_agents/src '*PluginManager*.php' 10
 
-          section 'AGENT RUNNER'
-          sed -n '1,240p' web/modules/contrib/ai/modules/ai_assistant_api/src/Service/AgentRunner.php | tee -a "$out"
+          section 'AGENT RUNNER SOURCES'
+          dump_matches web/modules/contrib/ai/modules '*AgentRunner*.php' 10
+          grep -R -n -E 'function runAsAgent|runAsAgent\(' web/modules/contrib/ai/modules web/modules/contrib/ai_agents/src \
+            | head -n 80 | tee -a "$out" || true
 
           section 'SAMPLE AGENT CONFIGS'
-          find web/modules/contrib/ai_agents/config -type f -maxdepth 3 -name '*.yml' -print | sort | head -n 20 | tee -a "$out"
-          for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 5); do
+          find web/modules/contrib/ai_agents/config -maxdepth 3 -type f -name '*.yml' -print 2>/dev/null | sort | head -n 30 | tee -a "$out" || true
+          for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 8); do
             printf '\n--- %s ---\n' "$f" | tee -a "$out"
             cat "$f" | tee -a "$out"
           done
 
           section 'AI TEST PROVIDER FILES'
-          find web/modules/contrib/ai/tests/modules/ai_test -maxdepth 5 -type f | sort | tee -a "$out"
+          find web/modules/contrib/ai/tests/modules/ai_test -maxdepth 6 -type f 2>/dev/null | sort | tee -a "$out" || true
 
           section 'AI TEST PROVIDER IMPLEMENTATION'
-          for f in $(find web/modules/contrib/ai/tests/modules/ai_test/src -type f \( -iname '*Provider*.php' -o -iname '*Chat*.php' \) | sort); do
-            printf '\n--- %s ---\n' "$f" | tee -a "$out"
-            sed -n '1,340p' "$f" | tee -a "$out"
-          done
+          dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Provider*.php' 20
+          dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Chat*.php' 20
 
           section 'AI TEST CHAT REQUEST EXAMPLES'
-          find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f -print | sort | head -n 20 | tee -a "$out"
-          for f in $(find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f | sort | head -n 8); do
+          find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f -print 2>/dev/null | sort | head -n 30 | tee -a "$out" || true
+          for f in $(find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f 2>/dev/null | sort | head -n 12); do
             printf '\n--- %s ---\n' "$f" | tee -a "$out"
             cat "$f" | tee -a "$out"
           done
@@ -70,7 +86,7 @@ jobs:
           section 'TOOL CALL TYPES AND TEST REFERENCES'
           grep -R -n -E 'setChatTools|FunctionCall|tool_calls|function_call|runAsAgent\(' \
             web/modules/contrib/ai/tests web/modules/contrib/ai_agents/tests \
-            | head -n 240 | tee -a "$out" || true
+            | head -n 320 | tee -a "$out" || true
 
           cp "$out" agent-contract.txt
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/issue-516-inspect-agent-test-contract.yml
+++ b/.github/workflows/issue-516-inspect-agent-test-contract.yml
@@ -1,0 +1,81 @@
+name: Issue 516 inspect AI Agent test contract
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/issue-516-inspect-agent-test-contract.yml
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+      - name: Install Agency dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+      - name: Resolve AI Playwright evaluation packages ephemerally
+        run: composer require 'drupal/ai_playwright:1.0.0-alpha1' --no-interaction --no-progress
+      - name: Print exact AI Agent and AI Test contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=/tmp/agent-contract.txt
+          : > "$out"
+          section() { printf '\n===== %s =====\n' "$1" | tee -a "$out"; }
+
+          section 'RESOLVED PACKAGES'
+          composer show drupal/ai drupal/ai_agents drupal/ai_playwright 2>&1 | tee -a "$out" || true
+
+          section 'AI AGENT ENTITY'
+          sed -n '1,320p' web/modules/contrib/ai_agents/src/Entity/AiAgent.php | tee -a "$out"
+
+          section 'AI AGENT MANAGER'
+          sed -n '1,280p' web/modules/contrib/ai_agents/src/AiAgentManager.php | tee -a "$out"
+
+          section 'AGENT RUNNER'
+          sed -n '1,240p' web/modules/contrib/ai/modules/ai_assistant_api/src/Service/AgentRunner.php | tee -a "$out"
+
+          section 'SAMPLE AGENT CONFIGS'
+          find web/modules/contrib/ai_agents/config -type f -maxdepth 3 -name '*.yml' -print | sort | head -n 20 | tee -a "$out"
+          for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 5); do
+            printf '\n--- %s ---\n' "$f" | tee -a "$out"
+            cat "$f" | tee -a "$out"
+          done
+
+          section 'AI TEST PROVIDER FILES'
+          find web/modules/contrib/ai/tests/modules/ai_test -maxdepth 5 -type f | sort | tee -a "$out"
+
+          section 'AI TEST PROVIDER IMPLEMENTATION'
+          for f in $(find web/modules/contrib/ai/tests/modules/ai_test/src -type f \( -iname '*Provider*.php' -o -iname '*Chat*.php' \) | sort); do
+            printf '\n--- %s ---\n' "$f" | tee -a "$out"
+            sed -n '1,340p' "$f" | tee -a "$out"
+          done
+
+          section 'AI TEST CHAT REQUEST EXAMPLES'
+          find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f -print | sort | head -n 20 | tee -a "$out"
+          for f in $(find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f | sort | head -n 8); do
+            printf '\n--- %s ---\n' "$f" | tee -a "$out"
+            cat "$f" | tee -a "$out"
+          done
+
+          section 'TOOL CALL TYPES AND TEST REFERENCES'
+          grep -R -n -E 'setChatTools|FunctionCall|tool_calls|function_call|runAsAgent\(' \
+            web/modules/contrib/ai/tests web/modules/contrib/ai_agents/tests \
+            | head -n 240 | tee -a "$out" || true
+
+          cp "$out" agent-contract.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: issue-516-agent-contract
+          path: agent-contract.txt
+          if-no-files-found: error
+          retention-days: 2

--- a/.github/workflows/issue-516-inspect-agent-test-contract.yml
+++ b/.github/workflows/issue-516-inspect-agent-test-contract.yml
@@ -31,6 +31,15 @@ jobs:
           out=/tmp/agent-contract.txt
           : > "$out"
           section() { printf '\n===== %s =====\n' "$1" | tee -a "$out"; }
+          dump_file() {
+            local file="$1"
+            printf '\n--- %s ---\n' "$file" | tee -a "$out"
+            if [[ -f "$file" ]]; then
+              sed -n '1,760p' "$file" | tee -a "$out"
+            else
+              printf 'missing\n' | tee -a "$out"
+            fi
+          }
           dump_matches() {
             local root="$1" pattern="$2" limit="$3"
             local matches
@@ -40,8 +49,7 @@ jobs:
               return 0
             fi
             while IFS= read -r f; do
-              printf '\n--- %s ---\n' "$f" | tee -a "$out"
-              sed -n '1,360p' "$f" | tee -a "$out"
+              dump_file "$f"
             done <<< "$matches"
           }
 
@@ -51,7 +59,7 @@ jobs:
           done
 
           section 'AI AGENT ENTITY'
-          sed -n '1,360p' web/modules/contrib/ai_agents/src/Entity/AiAgent.php | tee -a "$out"
+          dump_file web/modules/contrib/ai_agents/src/Entity/AiAgent.php
 
           section 'AI AGENT MANAGER-LIKE SOURCES'
           dump_matches web/modules/contrib/ai_agents/src '*AgentManager*.php' 10
@@ -59,34 +67,32 @@ jobs:
 
           section 'AGENT RUNNER SOURCES'
           dump_matches web/modules/contrib/ai/modules '*AgentRunner*.php' 10
-          grep -R -n -E 'function runAsAgent|runAsAgent\(' web/modules/contrib/ai/modules web/modules/contrib/ai_agents/src \
-            | head -n 80 | tee -a "$out" || true
 
           section 'SAMPLE AGENT CONFIGS'
-          find web/modules/contrib/ai_agents/config -maxdepth 3 -type f -name '*.yml' -print 2>/dev/null | sort | head -n 30 | tee -a "$out" || true
           for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 8); do
-            printf '\n--- %s ---\n' "$f" | tee -a "$out"
-            cat "$f" | tee -a "$out"
+            dump_file "$f"
           done
 
-          section 'AI TEST PROVIDER FILES'
-          find web/modules/contrib/ai/tests/modules/ai_test -maxdepth 6 -type f 2>/dev/null | sort | tee -a "$out" || true
-
-          section 'AI TEST PROVIDER IMPLEMENTATION'
+          section 'AI TEST MODULE CONTRACT'
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/ai_test.info.yml
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/ai_test.services.yml
           dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Provider*.php' 20
           dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Chat*.php' 20
+          dump_matches web/modules/contrib/ai/tests/modules/ai_test/src 'EchoProvider.php' 20
 
-          section 'AI TEST CHAT REQUEST EXAMPLES'
-          find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f -print 2>/dev/null | sort | head -n 30 | tee -a "$out" || true
-          for f in $(find web/modules/contrib/ai -path '*/resources/ai_test/requests/chat/*' -type f 2>/dev/null | sort | head -n 12); do
-            printf '\n--- %s ---\n' "$f" | tee -a "$out"
-            cat "$f" | tee -a "$out"
-          done
+          section 'EXTERNALLY DRIVEN AGENT LOOP TEST'
+          dump_file web/modules/contrib/ai_agents/tests/src/Kernel/PluginBase/AiAgentExternallyDrivenLoopTest.php
 
-          section 'TOOL CALL TYPES AND TEST REFERENCES'
-          grep -R -n -E 'setChatTools|FunctionCall|tool_calls|function_call|runAsAgent\(' \
-            web/modules/contrib/ai/tests web/modules/contrib/ai_agents/tests \
-            | head -n 320 | tee -a "$out" || true
+          section 'ENTITY WRAPPER TEST'
+          dump_file web/modules/contrib/ai_agents/tests/src/Kernel/PluginBase/AiAgentEntityWrapperTest.php
+
+          section 'AI TEST TOOL CALL REQUEST'
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/tests/resources/ai_test/requests/chat/HostnameFilterToolBugTrigger.yml
+
+          section 'TOOL CALL DTO SOURCES'
+          dump_matches web/modules/contrib/ai/src '*Tool*.php' 30
+          dump_matches web/modules/contrib/ai/src '*ChatMessage*.php' 10
+          dump_matches web/modules/contrib/ai/src '*ChatOutput*.php' 10
 
           cp "$out" agent-contract.txt
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/issue-516-inspect-agent-test-contract.yml
+++ b/.github/workflows/issue-516-inspect-agent-test-contract.yml
@@ -35,7 +35,7 @@ jobs:
             local file="$1"
             printf '\n--- %s ---\n' "$file" | tee -a "$out"
             if [[ -f "$file" ]]; then
-              sed -n '1,760p' "$file" | tee -a "$out"
+              sed -n '1,900p' "$file" | tee -a "$out"
             else
               printf 'missing\n' | tee -a "$out"
             fi
@@ -48,9 +48,7 @@ jobs:
               printf 'No matches for %s under %s\n' "$pattern" "$root" | tee -a "$out"
               return 0
             fi
-            while IFS= read -r f; do
-              dump_file "$f"
-            done <<< "$matches"
+            while IFS= read -r f; do dump_file "$f"; done <<< "$matches"
           }
 
           section 'RESOLVED PACKAGES'
@@ -58,41 +56,34 @@ jobs:
             composer show "$p" --format=json | jq '{name,versions}' | tee -a "$out"
           done
 
-          section 'AI AGENT ENTITY'
+          section 'AI AGENT ENTITY AND RUNNER'
           dump_file web/modules/contrib/ai_agents/src/Entity/AiAgent.php
-
-          section 'AI AGENT MANAGER-LIKE SOURCES'
           dump_matches web/modules/contrib/ai_agents/src '*AgentManager*.php' 10
-          dump_matches web/modules/contrib/ai_agents/src '*PluginManager*.php' 10
-
-          section 'AGENT RUNNER SOURCES'
           dump_matches web/modules/contrib/ai/modules '*AgentRunner*.php' 10
 
           section 'SAMPLE AGENT CONFIGS'
-          for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 8); do
-            dump_file "$f"
-          done
+          for f in $(find web/modules/contrib/ai_agents/config/install -type f -name '*.yml' 2>/dev/null | sort | head -n 8); do dump_file "$f"; done
 
-          section 'AI TEST MODULE CONTRACT'
+          section 'AI TEST PROVIDER'
           dump_file web/modules/contrib/ai/tests/modules/ai_test/ai_test.info.yml
           dump_file web/modules/contrib/ai/tests/modules/ai_test/ai_test.services.yml
-          dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Provider*.php' 20
-          dump_matches web/modules/contrib/ai/tests/modules/ai_test/src '*Chat*.php' 20
           dump_matches web/modules/contrib/ai/tests/modules/ai_test/src 'EchoProvider.php' 20
 
-          section 'EXTERNALLY DRIVEN AGENT LOOP TEST'
-          dump_file web/modules/contrib/ai_agents/tests/src/Kernel/PluginBase/AiAgentExternallyDrivenLoopTest.php
+          section 'FUNCTION CALL REFERENCE PLUGINS'
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/src/Plugin/AiFunctionCall/Calculator.php
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/src/Plugin/AiFunctionCall/Trigger.php
+          dump_file web/modules/contrib/ai/tests/modules/ai_test/src/Plugin/AiFunctionCall/UrlTest.php
 
-          section 'ENTITY WRAPPER TEST'
-          dump_file web/modules/contrib/ai_agents/tests/src/Kernel/PluginBase/AiAgentEntityWrapperTest.php
+          section 'EXTERNALLY DRIVEN LOOP TEST AND CONFIG'
+          dump_file web/modules/contrib/ai_agents/tests/src/Kernel/PluginBase/AiAgentExternallyDrivenLoopTest.php
+          dump_file web/modules/contrib/ai_agents/tests/assets/config/ai_agents.ai_agent.loop_test_agent.yml
+
+          section 'EXACT LOOP FIXTURES'
+          find web/modules/contrib/ai_agents/tests -type f -path '*/resources/ai_test/requests/chat/*' -print | sort | tee -a "$out" || true
+          for f in $(find web/modules/contrib/ai_agents/tests -type f -path '*/resources/ai_test/requests/chat/*' 2>/dev/null | sort | head -n 30); do dump_file "$f"; done
 
           section 'AI TEST TOOL CALL REQUEST'
           dump_file web/modules/contrib/ai/tests/modules/ai_test/tests/resources/ai_test/requests/chat/HostnameFilterToolBugTrigger.yml
-
-          section 'TOOL CALL DTO SOURCES'
-          dump_matches web/modules/contrib/ai/src '*Tool*.php' 30
-          dump_matches web/modules/contrib/ai/src '*ChatMessage*.php' 10
-          dump_matches web/modules/contrib/ai/src '*ChatOutput*.php' 10
 
           cp "$out" agent-contract.txt
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Diagnostic GitHub-hosted éphémère — **NE PAS FUSIONNER**.

Objectif : inspecter le contrat exact des versions Composer résolues de `ai_agents` et du provider officiel `ai_test` avant d'encoder la Phase 3 agentique de #456/#516.

Le job :
- GitHub-hosted uniquement ;
- permissions `contents: read` ;
- installe les dépendances seulement dans son workspace ;
- ajoute `drupal/ai_playwright:1.0.0-alpha1` éphémèrement ;
- imprime/upload uniquement des sources publiques de packages : entité/manager Agent, `AgentRunner`, sample configs, provider AI Test et exemples de tool calls ;
- aucun DDEV self-hosted, aucun provider réseau, aucun secret, aucune production.

Cette PR sera fermée sans merge immédiatement après lecture.

Refs #516 #456