### PR TITLE
Issue #543: add trusted governed AI Playwright loop

### DIFF
--- a/.github/workflows/trusted-ai-playwright-governed-loop.yml
+++ b/.github/workflows/trusted-ai-playwright-governed-loop.yml
@@ -1,0 +1,273 @@
+name: Agency trusted governed AI Playwright loop
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #516 governed loop target
+    if: ${{ github.event.issue.pull_request && github.event.issue.number == 544 && github.event.comment.body == '/agency-ai-playwright-evaluate-516' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+      base_sha: ${{ steps.validate.outputs.base_sha }}
+    steps:
+      - name: Validate actor, PR and exact inert target
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$PR_NUMBER" == "544" ]]
+          [[ "$TRIGGER_COMMENT" == "/agency-ai-playwright-evaluate-516" ]]
+          [[ "$GITHUB_ACTOR" == "E-merging-digital" ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$pr_json")" == "open" ]]
+          [[ "$(jq -r '.draft' <<<"$pr_json")" == "true" ]]
+          [[ "$(jq -r '.base.ref' <<<"$pr_json")" == "main" ]]
+          [[ "$(jq -r '.head.ref' <<<"$pr_json")" == "feature/issue-516-ai-playwright-governed-loop-proof" ]]
+          [[ "$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")" == "$GITHUB_REPOSITORY" ]]
+
+          base_sha="$(jq -r '.base.sha' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          [[ "$base_sha" == "$EVENT_DEFAULT_SHA" ]] || {
+            echo "PR #544 must be evaluated against the workflow revision currently on main." >&2
+            exit 1
+          }
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          mapfile -t changed_files < <(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename'
+          )
+          if [[ "${#changed_files[@]}" -ne 1 || "${changed_files[0]}" != "docs/evaluations/ai-playwright-516-governed-loop.md" ]]; then
+            printf 'PR #544 must change exactly the inert #516 marker; got:\n%s\n' "${changed_files[*]}" >&2
+            exit 1
+          fi
+
+          marker="$(gh api "repos/$GITHUB_REPOSITORY/contents/docs/evaluations/ai-playwright-516-governed-loop.md?ref=$head_sha" --jq '.content' | tr -d '\n' | base64 --decode)"
+          [[ "$marker" == 'AI Playwright governed SDC loop #516 — DEV-ONLY inert target.' ]]
+
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+  report-start:
+    name: Publish governed loop run locator
+    needs: validate-target
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish trusted run locator
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF
+          ### #516 governed AI Playwright loop — trusted run locator
+
+          - Run ID: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+          - Trusted main: \`${BASE_SHA}\`
+          - Inert target: \`${HEAD_SHA}\`
+          - Provider: \`ai_test / echoai / gpt-test\`
+          - Network LLM/provider required: \`no\`
+          - State: \`validated; self-hosted proof pending\`
+
+          The target cannot modify the trusted runner logic. No secret or real provider is available to this route.
+          EOF
+          )"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"
+
+  governed-loop:
+    name: Run provider-free governed AI Playwright loop
+    needs: validate-target
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    concurrency:
+      group: agency-ai-playwright-516-${{ needs.validate-target.outputs.head_sha }}
+      cancel-in-progress: false
+    outputs:
+      evidence_status: ${{ steps.summarize.outputs.evidence_status }}
+      failure_phase: ${{ steps.summarize.outputs.failure_phase }}
+      failure_message: ${{ steps.summarize.outputs.failure_message }}
+      artifact_name: ${{ steps.summarize.outputs.artifact_name }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+          command -v node
+          node --version
+
+      - name: Checkout trusted implementation from main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.base_sha }}
+          path: trusted
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact inert #516 target
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.head_sha }}
+          path: target
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable runner logic and target
+        shell: bash
+        env:
+          EXPECTED_BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git -C trusted rev-parse HEAD)" == "$EXPECTED_BASE_SHA" ]]
+          [[ "$(git -C target rev-parse HEAD)" == "$EXPECTED_HEAD_SHA" ]]
+          test -f trusted/scripts/runner/run-ai-playwright-governed-loop.sh
+          bash -n trusted/scripts/runner/run-ai-playwright-governed-loop.sh
+          [[ "$(cat target/docs/evaluations/ai-playwright-516-governed-loop.md)" == 'AI Playwright governed SDC loop #516 — DEV-ONLY inert target.' ]]
+
+      - name: Isolate DDEV project
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-ai-playwright-516.yaml <<EOF
+          name: agency-ai-playwright-516-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-ai-playwright-516-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev start -y
+
+      - name: Run trusted governed agentic proof
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}/target
+          ARTIFACT_DIR: ${{ github.workspace }}/target/artifacts/ai-playwright-governed-loop
+        run: |
+          set -euo pipefail
+          bash trusted/scripts/runner/run-ai-playwright-governed-loop.sh
+
+      - name: Summarize bounded evidence
+        id: summarize
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file='target/artifacts/ai-playwright-governed-loop/result.json'
+          evidence_status='MISSING'
+          failure_phase='n/a'
+          failure_message='result.json unavailable'
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            evidence_status="$(jq -r '.status // "UNKNOWN"' "$result_file")"
+            failure_phase="$(jq -r '.phase // "none"' "$result_file")"
+            failure_message="$(jq -r '.message // "none"' "$result_file")"
+          fi
+          failure_phase="$(printf '%s' "$failure_phase" | tr '\r\n' '  ' | cut -c1-80)"
+          failure_message="$(printf '%s' "$failure_message" | tr '\r\n' '  ' | cut -c1-220)"
+          artifact_name="agency-ai-playwright-516-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "evidence_status=$evidence_status" >> "$GITHUB_OUTPUT"
+          echo "failure_phase=$failure_phase" >> "$GITHUB_OUTPUT"
+          echo "failure_message=$failure_message" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload governed loop evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-ai-playwright-516-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/artifacts/ai-playwright-governed-loop
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean DDEV and workspaces
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          if [[ -d target ]]; then
+            (
+              cd target
+              ddev delete --omit-snapshot --yes
+            )
+          fi
+          cd "$GITHUB_WORKSPACE"
+          rm -rf target trusted
+
+  report-result:
+    name: Report governed loop result
+    needs:
+      - validate-target
+      - governed-loop
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish bounded result
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          JOB_RESULT: ${{ needs.governed-loop.result }}
+          EVIDENCE_STATUS: ${{ needs.governed-loop.outputs.evidence_status }}
+          FAILURE_PHASE: ${{ needs.governed-loop.outputs.failure_phase }}
+          FAILURE_MESSAGE: ${{ needs.governed-loop.outputs.failure_message }}
+          ARTIFACT_NAME: ${{ needs.governed-loop.outputs.artifact_name }}
+          HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF
+          ### #516 governed AI Playwright loop — bounded outcome
+
+          - Exact inert target: \`${HEAD_SHA}\`
+          - Self-hosted job: \`${JOB_RESULT}\`
+          - Evidence status: \`${EVIDENCE_STATUS:-MISSING}\`
+          - Failure phase: \`${FAILURE_PHASE:-n/a}\`
+          - Failure message: \`${FAILURE_MESSAGE:-n/a}\`
+          - Artifact: \`${ARTIFACT_NAME:-agency-ai-playwright-516-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\`
+
+          This route uses only the local Drupal AI test provider. Inspect the artifact and before/after/restored captures before closing #516.
+          EOF
+          )"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
+++ b/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_ai_playwright_516_test\Plugin\AiFunctionCall;
+
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ai\Attribute\FunctionCall;
+use Drupal\ai\Base\FunctionCallBase;
+use Drupal\ai\Service\FunctionCalling\ExecutableFunctionCallInterface;
+
+#[FunctionCall(
+  id: 'agency_ai_playwright_516_test:bounded_canvas_heading',
+  function_name: 'bounded_canvas_heading',
+  name: 'Agency #516 bounded Canvas heading',
+  description: 'DEV-ONLY proof tool. Mutates or restores one fixed approved CTA heading on one fixed Canvas baseline page.',
+  context_definitions: [
+    'mode' => new ContextDefinition(
+      data_type: 'string',
+      label: new TranslatableMarkup('Mode'),
+      description: new TranslatableMarkup('Exactly mutate or restore.'),
+      required: TRUE,
+    ),
+  ],
+)]
+final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableFunctionCallInterface {
+
+  private string $readableOutput = '';
+
+  public function execute(): void {
+    $account = \Drupal::currentUser();
+    if (!$account->hasPermission('use agency 516 bounded canvas mutation')) {
+      throw new \RuntimeException('Bounded Canvas mutation permission denied.');
+    }
+
+    $mode = (string) $this->getContextValue('mode');
+    if (!in_array($mode, ['mutate', 'restore'], TRUE)) {
+      throw new \InvalidArgumentException('Unsupported bounded mutation mode.');
+    }
+
+    $ids = \Drupal::entityQuery('canvas_page')
+      ->accessCheck(FALSE)
+      ->condition('uuid', '52600000-0000-4000-8000-000000000001')
+      ->execute();
+    if (count($ids) !== 1) {
+      throw new \RuntimeException('The fixed Canvas baseline page was not found uniquely.');
+    }
+    $page = \Drupal::entityTypeManager()->getStorage('canvas_page')->load(reset($ids));
+    if (!$page || !$page->hasField('components')) {
+      throw new \RuntimeException('The fixed Canvas baseline has no components field.');
+    }
+
+    $state = \Drupal::state();
+    $components = $page->get('components')->getValue();
+    if ($mode === 'mutate') {
+      if ($state->get('agency_ai_playwright_516_test.original_components')) {
+        throw new \RuntimeException('A previous #516 mutation snapshot is still active.');
+      }
+      $state->set('agency_ai_playwright_516_test.original_components', json_encode($components, JSON_THROW_ON_ERROR));
+      $changed = FALSE;
+      foreach ($components as &$component) {
+        if (($component['uuid'] ?? NULL) !== '52600000-0000-4000-8000-000000000103') {
+          continue;
+        }
+        if (($component['component_id'] ?? NULL) !== 'sdc.emerging_digital.cta') {
+          throw new \RuntimeException('The fixed component UUID no longer identifies the approved CTA.');
+        }
+        if (($component['inputs']['heading'] ?? NULL) !== 'Composition Canvas bornée') {
+          throw new \RuntimeException('The original approved CTA heading changed; refusing mutation.');
+        }
+        $component['inputs']['heading'] = 'Composition Canvas bornée — vérification agentique';
+        $changed = TRUE;
+      }
+      unset($component);
+      if (!$changed) {
+        throw new \RuntimeException('The fixed approved CTA component was not found.');
+      }
+      $page->set('components', $components);
+      $page->save();
+      $this->readableOutput = 'MUTATED: Composition Canvas bornée — vérification agentique';
+      return;
+    }
+
+    $stored = $state->get('agency_ai_playwright_516_test.original_components');
+    if (!is_string($stored) || $stored === '') {
+      throw new \RuntimeException('No #516 mutation snapshot is available to restore.');
+    }
+    $original = json_decode($stored, TRUE, 512, JSON_THROW_ON_ERROR);
+    $page->set('components', $original);
+    $page->save();
+    $state->delete('agency_ai_playwright_516_test.original_components');
+    $this->readableOutput = 'RESTORED: Composition Canvas bornée';
+  }
+
+  public function getReadableOutput(): string {
+    return $this->readableOutput;
+  }
+
+}

--- a/scripts/runner/fixtures/ai-playwright-516/agency516-run.php
+++ b/scripts/runner/fixtures/ai-playwright-516/agency516-run.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\ai_agents\Event\AgentRequestEvent;
+
+$sequence = [
+  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline before the bounded #516 mutation.']],
+  ['name' => 'bounded_canvas_heading', 'args' => ['mode' => 'mutate']],
+  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after the bounded #516 heading mutation.']],
+  ['name' => 'bounded_canvas_heading', 'args' => ['mode' => 'restore']],
+  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after exact restoration.']],
+  ['name' => NULL, 'text' => '#516 governed AI Playwright loop complete.'],
+];
+$step = 0;
+$fixtureDir = DRUPAL_ROOT . '/modules/custom/agency_ai_playwright_516_test/tests/resources/ai_test/requests/chat';
+@mkdir($fixtureDir, 0775, TRUE);
+
+\Drupal::service('event_dispatcher')->addListener(
+  AgentRequestEvent::EVENT_NAME,
+  static function (AgentRequestEvent $event) use (&$step, $sequence, $fixtureDir): void {
+    if (!isset($sequence[$step])) {
+      throw new \RuntimeException('Provider requested more #516 hops than scripted.');
+    }
+    $planned = $sequence[$step];
+    if ($planned['name'] === NULL) {
+      $normalized = [
+        'role' => 'assistant',
+        'text' => $planned['text'],
+        'images' => [],
+        'remote_files' => [],
+        'tools' => NULL,
+        'tool_id' => NULL,
+      ];
+      $raw = ['role' => 'assistant', 'text' => $planned['text']];
+    }
+    else {
+      $call = [
+        'id' => 'agency_516_call_' . ($step + 1),
+        'type' => 'function',
+        'function' => [
+          'name' => $planned['name'],
+          'arguments' => json_encode($planned['args'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        ],
+      ];
+      $normalized = [
+        'role' => 'assistant',
+        'text' => '',
+        'images' => [],
+        'remote_files' => [],
+        'tools' => [$call],
+        'tool_id' => NULL,
+      ];
+      $raw = ['role' => 'assistant', 'text' => '', 'tools' => [$call]];
+    }
+    $fixture = [
+      'request' => $event->getChatInput()->toArray(),
+      'response' => [
+        'normalized' => $normalized,
+        'rawOutput' => $raw,
+        'metadata' => [],
+        'tokenUsage' => ['input' => NULL, 'output' => NULL, 'total' => NULL, 'reasoning' => NULL, 'cached' => NULL],
+        'rateLimits' => [
+          'rateLimitMaxRequests' => NULL,
+          'rateLimitMaxTokens' => NULL,
+          'rateLimitRemainingRequests' => NULL,
+          'rateLimitRemainingTokens' => NULL,
+          'rateLimitResetRequests' => NULL,
+          'rateLimitResetTokens' => NULL,
+        ],
+      ],
+      'operation_type' => 'chat',
+    ];
+    file_put_contents($fixtureDir . '/step-' . ($step + 1) . '.yml', Yaml::encode($fixture));
+    \Drupal::service('cache.default')->deleteAll();
+    $step++;
+  },
+  1000,
+);
+
+$user = user_load_by_name('agency_516_agent');
+if (!$user) {
+  throw new \RuntimeException('Least-privilege #516 actor not found.');
+}
+$switcher = \Drupal::service('account_switcher');
+$switcher->switchTo($user);
+try {
+  $agent = \Drupal::service('plugin.manager.ai_agents')->createInstance('agency_516_governed_loop');
+  $agent->setAiProvider(\Drupal::service('ai.provider')->createInstance('echoai'));
+  $agent->setModelName('gpt-test');
+  $agent->setLooped(FALSE);
+  $agent->setChatInput(new ChatInput([new ChatMessage('user', 'Run the deterministic governed #516 Canvas inspection, mutation, verification and restoration proof.') ]));
+
+  for ($loop = 0; $loop < 8 && !$agent->isFinished(); $loop++) {
+    $agent->determineSolvability();
+  }
+  if (!$agent->isFinished()) {
+    throw new \RuntimeException('The #516 agent did not finish within the bounded loop count.');
+  }
+  if ($step !== 6) {
+    throw new \RuntimeException(sprintf('Expected exactly 6 provider hops, observed %d.', $step));
+  }
+
+  $tools = [];
+  foreach ($agent->getToolResults() as $tool) {
+    $tools[] = [
+      'function_name' => $tool->getFunctionName(),
+      'output' => $tool->getReadableOutput(),
+    ];
+  }
+  $names = array_column($tools, 'function_name');
+  $expected = ['browser_preview', 'bounded_canvas_heading', 'browser_preview', 'bounded_canvas_heading', 'browser_preview'];
+  if ($names !== $expected) {
+    throw new \RuntimeException('Unexpected tool sequence: ' . json_encode($names));
+  }
+  if (!str_contains($tools[0]['output'], 'Composition Canvas bornée')) {
+    throw new \RuntimeException('Before inspection did not observe the original CTA heading.');
+  }
+  if (!str_contains($tools[2]['output'], 'Composition Canvas bornée — vérification agentique')) {
+    throw new \RuntimeException('After inspection did not observe the temporary CTA heading.');
+  }
+  if (!str_contains($tools[4]['output'], 'Composition Canvas bornée')) {
+    throw new \RuntimeException('Restored inspection did not observe the original CTA heading.');
+  }
+  if (str_contains($tools[4]['output'], 'Composition Canvas bornée — vérification agentique')) {
+    throw new \RuntimeException('Restored inspection still exposes the temporary heading.');
+  }
+
+  file_put_contents(
+    DRUPAL_ROOT . '/../artifacts/ai-playwright-governed-loop/agent-loop.json',
+    json_encode([
+      'status' => 'PASS',
+      'provider' => 'echoai',
+      'model' => 'gpt-test',
+      'provider_network_required' => FALSE,
+      'provider_hops' => $step,
+      'tool_sequence' => $tools,
+      'answer' => $agent->solve(),
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n",
+  );
+}
+finally {
+  $switcher->switchBack();
+}

--- a/scripts/runner/fixtures/ai-playwright-516/part-1.sh
+++ b/scripts/runner/fixtures/ai-playwright-516/part-1.sh
@@ -1,0 +1,170 @@
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+cd "$TARGET_DIR"
+
+write_failure() {
+  local phase="$1"
+  local message="$2"
+  jq -n \
+    --arg status 'FAIL' \
+    --arg phase "$phase" \
+    --arg message "$message" \
+    '{status:$status,phase:$phase,message:$message}' \
+    > "$ARTIFACT_DIR/result.json"
+}
+
+restore_if_needed() {
+  if ! command -v ddev >/dev/null 2>&1; then
+    return 0
+  fi
+  ddev drush php:eval '
+    $state = \Drupal::state();
+    $stored = $state->get("agency_ai_playwright_516_test.original_components");
+    if (is_string($stored) && $stored !== "") {
+      $values = json_decode($stored, TRUE, 512, JSON_THROW_ON_ERROR);
+      $ids = \Drupal::entityQuery("canvas_page")
+        ->accessCheck(FALSE)
+        ->condition("uuid", "52600000-0000-4000-8000-000000000001")
+        ->execute();
+      if ($ids) {
+        $page = \Drupal::entityTypeManager()->getStorage("canvas_page")->load(reset($ids));
+        if ($page) {
+          $page->set("components", $values);
+          $page->save();
+        }
+      }
+      $state->delete("agency_ai_playwright_516_test.original_components");
+    }
+  ' >/dev/null 2>&1 || true
+}
+
+on_exit() {
+  local rc=$?
+  trap - EXIT
+  restore_if_needed
+  rm -f .agency516-run.php
+  rm -rf "web/modules/custom/${TEST_MODULE}"
+  if [[ $rc -ne 0 && ! -s "$ARTIFACT_DIR/result.json" ]]; then
+    write_failure 'unexpected' "Trusted governed AI Playwright loop failed with exit code $rc"
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
+
+command -v ddev >/dev/null
+command -v jq >/dev/null
+command -v git >/dev/null
+command -v openssl >/dev/null
+
+test -f composer.json
+test -f composer.lock
+test -f .ddev/config.yaml
+test -f docs/evaluations/ai-playwright-516-governed-loop.md
+test "$(cat docs/evaluations/ai-playwright-516-governed-loop.md)" = "$MARKER"
+if grep -q 'drupal/ai_playwright' composer.json; then
+  write_failure 'preflight' 'ai_playwright must not be a production Composer dependency.'
+  exit 1
+fi
+
+git diff --check
+before_composer="$(sha256sum composer.json | awk '{print $1}')"
+before_lock="$(sha256sum composer.lock | awk '{print $1}')"
+
+# Alpha dependency is deliberately workspace-only and disappears with DDEV/workspace cleanup.
+ddev composer require "${EXPECTED_PACKAGE}:${EXPECTED_VERSION}" --no-interaction --no-progress
+installed_version="$(ddev composer show "$EXPECTED_PACKAGE" --format=json | jq -r '.versions[]' | sed 's/^\* //' | head -n 1)"
+if [[ "$installed_version" != "$EXPECTED_VERSION" ]]; then
+  write_failure 'composer' "Expected $EXPECTED_VERSION, got $installed_version"
+  exit 1
+fi
+
+ddev composer show drupal/ai --format=json > "$ARTIFACT_DIR/ai-package.json"
+ddev composer show drupal/ai_agents --format=json > "$ARTIFACT_DIR/ai-agents-package.json"
+ddev composer show drupal/canvas --format=json > "$ARTIFACT_DIR/canvas-package.json"
+ddev composer show "$EXPECTED_PACKAGE" --format=json > "$ARTIFACT_DIR/ai-playwright-package.json"
+
+module_dir='/var/www/html/web/modules/contrib/ai_playwright'
+ddev exec node --version > "$ARTIFACT_DIR/ddev-node-version.txt"
+ddev exec npm --version > "$ARTIFACT_DIR/ddev-npm-version.txt"
+ddev exec bash -lc "cd '$module_dir' && npm install --no-audit --no-fund"
+if ! ddev exec bash -lc "cd '$module_dir' && npx playwright install --with-deps chromium" \
+  > "$ARTIFACT_DIR/chromium-install.txt" 2>&1; then
+  msg="$(tail -n 8 "$ARTIFACT_DIR/chromium-install.txt" | tr '\r\n' '  ' | cut -c1-300)"
+  write_failure 'chromium-install' "${msg:-Playwright Chromium installation failed.}"
+  exit 1
+fi
+
+if ! ddev exec bash -lc "cd '$module_dir' && node - <<'NODE'
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const version = browser.version();
+  await browser.close();
+  process.stdout.write(JSON.stringify({ ok: true, version }));
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});
+NODE" > "$ARTIFACT_DIR/chromium-smoke.json" 2> "$ARTIFACT_DIR/chromium-smoke-error.txt"; then
+  msg="$(tr '\r\n' '  ' < "$ARTIFACT_DIR/chromium-smoke-error.txt" | cut -c1-300)"
+  write_failure 'chromium-smoke' "${msg:-Chromium direct launch failed.}"
+  exit 1
+fi
+jq -e '.ok == true' "$ARTIFACT_DIR/chromium-smoke.json" >/dev/null
+
+admin_pass="$(openssl rand -hex 24)"
+ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+unset admin_pass
+
+# ai_test lives under the AI package tests tree; this is enabled only in this disposable DDEV.
+cat >> web/sites/default/settings.php <<'PHP'
+
+// #516 trusted DEV-ONLY proof: discover ai_test from the contrib package test tree.
+$settings['extension_discovery_scan_tests'] = TRUE;
+PHP
+
+ddev drush cim -y
+ddev drush cr
+ddev drush emerging:governed-content --all
+ddev drush en ai_test ai_agents ai_playwright -y
+ddev drush cr
+
+ddev drush cset ai_playwright.settings internal_base 'http://localhost' -y
+ddev drush cset ai_playwright.settings node_binary 'node' -y
+ddev drush cset ai_playwright.settings timeout 60 -y
+ddev drush cset ai_playwright.settings screenshot_scheme 'public' -y
+ddev drush cset ai_playwright.settings allow_external_urls 0 -y
+ddev drush cset ai.settings default_providers.chat_with_tools.provider_id echoai -y
+ddev drush cset ai.settings default_providers.chat_with_tools.model_id gpt-test -y
+ddev drush cr
+
+ddev exec curl -fsS "http://localhost${BASELINE_PATH}" > /dev/null
+
+# Runtime-only test adapter: one mutation, one UUID, one component and one prop.
+mkdir -p "web/modules/custom/${TEST_MODULE}/src/Plugin/AiFunctionCall"
+cat > "web/modules/custom/${TEST_MODULE}/${TEST_MODULE}.info.yml" <<'YAML'
+name: 'Agency AI Playwright #516 Test'
+type: module
+description: 'Ephemeral trusted test adapter for the governed #516 proof.'
+package: Testing
+core_version_requirement: ^11
+dependencies:
+  - ai:ai
+  - ai_agents:ai_agents
+  - ai_playwright:ai_playwright
+  - canvas:canvas
+YAML
+cat > "web/modules/custom/${TEST_MODULE}/${TEST_MODULE}.permissions.yml" <<'YAML'
+use agency 516 bounded canvas mutation:
+  title: 'Use Agency #516 bounded Canvas mutation'
+  restrict access: true
+YAML
+cp "$TRUSTED_FIXTURE_DIR/BoundedCanvasHeading.php" "web/modules/custom/${TEST_MODULE}/src/Plugin/AiFunctionCall/BoundedCanvasHeading.php"
+
+ddev drush en "$TEST_MODULE" -y
+ddev drush cr
+

--- a/scripts/runner/fixtures/ai-playwright-516/part-2.sh
+++ b/scripts/runner/fixtures/ai-playwright-516/part-2.sh
@@ -1,0 +1,81 @@
+# Least-privilege actor used by both ai_playwright and the bounded mutation tool.
+ddev drush php:eval '
+  use Drupal\user\Entity\Role;
+  use Drupal\user\Entity\User;
+  $role_id = "agency_516_agent";
+  $role = Role::load($role_id) ?: Role::create(["id" => $role_id, "label" => "Agency #516 agent"]);
+  $role->grantPermission("use ai playwright");
+  $role->grantPermission("use agency 516 bounded canvas mutation");
+  $role->save();
+  $existing = user_load_by_name("agency_516_agent");
+  if (!$existing) {
+    $user = User::create([
+      "name" => "agency_516_agent",
+      "mail" => "agency-516-agent@example.test",
+      "status" => 1,
+      "roles" => [$role_id],
+    ]);
+    $user->save();
+  }
+'
+
+# Persist a config-agent only inside the disposable site. It exposes exactly two tools.
+ddev drush php:eval '
+  $storage = \Drupal::entityTypeManager()->getStorage("ai_agent");
+  if ($old = $storage->load("agency_516_governed_loop")) {
+    $old->delete();
+  }
+  $agent = $storage->create([
+    "id" => "agency_516_governed_loop",
+    "label" => "Agency #516 governed loop",
+    "description" => "Ephemeral deterministic DEV-ONLY proof agent.",
+    "system_prompt" => "Execute only the scripted #516 proof tools. Never navigate externally or perform any other mutation.",
+    "secured_system_prompt" => "",
+    "default_information_tools" => "",
+    "tools" => [
+      "ai_playwright:browser_preview" => TRUE,
+      "agency_ai_playwright_516_test:bounded_canvas_heading" => TRUE,
+    ],
+    "tool_settings" => [
+      "ai_playwright:browser_preview" => ["return_directly" => 0, "require_usage" => 0, "description_override" => "", "progress_message" => "", "use_artifacts" => 0],
+      "agency_ai_playwright_516_test:bounded_canvas_heading" => ["return_directly" => 0, "require_usage" => 0, "description_override" => "", "progress_message" => "", "use_artifacts" => 0],
+    ],
+    "tool_usage_limits" => [
+      "ai_playwright:browser_preview" => [],
+      "agency_ai_playwright_516_test:bounded_canvas_heading" => [],
+    ],
+    "orchestration_agent" => FALSE,
+    "triage_agent" => FALSE,
+    "max_loops" => 8,
+    "max_loops_message" => "#516 deterministic loop exceeded its bounded maximum.",
+    "masquerade_roles" => [],
+    "exclude_users_role" => FALSE,
+    "structured_output_enabled" => FALSE,
+    "structured_output_schema" => "",
+    "hostname_filter_disabled" => FALSE,
+    "guardrail_set" => "",
+  ]);
+  $agent->save();
+'
+
+# Baseline sanity before the agent starts.
+ddev drush php:eval '
+  $ids = \Drupal::entityQuery("canvas_page")->accessCheck(FALSE)->condition("uuid", "52600000-0000-4000-8000-000000000001")->execute();
+  if (count($ids) !== 1) { throw new \RuntimeException("Baseline page not found uniquely."); }
+  $page = \Drupal::entityTypeManager()->getStorage("canvas_page")->load(reset($ids));
+  $values = $page->get("components")->getValue();
+  $ids_seen = [];
+  $heading = NULL;
+  foreach ($values as $component) {
+    $ids_seen[] = $component["component_id"] ?? NULL;
+    if (($component["uuid"] ?? NULL) === "52600000-0000-4000-8000-000000000103") {
+      $heading = $component["inputs"]["heading"] ?? NULL;
+    }
+  }
+  if ($ids_seen !== ["sdc.emerging_digital.hero", "sdc.emerging_digital.trust-list", "sdc.emerging_digital.cta"]) {
+    throw new \RuntimeException("Baseline component allowlist/order changed.");
+  }
+  if ($heading !== "Composition Canvas bornée") { throw new \RuntimeException("Baseline CTA heading changed."); }
+  echo json_encode(["component_ids" => $ids_seen, "heading" => $heading], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+' > "$ARTIFACT_DIR/baseline-before.json"
+

--- a/scripts/runner/fixtures/ai-playwright-516/part-3.sh
+++ b/scripts/runner/fixtures/ai-playwright-516/part-3.sh
@@ -1,0 +1,99 @@
+cp "$TRUSTED_FIXTURE_DIR/agency516-run.php" .agency516-run.php
+
+if ! ddev drush scr .agency516-run.php > "$ARTIFACT_DIR/agent-run.stdout.txt" 2> "$ARTIFACT_DIR/agent-run.stderr.txt"; then
+  msg="$(tail -n 12 "$ARTIFACT_DIR/agent-run.stderr.txt" | tr '\r\n' '  ' | cut -c1-500)"
+  write_failure 'agent-loop' "${msg:-Deterministic AI Agents loop failed.}"
+  exit 1
+fi
+jq -e '.status == "PASS" and .provider == "echoai" and .provider_network_required == false and .provider_hops == 6' "$ARTIFACT_DIR/agent-loop.json" >/dev/null
+
+# Verify exact restoration at entity level and capture the generated managed-file evidence.
+ddev drush php:eval '
+  $ids = \Drupal::entityQuery("canvas_page")->accessCheck(FALSE)->condition("uuid", "52600000-0000-4000-8000-000000000001")->execute();
+  $page = \Drupal::entityTypeManager()->getStorage("canvas_page")->load(reset($ids));
+  $values = $page->get("components")->getValue();
+  $heading = NULL;
+  foreach ($values as $component) {
+    if (($component["uuid"] ?? NULL) === "52600000-0000-4000-8000-000000000103") {
+      $heading = $component["inputs"]["heading"] ?? NULL;
+    }
+  }
+  if ($heading !== "Composition Canvas bornée") { throw new \RuntimeException("CTA heading was not restored exactly."); }
+  if (\Drupal::state()->get("agency_ai_playwright_516_test.original_components")) { throw new \RuntimeException("Restore snapshot still exists."); }
+  echo json_encode(["heading" => $heading, "restored" => TRUE], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+' > "$ARTIFACT_DIR/baseline-restored.json"
+
+# Exactly three browser_preview executions should have produced three managed screenshots.
+ddev drush php:eval '
+  $ids = \Drupal::entityQuery("file")->accessCheck(FALSE)->condition("uri", "public://ai_playwright/%", "LIKE")->sort("fid", "ASC")->execute();
+  $files = \Drupal::entityTypeManager()->getStorage("file")->loadMultiple($ids);
+  $out = [];
+  foreach ($files as $file) {
+    $out[] = ["fid" => (int) $file->id(), "uri" => $file->getFileUri()];
+  }
+  echo json_encode($out, JSON_UNESCAPED_SLASHES);
+' > "$ARTIFACT_DIR/screenshots.json"
+jq -e 'length == 3' "$ARTIFACT_DIR/screenshots.json" >/dev/null
+mapfile -t screenshot_uris < <(jq -r '.[].uri' "$ARTIFACT_DIR/screenshots.json")
+labels=(before after restored)
+for i in 0 1 2; do
+  uri="${screenshot_uris[$i]}"
+  [[ "$uri" == public://ai_playwright/* ]]
+  host_path="web/sites/default/files/${uri#public://}"
+  test -s "$host_path"
+  cp "$host_path" "$ARTIFACT_DIR/${labels[$i]}.png"
+done
+
+# Re-prove same-site boundary and least privilege at the end of the run.
+ddev drush php:eval '
+  $runner = \Drupal::service("ai_playwright.runner");
+  if ($runner->resolveUrl("https://example.com") !== NULL) { throw new \RuntimeException("Off-site URL accepted."); }
+  if ($runner->resolveUrl("file:///etc/passwd") !== NULL) { throw new \RuntimeException("file URL accepted."); }
+  $role = \Drupal\user\Entity\Role::load("agency_516_agent");
+  if (!$role || !$role->hasPermission("use ai playwright") || !$role->hasPermission("use agency 516 bounded canvas mutation")) {
+    throw new \RuntimeException("Least-privilege role is incomplete.");
+  }
+  $permissions = array_values($role->getPermissions());
+  sort($permissions);
+  echo json_encode(["offsite_refused" => TRUE, "file_scheme_refused" => TRUE, "permissions" => $permissions]);
+' > "$ARTIFACT_DIR/security-boundary.json"
+jq -e '.offsite_refused == true and .file_scheme_refused == true' "$ARTIFACT_DIR/security-boundary.json" >/dev/null
+
+# The runtime-only test adapter and fixture files are enidence mechanics, never product code.
+rm -f .agency516-run.php
+rm -rf "web/modules/custom/${TEST_MODULE}"
+
+after_composer="$(sha256sum composer.json | awk '{print $1}')"
+after_lock="$(sha256sum composer.lock | awk '{print $1}')"
+
+jq -n \
+  --arg status 'PASS' \
+  --arg package "$EXPECTED_PACKAGE" \
+  --arg version "$installed_version" \
+  --arg baseline_uuid "$BASELINE_UUID" \
+  --arg baseline_path "$BASELINE_PATH" \
+  --arg original_heading "$ORIGINAL_HEADING" \
+  --arg temporary_heading "$TEMP_HEADING" \
+  --arg before_composer "$before_composer" \
+  --arg after_composer "$after_composer" \
+  --arg before_lock "$before_lock" \
+  --arg after_lock "$after_lock" \
+  '{
+    status:$status,
+    package:$package,
+    version:$version,
+    mode:"DEV_ONLY_EPHEMERAL",
+    contrib_modules_first:true,
+    provider:{id:"echoai",model:"gpt-test",network_required:false,secret_required:false},
+    baseline:{uuid:$baseline_uuid,path:$baseline_path},
+    mutation:{component:"sdc.emerging_digital.cta",prop:"heading",original:$original_heading,temporary:$temporary_heading},
+    inspections:["before","after","restored"],
+    browser_preview_tool_calls:3,
+    bounded_mutation_tool_calls:2,
+    restored:true,
+    same_site_only:true,
+    production_dependency_persisted:false,
+    composer_hashes:{before:$before_composer,ephemeral_after:$after_composer},
+    lock_hashes:{before:$before_lock,ephemeral_after:$after_lock}
+  }' > "$ARTIFACT_DIR/result.json"
+jq -e '.status == "PASS" and .restored == true and .provider.network_required == false and .browser_preview_tool_calls == 3' "$ARTIFACT_DIR/result.json" >/dev/null

--- a/scripts/runner/run-ai-playwright-governed-loop.sh
+++ b/scripts/runner/run-ai-playwright-governed-loop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRUSTED_FIXTURE_DIR="$SCRIPT_DIR/fixtures/ai-playwright-516"
+test -f "$TRUSTED_FIXTURE_DIR/BoundedCanvasHeading.php"
+test -f "$TRUSTED_FIXTURE_DIR/agency516-run.php"
+
+EXPECTED_PACKAGE='drupal/ai_playwright'
+EXPECTED_VERSION='1.0.0-alpha1'
+BASELINE_UUID='52600000-0000-4000-8000-000000000001'
+BASELINE_PATH='/canvas-governed-sdc-baseline'
+ORIGINAL_HEADING='Composition Canvas bornée'
+TEMP_HEADING='Composition Canvas bornée — vérification agentique'
+MARKER='AI Playwright governed SDC loop #516 — DEV-ONLY inert target.'
+TEST_MODULE='agency_ai_playwright_516_test'
+ARTIFACT_REL='artifacts/ai-playwright-governed-loop'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+
+source "$TRUSTED_FIXTURE_DIR/part-1.sh"
+source "$TRUSTED_FIXTURE_DIR/part-2.sh"
+source "$TRUSTED_FIXTURE_DIR/part-3.sh"


### PR DESCRIPTION
## Résumé

Étend la capability DEV-ONLY #456 pour exécuter la preuve #516 sans introduire de moteur Agency concurrent.

**CONTRIBUTED MODULES FIRST** : la route utilise `drupal/ai_playwright:1.0.0-alpha1` uniquement de manière éphémère dans DDEV, le vrai tool contrib `ai_playwright:browser_preview`, AI Agents et le provider local déterministe `ai_test`/`echoai`. Aucune clé/provider réseau n'est requis.

## Frontière de confiance

- workflow + runner + fixtures de preuve sont possédés par `main` ;
- cible produit : PR #544, draft et inerte, exactement un marqueur documentaire fixe ;
- la PR cible ne peut modifier ni le workflow, ni le runner, ni la mutation ;
- aucune dépendance alpha persistée dans Composer ;
- aucune configuration/runtime de production modifiée.

## Boucle #516

Un seul agent, séquence déterministe bornée :

`browser_preview -> mutate CTA heading -> browser_preview -> restore -> browser_preview -> réponse finale`

La mutation trusted refuse de s'exécuter sauf si :

- `canvas_page` UUID = `52600000-0000-4000-8000-000000000001` ;
- composant UUID = `52600000-0000-4000-8000-000000000103` ;
- component ID = `sdc.emerging_digital.cta` ;
- heading initial = `Composition Canvas bornée`.

La restauration complète du champ `components` est sauvegardée en state et un trap tente aussi la restauration en cas d'échec.

## Preuves produites

- `result.json` ;
- `agent-loop.json` ;
- baseline/security metadata ;
- captures `before.png`, `after.png`, `restored.png` ;
- packages réellement résolus ;
- preuve same-site/SSRF + permissions least-privilege ;
- cleanup DDEV/workspaces.

## Diff

Infra uniquement :

- `.github/workflows/trusted-ai-playwright-governed-loop.yml` ;
- `scripts/runner/run-ai-playwright-governed-loop.sh` ;
- fixtures trusted #516 sous `scripts/runner/fixtures/ai-playwright-516/`.

Validations locales avant publication : Bash `-n`, PHP `-l` des deux fixtures PHP, YAML parse OK.

Closes #543
Refs #516 #544 #456 #519 #526 #530 #541