### PR TITLE
Issue #531: extract stale DDEV names from warning JSON

### DIFF
--- a/.github/workflows/trusted-composer-materialization.yml
+++ b/.github/workflows/trusted-composer-materialization.yml
@@ -208,32 +208,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ddev list --json-output > /tmp/ddev-projects.json
-          python3 - <<'PY' > /tmp/stale-composer-projects.txt
-          import json
-          import re
-
-          with open('/tmp/ddev-projects.json', encoding='utf-8') as handle:
-              data = json.load(handle)
-
-          matches = set()
-
-          def walk(value):
-              if isinstance(value, dict):
-                  for child in value.values():
-                      walk(child)
-              elif isinstance(value, list):
-                  for child in value:
-                      walk(child)
-              elif isinstance(value, str) and re.fullmatch(
-                  r'agency-composer-[0-9]+-[0-9]+', value
-              ):
-                  matches.add(value)
-
-          walk(data)
-          for project in sorted(matches):
-              print(project)
-          PY
+          ddev list --json-output \
+            | python3 trusted/scripts/runner/extract-stale-composer-ddev-projects.py \
+            > /tmp/stale-composer-projects.txt
 
           while IFS= read -r stale_project; do
             [[ -n "$stale_project" ]] || continue

--- a/scripts/runner/extract-stale-composer-ddev-projects.py
+++ b/scripts/runner/extract-stale-composer-ddev-projects.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""Extract governed Composer DDEV project names from DDEV JSON output."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_-])agency-composer-[0-9]+-[0-9]+(?![A-Za-z0-9_-])"
+)
+
+
+def extract_projects(value: Any) -> set[str]:
+    """Return only project names in the governed Agency Composer namespace."""
+    matches: set[str] = set()
+
+    def walk(item: Any) -> None:
+        if isinstance(item, dict):
+            for child in item.values():
+                walk(child)
+        elif isinstance(item, list):
+            for child in item:
+                walk(child)
+        elif isinstance(item, str):
+            matches.update(_PATTERN.findall(item))
+
+    walk(value)
+    return matches
+
+
+def self_test() -> None:
+    """Exercise exact values, DDEV warning messages and rejection boundaries."""
+    payload = {
+        "level": "warning",
+        "msg": (
+            "Project 'agency-website-drupal' is already used by project "
+            "'agency-composer-32194449906-1'."
+        ),
+        "raw": [
+            {"name": "agency-composer-42-2"},
+            {"name": "agency-composer-42-2"},
+            {"name": "agency-composer-42-2-extra"},
+            {"name": "unrelated-project"},
+        ],
+    }
+    expected = {
+        "agency-composer-32194449906-1",
+        "agency-composer-42-2",
+    }
+    actual = extract_projects(payload)
+    if actual != expected:
+        raise SystemExit(
+            f"self-test failed: expected {sorted(expected)}, got {sorted(actual)}"
+        )
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        print("PASS")
+        raise SystemExit(0)
+    if sys.argv[1:]:
+        raise SystemExit("Usage: extract-stale-composer-ddev-projects.py [--self-test]")
+
+    data = json.load(sys.stdin)
+    for project in sorted(extract_projects(data)):
+        print(project)

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -131,7 +131,8 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
 
     self::assertStringContainsString('ddev list --json-output', $generate);
     self::assertStringContainsString(
-      "r'agency-composer-[0-9]+-[0-9]+'",
+      'python3 trusted/scripts/runner/'
+      . 'extract-stale-composer-ddev-projects.py',
       $generate,
     );
     self::assertStringContainsString(
@@ -164,6 +165,33 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       'git push origin "HEAD:$EXPECTED_HEAD_REF"',
       $publish,
     );
+  }
+
+  /**
+   * DDEV warnings must be parsed without widening the cleanup namespace.
+   */
+  public function testStaleDdevProjectExtractorIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/extract-stale-composer-ddev-projects.py';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'agency-composer-[0-9]+-[0-9]+',
+      $script,
+    );
+    self::assertStringContainsString('_PATTERN.findall(item)', $script);
+
+    $output = [];
+    $exitCode = 0;
+    exec(
+      'python3 ' . escapeshellarg($path) . ' --self-test 2>&1',
+      $output,
+      $exitCode,
+    );
+    self::assertSame(0, $exitCode, implode("\n", $output));
+    self::assertContains('PASS', $output);
   }
 
   /**


### PR DESCRIPTION
## Résumé

Correctif borné de #531 après la preuve observable v3 `32195927413` contre #533.

## Cause démontrée

DDEV 1.25.3 renvoie le projet stale dans le texte d'un warning JSON, par exemple :

```text
Project 'agency-website-drupal' ... already used by project 'agency-composer-32194449906-1'
```

Le parseur inline précédent utilisait `re.fullmatch()` sur chaque valeur string. Il ne pouvait donc extraire un nom imbriqué dans le champ `msg`.

## Correctif

- ajoute `scripts/runner/extract-stale-composer-ddev-projects.py` ;
- parcourt récursivement dict/list/string ;
- extrait les sous-chaînes bornées `agency-composer-<run>-<attempt>` ;
- rejette les préfixes élargis comme `agency-composer-42-2-extra` ;
- déduplique les occurrences ;
- le workflow trusted pipe directement `ddev list --json-output` dans ce parseur avant `ddev stop --unlist --omit-snapshot`.

## Tests

Le parseur possède `--self-test` couvrant : valeur exacte, warning DDEV embarqué, doublon, valeur non liée et suffixe interdit.

`GovernedComposerMaterializationWorkflowTest` :

- exige l'appel au parseur trusted ;
- exécute réellement `python3 ... --self-test` ;
- conserve les invariants #531 : self-hosted read-only, `--no-install`, `--no-scripts`, lock-only, cleanup explicite et hosted writer séparé.

## Proof attendu après merge

`issue-530-ai-agents-v4` contre #533 doit :

1. extraire et unlist `agency-composer-32194449906-1` ;
2. démarrer le nouveau DDEV isolé ;
3. atteindre la résolution Composer lock-only ;
4. publier `composer.lock` automatiquement si le diff reste strictement lock-only.

Refs #531 #530 #533 #534.