### PR TITLE
Issue #531: capture DDEV stderr JSON in stale cleanup

### DIFF
--- a/.github/workflows/trusted-composer-materialization.yml
+++ b/.github/workflows/trusted-composer-materialization.yml
@@ -208,7 +208,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ddev list --json-output \
+          ddev list --json-output 2>&1 \
             | python3 trusted/scripts/runner/extract-stale-composer-ddev-projects.py \
             > /tmp/stale-composer-projects.txt
 

--- a/scripts/runner/extract-stale-composer-ddev-projects.py
+++ b/scripts/runner/extract-stale-composer-ddev-projects.py
@@ -14,6 +14,29 @@ _PATTERN = re.compile(
 )
 
 
+def parse_json_documents(raw: str) -> list[Any]:
+    """Parse one or more whitespace-separated JSON documents fail closed."""
+    decoder = json.JSONDecoder()
+    documents: list[Any] = []
+    offset = 0
+
+    while offset < len(raw):
+        while offset < len(raw) and raw[offset].isspace():
+            offset += 1
+        if offset >= len(raw):
+            break
+
+        try:
+            document, offset = decoder.raw_decode(raw, offset)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"Non-JSON data in DDEV output at character {error.pos}."
+            ) from error
+        documents.append(document)
+
+    return documents
+
+
 def extract_projects(value: Any) -> set[str]:
     """Return only project names in the governed Agency Composer namespace."""
     matches: set[str] = set()
@@ -33,13 +56,15 @@ def extract_projects(value: Any) -> set[str]:
 
 
 def self_test() -> None:
-    """Exercise exact values, DDEV warning messages and rejection boundaries."""
-    payload = {
+    """Exercise DDEV warnings, streams and rejection boundaries."""
+    warning = {
         "level": "warning",
         "msg": (
             "Project 'agency-website-drupal' is already used by project "
             "'agency-composer-32194449906-1'."
         ),
+    }
+    listing = {
         "raw": [
             {"name": "agency-composer-42-2"},
             {"name": "agency-composer-42-2"},
@@ -47,15 +72,27 @@ def self_test() -> None:
             {"name": "unrelated-project"},
         ],
     }
+    stream = json.dumps(warning) + "\n" + json.dumps(listing)
+    documents = parse_json_documents(stream)
+
     expected = {
         "agency-composer-32194449906-1",
         "agency-composer-42-2",
     }
-    actual = extract_projects(payload)
+    actual: set[str] = set()
+    for document in documents:
+        actual.update(extract_projects(document))
     if actual != expected:
         raise SystemExit(
             f"self-test failed: expected {sorted(expected)}, got {sorted(actual)}"
         )
+
+    try:
+        parse_json_documents(stream + "\nnot-json")
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("self-test failed: non-JSON input was accepted")
 
 
 if __name__ == "__main__":
@@ -66,6 +103,13 @@ if __name__ == "__main__":
     if sys.argv[1:]:
         raise SystemExit("Usage: extract-stale-composer-ddev-projects.py [--self-test]")
 
-    data = json.load(sys.stdin)
-    for project in sorted(extract_projects(data)):
+    try:
+        parsed = parse_json_documents(sys.stdin.read())
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+    projects: set[str] = set()
+    for document in parsed:
+        projects.update(extract_projects(document))
+    for project in sorted(projects):
         print(project)

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -129,7 +129,10 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       $generate,
     );
 
-    self::assertStringContainsString('ddev list --json-output', $generate);
+    self::assertStringContainsString(
+      'ddev list --json-output 2>&1',
+      $generate,
+    );
     self::assertStringContainsString(
       'python3 trusted/scripts/runner/'
       . 'extract-stale-composer-ddev-projects.py',
@@ -182,6 +185,11 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       $script,
     );
     self::assertStringContainsString('_PATTERN.findall(item)', $script);
+    self::assertStringContainsString('decoder.raw_decode(raw, offset)', $script);
+    self::assertStringContainsString(
+      'Non-JSON data in DDEV output',
+      $script,
+    );
 
     $output = [];
     $exitCode = 0;


### PR DESCRIPTION
## Résumé

Correctif final borné de #531 après le proof v4 `32196445370`.

## Cause démontrée

Le warning de collision DDEV est bien du JSON, mais il est émis sur `stderr`. Le workflow pipait uniquement `stdout`, donc le parseur #537 ne recevait rien malgré le warning visible dans les logs.

## Correctif

- `ddev list --json-output 2>&1` alimente maintenant le parseur trusted ;
- le parseur accepte un ou plusieurs documents JSON séparés par des espaces/newlines via `JSONDecoder.raw_decode` ;
- il reste fail-closed : toute donnée non-JSON provoque un échec ;
- l'extraction reste bornée à `agency-composer-<run>-<attempt>` et dédupliquée ;
- aucune permission ou surface d'entrée n'est élargie.

## Tests

Le self-test couvre désormais :

- warning DDEV JSON ;
- second document JSON dans le même flux ;
- doublons ;
- suffixe interdit ;
- texte non-JSON rejeté.

`GovernedComposerMaterializationWorkflowTest` exige explicitement `ddev list --json-output 2>&1`, le parseur trusted, le raw decoder fail-closed et tous les invariants read-only/lock-only existants.

## Proof attendu après merge

`issue-530-ai-agents-v5` contre #533 doit enfin unlist `agency-composer-32194449906-1`, démarrer DDEV, exécuter la résolution `--no-install`, produire uniquement `composer.lock`, puis laisser le writer GitHub-hosted publier le lockfile.

Refs #531 #530 #533 #534.