### PR TITLE
Issue #546: remove host Node preflight requirement

### DIFF
--- a/.github/workflows/trusted-ai-playwright-governed-loop.yml
+++ b/.github/workflows/trusted-ai-playwright-governed-loop.yml
@@ -135,8 +135,6 @@ jobs:
           command -v ddev
           ddev version
           command -v jq
-          command -v node
-          node --version
 
       - name: Checkout trusted implementation from main
         uses: actions/checkout@v6


### PR DESCRIPTION
Correction bornée du premier run #516 `32244388344`.

Le runner Agency possède Git/Docker/DDEV/jq mais pas Node sur l'hôte. Ce n'est pas un prérequis : `ai_playwright` lance Node/Chromium depuis le conteneur DDEV, déjà vérifié par le runner trusted comme dans #456.

Diff exact :

- supprimer `command -v node` ;
- supprimer `node --version` ;
- aucun autre changement.

Le premier run a échoué avant checkout/DDEV/mutation ; zéro mutation Canvas et zéro provider réseau.

Après merge : resynchroniser la cible inerte #544 avec `main` puis relancer le proof #516.

Closes #546
Refs #516 #543 #544 #545