### PR TITLE
Issue #573: add trusted CCC beta3 DDEV pilot

### DIFF
--- a/.github/workflows/trusted-ai-context-beta3-pilot.yml
+++ b/.github/workflows/trusted-ai-context-beta3-pilot.yml
@@ -1,0 +1,249 @@
+name: Agency trusted CCC beta3 pilot
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate fixed #573 CCC pilot request
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.number == 573 && github.event.comment.body == '/agency-ai-context-pilot-573' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$ISSUE_NUMBER" == "573" ]]
+          [[ "$TRIGGER_COMMENT" == "/agency-ai-context-pilot-573" ]]
+          [[ "$GITHUB_ACTOR" == "E-merging-digital" ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == "open" ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == "" ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$main_sha" == "$EVENT_DEFAULT_SHA" ]] || {
+            echo "Issue #573 pilot must execute the workflow revision currently on live main." >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  report-start:
+    name: Publish CCC pilot run locator
+    needs: validate-request
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish trusted run locator
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF
+          ### #573 CCC beta3 trusted pilot — run locator
+
+          - Run ID: \`${GITHUB_RUN_ID}\` (attempt \`${GITHUB_RUN_ATTEMPT}\`)
+          - Trusted main: \`${MAIN_SHA}\`
+          - Package: \`drupal/ai_context 1.0.0-beta3\`
+          - Mode: \`DEV-ONLY / isolated DDEV / ephemeral Composer\`
+          - Provider/network LLM required: \`no\`
+          - State: \`validated; self-hosted pilot pending\`
+
+          The issue comment supplies no executable code. The self-hosted runner executes only the workflow and pilot script already present on trusted \`main\`.
+          EOF
+          )"
+          gh issue comment 573 --repo "$GITHUB_REPOSITORY" --body "$body"
+
+  pilot:
+    name: Run provider-free CCC beta3 pilot
+    needs: validate-request
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    concurrency:
+      group: agency-ai-context-573-${{ needs.validate-request.outputs.main_sha }}
+      cancel-in-progress: false
+    outputs:
+      evidence_status: ${{ steps.summarize.outputs.evidence_status }}
+      verdict: ${{ steps.summarize.outputs.verdict }}
+      failure_phase: ${{ steps.summarize.outputs.failure_phase }}
+      failure_message: ${{ steps.summarize.outputs.failure_message }}
+      artifact_name: ${{ steps.summarize.outputs.artifact_name }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+          command -v openssl
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          path: target
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable pilot implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git -C target rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f target/scripts/runner/run-ai-context-beta3-pilot.sh
+          bash -n target/scripts/runner/run-ai-context-beta3-pilot.sh
+          grep -F "EXPECTED_VERSION='1.0.0-beta3'" target/scripts/runner/run-ai-context-beta3-pilot.sh
+          ! grep -q '"drupal/ai_context"' target/composer.json
+
+      - name: Isolate DDEV project
+        shell: bash
+        working-directory: target
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-ai-context-573.yaml <<EOF
+          name: agency-ai-context-573-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-ai-context-573-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev start -y
+
+      - name: Run trusted CCC beta3 pilot
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}/target
+          ARTIFACT_DIR: ${{ github.workspace }}/target/artifacts/ai-context-387-pilot
+        run: |
+          set -euo pipefail
+          bash target/scripts/runner/run-ai-context-beta3-pilot.sh
+
+      - name: Summarize bounded evidence
+        id: summarize
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result_file='target/artifacts/ai-context-387-pilot/result.json'
+          evidence_status='MISSING'
+          verdict='UNKNOWN'
+          failure_phase='n/a'
+          failure_message='result.json unavailable'
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            evidence_status="$(jq -r '.status // "UNKNOWN"' "$result_file")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result_file")"
+            failure_phase="$(jq -r '.phase // "none"' "$result_file")"
+            failure_message="$(jq -r '.message // "none"' "$result_file")"
+          fi
+          failure_phase="$(printf '%s' "$failure_phase" | tr '\r\n' '  ' | cut -c1-80)"
+          failure_message="$(printf '%s' "$failure_message" | tr '\r\n' '  ' | cut -c1-220)"
+          artifact_name="agency-ai-context-573-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "evidence_status=$evidence_status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "failure_phase=$failure_phase" >> "$GITHUB_OUTPUT"
+          echo "failure_message=$failure_message" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload CCC pilot evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-ai-context-573-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/artifacts/ai-context-387-pilot
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          if [[ -d target ]]; then
+            (
+              cd target
+              ddev delete --omit-snapshot --yes
+            )
+          fi
+          cd "$GITHUB_WORKSPACE"
+          rm -rf target
+
+  report-result:
+    name: Report CCC pilot result
+    needs:
+      - validate-request
+      - pilot
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish bounded result
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_RESULT: ${{ needs.pilot.result }}
+          EVIDENCE_STATUS: ${{ needs.pilot.outputs.evidence_status }}
+          VERDICT: ${{ needs.pilot.outputs.verdict }}
+          FAILURE_PHASE: ${{ needs.pilot.outputs.failure_phase }}
+          FAILURE_MESSAGE: ${{ needs.pilot.outputs.failure_message }}
+          ARTIFACT_NAME: ${{ needs.pilot.outputs.artifact_name }}
+          MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF
+          ### #573 CCC beta3 trusted pilot — bounded outcome
+
+          - Trusted main: \`${MAIN_SHA}\`
+          - Self-hosted job: \`${JOB_RESULT}\`
+          - Evidence status: \`${EVIDENCE_STATUS:-MISSING}\`
+          - Verdict: \`${VERDICT:-UNKNOWN}\`
+          - Failure phase: \`${FAILURE_PHASE:-n/a}\`
+          - Failure message: \`${FAILURE_MESSAGE:-n/a}\`
+          - Artifact: \`${ARTIFACT_NAME:-agency-ai-context-573-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\`
+
+          This proof is DEV-only and provider-free. Inspect the artifact before updating #387 or deciding any production adoption.
+          EOF
+          )"
+          gh issue comment 573 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/run-ai-context-beta3-pilot.sh
+++ b/scripts/runner/run-ai-context-beta3-pilot.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+
+EXPECTED_PACKAGE='drupal/ai_context'
+EXPECTED_VERSION='1.0.0-beta3'
+ARTIFACT_REL='artifacts/ai-context-387-pilot'
+
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+write_failure() {
+  local phase="$1"
+  local message="$2"
+  jq -n \
+    --arg status 'FAIL' \
+    --arg verdict 'BLOCKED_BY_RELEASED_API' \
+    --arg phase "$phase" \
+    --arg message "$message" \
+    '{status:$status,verdict:$verdict,phase:$phase,message:$message}' \
+    > "$ARTIFACT_DIR/result.json"
+}
+
+on_exit() {
+  local rc=$?
+  trap - EXIT
+  rm -f .agency573-audit.php
+  if [[ $rc -ne 0 && ! -s "$ARTIFACT_DIR/result.json" ]]; then
+    write_failure 'unexpected' "Trusted CCC beta3 pilot failed with exit code $rc"
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
+
+command -v ddev >/dev/null
+command -v jq >/dev/null
+command -v git >/dev/null
+command -v sha256sum >/dev/null
+command -v openssl >/dev/null
+
+test -f composer.json
+test -f composer.lock
+test -f .ddev/config.yaml
+test -f docs/drupal-ai-context-architecture.md
+
+if grep -q '"drupal/ai_context"' composer.json; then
+  write_failure 'preflight' 'ai_context must not be a production Composer dependency.'
+  exit 1
+fi
+
+git diff --check
+before_composer="$(sha256sum composer.json | awk '{print $1}')"
+before_lock="$(sha256sum composer.lock | awk '{print $1}')"
+
+# Beta dependency is deliberately workspace-only. The workflow always deletes
+# the isolated DDEV project and checkout after uploading evidence.
+if ! ddev composer require "${EXPECTED_PACKAGE}:${EXPECTED_VERSION}" \
+  --with-all-dependencies --no-interaction --no-progress; then
+  write_failure 'composer' "Unable to resolve ${EXPECTED_PACKAGE}:${EXPECTED_VERSION} in isolated DDEV."
+  exit 1
+fi
+
+installed_version="$(
+  ddev composer show "$EXPECTED_PACKAGE" --format=json |
+    jq -r '.versions[]' |
+    sed 's/^\* //' |
+    head -n 1
+)"
+if [[ "$installed_version" != "$EXPECTED_VERSION" ]]; then
+  write_failure 'composer' "Expected $EXPECTED_VERSION, got $installed_version"
+  exit 1
+fi
+
+ddev composer show "$EXPECTED_PACKAGE" --format=json > "$ARTIFACT_DIR/package.json"
+ddev composer show drupal/ai --format=json > "$ARTIFACT_DIR/ai-package.json"
+
+after_composer="$(sha256sum composer.json | awk '{print $1}')"
+after_lock="$(sha256sum composer.lock | awk '{print $1}')"
+mapfile -t workspace_changes < <(git diff --name-only)
+
+jq -n \
+  --arg before_composer "$before_composer" \
+  --arg after_composer "$after_composer" \
+  --arg before_lock "$before_lock" \
+  --arg after_lock "$after_lock" \
+  --argjson workspace_changes "$(printf '%s\n' "${workspace_changes[@]}" | jq -R . | jq -s .)" \
+  '{
+    production_persisted:false,
+    workspace_only:true,
+    composer_json:{before:$before_composer,after:$after_composer,changed:($before_composer != $after_composer)},
+    composer_lock:{before:$before_lock,after:$after_lock,changed:($before_lock != $after_lock)},
+    git_changed_files:$workspace_changes
+  }' > "$ARTIFACT_DIR/composer-integrity.json"
+
+admin_pass="$(openssl rand -hex 24)"
+ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+unset admin_pass
+
+ddev drush cim -y
+ddev drush cr
+ddev drush emerging:governed-content --all
+
+if ! ddev drush en ai_context -y; then
+  write_failure 'module-enable' 'Unable to enable ai_context beta3 in isolated DDEV.'
+  exit 1
+fi
+ddev drush cr
+
+cat > .agency573-audit.php <<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$artifactDir = '/var/www/html/artifacts/ai-context-387-pilot';
+
+$write = static function (string $name, array $data) use ($artifactDir): void {
+  file_put_contents(
+    $artifactDir . '/' . $name,
+    json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL
+  );
+};
+
+$entityTypeManager = \Drupal::entityTypeManager();
+$entityFieldManager = \Drupal::service('entity_field.manager');
+
+if (!$entityTypeManager->hasDefinition('ai_context_item')) {
+  $write('result.json', [
+    'status' => 'FAIL',
+    'verdict' => 'BLOCKED_BY_RELEASED_API',
+    'phase' => 'entity-contract',
+    'message' => 'ai_context_item entity type is unavailable after enabling beta3.',
+  ]);
+  exit(1);
+}
+
+$entityType = $entityTypeManager->getDefinition('ai_context_item');
+$baseFields = $entityFieldManager->getBaseFieldDefinitions('ai_context_item');
+
+$fieldReport = [];
+foreach ($baseFields as $name => $definition) {
+  $fieldReport[$name] = [
+    'type' => $definition->getType(),
+    'required' => $definition->isRequired(),
+    'translatable' => $definition->isTranslatable(),
+    'revisionable' => method_exists($definition, 'isRevisionable') ? $definition->isRevisionable() : null,
+    'read_only' => $definition->isReadOnly(),
+  ];
+}
+
+$entityContract = [
+  'entity_type' => 'ai_context_item',
+  'class' => $entityType->getClass(),
+  'keys' => $entityType->getKeys(),
+  'revisionable' => $entityType->isRevisionable(),
+  'translatable' => $entityType->isTranslatable(),
+  'revision_table' => $entityType->getRevisionTable(),
+  'data_table' => $entityType->getDataTable(),
+  'fields' => $fieldReport,
+];
+$write('entity-contract.json', $entityContract);
+
+$permissions = \Drupal::service('user.permissions')->getPermissions();
+$contextPermissions = [];
+foreach ($permissions as $permission => $info) {
+  $provider = (string) ($info['provider'] ?? '');
+  if ($provider === 'ai_context' || str_contains($permission, 'context')) {
+    $contextPermissions[$permission] = [
+      'provider' => $provider,
+      'title' => isset($info['title']) ? (string) $info['title'] : '',
+      'restrict_access' => (bool) ($info['restrict access'] ?? false),
+    ];
+  }
+}
+ksort($contextPermissions);
+$write('permissions.json', $contextPermissions);
+
+$modulePath = DRUPAL_ROOT . '/modules/contrib/ai_context';
+$servicesFile = $modulePath . '/ai_context.services.yml';
+$serviceReport = [];
+if (is_file($servicesFile)) {
+  $parsed = Yaml::parseFile($servicesFile);
+  foreach (($parsed['services'] ?? []) as $serviceId => $definition) {
+    if (!is_string($serviceId) || !str_starts_with($serviceId, 'ai_context.')) {
+      continue;
+    }
+    $class = is_array($definition) ? ($definition['class'] ?? null) : null;
+    $internal = null;
+    if (is_string($class) && class_exists($class)) {
+      $reflection = new ReflectionClass($class);
+      $doc = $reflection->getDocComment() ?: '';
+      $internal = str_contains($doc, '@internal');
+    }
+    $serviceReport[$serviceId] = [
+      'class' => $class,
+      'internal' => $internal,
+    ];
+  }
+}
+ksort($serviceReport);
+
+$eventFiles = [];
+if (is_dir($modulePath . '/src/Event')) {
+  foreach (glob($modulePath . '/src/Event/*Event.php') ?: [] as $file) {
+    $eventFiles[] = basename($file);
+  }
+}
+sort($eventFiles);
+
+$retrieverCandidates = [
+  'ai_context.retriever',
+  'ai_context.context_retriever',
+];
+$publicRetriever = null;
+foreach ($retrieverCandidates as $candidate) {
+  if (!isset($serviceReport[$candidate])) {
+    continue;
+  }
+  if ($serviceReport[$candidate]['internal'] === false) {
+    $publicRetriever = $candidate;
+    break;
+  }
+}
+
+$write('services-api.json', [
+  'services' => $serviceReport,
+  'event_files' => $eventFiles,
+  'public_non_agent_retriever' => $publicRetriever,
+  'consumer_policy' => $publicRetriever
+    ? 'PUBLIC_RETRIEVER_AVAILABLE'
+    : 'NO_PROVEN_PUBLIC_NON_AGENT_RETRIEVER',
+]);
+
+$proof = [
+  'created' => false,
+  'revision_proved' => false,
+  'translation_proved' => false,
+  'deleted' => false,
+  'id' => null,
+  'label_key' => $entityType->getKey('label'),
+  'fields_written' => [],
+  'error' => null,
+];
+
+try {
+  $storage = $entityTypeManager->getStorage('ai_context_item');
+  $values = [];
+
+  $labelKey = $entityType->getKey('label');
+  if (is_string($labelKey) && $labelKey !== '') {
+    $values[$labelKey] = 'Agency #573 brand.voice proof';
+  }
+
+  $langcodeKey = $entityType->getKey('langcode');
+  if (is_string($langcodeKey) && $langcodeKey !== '') {
+    $values[$langcodeKey] = 'fr';
+  }
+
+  $publishedKey = $entityType->getKey('published');
+  if (is_string($publishedKey) && $publishedKey !== '') {
+    $values[$publishedKey] = 1;
+  }
+
+  $sampleFr = 'Ton professionnel, calme, concret et vérifiable. Éviter les superlatifs non démontrés.';
+  $sampleEn = 'Professional, calm, concrete and verifiable tone. Avoid unsupported superlatives.';
+
+  foreach (['content', 'description', 'context', 'text', 'purpose'] as $candidate) {
+    if (!isset($baseFields[$candidate])) {
+      continue;
+    }
+    $type = $baseFields[$candidate]->getType();
+    if (in_array($type, ['string', 'string_long', 'text', 'text_long', 'text_with_summary'], true)) {
+      $values[$candidate] = $candidate === 'purpose'
+        ? 'Ephemeral Agency #573 brand.voice compatibility proof.'
+        : $sampleFr;
+    }
+  }
+
+  foreach ($baseFields as $name => $definition) {
+    if (!$definition->isRequired() || array_key_exists($name, $values) || $definition->isReadOnly()) {
+      continue;
+    }
+    if (in_array($name, ['id', 'uuid', 'revision_id', 'created', 'changed'], true)) {
+      continue;
+    }
+    $type = $definition->getType();
+    if (in_array($type, ['string', 'string_long', 'text', 'text_long', 'text_with_summary'], true)) {
+      $values[$name] = 'Agency #573 beta3 compatibility proof';
+    }
+    elseif ($type === 'boolean') {
+      $values[$name] = true;
+    }
+    elseif ($type === 'entity_reference' && in_array($name, ['uid', 'user_id', 'owner'], true)) {
+      $values[$name] = 1;
+    }
+  }
+
+  $entity = $storage->create($values);
+  if (!$entity instanceof FieldableEntityInterface) {
+    throw new RuntimeException('ai_context_item is not fieldable.');
+  }
+
+  $violations = $entity->validate();
+  if ($violations->count() > 0) {
+    $messages = [];
+    foreach ($violations as $violation) {
+      $messages[] = $violation->getPropertyPath() . ': ' . $violation->getMessage();
+    }
+    throw new RuntimeException('Entity validation failed: ' . implode(' | ', $messages));
+  }
+
+  $entity->save();
+  $proof['created'] = true;
+  $proof['id'] = $entity->id();
+  $proof['fields_written'] = array_keys($values);
+  $initialRevision = method_exists($entity, 'getRevisionId') ? $entity->getRevisionId() : null;
+
+  if ($entityType->isRevisionable()) {
+    $entity->setNewRevision(true);
+    if (method_exists($entity, 'setRevisionLogMessage')) {
+      $entity->setRevisionLogMessage('Agency #573 revision proof');
+    }
+    $entity->save();
+    $newRevision = method_exists($entity, 'getRevisionId') ? $entity->getRevisionId() : null;
+    $proof['revision_proved'] = $initialRevision !== null
+      && $newRevision !== null
+      && (string) $initialRevision !== (string) $newRevision;
+    $proof['initial_revision_id'] = $initialRevision;
+    $proof['new_revision_id'] = $newRevision;
+  }
+
+  $languageManager = \Drupal::languageManager();
+  if ($entityType->isTranslatable() && $languageManager->getLanguage('en')) {
+    $translationValues = [];
+    if (is_string($labelKey) && $labelKey !== '' && isset($baseFields[$labelKey]) && $baseFields[$labelKey]->isTranslatable()) {
+      $translationValues[$labelKey] = 'Agency #573 brand.voice proof EN';
+    }
+    foreach (['content', 'description', 'context', 'text', 'purpose'] as $candidate) {
+      if (!isset($baseFields[$candidate]) || !$baseFields[$candidate]->isTranslatable()) {
+        continue;
+      }
+      $type = $baseFields[$candidate]->getType();
+      if (in_array($type, ['string', 'string_long', 'text', 'text_long', 'text_with_summary'], true)) {
+        $translationValues[$candidate] = $candidate === 'purpose'
+          ? 'Ephemeral Agency #573 brand.voice compatibility proof.'
+          : $sampleEn;
+      }
+    }
+
+    $translation = $entity->addTranslation('en', $translationValues);
+    $translation->save();
+    $reloaded = $storage->loadUnchanged($entity->id());
+    $proof['translation_proved'] = $reloaded !== null && $reloaded->hasTranslation('en');
+  }
+
+  $id = $entity->id();
+  $entity->delete();
+  $storage->resetCache([$id]);
+  $proof['deleted'] = $storage->load($id) === null;
+}
+catch (Throwable $e) {
+  $proof['error'] = $e->getMessage();
+}
+$write('brand-voice-proof.json', $proof);
+
+$entityGovernancePass = $proof['created']
+  && $proof['deleted']
+  && (!$entityType->isRevisionable() || $proof['revision_proved'])
+  && (!$entityType->isTranslatable() || $proof['translation_proved']);
+
+if (!$entityGovernancePass) {
+  $write('result.json', [
+    'status' => 'FAIL',
+    'verdict' => 'BLOCKED_BY_RELEASED_API',
+    'phase' => 'brand-voice-proof',
+    'message' => $proof['error'] ?? 'Released beta3 entity governance proof is incomplete.',
+    'entity_governance' => $proof,
+    'public_non_agent_retriever' => $publicRetriever,
+  ]);
+  exit(1);
+}
+
+$verdict = $publicRetriever ? 'PILOT_CONFIRMED' : 'WAIT_FOR_RC';
+$write('result.json', [
+  'status' => 'PASS',
+  'verdict' => $verdict,
+  'phase' => 'complete',
+  'message' => $publicRetriever
+    ? 'Released beta3 entity governance and a public non-agent retrieval facade were proved.'
+    : 'Released beta3 entity governance was proved; no public non-agent retrieval facade was demonstrated, so Agency must wait for RC rather than wrap internal services.',
+  'ai_context_version' => '1.0.0-beta3',
+  'dev_only_ephemeral' => true,
+  'provider_network_required' => false,
+  'production_dependency_persisted' => false,
+  'entity_governance' => $proof,
+  'public_non_agent_retriever' => $publicRetriever,
+  'stable_extension_events_observed' => $eventFiles,
+]);
+PHP
+
+if ! ddev drush php:script /var/www/html/.agency573-audit.php; then
+  if [[ ! -s "$ARTIFACT_DIR/result.json" ]]; then
+    write_failure 'runtime-audit' 'CCC beta3 Drupal runtime audit failed.'
+  fi
+  exit 1
+fi
+
+jq -e '.status == "PASS"' "$ARTIFACT_DIR/result.json" >/dev/null


### PR DESCRIPTION
## Objet

Matérialise le pilote borné autorisé par #387 pour la dernière release réellement publiée de Context Control Center : `drupal/ai_context 1.0.0-beta3`.

## Implémentation

Deux fichiers nouveaux uniquement :

- `.github/workflows/trusted-ai-context-beta3-pilot.yml` ;
- `scripts/runner/run-ai-context-beta3-pilot.sh`.

La route est déclenchée par le commentaire exact `/agency-ai-context-pilot-573` sur l'issue #573, vérifie l'acteur `E-merging-digital` et le live `main`, puis exécute uniquement le code déjà fusionné sur `main` sur le runner self-hosted Agency/DDEV.

Le pilote :

- refuse si `drupal/ai_context` est déjà une dépendance production ;
- installe exactement `1.0.0-beta3` uniquement dans le workspace DDEV jetable ;
- reconstruit Drupal depuis `--existing-config` ;
- active CCC uniquement localement ;
- audite entity contract, fields, permissions, services et surfaces `@internal` ;
- crée dynamiquement un petit item `brand.voice` à partir du contrat released ;
- prouve save/révision/traduction FR/EN/rollback si le contrat beta3 le permet ;
- ne considère un consumer non-agent comme adoptable que si une façade publique non `@internal` est réellement observée ;
- produit un artifact machine-readable avec verdict `PILOT_CONFIRMED`, `WAIT_FOR_RC` ou `BLOCKED_BY_RELEASED_API` ;
- nettoie toujours DDEV et workspace.

Aucun provider réseau, secret, PII, changement produit, configuration production ou dépendance beta persistée.

## Sécurité

Le commentaire d'issue n'apporte aucun code exécutable. Le job self-hosted dispose uniquement de `contents: read`, checkout le SHA exact de `main` validé par un job GitHub-hosted et exécute le script trusted déjà présent sur ce SHA.

Ne pas déclencher le pilote avant merge de cette PR : la self-hosted proof doit impérativement provenir de `main`.

**Important : #573 doit rester OPEN après le merge**, car le workflow trusted exige une issue ouverte pour autoriser l'unique exécution self-hosted. La clôture de #573 n'interviendra qu'après inspection de l'artifact et report du verdict dans #387.

Refs #573 #387 #518 #530 #516 #32.