### PR TITLE
Issue #541: codify contrib modules first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,24 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
 - Documentation projet dans `docs/`.
 - Scripts d'exploitation dans `scripts/`.
 
+## 2.0 Doctrine CONTRIBUTED MODULES FIRST
+
+- Invariant : **CONTRIBUTED MODULES FIRST**. Avant toute nouvelle capacite ou
+  implementation custom Agency, rechercher d'abord si Drupal core couvre le
+  besoin, puis rechercher et evaluer les modules contrib pertinents.
+- `USE DRUPAL` signifie **core + contrib**. Une absence de familiarite avec un
+  module existant ou l'absence de recherche contrib n'est jamais un gap Drupal.
+- L'evaluation contrib doit verifier au minimum : compatibilite Drupal/PHP,
+  release stable pertinente, maintenance recente, couverture de securite,
+  permissions/dependances introduites et adequation fonctionnelle au besoin.
+- Preferer un module core/contrib stable et security-covered a du code custom,
+  puis `EXTEND DRUPAL` si une extension bornee suffit. `BUILD IN AGENCY` exige
+  un gap reel, documente et demontre apres cette evaluation.
+- Pour le page building et l'IA de composition, evaluer et utiliser en priorite
+  Drupal Canvas, Drupal AI, Canvas AI, AI Agents et les autres primitives
+  upstream adaptees avant toute orchestration ou moteur Agency concurrent.
+- Cette doctrine s'applique a tous les domaines du projet, pas seulement a l'IA.
+
 ## 2.1 Doctrine Drupal AI
 
 - Pour toute tache touchant l'IA, la traduction IA ou une fonctionnalite IA du

--- a/docs/decisions/ADR-001-governed-ai-experience.md
+++ b/docs/decisions/ADR-001-governed-ai-experience.md
@@ -121,6 +121,26 @@ L’ordre de préférence est :
 USE DRUPAL > EXTEND DRUPAL > BUILD IN AGENCY
 ```
 
+### CONTRIBUTED MODULES FIRST
+
+`USE DRUPAL` signifie **Drupal core ET modules contrib**. Avant de conclure à un
+gap et avant tout `BUILD IN AGENCY`, il faut rechercher et évaluer les projets
+contrib pertinents. L’évaluation doit couvrir au minimum la compatibilité
+Drupal/PHP, la release stable pertinente, la maintenance, la couverture de
+sécurité, les permissions et dépendances introduites, ainsi que l’adéquation
+fonctionnelle au besoin.
+
+Lorsqu’un module core ou contrib stable, maintenu et security-covered couvre
+raisonnablement le besoin, Agency doit le préférer à une implémentation custom.
+Si une adaptation bornée suffit, `EXTEND DRUPAL` vient avant `BUILD IN AGENCY`.
+L’absence de recherche contrib ou de familiarité avec une capacité upstream ne
+constitue jamais un gap Drupal.
+
+Pour le page building et la composition IA, cette doctrine implique notamment
+d’évaluer et d’utiliser Drupal Canvas, Drupal AI, Canvas AI, AI Agents et les
+primitives upstream associées avant toute orchestration ou moteur concurrent
+propre à Agency.
+
 `BUILD IN AGENCY` exige un gap Drupal réel, documenté et démontré. Une absence
 de familiarité avec une capacité upstream n’est pas un gap.
 


### PR DESCRIPTION
## Résumé

Matérialise durablement la doctrine **CONTRIBUTED MODULES FIRST** demandée par le Project Lead.

- `AGENTS.md` impose désormais la recherche Drupal core + contrib avant toute implémentation custom.
- `USE DRUPAL` est défini explicitement comme core + contrib.
- L'évaluation doit couvrir compatibilité Drupal/PHP, stabilité, maintenance, couverture sécurité, permissions/dépendances et fit fonctionnel.
- `EXTEND DRUPAL` reste prioritaire sur `BUILD IN AGENCY` lorsqu'une adaptation bornée suffit.
- ADR-001 encode la même règle au niveau architectural durable.
- Pour le page building/IA, Drupal Canvas, Drupal AI, Canvas AI et AI Agents sont explicitement à évaluer/utiliser avant toute orchestration Agency concurrente.

Docs-only, aucun changement runtime.

Closes #541
Refs #518 #530