### PR TITLE
Issue #561: add governed Drupal maintenance Composer route

### DIFF
--- a/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
+++ b/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
@@ -1,0 +1,439 @@
+name: Agency trusted Drupal maintenance AI 1.5 RC1
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #562 maintenance target
+    if: ${{ github.event.issue.pull_request && github.event.issue.number == 563 && github.event.comment.body == '/agency-drupal-maintenance-ai-1.5-rc1' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+      base_sha: ${{ steps.validate.outputs.base_sha }}
+      head_ref: ${{ steps.validate.outputs.head_ref }}
+    steps:
+      - name: Checkout trusted profile definition
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate actor, exact PR and semantic composer delta
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+          COMPOSER_PROFILE: drupal-maintenance-ai-1.5-rc1
+        run: |
+          set -euo pipefail
+
+          test "$PR_NUMBER" = '563'
+          test "$TRIGGER_COMMENT" = '/agency-drupal-maintenance-ai-1.5-rc1'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          source scripts/runner/composer-materialization-profiles.sh
+          test "$COMPOSER_PACKAGE" = 'drupal/ai'
+          test "$COMPOSER_CONSTRAINT" = '1.5.0-rc1'
+          test "$COMPOSER_UPDATE_SELECTOR" = 'drupal/*'
+          test "$COMPOSER_OWNER_ISSUE" = '562'
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -r '.state' <<<"$pr_json")" = 'open'
+          test "$(jq -r '.draft' <<<"$pr_json")" = 'true'
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = 'main'
+          test "$(jq -r '.head.ref' <<<"$pr_json")" = 'feature/issue-562-drupal-contrib-ai-1-5-rc1'
+          test "$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
+
+          base_sha="$(jq -r '.base.sha' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          head_ref="$(jq -r '.head.ref' <<<"$pr_json")"
+          test "$base_sha" = "$EVENT_DEFAULT_SHA" || {
+            echo 'PR #563 must be rebased onto the trusted maintenance workflow revision on main.' >&2
+            exit 1
+          }
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          changed="$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+              --jq '.[].filename'
+          )"
+          if [[ "$changed" != 'composer.json' ]]; then
+            echo 'Pre-resolution target must change exactly composer.json.' >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+          gh api \
+            "repos/$GITHUB_REPOSITORY/contents/composer.json?ref=$base_sha" \
+            --jq '.content' | tr -d '\n' | base64 --decode > /tmp/composer-base.json
+          gh api \
+            "repos/$GITHUB_REPOSITORY/contents/composer.json?ref=$head_sha" \
+            --jq '.content' | tr -d '\n' | base64 --decode > /tmp/composer-target.json
+
+          python3 - <<'PY'
+          import copy
+          import json
+
+          with open('/tmp/composer-base.json', encoding='utf-8') as handle:
+              base = json.load(handle)
+          with open('/tmp/composer-target.json', encoding='utf-8') as handle:
+              target = json.load(handle)
+
+          expected = copy.deepcopy(base)
+          expected.setdefault('require', {})['drupal/ai'] = '1.5.0-rc1'
+          if target != expected:
+              raise SystemExit(
+                  'PR #563 composer.json must differ from trusted main only by '
+                  'drupal/ai = 1.5.0-rc1.'
+              )
+          PY
+
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+  report-start:
+    name: Publish maintenance run locator
+    needs: validate-target
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment exact trusted target
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          gh pr comment 563 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### #562 governed Drupal maintenance — trusted run locator
+
+          - Run ID: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+          - Trusted main: \`${BASE_SHA}\`
+          - Input HEAD: \`${HEAD_SHA}\`
+          - Composer selector: repository-owned \`drupal/*\`
+          - Required Drupal AI: \`1.5.0-rc1\`
+          - State: \`validated; self-hosted resolution pending\`
+
+          No package name, Composer argument or secret is supplied by the PR/comment.
+          EOF
+          )"
+
+  resolve-lock:
+    name: Resolve Drupal packages on trusted self-hosted DDEV
+    needs:
+      - validate-target
+      - report-start
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    outputs:
+      resolved_ai: ${{ steps.summarize.outputs.resolved_ai }}
+      change_count: ${{ steps.summarize.outputs.change_count }}
+      lock_sha256: ${{ steps.summarize.outputs.lock_sha256 }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          python3 --version
+
+      - name: Checkout trusted implementation from main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.base_sha }}
+          path: trusted
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact dependency target read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.head_sha }}
+          path: target
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable profile and target
+        shell: bash
+        env:
+          EXPECTED_BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          COMPOSER_PROFILE: drupal-maintenance-ai-1.5-rc1
+        run: |
+          set -euo pipefail
+          test "$(git -C trusted rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
+          test "$(git -C target rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          source trusted/scripts/runner/composer-materialization-profiles.sh
+          test "$COMPOSER_PACKAGE" = 'drupal/ai'
+          test "$COMPOSER_CONSTRAINT" = '1.5.0-rc1'
+          test "$COMPOSER_UPDATE_SELECTOR" = 'drupal/*'
+          test "$(jq -r '.require["drupal/ai"]' target/composer.json)" = '1.5.0-rc1'
+
+      - name: Isolate DDEV project
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-drupal-maintenance.yaml <<EOF
+          name: agency-drupal-maintenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-drupal-maintenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev start -y
+
+      - name: Resolve fixed Drupal package selector
+        id: summarize
+        shell: bash
+        working-directory: target
+        env:
+          COMPOSER_PROFILE: drupal-maintenance-ai-1.5-rc1
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          source ../trusted/scripts/runner/composer-materialization-profiles.sh
+          test "$COMPOSER_UPDATE_SELECTOR" = 'drupal/*'
+
+          cp composer.lock /tmp/composer-lock-before.json
+          ddev composer update "$COMPOSER_UPDATE_SELECTOR" \
+            --with-all-dependencies \
+            --no-install \
+            --no-interaction \
+            --no-progress \
+            --no-scripts
+
+          rm -f .ddev/config.gate-drupal-maintenance.yaml
+          test -z "$(git ls-files --others --exclude-standard)"
+          test -z "$(git diff --cached --name-only)"
+          changed="$(git diff --name-only)"
+          if [[ "$changed" != 'composer.lock' ]]; then
+            echo 'Trusted maintenance resolution must modify exactly composer.lock.' >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+          mkdir -p ../drupal-maintenance-artifact
+          cp composer.lock ../drupal-maintenance-artifact/composer.lock
+          ddev composer audit --format=json > ../drupal-maintenance-artifact/composer-audit.json
+
+          EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA" python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          before = json.loads(Path('/tmp/composer-lock-before.json').read_text(encoding='utf-8'))
+          after_path = Path('../drupal-maintenance-artifact/composer.lock')
+          after = json.loads(after_path.read_text(encoding='utf-8'))
+
+          def versions(lock):
+              return {
+                  package['name']: package.get('version', '')
+                  for section in ('packages', 'packages-dev')
+                  for package in lock.get(section, [])
+              }
+
+          old = versions(before)
+          new = versions(after)
+          changes = []
+          for name in sorted(set(old) | set(new)):
+              if not name.startswith('drupal/'):
+                  continue
+              if old.get(name) != new.get(name):
+                  changes.append({
+                      'package': name,
+                      'before': old.get(name),
+                      'after': new.get(name),
+                  })
+
+          ai = new.get('drupal/ai', '').lstrip('v')
+          if ai != '1.5.0-rc1':
+              raise SystemExit(f'Expected drupal/ai 1.5.0-rc1, got {ai!r}')
+
+          digest = hashlib.sha256(after_path.read_bytes()).hexdigest()
+          Path('../drupal-maintenance-artifact/package-changes.json').write_text(
+              json.dumps(changes, indent=2, ensure_ascii=False) + '\n',
+              encoding='utf-8',
+          )
+          Path('../drupal-maintenance-artifact/result.json').write_text(
+              json.dumps({
+                  'status': 'PASS',
+                  'target_head_sha': os.environ['EXPECTED_HEAD_SHA'],
+                  'resolved_ai': ai,
+                  'drupal_package_change_count': len(changes),
+                  'composer_lock_sha256': digest,
+              }, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          print(f'resolved_ai={ai}')
+          print(f'change_count={len(changes)}')
+          print(f'lock_sha256={digest}')
+          PY
+
+          cat ../drupal-maintenance-artifact/result.json
+          echo "resolved_ai=$(jq -r '.resolved_ai' ../drupal-maintenance-artifact/result.json)" >> "$GITHUB_OUTPUT"
+          echo "change_count=$(jq -r '.drupal_package_change_count' ../drupal-maintenance-artifact/result.json)" >> "$GITHUB_OUTPUT"
+          echo "lock_sha256=$(jq -r '.composer_lock_sha256' ../drupal-maintenance-artifact/result.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bounded maintenance artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-drupal-maintenance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: drupal-maintenance-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean DDEV and workspaces
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-drupal-maintenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if [[ -d target ]]; then
+            (
+              cd target
+              ddev delete --omit-snapshot --yes "$isolated_name" || \
+                ddev stop --unlist --omit-snapshot "$isolated_name" || true
+            )
+          fi
+          rm -rf target trusted drupal-maintenance-artifact
+
+  publish-lock:
+    name: Revalidate and publish maintenance lockfile
+    needs:
+      - validate-target
+      - resolve-lock
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout exact target with hosted write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.head_sha }}
+          fetch-depth: 1
+
+      - name: Download bounded maintenance artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: agency-drupal-maintenance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/drupal-maintenance
+
+      - name: Revalidate artifact and live PR HEAD
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          EXPECTED_HEAD_REF: ${{ needs.validate-target.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -r '.status' /tmp/drupal-maintenance/result.json)" = 'PASS'
+          test "$(jq -r '.target_head_sha' /tmp/drupal-maintenance/result.json)" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -r '.resolved_ai' /tmp/drupal-maintenance/result.json)" = '1.5.0-rc1'
+
+          actual_digest="$(sha256sum /tmp/drupal-maintenance/composer.lock | awk '{print $1}')"
+          test "$actual_digest" = "$(jq -r '.composer_lock_sha256' /tmp/drupal-maintenance/result.json)"
+
+          pr_json="$(gh api repos/$GITHUB_REPOSITORY/pulls/563)"
+          test "$(jq -r '.state' <<<"$pr_json")" = 'open'
+          test "$(jq -r '.draft' <<<"$pr_json")" = 'true'
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = 'main'
+          test "$(jq -r '.head.ref' <<<"$pr_json")" = "$EXPECTED_HEAD_REF"
+          test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" || {
+            echo 'Target PR advanced before lockfile publication.' >&2
+            exit 1
+          }
+
+          cp /tmp/drupal-maintenance/composer.lock composer.lock
+          test -z "$(git ls-files --others --exclude-standard)"
+          test -z "$(git diff --cached --name-only)"
+          changed="$(git diff --name-only)"
+          if [[ "$changed" != 'composer.lock' ]]; then
+            echo 'Hosted maintenance publisher may modify exactly composer.lock.' >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+      - name: Commit and push generated lockfile fast-forward only
+        id: publish
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          EXPECTED_HEAD_REF: ${{ needs.validate-target.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add composer.lock
+          test "$(git diff --cached --name-only)" = 'composer.lock'
+          git commit -m 'Issue #562: materialize Drupal maintenance lockfile'
+
+          live_head="$(gh api repos/$GITHUB_REPOSITORY/pulls/563 --jq '.head.sha')"
+          test "$live_head" = "$EXPECTED_HEAD_SHA" || {
+            echo 'Target PR advanced before final push.' >&2
+            exit 1
+          }
+          git push origin "HEAD:$EXPECTED_HEAD_REF"
+          echo "new_head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish maintenance resolution summary
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OLD_HEAD: ${{ needs.validate-target.outputs.head_sha }}
+          NEW_HEAD: ${{ steps.publish.outputs.new_head_sha }}
+          AI_VERSION: ${{ needs.resolve-lock.outputs.resolved_ai }}
+          CHANGE_COUNT: ${{ needs.resolve-lock.outputs.change_count }}
+          LOCK_SHA256: ${{ needs.resolve-lock.outputs.lock_sha256 }}
+        run: |
+          set -euo pipefail
+          changes="$(jq -r '.[] | "- `\(.package)`: `\(.before // "not installed")` -> `\(.after // "removed")`"' /tmp/drupal-maintenance/package-changes.json)"
+          gh pr comment 563 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### #562 governed Drupal maintenance — Composer resolution SUCCESS
+
+          - Drupal AI: \`${AI_VERSION}\`
+          - changed Drupal packages: \`${CHANGE_COUNT}\`
+          - input HEAD: \`${OLD_HEAD}\`
+          - published HEAD: \`${NEW_HEAD}\`
+          - composer.lock SHA-256: \`${LOCK_SHA256}\`
+          - trusted run: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+
+          ${changes}
+
+          The self-hosted runner remained read-only. Only the generated lockfile was published by the GitHub-hosted writer after exact live-HEAD revalidation.
+          EOF
+          )"

--- a/scripts/runner/composer-materialization-profiles.sh
+++ b/scripts/runner/composer-materialization-profiles.sh
@@ -3,15 +3,23 @@
 # Trusted Composer materialization profiles.
 #
 # Callers may select a reviewed profile name only. Package names, constraints,
-# commands and owning issues are repository-owned data and must never come from
-# a dispatch request.
+# update selectors, commands and owning issues are repository-owned data and
+# must never come from a dispatch request.
 
 case "${COMPOSER_PROFILE:-}" in
   canvas-ai-agents-530)
     COMPOSER_PACKAGE='drupal/ai_agents'
     COMPOSER_CONSTRAINT='^1.3'
     COMPOSER_VERSION_REGEX='^1\.3\.[0-9]+$'
+    COMPOSER_UPDATE_SELECTOR='drupal/ai_agents'
     COMPOSER_OWNER_ISSUE='530'
+    ;;
+  drupal-maintenance-ai-1.5-rc1)
+    COMPOSER_PACKAGE='drupal/ai'
+    COMPOSER_CONSTRAINT='1.5.0-rc1'
+    COMPOSER_VERSION_REGEX='^1\.5\.0-rc1$'
+    COMPOSER_UPDATE_SELECTOR='drupal/*'
+    COMPOSER_OWNER_ISSUE='562'
     ;;
   *)
     printf 'Unsupported Composer materialization profile: %s\n' \
@@ -23,4 +31,5 @@ esac
 export COMPOSER_PACKAGE
 export COMPOSER_CONSTRAINT
 export COMPOSER_VERSION_REGEX
+export COMPOSER_UPDATE_SELECTOR
 export COMPOSER_OWNER_ISSUE

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
@@ -86,7 +86,7 @@ final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
   }
 
   /**
-   * Self-hosted resolution stays read-only and the hosted writer stays lock-only.
+   * Self-hosted resolution stays read-only and hosted writes stay lock-only.
    */
   public function testResolverAndPublisherKeepPrivilegeSeparation(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -109,7 +109,10 @@ final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
 
     self::assertStringContainsString('contents: read', $resolver);
     self::assertStringNotContainsString('contents: write', $resolver);
-    self::assertStringContainsString('persist-credentials: false', $resolver);
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $resolver,
+    );
     self::assertStringContainsString(
       'ddev composer update "$COMPOSER_UPDATE_SELECTOR"',
       $resolver,

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
@@ -32,7 +32,7 @@ final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
       $workflow,
     );
     self::assertStringContainsString(
-      "/agency-drupal-maintenance-ai-1-5-rc1",
+      "github.event.comment.body == '/agency-drupal-maintenance-ai-1.5-rc1'",
       $workflow,
     );
     self::assertStringContainsString(

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the fixed Drupal/contrib + AI RC maintenance execution route.
+ *
+ * @group agency_project_tests
+ * @group governed_composer
+ */
+final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
+
+  /**
+   * The maintenance trigger and target must remain fixed and non-generic.
+   */
+  public function testMaintenanceRouteIsFixedToReviewedTarget(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      "github.event.issue.number == 563",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "/agency-drupal-maintenance-ai-1-5-rc1",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "feature/issue-562-drupal-contrib-ai-1-5-rc1",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "expected.setdefault('require', {})['drupal/ai'] = '1.5.0-rc1'",
+      $workflow,
+    );
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * Composer package selection must come only from trusted repository code.
+   */
+  public function testMaintenanceComposerSelectorIsRepositoryOwned(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $profilePath = $root
+      . '/scripts/runner/composer-materialization-profiles.sh';
+    $profiles = (string) file_get_contents($profilePath);
+
+    self::assertStringContainsString(
+      'drupal-maintenance-ai-1.5-rc1)',
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_PACKAGE='drupal/ai'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_CONSTRAINT='1.5.0-rc1'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_UPDATE_SELECTOR='drupal/*'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_OWNER_ISSUE='562'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_UPDATE_SELECTOR='drupal/ai_agents'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      'Unsupported Composer materialization profile',
+      $profiles,
+    );
+  }
+
+  /**
+   * Self-hosted resolution stays read-only and the hosted writer stays lock-only.
+   */
+  public function testResolverAndPublisherKeepPrivilegeSeparation(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml';
+    $workflow = (string) file_get_contents($path);
+
+    $resolverStart = strpos($workflow, "  resolve-lock:\n");
+    $publisherStart = strpos($workflow, "  publish-lock:\n");
+    self::assertIsInt($resolverStart);
+    self::assertIsInt($publisherStart);
+    self::assertGreaterThan($resolverStart, $publisherStart);
+
+    $resolver = substr(
+      $workflow,
+      $resolverStart,
+      $publisherStart - $resolverStart,
+    );
+    $publisher = substr($workflow, $publisherStart);
+
+    self::assertStringContainsString('contents: read', $resolver);
+    self::assertStringNotContainsString('contents: write', $resolver);
+    self::assertStringContainsString('persist-credentials: false', $resolver);
+    self::assertStringContainsString(
+      'ddev composer update "$COMPOSER_UPDATE_SELECTOR"',
+      $resolver,
+    );
+    self::assertStringContainsString('--with-all-dependencies', $resolver);
+    self::assertStringContainsString('--no-install', $resolver);
+    self::assertStringContainsString('--no-scripts', $resolver);
+    self::assertStringContainsString(
+      "changed\" != 'composer.lock'",
+      $resolver,
+    );
+
+    self::assertStringContainsString('contents: write', $publisher);
+    self::assertStringContainsString(
+      "test \"$(git diff --cached --name-only)\" = 'composer.lock'",
+      $publisher,
+    );
+    self::assertStringContainsString(
+      'Target PR advanced before final push.',
+      $publisher,
+    );
+    self::assertStringContainsString(
+      'git push origin "HEAD:$EXPECTED_HEAD_REF"',
+      $publisher,
+    );
+  }
+
+}


### PR DESCRIPTION
## Objet

Ajoute la route trusted strictement bornée nécessaire à #562 / PR #563 pour rafraîchir Drupal + contribs et résoudre Drupal AI `1.5.0-rc1` sans fabriquer le lockfile.

## Surface de contrôle

- trigger exact : commentaire `/agency-drupal-maintenance-ai-1-5-rc1` ;
- cible fixe : PR #563, branche `feature/issue-562-drupal-contrib-ai-1-5-rc1` ;
- target pré-résolution : `composer.json` uniquement ;
- delta sémantique autorisé : `drupal/ai = 1.5.0-rc1` uniquement ;
- selector Composer : `drupal/*`, défini dans le repository, jamais fourni par l'utilisateur ;
- self-hosted : `contents: read`, `persist-credentials: false`, `--no-install --no-scripts` ;
- publisher hosted : `composer.lock` uniquement après revalidation live HEAD + digest.

## Fichiers

- `scripts/runner/composer-materialization-profiles.sh` : nouveau profil maintenance, profil #530 conservé ;
- `.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml` : route fixe ;
- `GovernedDrupalMaintenanceWorkflowTest.php` : contrat de sécurité/régression.

Aucune dépendance, config Drupal, contenu, secret ou fonctionnalité IA n'est modifié dans cette PR.

Closes #561
Refs #562 #531 #530.