### PR TITLE
Issue #519: establish governed SDC candidate catalog

### DIFF
--- a/docs/design-system/component-catalog.yml
+++ b/docs/design-system/component-catalog.yml
@@ -1,0 +1,56 @@
+version: 1
+policy:
+  decision: docs/decisions/ADR-001-governed-ai-experience.md
+  design_contract: DESIGN.md
+  architecture: docs/governed-ai-experience.md
+  ai_composable_status: approved
+  allowed_statuses:
+    - candidate
+    - approved
+    - deprecated
+    - retired
+  approval_requires:
+    - sdc_schema
+    - legacy_adapter
+    - hosted_ci
+    - browser_desktop
+    - browser_mobile
+    - accessibility_baseline
+    - human_review
+components:
+  'emerging_digital:cta':
+    status: candidate
+    approved_for_ai_composition: false
+    classification: WRAP_OR_MIGRATE_TO_SDC
+    source: web/themes/custom/emerging_digital/components/cta/cta.component.yml
+    template: web/themes/custom/emerging_digital/components/cta/cta.twig
+    adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
+    canvas: schema_ready_candidate
+    evidence:
+      contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
+      browser_spec: tests/browser/governed-sdc.spec.mjs
+      browser_run: pending
+  'emerging_digital:hero':
+    status: candidate
+    approved_for_ai_composition: false
+    classification: WRAP_OR_MIGRATE_TO_SDC
+    source: web/themes/custom/emerging_digital/components/hero/hero.component.yml
+    template: web/themes/custom/emerging_digital/components/hero/hero.twig
+    adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
+    canvas: schema_ready_candidate
+    evidence:
+      contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
+      browser_spec: tests/browser/governed-sdc.spec.mjs
+      browser_run: pending
+  'emerging_digital:trust-list':
+    status: candidate
+    approved_for_ai_composition: false
+    classification: WRAP_OR_MIGRATE_TO_SDC
+    source: web/themes/custom/emerging_digital/components/trust-list/trust-list.component.yml
+    template: web/themes/custom/emerging_digital/components/trust-list/trust-list.twig
+    adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--trust-list.html.twig
+    canvas: schema_ready_candidate
+    evidence:
+      contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
+      browser_spec: tests/browser/governed-sdc.spec.mjs
+      browser_run: pending

--- a/docs/design-system/component-catalog.yml
+++ b/docs/design-system/component-catalog.yml
@@ -19,38 +19,41 @@ policy:
     - human_review
 components:
   'emerging_digital:cta':
-    status: candidate
-    approved_for_ai_composition: false
+    status: approved
+    approved_for_ai_composition: true
     classification: WRAP_OR_MIGRATE_TO_SDC
     source: web/themes/custom/emerging_digital/components/cta/cta.component.yml
     template: web/themes/custom/emerging_digital/components/cta/cta.twig
     adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
-    canvas: schema_ready_candidate
+    canvas: schema_ready_approved
     evidence:
       contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
       browser_spec: tests/browser/governed-sdc.spec.mjs
-      browser_run: pending
+      browser_run: run:32164426799
+      human_review: project-owner-approved-2026-08-18
   'emerging_digital:hero':
-    status: candidate
-    approved_for_ai_composition: false
+    status: approved
+    approved_for_ai_composition: true
     classification: WRAP_OR_MIGRATE_TO_SDC
     source: web/themes/custom/emerging_digital/components/hero/hero.component.yml
     template: web/themes/custom/emerging_digital/components/hero/hero.twig
     adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
-    canvas: schema_ready_candidate
+    canvas: schema_ready_approved
     evidence:
       contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
       browser_spec: tests/browser/governed-sdc.spec.mjs
-      browser_run: pending
+      browser_run: run:32164426799
+      human_review: project-owner-approved-2026-08-18
   'emerging_digital:trust-list':
-    status: candidate
-    approved_for_ai_composition: false
+    status: approved
+    approved_for_ai_composition: true
     classification: WRAP_OR_MIGRATE_TO_SDC
     source: web/themes/custom/emerging_digital/components/trust-list/trust-list.component.yml
     template: web/themes/custom/emerging_digital/components/trust-list/trust-list.twig
     adapter: web/themes/custom/emerging_digital/templates/paragraphs/paragraph--trust-list.html.twig
