### PR TITLE
Issue #518: establish Governed AI Experience architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,28 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - Avant `HUMAN_REQUIRED`, recharger le registre de capacites et verifier les
   routes machine gouvernees existantes.
 
+## 2.3 Governed AI Experience / design system
+
+- Avant toute decision concernant frontend, design system, Figma, SDC, Drupal
+  Canvas, Drupal AI applique a l'interface, generation de composants ou
+  generation/composition de pages, lire **obligatoirement** :
+  `docs/decisions/ADR-001-governed-ai-experience.md`, `DESIGN.md` et
+  `docs/governed-ai-experience.md`.
+- `ADR-001` est **ACCEPTED** et autoritative tant qu'une ADR ulterieure ne la
+  supersede pas explicitement.
+- Invariant : **COMPOSE BEFORE CREATE**. Rechercher les primitives approuvees,
+  composer avec elles et leurs variantes, puis ouvrir un gap de composant
+  separe seulement si elles ne peuvent raisonnablement pas couvrir le besoin.
+- Agency ne construit pas de moteur generique `prompt -> HTML/CSS/page
+  arbitraire`. Pour toute nouvelle capacite, classifier d'abord `USE DRUPAL`,
+  `EXTEND DRUPAL`, `BUILD IN AGENCY` ou `DEFER / EXPERIMENTAL`, avec preference
+  `USE DRUPAL > EXTEND DRUPAL > BUILD IN AGENCY`.
+- Le contexte de marque, tone of voice, audiences, terminologie et regles
+  editoriales suit `docs/drupal-ai-context-architecture.md`; ne pas le recopier
+  dans `DESIGN.md`.
+- AI Playwright peut servir d'auto-inspection DEV-ONLY ; la Browser Validation
+  Playwright de `docs/browser-validation.md` reste la preuve independante.
+
 ## 3. Workflow Git/branches
 
 - 1 ticket GitHub = 1 branche Git = 1 Pull Request.
@@ -224,7 +246,6 @@ ddev composer test:homepage-smoke
 ddev composer test:contact
 ddev composer test:project-functional
 ddev composer test:ai-translation:stable
-ddev composer ci
 npm run browser:validate
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ ddev composer test:homepage-smoke
 ddev composer test:contact
 ddev composer test:project-functional
 ddev composer test:ai-translation:stable
