### PR TITLE
Issue #557: clear stale dynamic page cache in #516 proof

### DIFF
--- a/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
+++ b/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
@@ -88,6 +88,7 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
       $state->set('agency_ai_playwright_516_test.original_components', json_encode($page->get('components')->getValue(), JSON_THROW_ON_ERROR));
       $page->set('components', $components);
       $page->save();
+      self::invalidateDynamicPageCache();
       $this->readableOutput = 'MUTATED: ' . self::TEMPORARY_HEADING;
       return;
     }
@@ -113,6 +114,7 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
     }
     $page->set('components', $original);
     $page->save();
+    self::invalidateDynamicPageCache();
     $state->delete('agency_ai_playwright_516_test.original_components');
     $this->readableOutput = 'RESTORED: ' . $originalHeading;
   }
@@ -137,6 +139,13 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
     return is_string($original)
       ? json_encode($inputs, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
       : $inputs;
+  }
+
+  /**
+   * Clears stale authenticated page output inside the disposable #516 DDEV.
+   */
+  private static function invalidateDynamicPageCache(): void {
+    \Drupal::service('cache.dynamic_page_cache')->deleteAll();
   }
 
   public function getReadableOutput(): string {


### PR DESCRIPTION
## Objet

Corrige uniquement le dernier blocker démontré de la preuve DEV-ONLY #516.

Le run trusted `32363285627` prouve simultanément :

- entity Canvas restaurée à `Composition Canvas bornée` via `loadUnchanged()` ;
- snapshot de restauration supprimé ;
- troisième `browser_preview` affichant encore `Composition Canvas bornée — vérification agentique`.

Les captures before/after/restored confirment visuellement la divergence. AI Playwright démarre un nouveau Chromium à chaque capture ; le rendu stale est donc côté Drupal. La capture est authentifiée, ce qui cible `dynamic_page_cache`.

## Diff

Un seul fichier trusted/test-only :

- `scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php`

Après chacun des deux `save()` bornés (mutation puis restauration), la fixture vide uniquement `cache.dynamic_page_cache` dans le DDEV jetable.

Il ne s'agit pas d'un fix Canvas produit : c'est un workaround de preuve pour un comportement de cache metadata stale déjà observé upstream. Les diagnostics #555 restent fail-closed et vérifieront encore l'état entity-level et les trois rendus.

## Invariants

- aucun `drush cr` ;
- aucun clear `cache.render` ou `cache.page` ;
- aucune dépendance/config production ;
- aucun changement de UUID, allowlist, permission, séquence tools, provider ou snapshot ;
- aucun code contrib modifié ;
- aucune généralisation hors #516.

Après merge trusted sur `main`, #544 sera réalignée et la boucle #516 relancée. Si elle devient GREEN, Browser Validation Agency indépendante restera requise avant clôture #516.

Closes #557
Refs #516 #544 #555.