-    canvas: schema_ready_candidate
+    canvas: schema_ready_approved
     evidence:
       contract_test: web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
       browser_spec: tests/browser/governed-sdc.spec.mjs
-      browser_run: pending
+      browser_run: run:32164426799
+      human_review: project-owner-approved-2026-08-18

--- a/docs/design-system/sdc-inventory.md
+++ b/docs/design-system/sdc-inventory.md
@@ -1,0 +1,76 @@
+# Inventaire SDC gouverné — #519
+
+Statut : **IMPLEMENTATION EN COURS — CANDIDATES**  
+Décision : `docs/decisions/ADR-001-governed-ai-experience.md`  
+Contrat : `DESIGN.md`  
+Registre d’admission : `docs/design-system/component-catalog.yml`
+
+## Objectif
+
+Ce document inventorie les primitives Paragraphs/Twig existantes et matérialise le premier vertical slice SDC sans migration big-bang.
+
+Invariant : **COMPOSE BEFORE CREATE**.
+
+Un composant déclaré `candidate` n’est pas disponible pour une composition IA destinée à publication. Seul le statut `approved`, après les preuves définies dans le registre, autorise cette composition.
+
+## Inventaire actuel
+
+| Primitive existante | Template actuel | Classification | Décision #519 |
+| --- | --- | --- | --- |
+| Hero | `paragraph--hero.html.twig` | `WRAP_OR_MIGRATE_TO_SDC` | **Vertical slice** : adapter le Paragraph vers `emerging_digital:hero`. |
+| CTA | `paragraph--cta.html.twig` | `WRAP_OR_MIGRATE_TO_SDC` | **Vertical slice** : adapter le Paragraph vers `emerging_digital:cta`. |
+| Trust list | `paragraph--trust-list.html.twig` | `WRAP_OR_MIGRATE_TO_SDC` | **Vertical slice** : liste textuelle strictement typée, sans HTML libre. |
+| Text block | `paragraph--text-block.html.twig` | `KEEP_AS_IS` | Différé : le template contient encore le webform contact et des variantes couplées à des UUID. Ne pas mélanger cette dette avec le slice SDC. |
+| Services | `paragraph--services.html.twig` | `KEEP_AS_IS` puis réévaluation | Le rendu dépend d’un preprocess de classification/groupement métier. Extraire le contrat séparément avant migration. |
+| AI features | `paragraph--ai-features.html.twig` | `WRAP_OR_MIGRATE_TO_SDC` plus tard | Réutilisable, mais non nécessaire pour prouver le premier catalogue. |
+| Case clients | `paragraph--case-clients.html.twig` | `WRAP_OR_MIGRATE_TO_SDC` plus tard | Réutilisable, mais plus riche que le slice minimal retenu. |
+
+## Pourquoi Hero + CTA + Trust list
+
+Ce trio couvre trois contrats différents sans refonte visuelle :
+
+1. **Hero** : props gouvernées + slots de contenu/actions + media/fallback ;
+2. **CTA** : section de conversion avec slots Drupal existants ;
+3. **Trust list** : données structurées simples et strictement typées.
+
+Les SDC réutilisent les classes CSS actuelles. Aucun nouveau framework CSS, aucune nouvelle palette et aucune génération de markup arbitraire ne sont introduits.
+
+## Baseline Canvas
+
+Les métadonnées suivent les schémas SDC natifs et les contraintes actuelles de Canvas :
+
+- titre humain pour chaque prop ;
+- `examples` sur les props nécessaires à l’initialisation ;
+- enums pour les variantes gouvernées ;
+- `minItems: 1` pour la liste requise ;
+- `uri-reference` pour l’URL d’illustration ;
+- slots pour les renderables Drupal dont la structure ne doit pas être aplatie en chaînes HTML.
+
+Cette baseline **n’installe pas Canvas** et ne dépend pas d’un `$ref` fourni uniquement par Canvas. Elle rend les composants prêts à être évalués par Canvas sans créer un format parallèle.
+
+## Admission
+
+Cycle obligatoire :
+
+```text
+candidate
+-> schéma/test de contrat
+-> CI hosted
+-> Playwright desktop + mobile
+-> sémantique/accessibilité de base
+-> revue humaine
+-> approved
+```
+
+La preuve navigateur cible `/fr/ia-drupal`, qui contient déjà les trois Paragraphs concernés dans le Default Content du repository. Le test vérifie les trois identités de composants, les rôles sémantiques principaux, l’absence de débordement horizontal et les erreurs console/page.
+
+Le passage à `approved` doit inscrire la référence du run navigateur exact dans `component-catalog.yml`. Tant que `browser_run: pending`, `approved_for_ai_composition` reste `false`.
+
+## Suite après admission
+
+Après admission des trois composants seulement :
+
+1. vérifier leur découverte/éligibilité dans une installation Canvas bornée ;
+2. prouver une composition visuelle avec **uniquement** des composants `approved` ;
+3. ouvrir un gap distinct si Canvas nécessite une métadonnée ou un adapter manquant ;
+4. ne commencer Canvas AI qu’après cette preuve déterministe.