+ddev composer ci
 npm run browser:validate
 ```
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,416 @@
+# DESIGN.md — contrat du design system Agency
+
+Statut : **CONTRAT FRONTEND AUTORITATIF**  
+Décision : `docs/decisions/ADR-001-governed-ai-experience.md`  
+Architecture : `docs/governed-ai-experience.md`  
+Issue d’implémentation progressive : #519
+
+## 1. Rôle
+
+`DESIGN.md` est le contrat durable entre :
+
+- design ;
+- développement frontend ;
+- agents de développement ;
+- composants Drupal ;
+- future composition Canvas / Canvas AI.
+
+Il définit **ce qui est autorisé visuellement et techniquement** pour construire
+l’interface Agency.
+
+Invariant : **COMPOSE BEFORE CREATE**.
+
+Une page ou une section doit d’abord réutiliser les primitives approuvées et
+leurs variantes. Une nouvelle primitive n’est créée qu’après démonstration d’un
+gap, validation et admission.
+
+## 2. Ce document ne possède pas le contexte éditorial
+
+`DESIGN.md` ne doit pas devenir un prompt global ni une seconde source de vérité
+pour :
+
+- positionnement commercial ;
+- tone of voice ;
+- audiences/personas ;
+- terminologie FR/EN ;
+- règles SEO éditoriales ;
+- contraintes réglementaires métier ;
+- règles de campagne ;
+- contexte propre au chatbot ou à un use case IA.
+
+Ces responsabilités suivent :
+
+- `docs/drupal-ai-context-architecture.md` ;
+- `docs/drupal-ai-architecture.md` ;
+- `docs/seo/strategie-seo.md` ;
+- les sources Drupal/versionnées spécialisées.
+
+Le design system et le contexte IA sont complémentaires, pas fusionnés.
+
+## 3. Hiérarchie des sources visuelles
+
+### Figma
+
+Figma est la source principale d’**intention visuelle** lorsqu’une maquette ou un
+système de variables existe : composition, proportions, variantes, états,
+interactions et références de composants.
+
+Figma n’est pas la seule source de vérité technique. Un export Figma ne peut pas
+contourner les contrats Drupal, SDC, accessibilité ou CSS de ce document.
+
+### DESIGN.md
+
+Ce document porte les règles durables et les critères de décision.
+
+### Tokens runtime
+
+Les valeurs effectivement rendues doivent être matérialisées dans le code du
+design system. Aujourd’hui, la baseline canonique est dans :
+
+```text
+web/themes/custom/emerging_digital/css/base.css
+```
+
+À terme, #519 peut réorganiser leur consommation par SDC, mais ne doit pas créer
+une deuxième palette concurrente.
+
+### SDC
+
+Les Single Directory Components approuvés deviennent progressivement les
+primitives exécutables du design system. Le code du composant reste la source de
+vérité de son rendu et de son API props/slots.
+
+## 4. Baseline de tokens existante
+
+Les valeurs ci-dessous sont **l’état réel du thème au 18 août 2026**. Elles ne
+constituent pas une invitation à refondre la direction artistique sous #518.
+
+### Couleurs
+
+| Token | Valeur actuelle | Rôle |
+| --- | --- | --- |
+| `--color-bg` | `#ffffff` | fond principal |
+| `--color-surface` | `#f6f7fb` | surfaces secondaires |
+| `--color-text` | `#111827` | texte principal |
+| `--color-muted` | `#4b5563` | texte secondaire |
+| `--color-border` | `#d1d5db` | bordures |
+| `--color-primary` | `#005bbb` | action/lien principal |
+| `--color-primary-contrast` | `#ffffff` | contenu sur primaire |
+
+Règle : toute nouvelle couleur sémantique récurrente doit devenir un token
+justifié. Ne pas multiplier des hex ad hoc dans de nouveaux composants.
+
+Une correction isolée peut conserver une valeur locale si elle ne représente
+pas un concept réutilisable ; la PR doit alors expliquer pourquoi un token serait
+inapproprié.
+
+### Typographie
+
+| Token | Valeur actuelle |
+| --- | --- |
+| `--font-body` | `"Inter", "Segoe UI", Roboto, Arial, sans-serif` |
+| `--font-heading` | `"Poppins", "Segoe UI", Roboto, Arial, sans-serif` |
+
+Le body utilise une hauteur de ligne `1.6`; les titres utilisent `1.2`.
+
+Règles :
+
+- réutiliser les familles existantes par défaut ;
+- ne pas introduire une troisième famille sans décision de design explicite ;
+- conserver une mesure et une hiérarchie lisibles ;
+- les composants ne doivent pas embarquer leur propre mini-système typographique
+  sans justification.
+
+### Espacements
+
+| Token | Valeur actuelle |
+| --- | --- |
+| `--space-1` | `0.25rem` |
+| `--space-2` | `0.5rem` |
+| `--space-3` | `0.75rem` |
+| `--space-4` | `1rem` |
+| `--space-5` | `1.5rem` |
+| `--space-6` | `2rem` |
+| `--space-7` | `3rem` |
+
+Règle : les nouveaux composants utilisent cette échelle avant de créer une
+valeur d’espacement nouvelle.
+
+Une nouvelle marche d’échelle doit répondre à un besoin récurrent et être revue
+comme évolution du design system.
+
+### Conteneur, rayons et ombre
+
+| Token | Valeur actuelle |
+| --- | --- |
+| `--container-width` | `72rem` |
+| `--radius-sm` | `0.25rem` |
+| `--radius-md` | `0.5rem` |
+| `--radius-lg` | `0.85rem` |
+| `--shadow-sm` | `0 1px 2px rgb(0 0 0 / 8%)` |
+
+Les conteneurs `.page-container` et `.ed-container` utilisent cette largeur avec
+des gouttières issues de l’échelle d’espacement.
+
+## 5. Responsive
+
+Principes :
+
+- mobile et petits écrans font partie du contrat du composant, pas d’une passe de
+  correction finale ;
+- éviter le débordement horizontal ;
+- images, SVG, vidéo et iframe doivent rester contenus ;
+- les props/slots d’un composant doivent produire un comportement prévisible à
+  toutes les largeurs supportées ;
+- ne pas créer une variante uniquement pour masquer un défaut responsive d’une
+  primitive existante.
+
+Le thème possède actuellement une adaptation de gouttière à `30rem` dans
+`base.css`. Les autres breakpoints existants restent dans les CSS du thème et
+doivent être inventoriés avant toute normalisation dans #519.
+
+Ne pas créer un nouveau système de breakpoints dans un composant isolé sans
+justification.
+
+## 6. Accessibilité
+
+Cible de conception : **WCAG 2.2 AA**, sauf exigence de ticket plus stricte.
+
+Chaque primitive admise doit au minimum considérer :
+
+- HTML sémantique ;
+- hiérarchie de titres dans son contexte d’utilisation ;
+- nom accessible des contrôles ;
+- navigation clavier ;
+- focus visible ;
+- contrastes ;
+- taille/zone des cibles interactives ;
+- erreurs et aides de formulaire ;
+- texte alternatif ou traitement décoratif des images ;
+- mouvement/animation non indispensable ;
+- responsive sans perte d’information ou d’action.
+
+Une apparence conforme à Figma ne justifie jamais de dégrader ces critères.
+
+## 7. CSS
+
+Règles pour tout nouveau travail :
+
+1. utiliser les tokens existants avant une valeur brute ;
+2. préférer un style local au composant SDC lorsqu’il appartient réellement à la
+   primitive ;
+3. ne pas créer de dépendance à l’ordre accidentel des champs ou du DOM ;
+4. éviter les sélecteurs globaux qui modifient des composants non concernés ;
+5. conserver des noms de classes explicites et stables ;
+6. ne pas générer du CSS à la volée depuis un prompt de page ;
+7. ne pas ajouter de framework frontend lourd pour résoudre un besoin couvert par
+   le thème/Drupal ;
+8. toute nouvelle primitive visuelle récurrente doit avoir un owner et un contrat
+   de composant.
+
+Les CSS historiques ne doivent pas être refactorisés en masse simplement pour
+respecter ce document. La convergence se fait au fil de tickets bornés.
+
+## 8. Contrat SDC cible
+
+Le design system exécutable converge vers Drupal core SDC.
+
+Structure attendue pour une primitive nouvelle ou migrée :
+
+```text
+web/themes/custom/emerging_digital/components/<component>/
+  <component>.component.yml
+  <component>.twig
+  <component>.css       # si nécessaire
+  <component>.js        # si nécessaire
+```
+
+Le `*.component.yml` décrit l’API publique du composant.
+
+### Props
+
+Utiliser des props pour les valeurs structurées : texte court, booléens,
+énumérations, URL, choix de variante, données simples.
+
+Principes :
+
+- noms explicites ;
+- types stricts ;
+- valeurs obligatoires seulement lorsqu’elles le sont réellement ;
+- enum pour une liste fermée de variantes ;
+- pas de prop « HTML/CSS arbitraire » servant de porte de contournement ;
+- éviter `extra_classes` générique lorsqu’il permettrait à une IA d’inventer une
+  nouvelle apparence hors design system.
+
+### Slots
+
+Utiliser des slots pour les zones de contenu/composition imbriquée prévues par le
+composant.
+
+Un slot n’est pas une permission d’insérer n’importe quoi : la future politique
+d’admission Canvas doit pouvoir restreindre les composants pertinents par
+contexte lorsque nécessaire.
+
+### Variantes
+
+Préférer une variante d’une primitive lorsque :
+
+- la structure et le rôle fonctionnel restent les mêmes ;
+- seule une dimension explicitement prévue varie ;
+- la variante peut être nommée, testée et documentée.
+
+Créer un composant distinct lorsque la sémantique, la structure ou les
+interactions deviennent réellement différentes.
+
+## 9. Critères d’admission d’un composant
+
+Un composant n’entre pas dans le catalogue autorisé uniquement parce qu’il rend
+correctement une capture.
+
+Critères minimaux :
+
+- besoin réel et rôle fonctionnel clair ;
+- impossibilité raisonnable de couvrir le besoin avec une primitive/variante
+  approuvée existante ;
+- API props/slots bornée ;
+- tokens réutilisés ;
+- responsive validé ;
+- accessibilité de base validée ;
+- rendu Drupal sans erreur ;
+- browser proof pertinente ;
+- aucune dépendance ou permission disproportionnée ;
+- revue humaine ;
+- statut `approved` matérialisé selon le mécanisme défini dans #519.
+
+Pour une nouvelle primitive, le ticket doit répondre explicitement :
+
+```text
+Pourquoi les composants existants + leurs variantes ne suffisent-ils pas ?
+```
+
+Sans réponse démontrable, la primitive n’est pas admise.
+
+## 10. COMPOSE BEFORE CREATE pour les agents
+
+Lorsqu’un agent reçoit une demande frontend/page :
+
+```text
+1. lire ADR-001 + DESIGN.md
+2. inventorier les composants approuvés utiles
+3. composer avec eux
+4. essayer leurs variantes
+5. signaler le gap restant
+6. ne pas créer de primitive sans ticket/gate dédié
+```
+
+Interdictions :
+
+- générer une page entière en HTML/CSS libre pour « aller plus vite » ;
+- injecter du style inline afin de contourner les tokens ;
+- créer une nouvelle variante implicite via classes arbitraires ;
+- modifier un composant partagé pour un seul écran sans vérifier les usages ;
+- utiliser Canvas AI comme autorité du design system.
+
+Canvas AI sélectionne et compose **le système approuvé** ; il ne définit pas ce
+système.
+
+## 11. Figma -> DESIGN.md -> SDC
+
+Pour une décision provenant de Figma :
+
+```text
+maquette / variable / composant de référence
+-> identifier la décision durable
+-> mapper vers token / variante / primitive
+-> implémenter dans le système Drupal
+-> prouver le rendu
+```
+
+Les pixels extraits d’une maquette ne deviennent pas automatiquement des tokens.
+Une valeur devient un token lorsqu’elle porte une intention réutilisable.
+
+Une future automatisation Figma/MCP doit produire ou proposer des changements
+reviewables dans cette chaîne, pas écrire directement une page production.
+
+## 12. Validation des changements frontend
+
+Selon le ticket :
+
+### Obligatoire au niveau code
+
+- `git diff --check` ;
+- lint/qualité projet ;
+- tests Drupal concernés.
+
+### Changement visible ou interactif significatif
+
+Utiliser la preuve définie par `docs/browser-validation.md` :
+
+- vrai Chromium ;
+- desktop/mobile ;
+- DOM ;
+- console ;
+- réseau ;
+- interactions ;
+- screenshots/traces lorsque pertinents.
+
+### Composants SDC admis
+
+#519 devra ajouter une validation reproductible du contrat de composant, avec au
+minimum :
+
+- schéma/props ;
+- rendu ;
+- responsive ;
+- accessibilité ciblée ;
+- preuve visuelle pertinente ;
+- non-régression des usages existants.
+
+Une régression visuelle automatisée est ajoutée uniquement lorsque la stabilité
+de la surface et le coût de maintenance la rendent utile ; elle ne remplace pas
+les contrôles sémantiques/fonctionnels.
+
+## 13. Architecture actuelle et migration
+
+Le thème existant est basé sur Paragraphs, Twig et CSS global/thématique. Ce
+modèle n’est pas déclaré « incorrect » par cette décision.
+
+Trajectoire :
+
+```text
+inventaire
+-> identifier les primitives réellement réutilisables
+-> vertical slice SDC
+-> preuve
+-> admission
+-> migration progressive des usages lorsque rentable
+```
+
+Pas de migration big-bang.
+
+Les Paragraphs peuvent continuer à porter du contenu structuré et appeler des
+SDC pour le rendu. Canvas n’impose pas de supprimer l’architecture éditoriale
+Drupal existante.
+
+## 14. Définition d’une page conforme au design system
+
+Une page candidate est conforme lorsque :
+
+- chaque primitive visible appartient au catalogue autorisé ou à une surface
+  explicitement hors catalogue ;
+- ses variantes et props sont valides ;
+- les tokens sont respectés ;
+- aucun markup/CSS libre n’a été généré pour contourner le catalogue ;
+- responsive et accessibilité passent les contrôles applicables ;
+- les interactions et formulaires restent fonctionnels ;
+- le contexte éditorial provient de ses sources de vérité ;
+- la page reste une révision/candidate reviewable avant publication.
+
+## 15. Évolution de ce contrat
+
+Une modification de token, convention SDC ou critère d’admission passe par une
+PR et doit considérer ses effets sur les composants existants.
+
+Un changement qui remet en cause le principe de composition gouvernée ou
+`COMPOSE BEFORE CREATE` nécessite une nouvelle ADR qui supersède explicitement
+`ADR-001`.

