### PR TITLE
Issue #534: make Composer materialization observable

### DIFF
--- a/.github/workflows/agent-composer-materialization-dispatch.yml
+++ b/.github/workflows/agent-composer-materialization-dispatch.yml
@@ -10,12 +10,15 @@ on:
 permissions:
   actions: write
   contents: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
+  statuses: write
 
 jobs:
   dispatch:
-    name: Validate governed Composer request and dispatch trusted workflow
+    name: Validate, dispatch and observe governed Composer materialization
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - name: Checkout control branch history
         uses: actions/checkout@v6
@@ -142,6 +145,22 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
 
+      - name: Snapshot trusted workflow run IDs
+        id: before
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow trusted-composer-materialization.yml \
+            --event workflow_dispatch \
+            --limit 30 \
+            --json databaseId \
+            --jq '.[].databaseId' \
+            | sort -n > /tmp/composer-runs-before.txt
+
       - name: Dispatch trusted Composer materialization
         shell: bash
         env:
@@ -159,3 +178,151 @@ jobs:
             -f "pr_number=$PR_NUMBER" \
             -f "head_sha=$HEAD_SHA" \
             -f "profile=$PROFILE"
+
+      - name: Discover exact trusted workflow run
+        id: trusted
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          trusted_run_id=''
+          for _ in $(seq 1 30); do
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow trusted-composer-materialization.yml \
+              --event workflow_dispatch \
+              --limit 30 \
+              --json databaseId \
+              --jq '.[].databaseId' \
+              | sort -n > /tmp/composer-runs-after.txt
+
+            trusted_run_id="$(
+              comm -13 \
+                /tmp/composer-runs-before.txt \
+                /tmp/composer-runs-after.txt \
+                | tail -n 1
+            )"
+            if [[ -n "$trusted_run_id" ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "$trusted_run_id" ]]; then
+            echo 'Trusted Composer workflow run was not discoverable.' >&2
+            exit 1
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${trusted_run_id}"
+          echo "run_id=$trusted_run_id" >> "$GITHUB_OUTPUT"
+          echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+
+      - name: Publish pending target status
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          RUN_URL: ${{ steps.trusted.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state='pending' \
+            -f context='agency/composer-materialization' \
+            -f description='Governed Composer materialization running' \
+            -f target_url="$RUN_URL" >/dev/null
+
+      - name: Observe trusted workflow conclusion
+        id: conclusion
+        if: ${{ always() && steps.trusted.outputs.run_id != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_RUN_ID: ${{ steps.trusted.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          conclusion=''
+          for _ in $(seq 1 900); do
+            run_json="$(
+              gh run view "$TRUSTED_RUN_ID" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json status,conclusion
+            )"
+            status="$(jq -r '.status' <<<"$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<<"$run_json")"
+            if [[ "$status" == 'completed' ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "$conclusion" ]]; then
+            conclusion='timed_out'
+          fi
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+
+      - name: Publish final target status and diagnostic comment
+        if: ${{ always() && steps.trusted.outputs.run_id != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.request.outputs.pr_number }}
+          INPUT_HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          TRUSTED_RUN_ID: ${{ steps.trusted.outputs.run_id }}
+          RUN_URL: ${{ steps.trusted.outputs.run_url }}
+          CONCLUSION: ${{ steps.conclusion.outputs.conclusion }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+        run: |
+          set -euo pipefail
+
+          state='failure'
+          description="Composer materialization ${CONCLUSION:-unknown}"
+          if [[ "$CONCLUSION" == 'success' ]]; then
+            state='success'
+            description='Governed Composer materialization succeeded'
+          fi
+
+          publish_status() {
+            local sha="$1"
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/statuses/$sha" \
+              -f state="$state" \
+              -f context='agency/composer-materialization' \
+              -f description="$description" \
+              -f target_url="$RUN_URL" >/dev/null
+          }
+
+          publish_status "$INPUT_HEAD_SHA"
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          live_head="$(jq -r '.head.sha' <<<"$pr_json")"
+          output_head="$INPUT_HEAD_SHA"
+          if [[ "$state" == 'success' && "$live_head" != "$INPUT_HEAD_SHA" ]]; then
+            parent_sha="$(
+              gh api "repos/$GITHUB_REPOSITORY/commits/$live_head" \
+                --jq '.parents[0].sha // ""'
+            )"
+            if [[ "$parent_sha" == "$INPUT_HEAD_SHA" ]]; then
+              publish_status "$live_head"
+              output_head="$live_head"
+            fi
+          fi
+
+          body="$(cat <<EOF
+          ### Governed Composer materialization — ${CONCLUSION:-unknown}
+
+          - request: \`${REQUEST_ID}\`
+          - trusted workflow run: \`${TRUSTED_RUN_ID}\`
+          - input HEAD: \`${INPUT_HEAD_SHA}\`
+          - observed output HEAD: \`${output_head}\`
+          - status context: \`agency/composer-materialization\`
+
+          The observable gateway tracked the exact trusted run. Inspect the linked status run for the failing job when the conclusion is not success.
+          EOF
+          )"
+          gh pr comment "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "$body"
+
+          test "$state" = 'success'

--- a/docs/operations/governed-composer-materialization.md
+++ b/docs/operations/governed-composer-materialization.md
@@ -136,6 +136,36 @@ the lockfile to a different target.
 A successful run comments on the target PR with the input SHA, new SHA,
 resolved package version, lockfile SHA-256 and workflow run ID.
 
+## Observability contract
+
+Issue #534 adds fail-closed observability without changing the self-hosted
+permission model.
+
+After a request has passed schema, PR, exact-HEAD and semantic Composer checks,
+the GitHub-hosted gateway snapshots the existing trusted workflow run IDs,
+dispatches the trusted workflow and discovers the newly created run by set
+difference. The target commit then receives:
+
+```text
+context    = agency/composer-materialization
+state      = pending
+ target_url = exact trusted workflow run
+```
+
+The gateway remains on GitHub-hosted infrastructure while it observes that exact
+run. When the trusted run completes it publishes `success` or `failure` on the
+input HEAD. On success, if the publisher created the expected direct-child
+lockfile commit, the same `success` status is also published on that new HEAD.
+
+The target PR receives a final diagnostic comment containing the request ID,
+trusted run ID, input HEAD and observed output HEAD. This makes failures before
+`publish-lock` diagnosable from the cockpit instead of leaving a request with no
+observable result.
+
+The observable gateway does not receive product secrets and does not make the
+self-hosted job write-capable. A failure remains a failure; the gateway exits
+non-zero after publishing the diagnostic state.
+
 ## Explicit non-capabilities
 
 This route does **not** provide:

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -80,7 +80,7 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       $workflow,
     );
     self::assertStringContainsString(
-      "if [[ \"$CONCLUSION\" == 'success' ]]",
+      'if [[ "$CONCLUSION" == \'success\' ]]',
       $workflow,
     );
     self::assertStringContainsString(
@@ -88,7 +88,7 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       $workflow,
     );
     self::assertStringContainsString(
-      "test \"$state\" = 'success'",
+      'test "$state" = \'success\'',
       $workflow,
     );
   }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -53,6 +53,47 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
   }
 
   /**
+   * Every valid dispatch must expose its exact trusted run and conclusion.
+   */
+  public function testDispatchGatewayPublishesObservableRunStatus(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/agent-composer-materialization-dispatch.yml';
+    $workflow = (string) file_get_contents($path);
+
+    self::assertStringContainsString('statuses: write', $workflow);
+    self::assertStringContainsString(
+      "context='agency/composer-materialization'",
+      $workflow,
+    );
+    self::assertStringContainsString("state='pending'", $workflow);
+    self::assertStringContainsString(
+      '--workflow trusted-composer-materialization.yml',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'Trusted Composer workflow run was not discoverable.',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'gh run view "$TRUSTED_RUN_ID"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "if [[ \"$CONCLUSION\" == 'success' ]]",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'Inspect the linked status run for the failing job',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "test \"$state\" = 'success'",
+      $workflow,
+    );
+  }
+
+  /**
    * The self-hosted job must never receive repository write authority.
    */
   public function testSelfHostedResolverIsReadOnly(): void {


### PR DESCRIPTION
## Résumé

Follow-up borné de #531 après le premier proof réel contre #533.

Le premier dispatch n'a produit ni nouveau HEAD ni résultat observable depuis le cockpit. Cette PR corrige ce défaut **sans modifier le modèle de privilèges self-hosted**.

## Changement

Le gateway GitHub-hosted :

1. valide toujours acteur, requête, PR, exact HEAD et delta sémantique `composer.json` ;
2. snapshot les IDs de runs trusted existants ;
3. dispatch `trusted-composer-materialization.yml` sur `main` ;
4. découvre l'ID exact du nouveau run par différence d'ensembles ;
5. publie `agency/composer-materialization = pending` sur le HEAD cible avec le lien du run ;
6. observe ce run exact jusqu'à sa conclusion ;
7. publie `success` ou `failure` et un commentaire diagnostic ;
8. sur succès, publie aussi `success` sur le nouveau HEAD uniquement s'il est un enfant direct du HEAD d'entrée.

## Sécurité inchangée

- le self-hosted reste `contents: read` ;
- aucun token write supplémentaire sur DDEV ;
- aucun package/constraint/shell libre ;
- aucun secret provider ;
- la route reste profilée `canvas-ai-agents-530` ;
- un run failed reste failed : le gateway sort non-zero après publication du diagnostic.

## Tests

`GovernedComposerMaterializationWorkflowTest` protège désormais :

- parsing YAML ;
- `statuses: write` uniquement sur le gateway ;
- contexte `agency/composer-materialization` ;
- pending ;
- découverte du run trusted ;
- observation `gh run view` ;
- success/failure final ;
- diagnostic lié au run ;
- invariants read-only self-hosted préexistants.

## Proof final attendu

Après merge, le gateway de la control branch sera synchronisé avec cette version et une nouvelle request `issue-530-ai-agents-v2` sera lancée contre #533. Le proof doit soit matérialiser le lockfile, soit rendre le job exact en échec directement inspectable.

Closes #534
Refs #531 #530 #533.