### PR TITLE
Issue #569: follow local redirect in restore HTTP diagnostics

### DIFF
--- a/scripts/runner/fixtures/ai-playwright-516/part-3.sh
+++ b/scripts/runner/fixtures/ai-playwright-516/part-3.sh
@@ -9,7 +9,7 @@ if ! ddev drush scr .agency516-run.php > "$ARTIFACT_DIR/agent-run.stdout.txt" 2>
     local headers_tmp="/tmp/agency516-${label}.headers"
     local body_tmp="/tmp/agency516-${label}.html"
 
-    if ddev exec bash -lc "curl -fsS -D '$headers_tmp' -o '$body_tmp' '$url'" >/dev/null 2>&1; then
+    if ddev exec bash -lc "curl -fsS -L --max-redirs 5 -D '$headers_tmp' -o '$body_tmp' '$url'" >/dev/null 2>&1; then
       ddev exec cat "$headers_tmp" > "$ARTIFACT_DIR/restored-http-${label}.headers.txt" 2>/dev/null || true
       ddev exec cat "$body_tmp" > "$ARTIFACT_DIR/restored-http-${label}.html" 2>/dev/null || true
       printf '%s' 'ok'


### PR DESCRIPTION
## Objet

Corrige uniquement la mécanique diagnostique trusted/test-only de #567 afin que les probes HTTP de restauration atteignent le rendu Canvas final après la normalisation linguistique Drupal.

## Changement

Dans `scripts/runner/fixtures/ai-playwright-516/part-3.sh` :

- `curl` suit désormais les redirections avec `-L --max-redirs 5` ;
- les headers de la chaîne et le body final restent persistés dans l'artifact ;
- la classification `original` / `temporary` / `neither` reste inchangée.

Diff exact : un seul fichier, une ligne remplacée.

Aucune invalidation supplémentaire, aucun `drush cr`, aucun changement de `BoundedCanvasHeading.php`, aucune dépendance/config production, aucun provider réseau.

Closes #569
Refs #516 #544 #567.