--- a/docs/decisions/ADR-001-governed-ai-experience.md
+++ b/docs/decisions/ADR-001-governed-ai-experience.md
@@ -1,0 +1,249 @@
+# ADR-001 — Governed AI Experience
+
+- **Statut : ACCEPTED**
+- **Date : 2026-08-18**
+- **Issue : #518**
+- **Parents stratégiques : #3, #32**
+- **Supersède : aucune décision**
+
+## 1. Contexte
+
+Agency dispose déjà d’un socle Drupal solide : contenu structuré, traductions,
+révisions, permissions, thème custom, Paragraphs, Drupal AI, validation
+navigateur Playwright et règles de gouvernance. Le projet a également démontré
+une capacité DEV-ONLY d’auto-inspection via AI Playwright.
+
+En parallèle, l’écosystème Drupal a suffisamment évolué pour que la création de
+pages assistée par IA ne doive plus être traitée comme un problème à résoudre
+par un moteur propriétaire Agency. Au 18 août 2026 :
+
+- Drupal Canvas publie une branche stable compatible Drupal 11 ;
+- Single Directory Components (SDC) fait partie du système de rendu de Drupal
+  core ;
+- l’initiative Drupal AI travaille explicitement sur la construction de pages
+  Canvas à partir de composants, de métadonnées de design system et de contexte
+  gouverné ;
+- Context Control Center reste une capacité upstream à suivre et à revalider
+  avant adoption production ;
+- certaines opérations Canvas AI restent en évolution et doivent donc être
+  prouvées localement avant généralisation.
+
+Références upstream au moment de la décision :
+
+- https://www.drupal.org/project/canvas
+- https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components/about-single-directory-components
+- https://www.drupal.org/project/ai_initiative/issues/3547195
+- https://www.drupal.org/project/canvas/issues/3541783
+- https://www.drupal.org/project/ai_context
+
+Ces références sont temporelles. Leur état doit être revalidé avant toute
+installation ou décision de maturité.
+
+## 2. Décision
+
+Agency est une **plateforme Drupal de création d’expériences gouvernées**.
+
+Agency **ne développe pas** un moteur générique propriétaire :
+
+```text
+prompt -> HTML/CSS/page arbitraire
+```
+
+La cible est :
+
+```text
+Figma / identité visuelle
+        |
+        v
+DESIGN.md / design tokens
+        |
+        v
+Design System
+        |
+        v
+SDC / Canvas Component Library approuvée
+        |
+        +-----------------------+
+        |                       |
+        v                       v
+Drupal AI Context           Canvas AI
+        |                       |
+        +-----------+-----------+
+                    |
+                    v
+              Page candidate
+                    |
+                    v
+             Automated checks
+                    |
+                    v
+               Human review
+                    |
+                    v
+                 Publish
+```
+
+Drupal reste autoritatif pour les entités, permissions, traductions, révisions,
+workflows et publication.
+
+## 3. Invariant — COMPOSE BEFORE CREATE
+
+Toute demande de page ou d’expérience suit cet ordre :
+
+1. rechercher les composants approuvés existants ;
+2. essayer une composition avec ces composants ;
+3. utiliser leurs variantes, props et slots existants ;
+4. ne proposer une nouvelle primitive que si le besoin ne peut raisonnablement
+   pas être couvert ;
+5. documenter le gap exact ;
+6. concevoir, implémenter, tester et faire approuver cette primitive séparément ;
+7. seulement après admission, rendre la primitive disponible à la composition
+   humaine ou IA.
+
+Une capacité de page building, humaine ou IA, ne doit pas pouvoir contourner ce
+processus en générant librement du markup ou du CSS ad hoc.
+
+## 4. Priorité de solution
+
+Avant toute nouvelle fonctionnalité IA, Canvas ou page-builder, le ticket doit
+classifier explicitement la solution :
+
+```text
+USE DRUPAL
+EXTEND DRUPAL
+BUILD IN AGENCY
+DEFER / EXPERIMENTAL
+```
+
+L’ordre de préférence est :
+
+```text
+USE DRUPAL > EXTEND DRUPAL > BUILD IN AGENCY
+```
+
+`BUILD IN AGENCY` exige un gap Drupal réel, documenté et démontré. Une absence
+de familiarité avec une capacité upstream n’est pas un gap.
+
+`DEFER / EXPERIMENTAL` s’applique lorsqu’une capacité est pertinente mais pas
+suffisamment mûre, security-covered ou prouvée pour le contexte visé.
+
+## 5. Responsabilités
+
+### Figma
+
+Figma exprime l’intention visuelle : maquettes, variables, composants de
+référence, variantes et interactions. Figma n’est pas la seule source de vérité
+technique et ne peut pas imposer directement du code runtime.
+
+### DESIGN.md
+
+`DESIGN.md` est le contrat durable entre design, développement, agents et
+composants. Il définit les tokens, règles frontend, conventions de composants,
+accessibilité, responsive, réutilisation et critères de création d’une nouvelle
+primitive.
+
+Il ne duplique pas le tone of voice, les audiences, les règles éditoriales ou
+les politiques IA, qui appartiennent au contexte gouverné et aux documents
+spécialisés.
+
+### SDC / Canvas components
+
+Les SDC approuvés constituent la cible des **primitives exécutables autorisées**.
+Leur API est explicite via props, slots et variantes. La transition depuis les
+Paragraphs/Twig existants se fait progressivement, par vertical slices, sans
+refonte big-bang.
+
+### Drupal AI / Canvas AI
+
+Drupal AI et Canvas AI sont le moteur privilégié pour interpréter un brief,
+sélectionner des composants, proposer une structure, renseigner des propriétés
+et composer une page candidate lorsque les capacités sont suffisamment mûres et
+prouvées.
+
+Agency ne construit pas un orchestrateur concurrent sauf gap démontré.
+
+### Contexte IA Drupal
+
+Le contexte de marque, audiences, terminologie, règles éditoriales, conformité,
+localisation et contraintes propres aux use cases suit
+`docs/drupal-ai-context-architecture.md`. `DESIGN.md` ne devient pas une seconde
+base éditoriale.
+
+### Validation
+
+Les validations comprennent, selon l’impact : tests techniques, vrai navigateur,
+responsive, console/réseau, DOM pertinent, accessibilité, conformité aux
+composants/tokens, régression visuelle, liens, formulaires et règles éditoriales.
+
+AI Playwright peut fournir des « yeux » à un agent en environnement borné. Il ne
+remplace jamais la preuve indépendante décrite dans `docs/browser-validation.md`.
+
+## 6. Frontière Agency / Preflight
+
+La séparation cible est :
+
+```text
+Agency
+= production et composition de l’expérience Drupal
+
+Preflight
+= validation, preuves et gouvernance indépendante
+```
+
+Agency doit produire des candidats et des preuves machine-readable suffisamment
+propres pour qu’une future intégration Preflight puisse les vérifier sans
+partager le même mécanisme de génération.
+
+Le générateur et le validateur indépendant ne doivent pas devenir une seule
+source de vérité.
+
+## 7. Conséquences
+
+### Positives
+
+- moins de code propriétaire générique ;
+- meilleur alignement avec Drupal core, Canvas et Drupal AI ;
+- composants réutilisables et testables ;
+- pages IA plus cohérentes avec l’identité visuelle ;
+- validation plus indépendante et auditable ;
+- possibilité de faire évoluer Figma, Canvas AI ou le provider IA sans changer
+  la doctrine de gouvernance.
+
+### Coûts assumés
+
+- formaliser le design system existant avant la génération de pages ;
+- convertir progressivement les primitives pertinentes vers SDC ;
+- maintenir un catalogue d’admission et des preuves de composants ;
+- accepter que certaines fonctions Canvas AI restent expérimentales jusqu’à
+  preuve suffisante.
+
+## 8. Ce que cette ADR n’autorise pas
+
+Cette décision n’autorise pas à elle seule :
+
+- l’installation ou l’activation production de Canvas/Canvas AI ;
+- l’installation production d’une dépendance alpha/beta ;
+- la génération automatique de nouveaux composants ;
+- l’auto-publication ;
+- une mutation production autonome ;
+- un accès agentique aux secrets, utilisateurs ou permissions ;
+- une migration big-bang des Paragraphs/Twig ;
+- un moteur Agency de génération HTML/CSS libre.
+
+Chaque activation reste soumise aux règles de `docs/drupal-ai-architecture.md`,
+aux tickets dédiés et aux preuves du projet.
+
+## 9. Supersession
+
+Cette ADR a statut **ACCEPTED** et est autoritative pour les décisions de design
+system, composants, Canvas et génération de pages.
+
+Elle ne peut être remplacée que par une **nouvelle ADR explicite**, avec :
+
+- un statut clair ;
+- le lien vers cette ADR ;
+- la motivation du changement ;
+- les conséquences et le plan de migration.
+
+Une conversation ChatGPT, un prompt de ticket ou un document non décisionnel ne
+peut pas la superséder.

