### PR TITLE
Issue #559: clear stale render cache in #516 proof

### DIFF
--- a/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
+++ b/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
@@ -88,7 +88,7 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
       $state->set('agency_ai_playwright_516_test.original_components', json_encode($page->get('components')->getValue(), JSON_THROW_ON_ERROR));
       $page->set('components', $components);
       $page->save();
-      self::invalidateDynamicPageCache();
+      self::invalidateRenderedPageCaches();
       $this->readableOutput = 'MUTATED: ' . self::TEMPORARY_HEADING;
       return;
     }
@@ -114,7 +114,7 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
     }
     $page->set('components', $original);
     $page->save();
-    self::invalidateDynamicPageCache();
+    self::invalidateRenderedPageCaches();
     $state->delete('agency_ai_playwright_516_test.original_components');
     $this->readableOutput = 'RESTORED: ' . $originalHeading;
   }
@@ -142,9 +142,10 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
   }
 
   /**
-   * Clears stale authenticated page output inside the disposable #516 DDEV.
+   * Clears stale rendered output inside the disposable #516 DDEV only.
    */
-  private static function invalidateDynamicPageCache(): void {
+  private static function invalidateRenderedPageCaches(): void {
+    \Drupal::service('cache.render')->deleteAll();
     \Drupal::service('cache.dynamic_page_cache')->deleteAll();
   }
 


### PR DESCRIPTION
## Objet

Le run trusted #516 `32367017577` a démontré que vider uniquement `cache.dynamic_page_cache` ne suffit pas : l'entité Canvas est restaurée correctement, mais le rendu authentifié reste stale.

Comme le DPC est déjà explicitement vidé et que Page Cache ne sert pas les utilisateurs authentifiés, le cache de rendu est la couche restante pertinente.

## Diff

Un seul fichier trusted/test-only :

- `scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php`

Le helper introduit par #557 devient `invalidateRenderedPageCaches()` et vide, après chacun des deux saves bornés :

```text
cache.render
cache.dynamic_page_cache
```

## Invariants

- aucun `drush cr` ;
- aucun `cache.page` ;
- aucune dépendance/config produit ;
- aucun code contrib modifié ;
- aucun changement UUID/allowlist/permission/snapshot/provider/séquence tools ;
- workaround limité au DDEV jetable de #516 ;
- diagnostics #555 et assertions finales inchangés/fail-closed.

Après merge trusted, #544 sera réalignée et la boucle #516 relancée. Si elle passe, une Browser Validation Agency indépendante restera le dernier gate avant clôture de #516.

Closes #559
Refs #516 #544 #557 #555.