### PR TITLE
Issue #571: invalidate internal page cache in #516 fixture

### DIFF
--- a/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
+++ b/scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php
@@ -147,6 +147,7 @@ final class BoundedCanvasHeading extends FunctionCallBase implements ExecutableF
   private static function invalidateRenderedPageCaches(): void {
     \Drupal::service('cache.render')->deleteAll();
     \Drupal::service('cache.dynamic_page_cache')->deleteAll();
+    \Drupal::service('cache.page')->deleteAll();
   }
 
   public function getReadableOutput(): string {


### PR DESCRIPTION
## Objet

Applique le correctif minimal démontré par l'artifact #516 `32400498711` : compléter l'invalidation DEV-only après chaque save Canvas avec Drupal Internal Page Cache.

## Preuve

Après restauration :

- entity-level = heading original ;
- canonique = `X-Drupal-Cache: HIT` + heading temporaire ;
- même route avec clé HTTP neuve = `X-Drupal-Cache: MISS` + heading original ;
- DPC = MISS dans les deux réponses finales.

## Changement

Un seul fichier trusted/test-only :

`scripts/runner/fixtures/ai-playwright-516/BoundedCanvasHeading.php`

Une seule ligne ajoutée :

```php
\Drupal::service('cache.page')->deleteAll();
```

Aucun `drush cr`, aucun code produit/contrib, aucune dépendance/config production, aucun changement UUID/allowlist/provider/permissions/tool sequence.

Closes #571
Refs #516 #544 #557 #559 #567 #569.