--- a/docs/governed-ai-experience.md
+++ b/docs/governed-ai-experience.md
@@ -1,0 +1,384 @@
+# Governed AI Experience — architecture cible
+
+Statut : **SOURCE D’ARCHITECTURE ACTIVE**  
+Décision : `docs/decisions/ADR-001-governed-ai-experience.md`  
+Issue : #518  
+Parents : #3, #32  
+Date de cadrage : 2026-08-18
+
+## 1. Mission
+
+Agency doit démontrer qu’un site Drupal peut devenir une plateforme de création
+d’expériences assistée par IA **sans abandonner le design system, la structure,
+les permissions, les révisions ni la validation humaine**.
+
+Le produit cible n’est pas un générateur de pages libre. Le produit cible est un
+système de **composition gouvernée**.
+
+```text
+brief
+-> contexte autorisé
+-> catalogue de composants approuvés
+-> composition candidate
+-> preuves automatiques
+-> revue humaine
+-> publication Drupal
+```
+
+L’invariant de décision est : **COMPOSE BEFORE CREATE**.
+
+## 2. Architecture
+
+```text
+Figma
+  |
+  v
+DESIGN.md / tokens
+  |
+  v
+Design System
+  |
+  v
+SDC / Canvas Component Library
+  |
+  +---------------------+
+  |                     |
+  v                     v
+Drupal AI Context    Canvas AI
+  |                     |
+  +----------+----------+
+             |
+             v
+       Page candidate
+             |
+             v
+      Automated checks
+             |
+             v
+        Human review
+             |
+             v
+          Publish
+```
+
+La future frontière inter-projets est :
+
+```text
+Agency
+  produit / compose / prévisualise
+          |
+          v
+preuves et candidat structurés
+          |
+          v
+Preflight
+  vérifie indépendamment / gouverne les preuves
+```
+
+Preflight ne doit pas être requis pour rendre une page dans Agency. Il constitue
+une future couche indépendante de vérification et de gouvernance.
+
+## 3. État réel du repository au 18 août 2026
+
+### Déjà présent
+
+- Drupal 11.4.x ;
+- Drupal AI stable dans le projet ;
+- thème custom `emerging_digital` ;
+- Paragraphs et templates Twig explicites ;
+- tokens CSS dans `web/themes/custom/emerging_digital/css/base.css` ;
+- validation Playwright réelle desktop/mobile ;
+- Playwright MCP et Chrome DevTools MCP disponibles sur le runner ;
+- preuve DEV-ONLY de `drupal/ai_playwright` ;
+- contrat de contexte partagé dans `docs/drupal-ai-context-architecture.md`.
+
+### Pas encore présent
+
+- intégration Drupal Canvas dans le produit Agency ;
+- catalogue SDC Agency gouverné ;
+- catalogue d’admission de composants pour composition IA ;
+- intégration technique Figma ;
+- validation automatique de conformité à un catalogue SDC ;
+- Context Control Center en production ;
+- génération de pages Canvas AI activée comme capacité produit.
+
+Ce document ne doit jamais présenter un élément de la seconde liste comme une
+capacité déjà livrée.
+
+## 4. Classification upstream-first
+
+Avant tout chantier, revalider les sources Drupal officielles et appliquer la
+classification suivante.
+
+| Capacité | Classification cible | Décision Agency |
+| --- | --- | --- |
+| Single Directory Components | `USE DRUPAL` | API de composants cible ; aucune réimplémentation custom de framework de composants. |
+| Drupal Canvas — composition visuelle | `USE DRUPAL` | moteur de composition privilégié une fois la bibliothèque Agency prête et le vertical slice prouvé. |
+| Canvas AI — page building | `DEFER / EXPERIMENTAL` puis `USE DRUPAL` si preuve suffisante | moteur IA privilégié ; ne pas construire un concurrent pendant l’évaluation upstream. |
+| Métadonnées design system pour Canvas AI | `EXTEND DRUPAL` si nécessaire | compléter les métadonnées des composants Agency, pas créer un format parallèle générique. |
+| Context Control Center | `DEFER / EXPERIMENTAL` | suivre #387 ; ne pas reconstruire CCC dans Agency. |
+| Drupal AI | `USE DRUPAL` | abstraction IA par défaut selon `docs/drupal-ai-architecture.md`. |
+| AI Playwright | `DEFER / EXPERIMENTAL` en production ; usage DEV-ONLY prouvé | auto-inspection complémentaire, jamais gate unique. |
+| Playwright Test indépendant Agency | `BUILD IN AGENCY` justifié | preuve indépendante spécifique au projet ; futur point d’intégration avec Preflight. |
+| Figma -> code/page automatique | `DEFER / EXPERIMENTAL` | Figma fournit l’intention ; ne pas créer de pipeline custom tant qu’un gap Drupal réel n’est pas prouvé. |
+| Générateur propriétaire prompt -> HTML/CSS | **interdit par ADR-001** | ne pas construire. |
+
+La classification n’est pas un snapshot de versions. Une dépendance ou une
+activation production exige toujours une revalidation de maturité, compatibilité
+et security advisory coverage.
+
+## 5. Flux — COMPOSE BEFORE CREATE
+
+Pour une demande de page :
+
+```text
+brief
+-> identifier audience/contexte autorisé
+-> interroger le catalogue de composants approuvés
+-> choisir props/slots/variantes existantes
+-> produire la composition
+-> valider
+```
+
+Si la composition ne couvre pas raisonnablement le besoin :
+
+```text
+gap explicite
+-> issue de nouvelle primitive
+-> design / contrat
+-> implémentation SDC
+-> tests composant
+-> accessibilité / responsive
+-> browser proof
+-> revue humaine
+-> admission au catalogue
+-> seulement ensuite composition de page
+```
+
+### Règle de refus
+
+Une IA ne peut pas considérer « je peux générer du HTML/CSS » comme une raison
+suffisante pour créer une primitive. La question est : **le besoin fonctionnel
+ou visuel ne peut-il réellement pas être couvert par le catalogue et ses
+variantes ?**
+
+## 6. Catalogue de composants gouverné
+
+Le catalogue d’admission sera matérialisé dans #519. Il doit rester dérivable du
+code et ne pas devenir une seconde implémentation des composants.
+
+Un composant admis devra au minimum avoir :
+
+- identifiant stable ;
+- source SDC ;
+- rôle fonctionnel ;
+- props/slots contractuels ;
+- variantes autorisées ;
+- dépendances de tokens ;
+- contraintes responsive ;
+- contraintes accessibilité ;
+- statut d’admission ;
+- preuve de validation ;
+- règle de dépréciation/migration si nécessaire.
+
+États logiques recommandés :
+
+```text
+candidate -> approved -> deprecated -> retired
+```
+
+Seuls les composants `approved` sont disponibles à une composition IA destinée
+à produire un candidat publiable.
+
+## 7. Figma et identité visuelle
+
+Figma peut décrire :
+
+- la maquette ;
+- les variables et décisions visuelles ;
+- des composants de référence ;
+- les états/variantes ;
+- les interactions ;
+- les intentions responsive.
+
+Le passage Figma -> Drupal ne doit pas être un export aveugle de markup.
+
+La traduction vers le runtime suit :
+
+```text
+Figma
+-> décision/token/variant identifiée
+-> DESIGN.md ou token canonique
+-> composant SDC
+-> validation Drupal/Playwright
+```
+
+Une future intégration Figma MCP ou Canvas AI peut accélérer cette boucle, mais
+elle doit alimenter le même contrat, pas créer une deuxième voie de production.
+
+## 8. DESIGN.md et contexte IA
+
+`DESIGN.md` possède les règles **visuelles et d’implémentation frontend**.
+
+Il ne possède pas :
+
+- le positionnement commercial ;
+- le tone of voice éditorial ;
+- les personas/audiences ;
+- les règles de conformité métier ;
+- les règles propres au chatbot ;
+- les prompts provider.
+
+Ces éléments suivent `docs/drupal-ai-context-architecture.md`, les sources SEO et
+les entités Drupal correspondantes.
+
+La composition de page peut consommer les deux familles :
+
+```text
+contrat visuel / composant
++
+contexte éditorial gouverné
+```
+
+sans les fusionner en un fichier monolithique.
+
+## 9. Candidat de page et publication
+
+Une page générée ou fortement assistée par IA est toujours un **candidat**.
+
+Le moteur de composition doit préférer des données structurées : identifiants de
+composants, props, slots, ordre, contexte d’entité et métadonnées. Le markup final
+est produit par les primitives Drupal approuvées.
+
+Le cycle cible est :
+
+```text
+AI proposes composition
+-> Drupal materializes a draft/revision candidate
+-> automated evidence
+-> human reviews
+-> Drupal publishes
+```
+
+Pas d’auto-publication implicite.
+
+## 10. Validation automatique
+
+Pour toute génération importante, sélectionner les contrôles pertinents :
+
+### Technique
+
+- schémas SDC / props ;
+- rendu Drupal sans erreur ;
+- configuration propre ;
+- tests PHP/JS concernés.
+
+### Navigateur
+
+- Chromium réel ;
+- desktop/mobile et viewports pertinents ;
+- DOM/sémantique ;
+- erreurs console/page ;
+- erreurs réseau same-origin ;
+- interactions ;
+- liens ;
+- formulaires ;
+- captures et traces.
+
+Source : `docs/browser-validation.md`.
+
+### Accessibilité
+
+La trajectoire doit aller au-delà des simples locators sémantiques existants :
+
+- structure des titres ;
+- nom accessible ;
+- clavier/focus ;
+- contrastes ;
+- formulaires ;
+- absence de débordement ;
+- contrôles automatisables pertinents ;
+- revue humaine lorsque l’automatisation ne suffit pas.
+
+Cible de conception : WCAG 2.2 AA, sauf exigence de ticket plus stricte.
+
+### Design system
+
+À mesure que #519 matérialise le catalogue :
+
+- aucun composant non approuvé dans le candidat ;
+- props/variantes conformes ;
+- usage des tokens ;
+- absence de CSS ad hoc créé par le page builder ;
+- régression visuelle lorsque la surface le justifie.
+
+### Éditorial / marque
+
+Selon le use case :
+
+- langue ;
+- terminologie ;
+- règles de marque ;
+- assertions factuelles ;
+- SEO/AEO ;
+- conformité ;
+- absence d’auto-publication.
+
+Ces contrôles consomment le contexte gouverné, pas `DESIGN.md` seul.
+
+## 11. Rôle d’AI Playwright
+
+Le pilote #456 a démontré l’intérêt de donner des « yeux » navigateur à un agent
+Drupal dans un environnement DDEV borné.
+
+Classification stratégique :
+
+```text
+AI Playwright
+= boucle d’auto-inspection / diagnostic DEV-ONLY
+
+Playwright Test Agency
+= preuve indépendante reproductible
+```
+
+#516 ne doit pas évoluer en moteur générique de modification de pages. Sa boucle
+agentique ne redevient prioritaire qu’après le contrat composants/SDC de #519 et
+doit opérer sur des primitives autorisées.
+
+## 12. Roadmap de convergence
+
+Ordre architectural :
+
+1. **#518 — architecture durable** : ADR, `DESIGN.md`, règles agents.
+2. **#519 — design system exécutable** : inventaire, vertical slice SDC,
+   admission gouvernée.
+3. **Validation** : renforcer l’accessibilité et la conformité composants dans la
+   preuve navigateur existante, sans créer un second framework de test.
+4. **Canvas** : vertical slice de composition visuelle avec les SDC approuvés.
+5. **Canvas AI** : pilote borné de sélection/composition de ces mêmes composants.
+6. **#387 / contexte** : brancher le contexte de marque gouverné lorsque la
+   maturité upstream le permet ; ne pas dupliquer CCC.
+7. **Page generation contrôlée** : brief -> composition candidate -> preuves ->
+   revue humaine ; aucune génération libre de markup.
+8. **Preflight** : préparer/brancher la validation indépendante lorsque son
+   contrat d’intégration est prêt.
+
+Cette séquence peut être ajustée par ticket, mais **aucune étape ultérieure ne
+justifie de contourner COMPOSE BEFORE CREATE**.
+
+## 13. Questions à poser avant tout nouveau développement
+
+Avant de coder une nouvelle fonctionnalité frontend/IA/page-builder :
+
+1. existe-t-elle déjà dans Drupal core ?
+2. existe-t-elle dans Canvas ?
+3. existe-t-elle dans Drupal AI / contrib officiel pertinent ?
+4. quelle est la maturité/security coverage actuelle ?
+5. quel est le gap Agency exact ?
+6. peut-on le résoudre par configuration ou métadonnées ?
+7. peut-on étendre une primitive Drupal plutôt que créer un moteur parallèle ?
+8. quelle preuve indépendante valide le résultat ?
+9. quelle revue humaine précède la publication ?
+
+Si le gap ne peut pas être formulé précisément, le développement custom n’est
+pas autorisé.


