### PR TITLE
Issue #531: make Composer resolution lock-only and DDEV cleanup idempotent

### DIFF
--- a/.github/workflows/trusted-composer-materialization.yml
+++ b/.github/workflows/trusted-composer-materialization.yml
@@ -204,6 +204,43 @@ jobs:
               )
           PY
 
+      - name: Remove stale governed Composer DDEV registrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev list --json-output > /tmp/ddev-projects.json
+          python3 - <<'PY' > /tmp/stale-composer-projects.txt
+          import json
+          import re
+
+          with open('/tmp/ddev-projects.json', encoding='utf-8') as handle:
+              data = json.load(handle)
+
+          matches = set()
+
+          def walk(value):
+              if isinstance(value, dict):
+                  for child in value.values():
+                      walk(child)
+              elif isinstance(value, list):
+                  for child in value:
+                      walk(child)
+              elif isinstance(value, str) and re.fullmatch(
+                  r'agency-composer-[0-9]+-[0-9]+', value
+              ):
+                  matches.add(value)
+
+          walk(data)
+          for project in sorted(matches):
+              print(project)
+          PY
+
+          while IFS= read -r stale_project; do
+            [[ -n "$stale_project" ]] || continue
+            echo "Removing stale governed Composer DDEV project: $stale_project"
+            ddev stop --unlist --omit-snapshot "$stale_project"
+          done < /tmp/stale-composer-projects.txt
+
       - name: Isolate DDEV project
         shell: bash
         working-directory: target
@@ -234,6 +271,7 @@ jobs:
 
           ddev composer update "$COMPOSER_PACKAGE" \
             --with-all-dependencies \
+            --no-install \
             --no-interaction \
             --no-progress \
             --no-scripts
@@ -307,11 +345,13 @@ jobs:
         shell: bash
         run: |
           set +e
+          isolated_name="agency-composer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           if [[ -d target ]]; then
             (
               cd target
+              ddev delete --omit-snapshot --yes "$isolated_name" || \
+                ddev stop --unlist --omit-snapshot "$isolated_name" || true
               rm -f .ddev/config.gate-composer-ci.yaml
-              ddev delete --omit-snapshot --yes
             )
           fi
           cd "$GITHUB_WORKSPACE"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -94,9 +94,9 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
   }
 
   /**
-   * The self-hosted job must never receive repository write authority.
+   * The self-hosted job must remain read-only and lockfile-only.
    */
-  public function testSelfHostedResolverIsReadOnly(): void {
+  public function testSelfHostedResolverIsReadOnlyAndLockOnly(): void {
     $root = dirname(DRUPAL_ROOT);
     $path = $root
       . '/.github/workflows/trusted-composer-materialization.yml';
@@ -122,11 +122,38 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
     self::assertStringContainsString('contents: read', $generate);
     self::assertStringNotContainsString('contents: write', $generate);
     self::assertStringContainsString('persist-credentials: false', $generate);
+    self::assertStringContainsString('--no-install', $generate);
     self::assertStringContainsString('--no-scripts', $generate);
     self::assertStringContainsString(
       "changed\" != 'composer.lock'",
       $generate,
     );
+
+    self::assertStringContainsString('ddev list --json-output', $generate);
+    self::assertStringContainsString(
+      "r'agency-composer-[0-9]+-[0-9]+'",
+      $generate,
+    );
+    self::assertStringContainsString(
+      'ddev stop --unlist --omit-snapshot "$stale_project"',
+      $generate,
+    );
+    self::assertStringContainsString(
+      'ddev delete --omit-snapshot --yes "$isolated_name"',
+      $generate,
+    );
+
+    $deletePosition = strpos(
+      $generate,
+      'ddev delete --omit-snapshot --yes "$isolated_name"',
+    );
+    $removeOverridePosition = strrpos(
+      $generate,
+      'rm -f .ddev/config.gate-composer-ci.yaml',
+    );
+    self::assertIsInt($deletePosition);
+    self::assertIsInt($removeOverridePosition);
+    self::assertLessThan($removeOverridePosition, $deletePosition);
 
     self::assertStringContainsString('contents: write', $publish);
     self::assertStringContainsString(


### PR DESCRIPTION
## Résumé

Correctif borné de #531 après les preuves réelles v1/v2 contre #533.

## Causes démontrées

- run v1 `32194449906` : résolution réussie de `drupal/ai_agents 1.3.4` + `drupal/modeler_api 1.1.4`, puis échec du garde-fou car la phase d'installation/scaffold Composer avait aussi modifié `web/robots.txt` ;
- cleanup v1 : suppression de l'override DDEV avant `ddev delete`, laissant `agency-composer-32194449906-1` enregistré ;
- run v2 `32195352764` : gateway/profile/HEAD/delta sémantique PASS, puis collision avec cette inscription DDEV stale au démarrage.

## Correctif

- `composer update` ajoute `--no-install` en plus de `--no-scripts` : seule la résolution/écriture du lockfile est attendue ;
- avant démarrage, le runner lit `ddev list --json-output` et ne purge que les noms correspondant exactement à `^agency-composer-[0-9]+-[0-9]+$` via `ddev stop --unlist --omit-snapshot` ;
- cleanup final cible explicitement `agency-composer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` avant suppression de `.ddev/config.gate-composer-ci.yaml` ;
- aucune permission supplémentaire ; self-hosted reste `contents: read` et `persist-credentials:false`.

## Garde-fous CI

`GovernedComposerMaterializationWorkflowTest` exige désormais :

- workflow YAML parseable ;
- `--no-install` + `--no-scripts` ;
- purge bornée au namespace `agency-composer-*` ;
- `ddev stop --unlist` pour les inscriptions stales ;
- delete de l'isolated project par nom explicite ;
- ordre cleanup : suppression DDEV avant suppression de l'override ;
- invariants write-separation existants inchangés.

## Proof attendu après merge

Relancer `issue-530-ai-agents-v3` contre #533. Le run doit nettoyer l'inscription v1, produire uniquement `composer.lock`, publier le lockfile depuis le job GitHub-hosted et faire passer `agency/composer-materialization` à success sur le nouveau HEAD.

Refs #531 #530 #533 #534.