### PR TITLE
Issue #553: use AI Playwright model-facing function name

### DIFF
--- a/scripts/runner/fixtures/ai-playwright-516/agency516-run.php
+++ b/scripts/runner/fixtures/ai-playwright-516/agency516-run.php
@@ -22,11 +22,11 @@ if ($originalHeading === $temporaryHeading) {
 }
 
 $sequence = [
-  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline before the bounded #516 mutation.']],
+  ['name' => 'ai_playwright_browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline before the bounded #516 mutation.']],
   ['name' => 'bounded_canvas_heading', 'args' => ['mode' => 'mutate']],
-  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after the bounded #516 heading mutation.']],
+  ['name' => 'ai_playwright_browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after the bounded #516 heading mutation.']],
   ['name' => 'bounded_canvas_heading', 'args' => ['mode' => 'restore']],
-  ['name' => 'browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after exact restoration.']],
+  ['name' => 'ai_playwright_browser_preview', 'args' => ['url' => '/canvas-governed-sdc-baseline', 'task' => 'Inspect the approved Canvas baseline after exact restoration.']],
   ['name' => NULL, 'text' => '#516 governed AI Playwright loop complete.'],
 ];
 $step = 0;
@@ -126,7 +126,7 @@ try {
     ];
   }
   $names = array_column($tools, 'function_name');
-  $expected = ['browser_preview', 'bounded_canvas_heading', 'browser_preview', 'bounded_canvas_heading', 'browser_preview'];
+  $expected = ['ai_playwright_browser_preview', 'bounded_canvas_heading', 'ai_playwright_browser_preview', 'bounded_canvas_heading', 'ai_playwright_browser_preview'];
   if ($names !== $expected) {
     throw new \RuntimeException('Unexpected tool sequence: ' . json_encode($names));
   }


### PR DESCRIPTION
## Objet

Corrige le blocker exact du run trusted #516 `32359776872`.

La release `drupal/ai_playwright 1.0.0-alpha1` définit :

```text
plugin id     = ai_playwright:browser_preview
function_name = ai_playwright_browser_preview
```

La fixture déterministe Agency utilisait à tort `browser_preview` dans la réponse synthétique du provider `ai_test`, ce qui provoquait `Function with name browser_preview not found` dès le premier hop.

## Diff

Un seul fichier trusted/test-only :

- `scripts/runner/fixtures/ai-playwright-516/agency516-run.php`

Changement :

- séquence modèle : `browser_preview` -> `ai_playwright_browser_preview` ;
- séquence attendue des tool results mise en cohérence ;
- plugin configuré `ai_playwright:browser_preview` inchangé ;
- `bounded_canvas_heading` inchangé.

## Non-objectifs

- aucune dépendance/config produit ;
- aucun provider réseau ;
- aucune permission nouvelle ;
- aucune modification Canvas ;
- aucune extension du scope #516.

Après merge trusted sur `main`, la preuve #516 sera relancée sur la cible inert #544 réalignée.

Closes #553
Refs #516 #550 #544.