### PR DESCRIPTION
## Résumé

Matérialise la réorientation stratégique Agency vers une **plateforme Drupal AI/Canvas de création d’expériences gouvernées**, et non un générateur propriétaire `prompt -> HTML/CSS/page arbitraire`.

### Sources de vérité ajoutées

- `docs/decisions/ADR-001-governed-ai-experience.md` — statut **ACCEPTED** ;
- `docs/governed-ai-experience.md` — architecture cible et séquence de convergence ;
- `DESIGN.md` — contrat design system / tokens / SDC / accessibilité / règles de création de composants.

### Mémoire agent

`AGENTS.md` ajoute un pointeur obligatoire : avant tout travail frontend, design system, Figma, SDC, Canvas, Drupal AI UI, génération de composants ou de pages, lire ADR-001, `DESIGN.md` et l’architecture Governed AI Experience.

### Invariants

- **COMPOSE BEFORE CREATE** ;
- `USE DRUPAL > EXTEND DRUPAL > BUILD IN AGENCY` ;
- `DEFER / EXPERIMENTAL` lorsque l’upstream n’est pas suffisamment mûr ;
- Figma = intention visuelle, pas unique source technique ;
- SDC/Canvas components = primitives exécutables approuvées ;
- Drupal AI/Canvas AI = moteur privilégié de composition une fois prouvé ;
- Context Control Center reste propriétaire du contexte gouverné, sans duplication dans `DESIGN.md` ;
- Playwright indépendant reste la preuve autoritative ; AI Playwright reste complément DEV-ONLY ;
- Agency = production/composition, Preflight = future vérification indépendante.

### État upstream revalidé le 18/08/2026

La décision se base sur les sources Drupal officielles revalidées avant écriture : Canvas stable/security-covered, SDC dans core, workstream Drupal AI de page generation/design-system/context et Context Control Center encore sans release stable supportée.

### Scope

4 fichiers seulement : documentation + `AGENTS.md`. Aucun Composer, module, config Drupal, workflow, contenu, secret ou production.

Backlog : #32 et #3 restent les epics existants ; #387 reste owner du contexte ; #456/#516 seront reclassés après merge ; #519 est l’unique gap d’implémentation suivant pour le catalogue SDC gouverné.

Closes #518
Refs #3 #32 #387 #456 #516 #519