### PR TITLE
Issue #539: add trusted Canvas AI provider proof route

### DIFF
--- a/.github/workflows/trusted-canvas-ai-provider-proof.yml
+++ b/.github/workflows/trusted-canvas-ai-provider-proof.yml
@@ -215,7 +215,6 @@ jobs:
           unset admin_pass
           ddev drush cim -y
           ddev drush cr
-
           ddev drush emerging:governed-content --all
           ddev drush cr
 
@@ -225,6 +224,20 @@ jobs:
           printf '%s\n' "$config_status"
           grep -Fq 'No differences' <<<"$config_status"
 
+          base_url="$(ddev describe -j | jq -r '.. | strings | select(test("^https://"))' | head -n 1)"
+          if [[ -z "$base_url" ]]; then
+            echo 'Unable to resolve isolated DDEV HTTPS URL.' >&2
+            exit 1
+          fi
+          login_url="$(ddev drush uli --uri="$base_url" --no-browser | tail -n 1)"
+          if [[ ! "$login_url" =~ ^https?:// ]]; then
+            echo 'Unable to generate one-time Drupal admin login URL.' >&2
+            exit 1
+          fi
+          echo "::add-mask::$login_url"
+          echo "PLAYWRIGHT_BASE_URL=$base_url" >> "$GITHUB_ENV"
+          echo "CANVAS_AI_ADMIN_LOGIN_URL=$login_url" >> "$GITHUB_ENV"
+
       - name: Run exactly one provider-backed Canvas AI composition
         shell: bash
         env:
@@ -232,7 +245,7 @@ jobs:
           CANVAS_AI_PROVIDER_PROOF: '1'
         run: |
           set -euo pipefail
-          npx playwright test tests/browser/canvas-ai-provider-proof.spec.mjs --project=chromium-desktop --workers=1
+          npx playwright test tests/browser/canvas-ai-provider-proof.spec.mjs --project=desktop --workers=1
 
       - name: Summarize bounded evidence
         id: summarize
@@ -258,8 +271,8 @@ jobs:
           name: agency-canvas-ai-provider-proof-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             artifacts/canvas-ai-provider-proof
+            artifacts/browser-validation/test-results
             playwright-report
-            test-results
           if-no-files-found: warn
           retention-days: 14
 
@@ -273,7 +286,8 @@ jobs:
           rm -f .ddev/config.gate-canvas-ai-provider.yaml
           git restore --worktree -- web/robots.txt config/sync
           git clean -fd -- config/sync
-          rm -rf artifacts/canvas-ai-provider-proof playwright-report test-results
+          rm -rf artifacts/canvas-ai-provider-proof artifacts/browser-validation/test-results playwright-report
+          rmdir artifacts/browser-validation 2>/dev/null || true
           rmdir artifacts 2>/dev/null || true
           git diff --check
           status="$(git status --porcelain)"

--- a/.github/workflows/trusted-canvas-ai-provider-proof.yml
+++ b/.github/workflows/trusted-canvas-ai-provider-proof.yml
@@ -1,0 +1,316 @@
+name: Agency trusted Canvas AI provider proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate bounded Canvas AI provider target
+    if: ${{ github.event.issue.pull_request && github.event.issue.number == 533 && github.event.comment.body == '/agency-canvas-ai-provider-proof-530' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+    steps:
+      - name: Validate actor, PR and exact bounded diff
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+
+          [[ "$PR_NUMBER" == '533' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-canvas-ai-provider-proof-530' ]]
+
+          if [[ "$GITHUB_ACTOR" != 'E-merging-digital' && "$GITHUB_ACTOR" != 'github-actions[bot]' ]]; then
+            echo "Refusing provider proof actor: $GITHUB_ACTOR" >&2
+            exit 1
+          fi
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -r '.state' <<<"$pr_json")"
+          base_ref="$(jq -r '.base.ref' <<<"$pr_json")"
+          head_ref="$(jq -r '.head.ref' <<<"$pr_json")"
+          head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+
+          [[ "$state" == 'open' ]]
+          [[ "$base_ref" == 'main' ]]
+          [[ "$head_ref" == 'feature/issue-530-bounded-canvas-ai-composition' ]]
+          [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          mapfile -t changed_files < <(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename' | sort
+          )
+          allowed_files="$(cat <<'EOF'
+          composer.json
+          composer.lock
+          config/sync/canvas_ai.settings.yml
+          config/sync/core.extension.yml
+          docs/ai/canvas-ai-proof-policy.yml
+          tests/browser/canvas-ai-provider-proof.spec.mjs
+          web/modules/custom/agency_project_tests/tests/src/Unit/CanvasAiPreProviderAuditTest.php
+          EOF
+          )"
+
+          unexpected=''
+          for path in "${changed_files[@]}"; do
+            if ! grep -Fxq "$path" <<<"$allowed_files"; then
+              unexpected+="$path"$'\n'
+            fi
+          done
+          if [[ -n "$unexpected" ]]; then
+            printf 'Provider proof target contains untrusted files:\n%s' "$unexpected" >&2
+            exit 1
+          fi
+
+          required_files=(
+            composer.json
+            composer.lock
+            config/sync/core.extension.yml
+            docs/ai/canvas-ai-proof-policy.yml
+            tests/browser/canvas-ai-provider-proof.spec.mjs
+            web/modules/custom/agency_project_tests/tests/src/Unit/CanvasAiPreProviderAuditTest.php
+          )
+          for path in "${required_files[@]}"; do
+            if ! printf '%s\n' "${changed_files[@]}" | grep -Fxq "$path"; then
+              echo "Required #530 proof file missing from target diff: $path" >&2
+              exit 1
+            fi
+          done
+
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+  report-start:
+    name: Publish provider proof run locator
+    needs: validate-target
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish trusted run locator
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh pr comment 533 --repo "$GITHUB_REPOSITORY" --body "### Canvas AI provider proof — trusted run locator
+
+          - Run ID: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+          - Exact target: \`${TARGET_SHA}\`
+          - State: \`validated; provider proof pending\`
+
+          The target PR, branch and bounded diff were validated on GitHub-hosted infrastructure before the secret-capable self-hosted job was admitted."
+
+  provider-proof:
+    name: Run one bounded Canvas AI provider composition
+    needs:
+      - validate-target
+      - report-start
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    outputs:
+      evidence_status: ${{ steps.summarize.outputs.evidence_status }}
+      failure_phase: ${{ steps.summarize.outputs.failure_phase }}
+      artifact_name: ${{ steps.summarize.outputs.artifact_name }}
+    steps:
+      - name: Verify runner identity and trusted toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          command -v docker
+          command -v ddev
+          command -v jq
+          git --version
+          docker --version
+          ddev version
+
+      - name: Checkout exact validated target
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable proof route
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -f tests/browser/canvas-ai-provider-proof.spec.mjs
+          test -f docs/ai/canvas-ai-proof-policy.yml
+          test -f package-lock.json
+          git diff --check
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install browser dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install chromium
+
+      - name: Inject OpenAI key only into isolated DDEV runtime
+        shell: bash
+        env:
+          PROVIDER_SECRET: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$PROVIDER_SECRET" ]]; then
+            echo 'OPENAI_API_KEY repository secret is unavailable; refusing provider proof.' >&2
+            exit 1
+          fi
+          umask 077
+          printf 'OPENAI_API_KEY=%s\n' "$PROVIDER_SECRET" > .ddev/.env.web
+          unset PROVIDER_SECRET
+          test -s .ddev/.env.web
+
+      - name: Rebuild exact target with provider available to Drupal only
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-canvas-ai-provider.yaml <<EOF
+          name: agency-canvas-ai-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-canvas-ai-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          ddev drush emerging:governed-content --all
+          ddev drush cr
+
+          ddev drush php:eval '$key = \Drupal::service("key.repository")->getKey("openai_api_key"); if (!$key || trim((string) $key->getKeyValue()) === "") { throw new \RuntimeException("OpenAI key is unavailable through Drupal Key."); } print "Drupal Key provider readiness: OK\n";'
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Run exactly one provider-backed Canvas AI composition
+        shell: bash
+        env:
+          CI: 'true'
+          CANVAS_AI_PROVIDER_PROOF: '1'
+        run: |
+          set -euo pipefail
+          npx playwright test tests/browser/canvas-ai-provider-proof.spec.mjs --project=chromium-desktop --workers=1
+
+      - name: Summarize bounded evidence
+        id: summarize
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file='artifacts/canvas-ai-provider-proof/result.json'
+          evidence_status='MISSING'
+          failure_phase='result_unavailable'
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            evidence_status="$(jq -r '.status // "UNKNOWN"' "$result_file")"
+            failure_phase="$(jq -r '.failure_phase // "none"' "$result_file")"
+          fi
+          echo "evidence_status=$evidence_status" >> "$GITHUB_OUTPUT"
+          echo "failure_phase=$failure_phase" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=agency-canvas-ai-provider-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bounded Canvas AI evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-canvas-ai-provider-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/canvas-ai-provider-proof
+            playwright-report
+            test-results
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Remove secret runtime and clean DDEV/workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          rm -f .ddev/.env.web
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-canvas-ai-provider.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/canvas-ai-provider-proof playwright-report test-results
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Report bounded provider proof result
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - report-start
+      - provider-proof
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish bounded outcome without secret data
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          JOB_RESULT: ${{ needs.provider-proof.result }}
+          EVIDENCE_STATUS: ${{ needs.provider-proof.outputs.evidence_status }}
+          FAILURE_PHASE: ${{ needs.provider-proof.outputs.failure_phase }}
+          ARTIFACT_NAME: ${{ needs.provider-proof.outputs.artifact_name }}
+        run: |
+          set -euo pipefail
+          gh pr comment 533 --repo "$GITHUB_REPOSITORY" --body "### Canvas AI provider proof — bounded outcome
+
+          - Exact target: \`${TARGET_SHA}\`
+          - Self-hosted job: \`${JOB_RESULT}\`
+          - Evidence status: \`${EVIDENCE_STATUS:-MISSING}\`
+          - Failure phase: \`${FAILURE_PHASE:-n/a}\`
+          - Artifact: \`${ARTIFACT_NAME:-agency-canvas-ai-provider-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\`
+
+          This report contains bounded execution metadata only. No provider secret is included. Inspect the artifact before any product admission decision."


### PR DESCRIPTION
## Résumé

Infrastructure étroite nécessaire à la Phase B de #530.

Cette PR ajoute uniquement une route trusted provider-backed pour la preuve Canvas AI #530. Elle ne réalise aucun appel LLM pendant sa propre validation et n'ajoute aucun secret au dépôt.

## Frontière de confiance

- trigger exact : commentaire `/agency-canvas-ai-provider-proof-530` sur PR #533 uniquement ;
- actor limité à `E-merging-digital` / `github-actions[bot]` ;
- PR cible même dépôt, base `main`, branche exacte #530 ;
- diff cible vérifié contre une allowlist fermée avant admission du self-hosted ;
- workflow trusted réside sur `main` avant toute exécution provider ;
- `OPENAI_API_KEY` lu uniquement depuis GitHub Actions Secrets ;
- secret écrit avec `umask 077` dans `.ddev/.env.web`, jamais imprimé ni uploadé ;
- Playwright n'hérite pas du secret ;
- cleanup du fichier secret et de DDEV sous `always()` ;
- un seul test/provider composition, un worker, un projet browser.

## Usage prévu après merge

#533 ajoutera le spec borné `tests/browser/canvas-ai-provider-proof.spec.mjs`. Le workflow reconstruira le HEAD exact, vérifiera Drupal Key sans afficher la valeur, exécutera exactement cette preuve puis publiera seulement metadata/artifacts expurgés.

## Hors périmètre

- aucun secret créé ou modifié ;
- aucun appel provider dans cette PR d'infrastructure ;
- aucune généralisation à d'autres PR ;
- aucune modification Drupal/Canvas produit.

Closes #539
Refs #530 #533