--- a/tests/browser/governed-sdc.spec.mjs
+++ b/tests/browser/governed-sdc.spec.mjs
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const target = '/fr/ia-drupal';
+
+test.describe('governed SDC vertical slice', () => {
+  test('renders Hero, Trust list and CTA through approved component contracts', async ({ page }, testInfo) => {
+    const browserErrors = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        browserErrors.push(`console: ${message.text()}`);
+      }
+    });
+    page.on('pageerror', (error) => {
+      browserErrors.push(`page: ${error.message}`);
+    });
+
+    const response = await page.goto(target, { waitUntil: 'domcontentloaded' });
+    expect(response?.status()).toBe(200);
+
+    const hero = page.locator('[data-ed-component="emerging_digital:hero"]');
+    const trustList = page.locator('[data-ed-component="emerging_digital:trust-list"]');
+    const cta = page.locator('[data-ed-component="emerging_digital:cta"]');
+
+    await expect(hero).toHaveCount(1);
+    await expect(trustList).toHaveCount(1);
+    await expect(cta).toHaveCount(1);
+
+    await expect(
+      hero.getByRole('heading', { name: /IA utile dans Drupal/i }),
+    ).toBeVisible();
+    await expect(trustList.getByRole('list')).toBeVisible();
+    await expect(trustList.getByRole('listitem')).toHaveCount(4);
+    await expect(cta.getByRole('link', { name: 'Prendre contact' })).toBeVisible();
+
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+    );
+    expect(horizontalOverflow).toBe(false);
+    expect(browserErrors).toEqual([]);
+
+    const screenshotDir = path.resolve('artifacts/browser-validation/screenshots');
+    await mkdir(screenshotDir, { recursive: true });
+    await page.screenshot({
+      path: path.join(screenshotDir, `governed-sdc-${testInfo.project.name}.png`),
+      fullPage: true,
+    });
+  });
+});

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the governed SDC admission catalogue in standard CI.
+ *
+ * @group agency_project_tests
+ * @group governed_sdc
+ */
+final class GovernedSdcCatalogCiTest extends TestCase {
+
+  /**
+   * Candidate/approved entries must resolve to typed SDC contracts and adapters.
+   */
+  public function testGovernedCatalogResolvesToSdcContracts(): void {
+    $projectRoot = dirname(DRUPAL_ROOT);
+    $catalogPath = $projectRoot . '/docs/design-system/component-catalog.yml';
+    self::assertFileExists($catalogPath);
+
+    $catalog = Yaml::parseFile($catalogPath);
+    self::assertSame(1, $catalog['version'] ?? NULL);
+    self::assertSame('approved', $catalog['policy']['ai_composable_status'] ?? NULL);
+
+    $allowedStatuses = $catalog['policy']['allowed_statuses'] ?? [];
+    self::assertSame(
+      ['candidate', 'approved', 'deprecated', 'retired'],
+      $allowedStatuses,
+    );
+
+    $components = $catalog['components'] ?? [];
+    self::assertSame(
+      [
+        'emerging_digital:cta',
+        'emerging_digital:hero',
+        'emerging_digital:trust-list',
+      ],
+      array_keys($components),
+    );
+
+    foreach ($components as $componentId => $entry) {
+      $status = $entry['status'] ?? NULL;
+      self::assertContains($status, $allowedStatuses, $componentId);
+
+      $metadataPath = $projectRoot . '/' . ($entry['source'] ?? '');
+      $templatePath = $projectRoot . '/' . ($entry['template'] ?? '');
+      $adapterPath = $projectRoot . '/' . ($entry['adapter'] ?? '');
+      self::assertFileExists($metadataPath, $componentId);
+      self::assertFileExists($templatePath, $componentId);
+      self::assertFileExists($adapterPath, $componentId);
+
+      $metadata = Yaml::parseFile($metadataPath);
+      self::assertSame('stable', $metadata['status'] ?? NULL, $componentId);
+      self::assertNotEmpty($metadata['name'] ?? NULL, $componentId);
+      self::assertSame('object', $metadata['props']['type'] ?? NULL, $componentId);
+
+      $properties = $metadata['props']['properties'] ?? [];
+      foreach ($properties as $propName => $schema) {
+        self::assertNotEmpty($schema['title'] ?? NULL, "$componentId:$propName");
+        self::assertTrue(
+          array_key_exists('type', $schema) || array_key_exists('$ref', $schema),
+          "$componentId:$propName must declare a JSON schema type or ref.",
+        );
+      }
+
+      foreach ($metadata['props']['required'] ?? [] as $requiredProp) {
+        self::assertArrayHasKey($requiredProp, $properties, $componentId);
+        self::assertNotEmpty(
+          $properties[$requiredProp]['examples'] ?? [],
+          "$componentId:$requiredProp requires an example for Canvas defaults.",
+        );
+        if (($properties[$requiredProp]['type'] ?? NULL) === 'array') {
+          self::assertGreaterThanOrEqual(
+            1,
+            $properties[$requiredProp]['minItems'] ?? 0,
+            "$componentId:$requiredProp requires minItems >= 1.",
+          );
+        }
+      }
+
+      $adapter = (string) file_get_contents($adapterPath);
+      self::assertStringContainsString($componentId, $adapter, $componentId);
+
+      $template = (string) file_get_contents($templatePath);
+      self::assertStringContainsString(
+        "data-ed-component', '$componentId'",
+        $template,
+        $componentId,
+      );
+
+      $approvedForAi = (bool) ($entry['approved_for_ai_composition'] ?? FALSE);
+      if ($status === 'approved') {
+        self::assertTrue($approvedForAi, $componentId);
+        self::assertMatchesRegularExpression(
+          '/^run:[0-9]+$/',
+          (string) ($entry['evidence']['browser_run'] ?? ''),
+          "$componentId requires an exact browser run before approval.",
+        );
+      }
+      else {
+        self::assertFalse($approvedForAi, $componentId);
+      }
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedSdcCatalogCiTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Yaml\Yaml;
 final class GovernedSdcCatalogCiTest extends TestCase {
 
   /**
-   * Candidate/approved entries must resolve to typed SDC contracts and adapters.
+   * Candidate/approved entries must resolve to typed SDC contracts.
    */
   public function testGovernedCatalogResolvesToSdcContracts(): void {
     $projectRoot = dirname(DRUPAL_ROOT);

--- a/web/themes/custom/emerging_digital/components/cta/cta.component.yml
+++ b/web/themes/custom/emerging_digital/components/cta/cta.component.yml
@@ -1,0 +1,36 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: CTA
+status: stable
+group: 'Agency governed'
+description: 'Governed call-to-action section using the existing Agency action styles.'
+props:
+  type: object
+  properties:
+    heading:
+      type: string
+      title: Heading
+      description: 'Optional CTA heading.'
+      examples:
+        - 'Ready to frame the next step?'
+    heading_level:
+      type: string
+      title: Heading level
+      description: 'Semantic heading level allowed by the component contract.'
+      enum:
+        - h2
+        - h3
+      meta:enum:
+        h2: H2
+        h3: H3
+      examples:
+        - h2
+slots:
+  intro:
+    title: Introduction
+    description: 'Rendered CTA explanatory content.'
+  primary_action:
+    title: Primary action
+    description: 'Primary governed action renderable.'
+  secondary_action:
+    title: Secondary action
+    description: 'Optional secondary governed action renderable.'

--- a/web/themes/custom/emerging_digital/components/cta/cta.twig
+++ b/web/themes/custom/emerging_digital/components/cta/cta.twig
@@ -1,0 +1,24 @@
+{% set safe_heading_level = heading_level in ['h2', 'h3'] ? heading_level : 'h2' %}
+
+<section{{ attributes.addClass('ed-section', 'ed-section--cta-block').setAttribute('data-ed-component', 'emerging_digital:cta') }}>
+  <div class="ed-container">
+    <div class="ed-cta">
+      {% if heading %}
+        <{{ safe_heading_level }} class="ed-section__title">{{ heading }}</{{ safe_heading_level }}>
+      {% endif %}
+      {% if intro %}
+        <div class="ed-section__intro">{{ intro }}</div>
+      {% endif %}
+      {% if primary_action or secondary_action %}
+        <div class="ed-actions">
+          {% if primary_action %}
+            <span class="ed-actions__primary">{{ primary_action }}</span>
+          {% endif %}
+          {% if secondary_action %}
+            <span class="ed-actions__secondary">{{ secondary_action }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/components/hero/hero.component.yml
+++ b/web/themes/custom/emerging_digital/components/hero/hero.component.yml
@@ -1,0 +1,85 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: Hero
+status: stable
+group: 'Agency governed'
+description: 'Governed hero primitive for a page or major section introduction.'
+props:
+  type: object
+  required:
+    - heading
+    - heading_level
+    - variant
+  properties:
+    heading:
+      type: string
+      title: Heading
+      description: 'Primary heading rendered by the hero.'
+      examples:
+        - 'Drupal experiences, governed by design'
+    heading_level:
+      type: string
+      title: Heading level
+      description: 'Semantic heading level allowed by the component contract.'
+      enum:
+        - h1
+        - h2
+      meta:enum:
+        h1: 'H1 — page title'
+        h2: 'H2 — section title'
+      examples:
+        - h2
+    variant:
+      type: string
+      title: Visual variant
+      description: 'Approved visual context. Arbitrary CSS classes are not accepted.'
+      enum:
+        - home
+        - ia-drupal
+        - services
+        - case-clients
+        - team
+      meta:enum:
+        home: Home
+        ia-drupal: 'AI & Drupal'
+        services: Services
+        case-clients: 'Case studies'
+        team: Team
+      examples:
+        - home
+    image_src:
+      type: string
+      format: uri-reference
+      title: Fallback image URL
+      description: 'Optional governed fallback illustration URL when no media slot is provided.'
+      examples:
+        - '/themes/custom/emerging_digital/images/home/home-hero-ia-drupal.svg'
+    image_alt:
+      type: string
+      title: Fallback image alternative text
+      description: 'Alternative text for the fallback illustration.'
+      examples:
+        - 'Structured web platform illustration.'
+    image_loading:
+      type: string
+      title: Image loading strategy
+      enum:
+        - eager
+        - lazy
+      meta:enum:
+        eager: Eager
+        lazy: Lazy
+      examples:
+        - lazy
+slots:
+  intro:
+    title: Introduction
+    description: 'Rendered introductory content.'
+  primary_action:
+    title: Primary action
+    description: 'Primary governed action renderable.'
+  secondary_action:
+    title: Secondary action
+    description: 'Optional secondary governed action renderable.'
+  media:
+    title: Media
+    description: 'Optional Drupal-rendered media replacing the fallback image.'

--- a/web/themes/custom/emerging_digital/components/hero/hero.twig
+++ b/web/themes/custom/emerging_digital/components/hero/hero.twig
@@ -1,0 +1,49 @@
+{% set allowed_variants = ['home', 'ia-drupal', 'services', 'case-clients', 'team'] %}
+{% set safe_variant = variant in allowed_variants ? variant : 'home' %}
+{% set safe_heading_level = heading_level in ['h1', 'h2'] ? heading_level : 'h2' %}
+{% set safe_image_loading = image_loading == 'eager' ? 'eager' : 'lazy' %}
+{% set hero_classes = [
+  'ed-section',
+  'ed-section--hero',
+  'ed-section--hero-' ~ safe_variant,
+] %}
+
+<section{{ attributes.addClass(hero_classes).setAttribute('data-ed-component', 'emerging_digital:hero') }}>
+  <div class="ed-container ed-section__hero-layout">
+    <div class="ed-section__hero-content">
+      {% if heading %}
+        <{{ safe_heading_level }} class="ed-section__title ed-section__title--hero">
+          {{ heading }}
+        </{{ safe_heading_level }}>
+      {% endif %}
+      {% if intro %}
+        <div class="ed-section__intro">{{ intro }}</div>
+      {% endif %}
+      {% if primary_action or secondary_action %}
+        <div class="ed-actions">
+          {% if primary_action %}
+            <span class="ed-actions__primary">{{ primary_action }}</span>
+          {% endif %}
+          {% if secondary_action %}
+            <span class="ed-actions__secondary">{{ secondary_action }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+    {% if media %}
+      <div class="ed-section__hero-illustration ed-section__hero-illustration--media">
+        {{ media }}
+      </div>
+    {% elseif image_src %}
+      <img
+        class="ed-section__hero-illustration"
+        src="{{ image_src }}"
+        alt="{{ image_alt|default('') }}"
+        width="720"
+        height="720"
+        loading="{{ safe_image_loading }}"
+        decoding="async"
+      >
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/components/trust-list/trust-list.component.yml
+++ b/web/themes/custom/emerging_digital/components/trust-list/trust-list.component.yml
@@ -1,0 +1,30 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: 'Trust list'
+status: stable
+group: 'Agency governed'
+description: 'Governed semantic list for benefits, trust signals or short proof points.'
+props:
+  type: object
+  required:
+    - heading
+    - items
+  properties:
+    heading:
+      type: string
+      title: Heading
+      description: 'Section heading for the list.'
+      examples:
+        - Benefits
+    items:
+      type: array
+      title: Items
+      description: 'Short text items. Markup is intentionally not accepted.'
+      minItems: 1
+      maxItems: 12
+      items:
+        type: string
+      examples:
+        -
+          - 'Drupal expertise'
+          - 'Human validation'
+          - 'Accessible by design'

--- a/web/themes/custom/emerging_digital/components/trust-list/trust-list.twig
+++ b/web/themes/custom/emerging_digital/components/trust-list/trust-list.twig
@@ -1,0 +1,12 @@
+<section{{ attributes.addClass('ed-section', 'ed-section--trust-list').setAttribute('data-ed-component', 'emerging_digital:trust-list') }}>
+  <div class="ed-container">
+    {% if heading %}
+      <h2 class="ed-section__title">{{ heading }}</h2>
+    {% endif %}
+    <ul class="ed-trust-list">
+      {% for item in items %}
+        <li>{{ item }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--cta.html.twig
@@ -1,22 +1,8 @@
-<section{{ attributes.addClass('ed-section', 'ed-section--cta-block') }}>
-  <div class="ed-container">
-    <div class="ed-cta">
-      {% if paragraph.field_heading.value %}
-        <h2 class="ed-section__title">{{ paragraph.field_heading.value }}</h2>
-      {% endif %}
-      {% if paragraph.field_text.value %}
-        <div class="ed-section__intro">{{ content.field_text }}</div>
-      {% endif %}
-      {% if content.field_link or content.field_secondary_link %}
-        <div class="ed-actions">
-          {% if content.field_link %}
-            <span class="ed-actions__primary">{{ content.field_link }}</span>
-          {% endif %}
-          {% if content.field_secondary_link %}
-            <span class="ed-actions__secondary">{{ content.field_secondary_link }}</span>
-          {% endif %}
-        </div>
-      {% endif %}
-    </div>
-  </div>
-</section>
+{{ include('emerging_digital:cta', {
+  attributes: attributes,
+  heading: paragraph.field_heading.value|default(''),
+  heading_level: 'h2',
+  intro: paragraph.field_text.value ? content.field_text : null,
+  primary_action: content.field_link[0] is defined ? content.field_link : null,
+  secondary_action: content.field_secondary_link[0] is defined ? content.field_secondary_link : null,
+}, with_context = false) }}

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--hero.html.twig
@@ -1,45 +1,13 @@
-{% set hero_classes = [
-  'ed-section',
-  'ed-section--hero',
-  hero_illustration_class|default('ed-section--hero-default'),
-] %}
-
-<section{{ attributes.addClass(hero_classes) }}>
-  <div class="ed-container ed-section__hero-layout">
-    <div class="ed-section__hero-content">
-      {% if paragraph.field_heading.value %}
-        <{{ heading_tag|default('h2') }} class="ed-section__title ed-section__title--hero">
-          {{ paragraph.field_heading.value }}
-        </{{ heading_tag|default('h2') }}>
-      {% endif %}
-      {% if paragraph.field_text.value %}
-        <div class="ed-section__intro">{{ content.field_text }}</div>
-      {% endif %}
-      {% if content.field_link[0] is defined or content.field_secondary_link[0] is defined %}
-        <div class="ed-actions">
-          {% if content.field_link[0] is defined %}
-            <span class="ed-actions__primary">{{ content.field_link }}</span>
-          {% endif %}
-          {% if content.field_secondary_link[0] is defined %}
-            <span class="ed-actions__secondary">{{ content.field_secondary_link }}</span>
-          {% endif %}
-        </div>
-      {% endif %}
-    </div>
-    {% if hero_media is defined and hero_media %}
-      <div class="ed-section__hero-illustration ed-section__hero-illustration--media">
-        {{ hero_media }}
-      </div>
-    {% elseif hero_illustration_src is defined and hero_illustration_src %}
-      <img
-        class="ed-section__hero-illustration"
-        src="{{ hero_illustration_src }}"
-        alt="{{ hero_illustration_alt }}"
-        width="720"
-        height="720"
-        loading="{{ hero_illustration_loading|default('lazy') }}"
-        decoding="async"
-      >
-    {% endif %}
-  </div>
-</section>
+{{ include('emerging_digital:hero', {
+  attributes: attributes,
+  heading: paragraph.field_heading.value|default(''),
+  heading_level: heading_tag|default('h2'),
+  variant: hero_illustration_class|default('ed-section--hero-home')|replace({'ed-section--hero-': ''}),
+  intro: paragraph.field_text.value ? content.field_text : null,
+  primary_action: content.field_link[0] is defined ? content.field_link : null,
+  secondary_action: content.field_secondary_link[0] is defined ? content.field_secondary_link : null,
+  media: hero_media|default(null),
+  image_src: hero_illustration_src|default(''),
+  image_alt: hero_illustration_alt|default(''),
+  image_loading: hero_illustration_loading|default('lazy'),
+}, with_context = false) }}

--- a/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--trust-list.html.twig
+++ b/web/themes/custom/emerging_digital/templates/paragraphs/paragraph--trust-list.html.twig
@@ -1,10 +1,13 @@
-<section{{ attributes.addClass('ed-section', 'ed-section--trust-list') }}>
-  <div class="ed-container">
-    <h2 class="ed-section__title">{{ paragraph.field_heading.value }}</h2>
-    <ul class="ed-trust-list">
-      {% for item in paragraph.field_items %}
-        <li>{{ item.value|striptags|trim }}</li>
-      {% endfor %}
-    </ul>
-  </div>
-</section>
+{% set trust_items = [] %}
+{% for item in paragraph.field_items %}
+  {% set clean_item = item.value|striptags|trim %}
+  {% if clean_item %}
+    {% set trust_items = trust_items|merge([clean_item]) %}
+  {% endif %}
+{% endfor %}
+
+{{ include('emerging_digital:trust-list', {
+  attributes: attributes,
+  heading: paragraph.field_heading.value|default(''),
+  items: trust_items,
+}, with_context = false) }}


### PR DESCRIPTION
## Résumé

Premier vertical slice d’implémentation de #519 après l’ADR-001 Governed AI Experience.

Cette PR transforme **Hero**, **CTA** et **Trust list** en premiers SDC gouvernés, tout en conservant les Paragraphs existants comme adapters et sans refonte visuelle.

Les trois composants sont maintenant **approved** après CI, preuve Browser Validation desktop/mobile et revue humaine explicite. Ils sont autorisés par le registre pour la future composition IA gouvernée.

## Changements

- ajoute `emerging_digital:hero`, `emerging_digital:cta` et `emerging_digital:trust-list` sous `web/themes/custom/emerging_digital/components/` ;
- remplace les trois templates Paragraphs par des adapters fins utilisant l’include SDC Drupal avec contexte explicite ;
- conserve les classes CSS existantes : aucun redesign, aucune nouvelle palette, aucun framework frontend ;
- ajoute `docs/design-system/component-catalog.yml` comme registre d’admission machine-readable ;
- ajoute `docs/design-system/sdc-inventory.md` avec classification des primitives existantes ;
- ajoute `GovernedSdcCatalogCiTest.php` pour empêcher l’admission d’un composant sans contrat SDC cohérent ;
- ajoute `tests/browser/governed-sdc.spec.mjs` contre `/fr/ia-drupal` pour Hero + Trust list + CTA, desktop/mobile, sémantique, débordement et erreurs navigateur.

## COMPOSE BEFORE CREATE

Le catalogue impose :

```text
candidate
-> SDC schema / adapter
-> hosted CI
-> browser desktop + mobile
-> accessibility baseline
-> human review
-> approved
```

Seul `approved` peut avoir `approved_for_ai_composition: true`.

## Inventaire / décisions

Vertical slice admis :

- Hero -> `approved` ;
- CTA -> `approved` ;
- Trust list -> `approved`.

Différés :

- Text block -> `KEEP_AS_IS` pour ce slice : webform contact + variantes couplées à des UUID ;
- Services -> réévaluation séparée : preprocess de groupement métier ;
- AI features / Case clients -> SDC ultérieurs, non nécessaires à la preuve initiale.

## Baseline Canvas

Les métadonnées utilisent le schéma SDC natif, des props typées, enums pour les variantes gouvernées, `examples` pour les props requises et `minItems` pour la liste requise. Aucun module Canvas n’est installé dans cette PR et aucun format parallèle Agency n’est introduit.

## Validations finales exact HEAD

HEAD final : `45a582b570442d2aca281e71d8dea8b221ab6189`.

### Hosted CI

- run `32165345295` / CI #924 : **SUCCESS** ;
- quality scripts : PASS ;
- custom PHPUnit suite : PASS, incluant `GovernedSdcCatalogCiTest` avec les trois composants au statut `approved`.

### Browser Validation gouvernée

- request : `issue-519-governed-sdc-pr525-v2` ;
- exact-head self-hosted run : `32165518426` : **SUCCESS** ;
- artifact : `9335420293` ;
- trusted target validation : PASS ;
- exact checkout / immutable infrastructure : PASS ;
- fresh Drupal rebuild + configuration convergence : PASS ;
- real-browser validation : PASS ;
- artifact upload : PASS ;
- DDEV/workspace cleanup : PASS ;
- final commit status `agency/browser-validation` : SUCCESS.

Machine-readable result :

```text
result              = PASS
functional          = PASS
dom                 = PASS
visual_desktop      = PASS
visual_mobile       = PASS
console_errors      = 0
console_warnings    = 0
page_errors         = 0
unexpected_http_4xx = 0
http_5xx            = 0
failed_requests     = 0
```

### Revue humaine et non-régression visuelle

Le project owner a explicitement validé les captures desktop/mobile dans le cockpit ChatGPT le 18 août 2026. Cette validation est enregistrée dans la review PR.

Après matérialisation de l’admission, le proof exact-head a régénéré les captures. Les SHA-256 des captures finales sont identiques à celles approuvées avant l’admission : aucune variation visuelle n’a été introduite par le commit de promotion du catalogue.

## Suite

Après merge, le prochain gap concret est un **essai Canvas borné sur ce catalogue approuvé**, en privilégiant `USE DRUPAL` et sans ouvrir Canvas AI/page generation libre en parallèle.

Closes #519
Refs #3 #518