### PR TITLE
[P1][Infra] Blog — route gouvernée de publication éditoriale

### DIFF
--- a/.github/workflows/trusted-editorial-publication.yml
+++ b/.github/workflows/trusted-editorial-publication.yml
@@ -241,7 +241,7 @@ jobs:
           retention-days: 30
 
       - name: Publish bounded result
-        if: ${{ always() }}
+        if: ${{ always() && steps.request.outcome == 'success' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/trusted-editorial-publication.yml
+++ b/.github/workflows/trusted-editorial-publication.yml
@@ -1,0 +1,299 @@
+name: Agency trusted editorial publication
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  editorial-publication:
+    name: Governed Article publication
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        (
+          github.event.comment.body == '/agency-editorial inspect' ||
+          github.event.comment.body == '/agency-editorial dry-run' ||
+          github.event.comment.body == '/agency-editorial apply'
+        )
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    concurrency:
+      group: agency-editorial-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]
+
+          case "$TRIGGER_COMMENT" in
+            '/agency-editorial inspect') mode='inspect' ;;
+            '/agency-editorial dry-run') mode='dry-run' ;;
+            '/agency-editorial apply') mode='apply' ;;
+            *) echo 'Unsupported editorial command.' >&2; exit 1 ;;
+          esac
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Editorial route must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Extract and canonicalize bounded editorial payload
+        id: payload
+        if: ${{ steps.request.outputs.mode != 'inspect' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          MODE: ${{ steps.request.outputs.mode }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
+            --jq '.[] | @base64' > /tmp/agency-editorial-comments.b64
+
+          python3 - <<'PY'
+          import base64
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          marker = '<!-- agency-editorial-payload:v1 -->'
+          owner = 'E-merging-digital'
+          issue_number = int(os.environ['ISSUE_NUMBER'])
+          mode = os.environ['MODE']
+          trusted_main = os.environ['TRUSTED_MAIN']
+          expected_top = {
+              'schema_version', 'issue_number', 'bundle', 'published',
+              'category', 'fr', 'en',
+          }
+          expected_lang = {'title', 'short_description', 'body_html'}
+          expected_category = {'tid', 'name'}
+
+          comments = []
+          for raw_line in Path('/tmp/agency-editorial-comments.b64').read_text(encoding='utf-8').splitlines():
+              if not raw_line.strip():
+                  continue
+              decoded = base64.b64decode(raw_line).decode('utf-8')
+              comments.append(json.loads(decoded))
+
+          payload_comment = None
+          payload = None
+          for comment in comments:
+              if comment.get('user', {}).get('login') != owner:
+                  continue
+              body = comment.get('body') or ''
+              if not body.startswith(marker):
+                  continue
+              candidate = body[len(marker):].strip()
+              try:
+                  parsed = json.loads(candidate)
+              except json.JSONDecodeError:
+                  continue
+              if not isinstance(parsed, dict):
+                  continue
+              payload_comment = comment
+              payload = parsed
+
+          if payload is None or payload_comment is None:
+              raise SystemExit('No valid owner-authored agency editorial payload was found.')
+          if set(payload) != expected_top:
+              raise SystemExit(f'Editorial payload keys must be exactly {sorted(expected_top)}.')
+          if payload.get('schema_version') != 1:
+              raise SystemExit('schema_version must be 1.')
+          if payload.get('issue_number') != issue_number:
+              raise SystemExit('Payload issue_number does not match the triggering issue.')
+          if payload.get('bundle') != 'article':
+              raise SystemExit('Only bundle=article is allowed.')
+          if not isinstance(payload.get('published'), bool):
+              raise SystemExit('published must be boolean.')
+          if not isinstance(payload.get('category'), dict) or set(payload['category']) != expected_category:
+              raise SystemExit('category must contain exactly tid and name.')
+          for lang in ('fr', 'en'):
+              value = payload.get(lang)
+              if not isinstance(value, dict) or set(value) != expected_lang:
+                  raise SystemExit(f'{lang} must contain exactly {sorted(expected_lang)}.')
+
+          canonical = json.dumps(
+              payload,
+              ensure_ascii=False,
+              sort_keys=True,
+              separators=(',', ':'),
+          ) + '\n'
+          payload_path = Path('/tmp/agency-editorial-payload.json')
+          payload_path.write_text(canonical, encoding='utf-8')
+          digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+          if mode == 'apply':
+              dry_run_pattern = re.compile(
+                  r'^### Agency editorial dry-run PASS\s*$.*?'
+                  r'^payload_sha256: `([0-9a-f]{64})`\s*$.*?'
+                  r'^trusted_main: `([0-9a-f]{40})`\s*$',
+                  re.MULTILINE | re.DOTALL,
+              )
+              authorized = False
+              for comment in comments:
+                  if comment.get('user', {}).get('login') != 'github-actions[bot]':
+                      continue
+                  body = comment.get('body') or ''
+                  match = dry_run_pattern.search(body)
+                  if match and match.group(1) == digest and match.group(2) == trusted_main:
+                      authorized = True
+              if not authorized:
+                  raise SystemExit(
+                      'Apply requires a prior bot-authored dry-run PASS for the same payload hash and live main.'
+                  )
+
+          output = Path(os.environ['GITHUB_OUTPUT'])
+          with output.open('a', encoding='utf-8') as handle:
+              handle.write(f'payload_sha256={digest}\n')
+              handle.write(f'payload_comment_id={payload_comment["id"]}\n')
+          PY
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f scripts/runner/run-editorial-publication.sh
+          test -f scripts/runner/editorial-publication.php
+          bash -n scripts/runner/run-editorial-publication.sh
+          php -l scripts/runner/editorial-publication.php
+
+      - name: Configure existing production SSH channel
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Execute bounded editorial route
+        id: route
+        shell: bash
+        env:
+          EDITORIAL_MODE: ${{ steps.request.outputs.mode }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PAYLOAD_SHA256: ${{ steps.payload.outputs.payload_sha256 }}
+          PAYLOAD_FILE: /tmp/agency-editorial-payload.json
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/editorial-publication
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-editorial-publication.sh
+
+      - name: Upload editorial evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-editorial-${{ github.event.issue.number }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/editorial-publication
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded result
+        if: ${{ always() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          MODE: ${{ steps.request.outputs.mode }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          PAYLOAD_SHA256: ${{ steps.payload.outputs.payload_sha256 }}
+          ROUTE_OUTCOME: ${{ steps.route.outcome }}
+        run: |
+          set -euo pipefail
+
+          result_file='artifacts/editorial-publication/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          node_id='n/a'
+          revision_id='n/a'
+          fr_alias='n/a'
+          en_alias='n/a'
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result_file")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result_file")"
+            node_id="$(jq -r '.node.id // "n/a"' "$result_file")"
+            revision_id="$(jq -r '.node.revision_id // "n/a"' "$result_file")"
+            fr_alias="$(jq -r '.node.aliases.fr // "n/a"' "$result_file")"
+            en_alias="$(jq -r '.node.aliases.en // "n/a"' "$result_file")"
+          fi
+
+          heading="### Agency editorial ${MODE} ${status}"
+          if [[ "$MODE" == 'dry-run' && "$ROUTE_OUTCOME" == 'success' && "$status" == 'PASS' ]]; then
+            heading='### Agency editorial dry-run PASS'
+          elif [[ "$MODE" == 'apply' && "$ROUTE_OUTCOME" == 'success' && "$status" == 'PASS' ]]; then
+            heading='### Agency editorial apply PASS'
+          elif [[ "$MODE" == 'inspect' && "$ROUTE_OUTCOME" == 'success' && "$status" == 'PASS' ]]; then
+            heading='### Agency editorial inspect PASS'
+          fi
+
+          artifact="agency-editorial-${ISSUE_NUMBER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          payload_sha256: \`${PAYLOAD_SHA256:-n/a}\`
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${verdict}\`
+          node_id: \`${node_id}\`
+          revision_id: \`${revision_id}\`
+          fr_alias: \`${fr_alias}\`
+          en_alias: \`${en_alias}\`
+          artifact: \`${artifact}\`
+
+          This route is restricted to editor-owned Drupal Articles and does not invoke Content Sync, deployment, arbitrary Drush or arbitrary shell input.
+          EOF_BODY
+          )"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/docs/operations/execution-capabilities.md
+++ b/docs/operations/execution-capabilities.md
@@ -3,7 +3,7 @@
 Status: **AUTHORITATIVE CAPABILITY REGISTRY**  
 Repository: `E-merging-digital/agency-website-drupal`  
 Registry owner: #421  
-Last materialized: 2026-08-19
+Last materialized: 2026-08-20
 
 ## 1. Purpose
 
@@ -205,7 +205,57 @@ Implementation and full contract:
 docs/operations/governed-composer-materialization.md
 ```
 
-## 6. What the agent can verify visually today
+## 6. Governed editor-owned Article publication route
+
+Issue #576 adds a bounded production mutation route for ordinary Blog Articles
+that are explicitly editor-owned in Drupal and outside Content Sync / Governed
+Content.
+
+This is **not** a generic production shell or content API. The only control
+surface is an exact issue comment authored by `E-merging-digital` on an OPEN
+owner-created issue:
+
+```text
+/agency-editorial inspect
+/agency-editorial dry-run
+/agency-editorial apply
+```
+
+The trusted workflow runs from the live `main` revision on GitHub-hosted
+infrastructure and reuses the existing deployment SSH secrets and production
+channel. Payload values are transferred only as a canonical JSON file and are
+never interpolated into shell or Drush commands.
+
+The v1 contract is fixed to:
+
+```text
+bundle                 = article
+source language        = fr
+required translation   = en
+text format            = basic_html
+category vocabulary    = blog_categories
+technical author       = uid 1
+aliases                 = Pathauto-owned
+```
+
+`dry-run` is read-only and publishes the canonical payload SHA-256. `apply`
+requires a previous bot-authored dry-run PASS for the same payload hash and the
+same live `main` SHA, performs a fresh Drupal preflight, creates a SQL backup,
+then mutates content only through Drupal Entity API. An issue-to-node state
+mapping is used only for idempotence/audit; it is not an editorial source of
+truth.
+
+The route may not invoke Content Sync, deployment, arbitrary Drush/shell,
+configuration import/update, taxonomy creation, another bundle or another text
+format.
+
+Implementation and full contract:
+
+```text
+docs/operations/governed-editorial-publication.md
+```
+
+## 7. What the agent can verify visually today
 
 The browser workflow publishes evidence including:
 
@@ -226,7 +276,7 @@ The final #399 proof on 2026-08-15 demonstrated this end-to-end. The #519 and
 #526 governed SDC/Canvas proofs subsequently reused the same route for exact-HEAD
 desktop/mobile validation and human visual review.
 
-## 7. Interactive MCP versus artifact review
+## 8. Interactive MCP versus artifact review
 
 Do not conflate these two paths.
 
@@ -268,7 +318,7 @@ an invocation route, first look for an existing governed executor/agent route.
 Only create a new route under a dedicated issue if the existing routes truly
 cannot invoke the installed capability.
 
-## 8. Tool responsibilities
+## 9. Tool responsibilities
 
 ```text
 Drupal BrowserTestBase
@@ -285,13 +335,17 @@ Chrome DevTools MCP
 
 Governed Composer materializer
   -> dependency-only lock resolution with separated write privilege
+
+Governed editorial publisher
+  -> bounded editor-owned Article inspect/dry-run/apply via trusted main
 ```
 
 MCP is not a replacement for deterministic tests, and deterministic tests are
 not a replacement for visual inspection. The Composer materializer is not a
-generic command executor.
+generic command executor. The editorial publisher is not a generic production
+content or shell API.
 
-## 9. Secrets and authenticated UI
+## 10. Secrets and authenticated UI
 
 Public validation requires no secret.
 
@@ -308,7 +362,11 @@ For future authenticated Drupal scenarios:
 The Composer materialization route carries no provider secret and must never be
 extended to transport one.
 
-## 10. Reload rule for future agents
+The editorial publication route reuses only the existing production SSH
+secrets. It must never expose those values in artifacts or comments and must not
+be widened to provider keys, Drupal passwords or arbitrary credentials.
+
+## 11. Reload rule for future agents
 
 Before any statement such as:
 
@@ -318,6 +376,7 @@ Playwright is unavailable
 Playwright MCP is unavailable
 Chrome DevTools MCP is unavailable
 Composer cannot be materialized without human file copying
+ordinary Drupal Article publication requires mechanical human entry
 I cannot validate the UI
 Jonathan must run this manually
 ```

--- a/docs/operations/governed-editorial-publication.md
+++ b/docs/operations/governed-editorial-publication.md
@@ -1,0 +1,275 @@
+# Governed editorial publication
+
+Status: **TRUSTED PRODUCTION MUTATION ROUTE**  
+Owner issue: #576  
+Initial consumer: #401
+
+## Purpose
+
+Agency ordinary editorial content, including Blog Articles, is editor-owned in
+Drupal and remains outside Content Sync / Governed Content.
+
+This route exists only to remove mechanical human data entry when an authorized
+operator or agent already has a reviewed Article payload. It does not move the
+editorial source of truth into Git. GitHub is the governed request and audit
+surface; after a successful apply, Drupal is the editorial source of truth.
+
+The initial route is deliberately limited to the `article` bundle.
+
+## Control surface
+
+On an OPEN repository issue created by `E-merging-digital`, the owner can post
+exactly one of:
+
+```text
+/agency-editorial inspect
+/agency-editorial dry-run
+/agency-editorial apply
+```
+
+The workflow refuses every other comment. It also verifies that:
+
+- `GITHUB_ACTOR` is exactly `E-merging-digital`;
+- the comment author is the actor;
+- the target is an OPEN issue, not a pull request;
+- the issue author is `E-merging-digital`;
+- the workflow revision is the current live `main` SHA.
+
+The trigger contains no shell, Drush command, server path or URL input.
+
+## Payload v1
+
+`inspect` needs no payload.
+
+`dry-run` and `apply` use the latest owner-authored issue comment beginning
+exactly with:
+
+```text
+<!-- agency-editorial-payload:v1 -->
+```
+
+The remainder of that comment must be one JSON object with exactly:
+
+```json
+{
+  "schema_version": 1,
+  "issue_number": 401,
+  "bundle": "article",
+  "published": true,
+  "category": {
+    "tid": 123,
+    "name": "Existing category name"
+  },
+  "fr": {
+    "title": "...",
+    "short_description": "...",
+    "body_html": "..."
+  },
+  "en": {
+    "title": "...",
+    "short_description": "...",
+    "body_html": "..."
+  }
+}
+```
+
+Unknown fields are refused. The workflow canonicalizes the JSON with stable key
+ordering and hashes the canonical UTF-8 bytes with SHA-256. The canonical JSON
+is transferred as a file; payload values are never interpolated into a command.
+
+## Drupal contract
+
+V1 is fixed to:
+
+```text
+bundle                 = article
+source language        = fr
+required translation   = en
+text format            = basic_html
+category vocabulary    = blog_categories
+technical author       = uid 1
+aliases                 = Pathauto-owned
+```
+
+The runtime script checks that the Article bundle, required fields, languages,
+`basic_html`, active uid 1 and the selected existing Blog category are present
+before any write.
+
+No user, role, permission, bundle, text format, alias or taxonomy creation is an
+input.
+
+### HTML boundary
+
+The body accepts only a conservative subset of the existing `basic_html`
+contract:
+
+```text
+p h2 h3 h4 ul ol li strong em a blockquote dl dt dd code br
+```
+
+Only `href` is accepted on `<a>`. Links must be same-site relative paths or an
+`https://emergingdigital.be/` URL. Scripts, styles, iframes, images, arbitrary
+attributes, unsafe schemes and tables are refused.
+
+This is intentionally narrower than the editor format. For #401 the audit
+"table" is therefore represented as structured paragraphs/list/definition list
+instead of widening the text format.
+
+`title`, category name and short description are plain text only.
+
+## Inspect
+
+`/agency-editorial inspect` performs no mutation. It returns a machine-readable
+`result.json` containing:
+
+- Article/runtime readiness;
+- presence of FR and EN;
+- `basic_html` availability;
+- active technical author uid 1;
+- existing `blog_categories` TIDs and FR/EN labels;
+- existing technical issue mapping, if any.
+
+Use inspect before preparing the final category/TID pair for an Article.
+
+## Dry-run
+
+`/agency-editorial dry-run`:
+
+1. loads and hashes the latest valid payload;
+2. transfers only the canonical JSON and trusted PHP helper over the existing
+   production SSH channel;
+3. validates the same schema again inside Drupal;
+4. checks runtime prerequisites and category TID/name consistency;
+5. checks idempotence and exact-title collision rules;
+6. performs no `save()`;
+7. publishes `DRY_RUN PASS` evidence with payload hash and trusted `main` SHA.
+
+The dry-run verdict is `READY` or `IDEMPOTENT`.
+
+## Apply authorization
+
+`/agency-editorial apply` is refused unless the same issue already contains a
+`github-actions[bot]` dry-run PASS for:
+
+- the exact current payload SHA-256; and
+- the exact current live `main` SHA.
+
+A change to the payload or trusted `main` therefore requires a new dry-run.
+
+The production runner also performs a fresh Drupal dry-run immediately before
+any backup or mutation.
+
+## Apply
+
+For a `READY` payload, the runner creates:
+
+```text
+/var/www/agency/shared/backups/editorial-issue-<N>-<UTC timestamp>.sql.gz
+```
+
+and verifies that the backup is non-empty before the first content write.
+
+The Drupal helper then:
+
+- switches the current account to active uid 1;
+- creates one FR Article through Entity API;
+- sets `field_short_description` and `body` with `basic_html`;
+- references only the validated existing Blog taxonomy term;
+- adds the EN translation through Entity API;
+- creates a revision with issue + payload hash in the technical revision log;
+- saves the Article;
+- writes the technical idempotence mapping;
+- reloads and verifies the Article and EN translation;
+- reports node ID, UUID, revision ID and FR/EN aliases;
+- returns control to the runner, which rebuilds Drupal caches.
+
+No direct SQL content mutation is used.
+
+## Idempotence and collision rules
+
+The technical state key is:
+
+```text
+agency_editorial.issue.<issue_number>
+```
+
+It stores only:
+
+```text
+node_id
+payload_sha256
+```
+
+This mapping is audit/idempotence metadata, not editorial content.
+
+Rules:
+
+- no mapping + no exact FR Article title => creation may proceed;
+- coherent mapping + same hash + same Article => `IDEMPOTENT`;
+- different hash for an existing mapping => fail closed;
+- missing/invalid mapped node => fail closed;
+- exact FR title already present without mapping => fail closed;
+- multiple/ambiguous content states are never auto-repaired.
+
+V1 never updates an existing Article.
+
+## Image boundary
+
+`field_feature_image` is optional at the Drupal field level, so the initial
+route can publish a safe textual Article. #401 is not complete until its required
+feature image and translated ALT are present and validated.
+
+V1 does not accept a remote image URL and does not download arbitrary media.
+Media support requires a separately reviewed bounded increment if no existing
+safe primitive is available.
+
+## Evidence
+
+Every run uploads:
+
+```text
+artifacts/editorial-publication/result.json
+artifacts/editorial-publication/preapply.json   # apply only
+```
+
+`apply` evidence also records the server-side backup path. Result comments expose
+only bounded metadata: status, verdict, node/revision IDs, aliases, trusted main,
+payload hash, run ID and artifact name.
+
+No secret, settings.php content, database content or payload body is copied into
+the result comment.
+
+## Explicit non-capabilities
+
+This route cannot:
+
+- execute arbitrary shell or Drush input;
+- run `drush cim` or `updb`;
+- invoke Governed Content / Content Sync;
+- deploy code;
+- change users or permissions;
+- create taxonomy terms;
+- edit menus or homepage;
+- mutate another bundle;
+- select another text format;
+- set arbitrary aliases;
+- invoke an AI provider;
+- update an existing Article in v1.
+
+## #401 sequence
+
+After #576 is merged and CI is green:
+
+```text
+/agency-editorial inspect
+-> choose an existing category returned by inspect
+-> post the final #401 payload
+-> /agency-editorial dry-run
+-> verify hash/verdict
+-> /agency-editorial apply
+-> verify node/revision/FR+EN aliases
+-> complete feature image + ALT if still required
+-> Browser Validation desktop/mobile
+-> verify canonical/hreflang/sitemap/console/network
+-> close #401 only when its complete DoD is satisfied
+```

--- a/scripts/runner/editorial-publication.php
+++ b/scripts/runner/editorial-publication.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\node\NodeInterface;

--- a/scripts/runner/editorial-publication.php
+++ b/scripts/runner/editorial-publication.php
@@ -1,0 +1,624 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Bounded helper for governed publication of editor-owned Drupal Articles.
+ *
+ * This file is intentionally not a Drupal runtime service. It is executed only
+ * through the trusted production route versioned in the repository.
+ */
+final class AgencyEditorialPublication {
+
+  private const BUNDLE = 'article';
+  private const SOURCE_LANGCODE = 'fr';
+  private const TRANSLATION_LANGCODE = 'en';
+  private const TEXT_FORMAT = 'basic_html';
+  private const CATEGORY_VOCABULARY = 'blog_categories';
+  private const AUTHOR_UID = 1;
+  private const STATE_PREFIX = 'agency_editorial.issue.';
+
+  /**
+   * Tags deliberately narrower than Drupal's complete basic_html definition.
+   */
+  private const ALLOWED_BODY_TAGS = [
+    'p',
+    'h2',
+    'h3',
+    'h4',
+    'ul',
+    'ol',
+    'li',
+    'strong',
+    'em',
+    'a',
+    'blockquote',
+    'dl',
+    'dt',
+    'dd',
+    'code',
+    'br',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly StateInterface $state,
+    private readonly AccountSwitcherInterface $accountSwitcher,
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly LanguageManagerInterface $languageManager,
+  ) {}
+
+  public static function fromContainer(ContainerInterface $container): self {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('state'),
+      $container->get('account_switcher'),
+      $container->get('path_alias.manager'),
+      $container->get('language_manager'),
+    );
+  }
+
+  /**
+   * Returns a read-only view of the runtime prerequisites for one issue.
+   */
+  public function inspect(int $issueNumber): array {
+    $fields = $this->entityTypeManager
+      ->getStorage('field_config')
+      ->loadByProperties(['entity_type' => 'node', 'bundle' => self::BUNDLE]);
+    $fieldNames = [];
+    foreach ($fields as $field) {
+      $fieldNames[] = $field->getName();
+    }
+    sort($fieldNames);
+
+    $articleType = $this->entityTypeManager
+      ->getStorage('node_type')
+      ->load(self::BUNDLE);
+    $format = $this->entityTypeManager
+      ->getStorage('filter_format')
+      ->load(self::TEXT_FORMAT);
+    $author = $this->loadAuthor();
+
+    $requiredFields = ['body', 'field_blog_category', 'field_short_description'];
+    $missingFields = array_values(array_diff($requiredFields, $fieldNames));
+    $languagesReady = $this->languageManager->getLanguage(self::SOURCE_LANGCODE) !== NULL
+      && $this->languageManager->getLanguage(self::TRANSLATION_LANGCODE) !== NULL;
+
+    $categories = [];
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $ids = $termStorage->getQuery()
+      ->condition('vid', self::CATEGORY_VOCABULARY)
+      ->accessCheck(FALSE)
+      ->sort('weight')
+      ->sort('name')
+      ->execute();
+    foreach ($termStorage->loadMultiple($ids) as $term) {
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
+      $item = [
+        'tid' => (int) $term->id(),
+        'fr' => $term->label(),
+        'en' => NULL,
+      ];
+      if ($term->hasTranslation(self::TRANSLATION_LANGCODE)) {
+        $item['en'] = $term->getTranslation(self::TRANSLATION_LANGCODE)->label();
+      }
+      $categories[] = $item;
+    }
+
+    $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
+    if (!is_array($mapping)) {
+      $mapping = NULL;
+    }
+
+    return [
+      'status' => 'PASS',
+      'verdict' => (
+        $articleType !== NULL
+        && $format !== NULL
+        && $author->isActive()
+        && $languagesReady
+        && $missingFields === []
+      ) ? 'READY' : 'NOT_READY',
+      'mode' => 'inspect',
+      'issue_number' => $issueNumber,
+      'contract' => [
+        'bundle' => self::BUNDLE,
+        'source_langcode' => self::SOURCE_LANGCODE,
+        'translation_langcode' => self::TRANSLATION_LANGCODE,
+        'text_format' => self::TEXT_FORMAT,
+        'category_vocabulary' => self::CATEGORY_VOCABULARY,
+        'author_uid' => self::AUTHOR_UID,
+      ],
+      'runtime' => [
+        'article_type' => $articleType !== NULL,
+        'basic_html' => $format !== NULL,
+        'languages' => $languagesReady,
+        'missing_fields' => $missingFields,
+        'author' => [
+          'uid' => (int) $author->id(),
+          'active' => $author->isActive(),
+        ],
+        'categories' => $categories,
+        'mapping' => $mapping,
+      ],
+    ];
+  }
+
+  /**
+   * Performs all validation without saving content.
+   */
+  public function dryRun(array $payload, int $issueNumber, string $payloadSha): array {
+    $this->assertRuntimeReady($issueNumber);
+    $this->validatePayload($payload, $issueNumber);
+    $category = $this->resolveCategory($payload['category']);
+    $duplicate = $this->classifyDuplicate($payload, $issueNumber, $payloadSha);
+
+    if ($duplicate['verdict'] === 'IDEMPOTENT') {
+      $node = $this->entityTypeManager
+        ->getStorage('node')
+        ->load((int) $duplicate['node_id']);
+      if (!$node instanceof NodeInterface) {
+        throw new RuntimeException('Idempotence mapping points to a missing node.');
+      }
+
+      return [
+        'status' => 'PASS',
+        'verdict' => 'IDEMPOTENT',
+        'mode' => 'dry-run',
+        'issue_number' => $issueNumber,
+        'payload_sha256' => $payloadSha,
+        'category' => $this->categoryResult($category),
+        'node' => $this->nodeResult($node),
+      ];
+    }
+
+    return [
+      'status' => 'PASS',
+      'verdict' => 'READY',
+      'mode' => 'dry-run',
+      'issue_number' => $issueNumber,
+      'payload_sha256' => $payloadSha,
+      'category' => $this->categoryResult($category),
+      'planned_change' => [
+        'operation' => 'create',
+        'bundle' => self::BUNDLE,
+        'source_langcode' => self::SOURCE_LANGCODE,
+        'translation_langcode' => self::TRANSLATION_LANGCODE,
+        'published' => $payload['published'],
+        'title_fr' => $payload['fr']['title'],
+        'title_en' => $payload['en']['title'],
+      ],
+    ];
+  }
+
+  /**
+   * Creates exactly one Article or returns the existing idempotent result.
+   */
+  public function apply(array $payload, int $issueNumber, string $payloadSha): array {
+    $dryRun = $this->dryRun($payload, $issueNumber, $payloadSha);
+    if ($dryRun['verdict'] === 'IDEMPOTENT') {
+      $dryRun['mode'] = 'apply';
+      return $dryRun;
+    }
+
+    $category = $this->resolveCategory($payload['category']);
+    $author = $this->loadAuthor();
+    $this->accountSwitcher->switchTo($author);
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('node');
+      $node = $storage->create([
+        'type' => self::BUNDLE,
+        'langcode' => self::SOURCE_LANGCODE,
+        'title' => $payload['fr']['title'],
+        'uid' => self::AUTHOR_UID,
+        'status' => $payload['published'],
+        'field_short_description' => [[
+          'value' => $payload['fr']['short_description'],
+          'format' => self::TEXT_FORMAT,
+        ]],
+        'body' => [[
+          'value' => $payload['fr']['body_html'],
+          'format' => self::TEXT_FORMAT,
+        ]],
+        'field_blog_category' => [[
+          'target_id' => (int) $category->id(),
+        ]],
+      ]);
+      if (!$node instanceof NodeInterface) {
+        throw new RuntimeException('Node storage did not create a node entity.');
+      }
+
+      $node->addTranslation(self::TRANSLATION_LANGCODE, [
+        'title' => $payload['en']['title'],
+        'field_short_description' => [[
+          'value' => $payload['en']['short_description'],
+          'format' => self::TEXT_FORMAT,
+        ]],
+        'body' => [[
+          'value' => $payload['en']['body_html'],
+          'format' => self::TEXT_FORMAT,
+        ]],
+        'field_blog_category' => [[
+          'target_id' => (int) $category->id(),
+        ]],
+      ]);
+
+      $node->setNewRevision(TRUE);
+      $node->setRevisionLogMessage(sprintf(
+        'Agency editorial issue #%d payload %s',
+        $issueNumber,
+        $payloadSha,
+      ));
+      $node->setRevisionUserId(self::AUTHOR_UID);
+
+      $violations = $node->validate();
+      if ($violations->count() > 0) {
+        $messages = [];
+        foreach ($violations as $violation) {
+          $messages[] = $violation->getPropertyPath() . ': ' . $violation->getMessage();
+        }
+        throw new RuntimeException('Article validation failed: ' . implode(' | ', $messages));
+      }
+
+      $node->save();
+      $nodeId = (int) $node->id();
+      $this->state->set(self::STATE_PREFIX . $issueNumber, [
+        'node_id' => $nodeId,
+        'payload_sha256' => $payloadSha,
+      ]);
+
+      $storage->resetCache([$nodeId]);
+      $reloaded = $storage->load($nodeId);
+      if (!$reloaded instanceof NodeInterface) {
+        throw new RuntimeException('Created Article could not be reloaded.');
+      }
+      if (!$reloaded->hasTranslation(self::TRANSLATION_LANGCODE)) {
+        throw new RuntimeException('Created Article is missing the EN translation.');
+      }
+
+      return [
+        'status' => 'PASS',
+        'verdict' => 'APPLIED',
+        'mode' => 'apply',
+        'issue_number' => $issueNumber,
+        'payload_sha256' => $payloadSha,
+        'category' => $this->categoryResult($category),
+        'node' => $this->nodeResult($reloaded),
+      ];
+    }
+    finally {
+      $this->accountSwitcher->switchBack();
+    }
+  }
+
+  /**
+   * Enforces the closed payload schema and conservative text contract.
+   */
+  public function validatePayload(array $payload, int $issueNumber): void {
+    $this->assertExactKeys($payload, [
+      'schema_version',
+      'issue_number',
+      'bundle',
+      'published',
+      'category',
+      'fr',
+      'en',
+    ], 'payload');
+
+    if (($payload['schema_version'] ?? NULL) !== 1) {
+      throw new InvalidArgumentException('schema_version must be 1.');
+    }
+    if (($payload['issue_number'] ?? NULL) !== $issueNumber) {
+      throw new InvalidArgumentException('Payload issue_number mismatch.');
+    }
+    if (($payload['bundle'] ?? NULL) !== self::BUNDLE) {
+      throw new InvalidArgumentException('Only bundle=article is allowed.');
+    }
+    if (!is_bool($payload['published'] ?? NULL)) {
+      throw new InvalidArgumentException('published must be boolean.');
+    }
+
+    if (!is_array($payload['category'] ?? NULL)) {
+      throw new InvalidArgumentException('category must be an object.');
+    }
+    $this->assertExactKeys($payload['category'], ['tid', 'name'], 'category');
+    if (!is_int($payload['category']['tid']) || $payload['category']['tid'] <= 0) {
+      throw new InvalidArgumentException('category.tid must be a positive integer.');
+    }
+    $this->assertPlainText($payload['category']['name'], 'category.name', 255);
+
+    foreach ([self::SOURCE_LANGCODE, self::TRANSLATION_LANGCODE] as $langcode) {
+      if (!is_array($payload[$langcode] ?? NULL)) {
+        throw new InvalidArgumentException("$langcode must be an object.");
+      }
+      $this->assertExactKeys(
+        $payload[$langcode],
+        ['title', 'short_description', 'body_html'],
+        $langcode,
+      );
+      $this->assertPlainText($payload[$langcode]['title'], "$langcode.title", 255);
+      $this->assertPlainText(
+        $payload[$langcode]['short_description'],
+        "$langcode.short_description",
+        1200,
+      );
+      $this->assertBodyHtml($payload[$langcode]['body_html'], "$langcode.body_html");
+    }
+  }
+
+  private function assertRuntimeReady(int $issueNumber): void {
+    $inspect = $this->inspect($issueNumber);
+    if ($inspect['verdict'] !== 'READY') {
+      throw new RuntimeException('Editorial runtime prerequisites are not ready.');
+    }
+  }
+
+  private function loadAuthor(): UserInterface {
+    $author = $this->entityTypeManager->getStorage('user')->load(self::AUTHOR_UID);
+    if (!$author instanceof UserInterface) {
+      throw new RuntimeException('Required Drupal author uid=1 does not exist.');
+    }
+    if (!$author->isActive()) {
+      throw new RuntimeException('Required Drupal author uid=1 is blocked.');
+    }
+    return $author;
+  }
+
+  private function resolveCategory(array $category): TermInterface {
+    $term = $this->entityTypeManager
+      ->getStorage('taxonomy_term')
+      ->load((int) $category['tid']);
+    if (!$term instanceof TermInterface) {
+      throw new InvalidArgumentException('Selected Blog category does not exist.');
+    }
+    if ($term->bundle() !== self::CATEGORY_VOCABULARY) {
+      throw new InvalidArgumentException('Selected taxonomy term is not a Blog category.');
+    }
+    if ($this->normalizePlainText($term->label()) !== $this->normalizePlainText($category['name'])) {
+      throw new InvalidArgumentException('Selected Blog category name/TID pair is stale or mismatched.');
+    }
+    return $term;
+  }
+
+  private function classifyDuplicate(
+    array $payload,
+    int $issueNumber,
+    string $payloadSha,
+  ): array {
+    $storage = $this->entityTypeManager->getStorage('node');
+    $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
+
+    if ($mapping !== NULL && !is_array($mapping)) {
+      throw new RuntimeException('Editorial idempotence mapping has an invalid shape.');
+    }
+
+    if (is_array($mapping)) {
+      $mappedId = $mapping['node_id'] ?? NULL;
+      $mappedHash = $mapping['payload_sha256'] ?? NULL;
+      if (!is_int($mappedId) || !is_string($mappedHash)) {
+        throw new RuntimeException('Editorial idempotence mapping is incomplete.');
+      }
+      if ($mappedHash !== $payloadSha) {
+        throw new RuntimeException('Issue already maps to a different editorial payload hash.');
+      }
+      $mapped = $storage->load($mappedId);
+      if (!$mapped instanceof NodeInterface || $mapped->bundle() !== self::BUNDLE) {
+        throw new RuntimeException('Editorial idempotence mapping points to an invalid node.');
+      }
+      if ($mapped->label() !== $payload[self::SOURCE_LANGCODE]['title']) {
+        throw new RuntimeException('Mapped Article title no longer matches the authorized payload.');
+      }
+      if (!$mapped->hasTranslation(self::TRANSLATION_LANGCODE)) {
+        throw new RuntimeException('Mapped Article no longer has the required EN translation.');
+      }
+      return ['verdict' => 'IDEMPOTENT', 'node_id' => $mappedId];
+    }
+
+    $candidateIds = $storage->getQuery()
+      ->condition('type', self::BUNDLE)
+      ->condition('langcode', self::SOURCE_LANGCODE)
+      ->condition('title', $payload[self::SOURCE_LANGCODE]['title'])
+      ->accessCheck(FALSE)
+      ->execute();
+
+    if ($candidateIds !== []) {
+      throw new RuntimeException(
+        'An Article with the exact FR title already exists without an issue mapping; refusing ambiguous creation.',
+      );
+    }
+
+    return ['verdict' => 'READY', 'node_id' => NULL];
+  }
+
+  private function nodeResult(NodeInterface $node): array {
+    $source = '/node/' . $node->id();
+    $this->aliasManager->cacheClear($source);
+    $en = $node->getTranslation(self::TRANSLATION_LANGCODE);
+
+    return [
+      'id' => (int) $node->id(),
+      'uuid' => $node->uuid(),
+      'revision_id' => (int) $node->getRevisionId(),
+      'published' => $node->isPublished(),
+      'title_fr' => $node->label(),
+      'title_en' => $en->label(),
+      'category_tid' => (int) $node->get('field_blog_category')->target_id,
+      'aliases' => [
+        'fr' => $this->aliasManager->getAliasByPath($source, self::SOURCE_LANGCODE),
+        'en' => $this->aliasManager->getAliasByPath($source, self::TRANSLATION_LANGCODE),
+      ],
+    ];
+  }
+
+  private function categoryResult(TermInterface $term): array {
+    return [
+      'tid' => (int) $term->id(),
+      'name' => $term->label(),
+    ];
+  }
+
+  private function assertExactKeys(array $value, array $expected, string $label): void {
+    $actual = array_keys($value);
+    sort($actual);
+    sort($expected);
+    if ($actual !== $expected) {
+      throw new InvalidArgumentException(
+        sprintf('%s keys must be exactly: %s.', $label, implode(', ', $expected)),
+      );
+    }
+  }
+
+  private function assertPlainText(mixed $value, string $label, int $maxLength): void {
+    if (!is_string($value)) {
+      throw new InvalidArgumentException("$label must be a string.");
+    }
+    $normalized = $this->normalizePlainText($value);
+    if ($normalized === '') {
+      throw new InvalidArgumentException("$label must not be empty.");
+    }
+    if ($normalized !== $value) {
+      throw new InvalidArgumentException("$label must be trimmed plain text without repeated whitespace.");
+    }
+    if (mb_strlen($value) > $maxLength) {
+      throw new InvalidArgumentException("$label is too long.");
+    }
+    if (strip_tags($value) !== $value || preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F]/u', $value)) {
+      throw new InvalidArgumentException("$label contains forbidden markup or control characters.");
+    }
+  }
+
+  private function normalizePlainText(string $value): string {
+    return preg_replace('/\s+/u', ' ', trim($value)) ?? '';
+  }
+
+  private function assertBodyHtml(mixed $value, string $label): void {
+    if (!is_string($value) || trim($value) === '') {
+      throw new InvalidArgumentException("$label must be non-empty HTML.");
+    }
+    if (strlen($value) > 100000) {
+      throw new InvalidArgumentException("$label is too large.");
+    }
+
+    $document = Html::load($value);
+    foreach ($document->getElementsByTagName('*') as $element) {
+      $tag = strtolower($element->tagName);
+      if (in_array($tag, ['html', 'body'], TRUE)) {
+        continue;
+      }
+      if (!in_array($tag, self::ALLOWED_BODY_TAGS, TRUE)) {
+        throw new InvalidArgumentException("$label contains forbidden tag <$tag>.");
+      }
+
+      $allowedAttributes = $tag === 'a' ? ['href'] : [];
+      foreach (iterator_to_array($element->attributes ?? []) as $attribute) {
+        if (!in_array(strtolower($attribute->name), $allowedAttributes, TRUE)) {
+          throw new InvalidArgumentException(
+            "$label contains forbidden attribute {$attribute->name} on <$tag>.",
+          );
+        }
+      }
+
+      if ($tag === 'a') {
+        $href = $element->getAttribute('href');
+        $allowedHref = str_starts_with($href, '/')
+          && !str_starts_with($href, '//');
+        $allowedHref = $allowedHref || str_starts_with(
+          $href,
+          'https://emergingdigital.be/',
+        );
+        if (!$allowedHref) {
+          throw new InvalidArgumentException(
+            "$label contains an external or unsafe link outside the bounded Agency contract.",
+          );
+        }
+      }
+    }
+  }
+
+}
+
+if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
+  $mode = getenv('AGENCY_EDITORIAL_MODE') ?: '';
+  $issueRaw = getenv('AGENCY_EDITORIAL_ISSUE') ?: '';
+  $payloadSha = getenv('AGENCY_EDITORIAL_PAYLOAD_SHA') ?: '';
+  $payloadPath = getenv('AGENCY_EDITORIAL_PAYLOAD_PATH') ?: '';
+  $resultPath = getenv('AGENCY_EDITORIAL_RESULT_PATH') ?: '';
+
+  $writeResult = static function (array $result) use ($resultPath): void {
+    if ($resultPath === '') {
+      throw new RuntimeException('AGENCY_EDITORIAL_RESULT_PATH is required.');
+    }
+    file_put_contents(
+      $resultPath,
+      json_encode(
+        $result,
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+      ) . PHP_EOL,
+    );
+  };
+
+  try {
+    if (!preg_match('/^[1-9][0-9]*$/', $issueRaw)) {
+      throw new InvalidArgumentException('AGENCY_EDITORIAL_ISSUE must be positive numeric.');
+    }
+    $issueNumber = (int) $issueRaw;
+    if (!in_array($mode, ['inspect', 'dry-run', 'apply'], TRUE)) {
+      throw new InvalidArgumentException('Unsupported AGENCY_EDITORIAL_MODE.');
+    }
+
+    $publisher = AgencyEditorialPublication::fromContainer(\Drupal::getContainer());
+    if ($mode === 'inspect') {
+      $result = $publisher->inspect($issueNumber);
+    }
+    else {
+      if (!preg_match('/^[0-9a-f]{64}$/', $payloadSha)) {
+        throw new InvalidArgumentException('AGENCY_EDITORIAL_PAYLOAD_SHA must be SHA-256.');
+      }
+      if ($payloadPath === '' || !is_file($payloadPath)) {
+        throw new InvalidArgumentException('Editorial payload file is missing.');
+      }
+      $actualHash = hash_file('sha256', $payloadPath);
+      if (!is_string($actualHash) || !hash_equals($payloadSha, $actualHash)) {
+        throw new RuntimeException('Editorial payload hash mismatch on production.');
+      }
+      $payload = json_decode(
+        (string) file_get_contents($payloadPath),
+        TRUE,
+        32,
+        JSON_THROW_ON_ERROR,
+      );
+      if (!is_array($payload)) {
+        throw new InvalidArgumentException('Editorial payload must decode to an object.');
+      }
+      $result = $mode === 'dry-run'
+        ? $publisher->dryRun($payload, $issueNumber, $payloadSha)
+        : $publisher->apply($payload, $issueNumber, $payloadSha);
+    }
+
+    $writeResult($result);
+  }
+  catch (Throwable $exception) {
+    $writeResult([
+      'status' => 'FAIL',
+      'verdict' => 'FAIL_CLOSED',
+      'mode' => $mode,
+      'issue_number' => ctype_digit($issueRaw) ? (int) $issueRaw : NULL,
+      'message' => $exception->getMessage(),
+    ]);
+    exit(1);
+  }
+}

--- a/scripts/runner/run-editorial-publication.sh
+++ b/scripts/runner/run-editorial-publication.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+MODE="${EDITORIAL_MODE:-}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+PAYLOAD_SHA256="${PAYLOAD_SHA256:-}"
+PAYLOAD_FILE="${PAYLOAD_FILE:-}"
+SERVER_HOST="${SERVER_HOST:-}"
+SERVER_USER="${SERVER_USER:-}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-artifacts/editorial-publication}"
+RUN_ID="${GITHUB_RUN_ID:-0}"
+RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
+
+case "$MODE" in
+  inspect|dry-run|apply) ;;
+  *) echo "Unsupported EDITORIAL_MODE: $MODE" >&2; exit 1 ;;
+esac
+
+[[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+  echo 'ISSUE_NUMBER must be a positive integer.' >&2
+  exit 1
+}
+[[ "$RUN_ID" =~ ^[0-9]+$ ]]
+[[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+[[ -n "$SERVER_HOST" ]]
+[[ -n "$SERVER_USER" ]]
+
+if [[ "$MODE" != 'inspect' ]]; then
+  [[ "$PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+    echo 'PAYLOAD_SHA256 must be a lowercase SHA-256.' >&2
+    exit 1
+  }
+  [[ -f "$PAYLOAD_FILE" ]] || {
+    echo 'PAYLOAD_FILE is required for dry-run/apply.' >&2
+    exit 1
+  }
+  actual_sha="$(sha256sum "$PAYLOAD_FILE" | awk '{print $1}')"
+  [[ "$actual_sha" == "$PAYLOAD_SHA256" ]] || {
+    echo 'Local editorial payload hash mismatch.' >&2
+    exit 1
+  }
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHP_SCRIPT="$SCRIPT_DIR/editorial-publication.php"
+[[ -f "$PHP_SCRIPT" ]]
+php -l "$PHP_SCRIPT" >/dev/null
+mkdir -p "$ARTIFACT_DIR"
+
+remote_stem="/tmp/agency-editorial-${ISSUE_NUMBER}-${RUN_ID}-${RUN_ATTEMPT}"
+remote_script="${remote_stem}.php"
+remote_payload="${remote_stem}.json"
+remote_result="${remote_stem}-result.json"
+remote_preapply="${remote_stem}-preapply.json"
+remote_target="${SERVER_USER}@${SERVER_HOST}"
+
+cleanup_remote() {
+  set +e
+  ssh "$remote_target" \
+    "rm -f '$remote_script' '$remote_payload' '$remote_result' '$remote_preapply'" \
+    >/dev/null 2>&1
+}
+trap cleanup_remote EXIT
+
+scp "$PHP_SCRIPT" "$remote_target:$remote_script" >/dev/null
+if [[ "$MODE" != 'inspect' ]]; then
+  scp "$PAYLOAD_FILE" "$remote_target:$remote_payload" >/dev/null
+fi
+
+remote_run() {
+  local run_mode="$1"
+  local remote_output="$2"
+  local payload_path=''
+  local payload_sha=''
+
+  if [[ "$run_mode" != 'inspect' ]]; then
+    payload_path="$remote_payload"
+    payload_sha="$PAYLOAD_SHA256"
+  fi
+
+  ssh "$remote_target" \
+    "set -euo pipefail; cd /var/www/agency/current; test -x vendor/bin/drush; vendor/bin/drush status --fields=bootstrap >/dev/null; AGENCY_EDITORIAL_MODE='$run_mode' AGENCY_EDITORIAL_ISSUE='$ISSUE_NUMBER' AGENCY_EDITORIAL_PAYLOAD_SHA='$payload_sha' AGENCY_EDITORIAL_PAYLOAD_PATH='$payload_path' AGENCY_EDITORIAL_RESULT_PATH='$remote_output' vendor/bin/drush php:script '$remote_script'"
+}
+
+case "$MODE" in
+  inspect)
+    remote_run inspect "$remote_result"
+    ;;
+
+  dry-run)
+    remote_run dry-run "$remote_result"
+    ;;
+
+  apply)
+    remote_run dry-run "$remote_preapply"
+    scp "$remote_target:$remote_preapply" "$ARTIFACT_DIR/preapply.json" >/dev/null
+    jq -e '.status == "PASS" and (.verdict == "READY" or .verdict == "IDEMPOTENT")' \
+      "$ARTIFACT_DIR/preapply.json" >/dev/null
+
+    preapply_verdict="$(jq -r '.verdict' "$ARTIFACT_DIR/preapply.json")"
+    backup_file=''
+    if [[ "$preapply_verdict" == 'READY' ]]; then
+      timestamp="$(date -u +%Y%m%d%H%M%S)"
+      backup_file="/var/www/agency/shared/backups/editorial-issue-${ISSUE_NUMBER}-${timestamp}.sql.gz"
+      ssh "$remote_target" \
+        "set -euo pipefail; cd /var/www/agency/current; mkdir -p /var/www/agency/shared/backups; vendor/bin/drush sql:dump --gzip --result-file='$backup_file' >/dev/null; test -s '$backup_file'"
+    fi
+
+    remote_run apply "$remote_result"
+    ssh "$remote_target" \
+      "set -euo pipefail; cd /var/www/agency/current; vendor/bin/drush cr >/dev/null"
+    ;;
+esac
+
+scp "$remote_target:$remote_result" "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.status == "PASS"' "$ARTIFACT_DIR/result.json" >/dev/null
+
+if [[ "$MODE" == 'apply' ]]; then
+  tmp_result="$ARTIFACT_DIR/result.tmp.json"
+  jq \
+    --arg backup_file "${backup_file:-}" \
+    '. + {cache_rebuilt:true, backup_file:(if $backup_file == "" then null else $backup_file end)}' \
+    "$ARTIFACT_DIR/result.json" > "$tmp_result"
+  mv "$tmp_result" "$ARTIFACT_DIR/result.json"
+fi

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Exercises the trusted Article mutation helper against a real Drupal kernel.
+ *
+ * @group agency_project_tests
+ * @group governed_editorial_publication
+ */
+#[Group('governed_editorial_publication')]
+final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'taxonomy',
+    'language',
+    'content_translation',
+    'path',
+    'path_alias',
+  ];
+
+  private object $publisher;
+  private int $categoryTid;
+  private int $sentinelNid;
+  private int $sentinelRevisionId;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['system', 'filter']);
+
+    foreach (['fr', 'en'] as $langcode) {
+      if (ConfigurableLanguage::load($langcode) === NULL) {
+        ConfigurableLanguage::createFromLangcode($langcode)->save();
+      }
+    }
+
+    NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+      'new_revision' => TRUE,
+    ])->save();
+
+    Vocabulary::create([
+      'vid' => 'blog_categories',
+      'name' => 'Blog categories',
+    ])->save();
+
+    FilterFormat::create([
+      'format' => 'basic_html',
+      'name' => 'Basic HTML',
+      'filters' => [],
+    ])->save();
+
+    User::create([
+      'uid' => 1,
+      'name' => 'agency-editorial-test-admin',
+      'status' => 1,
+    ])->save();
+
+    $this->createArticleFields();
+    $this->container
+      ->get('content_translation.manager')
+      ->setEnabled('node', 'article', TRUE);
+
+    $category = Term::create([
+      'vid' => 'blog_categories',
+      'langcode' => 'fr',
+      'name' => 'Conseil',
+    ]);
+    $category->addTranslation('en', ['name' => 'Consulting']);
+    $category->save();
+    $this->categoryTid = (int) $category->id();
+
+    $sentinel = Node::create([
+      'type' => 'article',
+      'langcode' => 'fr',
+      'title' => 'Sentinel',
+      'uid' => 1,
+      'status' => 1,
+      'field_short_description' => [[
+        'value' => 'Unchanged sentinel',
+        'format' => 'basic_html',
+      ]],
+      'body' => [[
+        'value' => '<p>Sentinel body.</p>',
+        'format' => 'basic_html',
+      ]],
+      'field_blog_category' => [['target_id' => $this->categoryTid]],
+    ]);
+    $sentinel->save();
+    $this->sentinelNid = (int) $sentinel->id();
+    $this->sentinelRevisionId = (int) $sentinel->getRevisionId();
+
+    if (!class_exists('AgencyEditorialPublication', FALSE)) {
+      if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
+        define('AGENCY_EDITORIAL_LIBRARY_ONLY', TRUE);
+      }
+      require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication.php';
+    }
+    $this->publisher = \AgencyEditorialPublication::fromContainer($this->container);
+  }
+
+  /**
+   * Creates FR+EN once and becomes idempotent for the same issue/hash.
+   */
+  public function testApplyCreatesTranslatedArticleAndIsIdempotent(): void {
+    $payload = $this->validPayload();
+    $hash = str_repeat('a', 64);
+
+    $dryRun = $this->publisher->dryRun($payload, 401, $hash);
+    self::assertSame('PASS', $dryRun['status']);
+    self::assertSame('READY', $dryRun['verdict']);
+
+    $applied = $this->publisher->apply($payload, 401, $hash);
+    self::assertSame('PASS', $applied['status']);
+    self::assertSame('APPLIED', $applied['verdict']);
+    self::assertSame($this->categoryTid, $applied['node']['category_tid']);
+    self::assertGreaterThan(0, $applied['node']['revision_id']);
+
+    $node = Node::load($applied['node']['id']);
+    self::assertNotNull($node);
+    self::assertSame('Checklist avant une refonte', $node->label());
+    self::assertTrue($node->hasTranslation('en'));
+    self::assertSame(
+      'Website redesign checklist',
+      $node->getTranslation('en')->label(),
+    );
+    self::assertSame('basic_html', $node->get('body')->format);
+    self::assertSame(
+      'basic_html',
+      $node->getTranslation('en')->get('body')->format,
+    );
+
+    $mapping = $this->container->get('state')->get('agency_editorial.issue.401');
+    self::assertSame($applied['node']['id'], $mapping['node_id']);
+    self::assertSame($hash, $mapping['payload_sha256']);
+
+    $idempotent = $this->publisher->apply($payload, 401, $hash);
+    self::assertSame('PASS', $idempotent['status']);
+    self::assertSame('IDEMPOTENT', $idempotent['verdict']);
+    self::assertSame($applied['node']['id'], $idempotent['node']['id']);
+
+    $sentinel = Node::load($this->sentinelNid);
+    self::assertNotNull($sentinel);
+    self::assertSame('Sentinel', $sentinel->label());
+    self::assertSame($this->sentinelRevisionId, (int) $sentinel->getRevisionId());
+  }
+
+  /**
+   * Category selection is restricted to an existing Blog taxonomy term.
+   */
+  public function testMissingCategoryFailsClosed(): void {
+    $payload = $this->validPayload();
+    $payload['category'] = ['tid' => 999999, 'name' => 'Missing'];
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Selected Blog category does not exist.');
+    $this->publisher->dryRun($payload, 401, str_repeat('b', 64));
+  }
+
+  /**
+   * The schema refuses another bundle or an injected text-format field.
+   */
+  public function testPayloadCannotWidenBundleOrTextFormat(): void {
+    $payload = $this->validPayload();
+    $payload['bundle'] = 'page';
+
+    try {
+      $this->publisher->dryRun($payload, 401, str_repeat('c', 64));
+      self::fail('A non-Article bundle was accepted.');
+    }
+    catch (\InvalidArgumentException $exception) {
+      self::assertStringContainsString('Only bundle=article', $exception->getMessage());
+    }
+
+    $payload = $this->validPayload();
+    $payload['body_format'] = 'full_html';
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('payload keys must be exactly');
+    $this->publisher->dryRun($payload, 401, str_repeat('d', 64));
+  }
+
+  /**
+   * A title collision without the technical mapping must never create a clone.
+   */
+  public function testUnmappedExactTitleCollisionFailsClosed(): void {
+    $payload = $this->validPayload();
+    Node::create([
+      'type' => 'article',
+      'langcode' => 'fr',
+      'title' => $payload['fr']['title'],
+      'uid' => 1,
+      'status' => 1,
+    ])->save();
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('exact FR title already exists');
+    $this->publisher->dryRun($payload, 401, str_repeat('e', 64));
+  }
+
+  /**
+   * Creates the exact fields the trusted helper may mutate.
+   */
+  private function createArticleFields(): void {
+    FieldStorageConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'type' => 'text_with_summary',
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Content',
+      'translatable' => TRUE,
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_short_description',
+      'entity_type' => 'node',
+      'type' => 'text_long',
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_short_description',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Short description',
+      'translatable' => TRUE,
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_blog_category',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'taxonomy_term'],
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_blog_category',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Blog category',
+      'translatable' => TRUE,
+      'settings' => [
+        'handler' => 'default:taxonomy_term',
+        'handler_settings' => [
+          'target_bundles' => ['blog_categories' => 'blog_categories'],
+        ],
+      ],
+    ])->save();
+  }
+
+  /**
+   * Returns a payload that conforms to the v1 closed schema.
+   */
+  private function validPayload(): array {
+    return [
+      'schema_version' => 1,
+      'issue_number' => 401,
+      'bundle' => 'article',
+      'published' => TRUE,
+      'category' => [
+        'tid' => $this->categoryTid,
+        'name' => 'Conseil',
+      ],
+      'fr' => [
+        'title' => 'Checklist avant une refonte',
+        'short_description' => 'Préparer une refonte avant la maquette.',
+        'body_html' => '<h2>Préparer le projet</h2><p>Conserver ce qui fonctionne.</p><dl><dt>Audit</dt><dd>Prioriser les risques.</dd></dl><p><a href="/contact">Contact</a></p>',
+      ],
+      'en' => [
+        'title' => 'Website redesign checklist',
+        'short_description' => 'Prepare a redesign before the mockups.',
+        'body_html' => '<h2>Prepare the project</h2><p>Keep what already works.</p><dl><dt>Audit</dt><dd>Prioritise risks.</dd></dl><p><a href="/contact">Contact</a></p>',
+      ],
+    ];
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
@@ -149,11 +149,11 @@ final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
       }
       require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication.php';
     }
-    if (!class_exists($class, FALSE)) {
-      throw new \RuntimeException('Trusted editorial helper did not load.');
+    $factory = [$class, 'fromContainer'];
+    if (!is_callable($factory)) {
+      throw new \RuntimeException('Trusted editorial helper factory did not load.');
     }
-    $method = (new \ReflectionClass($class))->getMethod('fromContainer');
-    $publisher = $method->invoke(NULL, $this->container);
+    $publisher = $factory($this->container);
     self::assertIsObject($publisher);
     $this->publisher = $publisher;
   }

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
@@ -42,9 +42,24 @@ final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
     'path_alias',
   ];
 
+  /**
+   * Trusted editorial publisher under test.
+   */
   private object $publisher;
+
+  /**
+   * Existing Blog category term ID used by the payload.
+   */
   private int $categoryTid;
+
+  /**
+   * Sentinel node ID used to prove no unrelated content changes.
+   */
   private int $sentinelNid;
+
+  /**
+   * Sentinel revision ID captured before publication.
+   */
   private int $sentinelRevisionId;
 
   /**
@@ -109,14 +124,18 @@ final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
       'title' => 'Sentinel',
       'uid' => 1,
       'status' => 1,
-      'field_short_description' => [[
-        'value' => 'Unchanged sentinel',
-        'format' => 'basic_html',
-      ]],
-      'body' => [[
-        'value' => '<p>Sentinel body.</p>',
-        'format' => 'basic_html',
-      ]],
+      'field_short_description' => [
+        [
+          'value' => 'Unchanged sentinel',
+          'format' => 'basic_html',
+        ],
+      ],
+      'body' => [
+        [
+          'value' => '<p>Sentinel body.</p>',
+          'format' => 'basic_html',
+        ],
+      ],
       'field_blog_category' => [['target_id' => $this->categoryTid]],
     ]);
     $sentinel->save();

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
@@ -149,6 +149,9 @@ final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
       }
       require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication.php';
     }
+    if (!class_exists($class, FALSE)) {
+      throw new \RuntimeException('Trusted editorial helper did not load.');
+    }
     $method = (new \ReflectionClass($class))->getMethod('fromContainer');
     $publisher = $method->invoke(NULL, $this->container);
     self::assertIsObject($publisher);

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php
@@ -142,13 +142,17 @@ final class GovernedEditorialPublicationKernelTest extends KernelTestBase {
     $this->sentinelNid = (int) $sentinel->id();
     $this->sentinelRevisionId = (int) $sentinel->getRevisionId();
 
-    if (!class_exists('AgencyEditorialPublication', FALSE)) {
+    $class = 'AgencyEditorialPublication';
+    if (!class_exists($class, FALSE)) {
       if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
         define('AGENCY_EDITORIAL_LIBRARY_ONLY', TRUE);
       }
       require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication.php';
     }
-    $this->publisher = \AgencyEditorialPublication::fromContainer($this->container);
+    $method = (new \ReflectionClass($class))->getMethod('fromContainer');
+    $publisher = $method->invoke(NULL, $this->container);
+    self::assertIsObject($publisher);
+    $this->publisher = $publisher;
   }
 
   /**

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the governed editor-owned Article publication route.
+ *
+ * @group agency_project_tests
+ * @group governed_editorial_publication
+ */
+final class GovernedEditorialPublicationWorkflowTest extends TestCase {
+
+  /**
+   * The workflow must remain comment-triggered, actor-bound and main-trusted.
+   */
+  public function testWorkflowControlSurfaceIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-editorial-publication.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString('issue_comment:', $workflow);
+    self::assertStringContainsString("github.event.comment.body == '/agency-editorial inspect'", $workflow);
+    self::assertStringContainsString("github.event.comment.body == '/agency-editorial dry-run'", $workflow);
+    self::assertStringContainsString("github.event.comment.body == '/agency-editorial apply'", $workflow);
+    self::assertStringContainsString("GITHUB_ACTOR\" == 'E-merging-digital'", $workflow);
+    self::assertStringContainsString("'.user.login'", $workflow);
+    self::assertStringContainsString('currently on live main', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * Payload data must stay data and apply must require an exact dry-run hash.
+   */
+  public function testPayloadAndApplyContractFailClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-editorial-publication.yml',
+    );
+
+    self::assertStringContainsString(
+      '<!-- agency-editorial-payload:v1 -->',
+      $workflow,
+    );
+    self::assertStringContainsString("sort_keys=True", $workflow);
+    self::assertStringContainsString("separators=(',', ':')", $workflow);
+    self::assertStringContainsString('hashlib.sha256', $workflow);
+    self::assertStringContainsString('github-actions[bot]', $workflow);
+    self::assertStringContainsString(
+      'Apply requires a prior bot-authored dry-run PASS',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "payload.get('bundle') != 'article'",
+      $workflow,
+    );
+    self::assertStringNotContainsString('eval ', $workflow);
+  }
+
+  /**
+   * The production runner may reuse SSH but must expose no generic executor.
+   */
+  public function testProductionRunnerIsArticleOnlyAndSyntaxValid(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $shellPath = $root . '/scripts/runner/run-editorial-publication.sh';
+    $phpPath = $root . '/scripts/runner/editorial-publication.php';
+    self::assertFileExists($shellPath);
+    self::assertFileExists($phpPath);
+
+    $shell = (string) file_get_contents($shellPath);
+    $php = (string) file_get_contents($phpPath);
+    $combined = $shell . "\n" . $php;
+
+    self::assertStringContainsString('/var/www/agency/current', $shell);
+    self::assertStringContainsString('vendor/bin/drush sql:dump', $shell);
+    self::assertStringContainsString('vendor/bin/drush php:script', $shell);
+    self::assertStringContainsString("private const BUNDLE = 'article'", $php);
+    self::assertStringContainsString("private const TEXT_FORMAT = 'basic_html'", $php);
+    self::assertStringContainsString("private const AUTHOR_UID = 1", $php);
+    self::assertStringContainsString('agency_editorial.issue.', $php);
+
+    foreach ([
+      'drush cim',
+      'drush updb',
+      'emerging:governed-content',
+      'deploy-production.sh',
+      'composer require',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $combined);
+    }
+
+    $output = [];
+    $exitCode = 0;
+    exec('bash -n ' . escapeshellarg($shellPath) . ' 2>&1', $output, $exitCode);
+    self::assertSame(0, $exitCode, implode("\n", $output));
+
+    $output = [];
+    $exitCode = 0;
+    exec('php -l ' . escapeshellarg($phpPath) . ' 2>&1', $output, $exitCode);
+    self::assertSame(0, $exitCode, implode("\n", $output));
+  }
+
+  /**
+   * Existing deployment secrets are the only production connection inputs.
+   */
+  public function testWorkflowReusesExistingSshSecrets(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-editorial-publication.yml',
+    );
+
+    self::assertStringContainsString('${{ secrets.SSH_PRIVATE_KEY }}', $workflow);
+    self::assertStringContainsString('${{ secrets.SERVER_HOST }}', $workflow);
+    self::assertStringContainsString('${{ secrets.SERVER_USER }}', $workflow);
+    self::assertStringNotContainsString('password:', $workflow);
+    self::assertStringNotContainsString('settings.php', $workflow);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
@@ -33,6 +33,10 @@ final class GovernedEditorialPublicationWorkflowTest extends TestCase {
     self::assertStringContainsString("'.user.login'", $workflow);
     self::assertStringContainsString('currently on live main', $workflow);
     self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString(
+      "always() && steps.request.outcome == 'success'",
+      $workflow,
+    );
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
   }
 


### PR DESCRIPTION
Closes #576

Blocker infrastructure de #401.

## Résumé

Cette PR ajoute une route trusted et volontairement bornée pour publier les Articles ordinaires editor-owned dans Drupal sans les réintroduire dans Content Sync / Governed Content.

- déclenchement uniquement par commentaire exact sur une issue OPEN créée par `E-merging-digital` ;
- commandes fermées : `inspect`, `dry-run`, `apply` ;
- exécution uniquement depuis le `main` trusted live ;
- payload Article FR/EN à schéma fermé, canonicalisé et hashé SHA-256 ;
- `apply` autorisé seulement après un dry-run PASS du même payload sur le même `main` ;
- réutilisation du canal SSH production existant, sans nouveau secret ni second mécanisme d’accès ;
- préflight Drupal read-only juste avant mutation ;
- sauvegarde SQL avant le premier write ;
- création du node et de la traduction EN via Entity API uniquement ;
- `basic_html`, bundle `article`, vocabulaire `blog_categories`, auteur technique uid=1 et aliases Pathauto fixés côté trusted ;
- mapping technique issue -> node/hash uniquement pour idempotence ;
- fail-closed sur collision, catégorie absente, payload différent ou état ambigu ;
- artifacts machine-readable et documentation durable du registre d’exécution.

## Diff

7 fichiers uniquement :

- `.github/workflows/trusted-editorial-publication.yml`
- `scripts/runner/run-editorial-publication.sh`
- `scripts/runner/editorial-publication.php`
- `web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php`
- `web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPublicationKernelTest.php`
- `docs/operations/governed-editorial-publication.md`
- `docs/operations/execution-capabilities.md`

## Validation préalable

- YAML parseable ;
- `bash -n` PASS ;
- `php -l` PASS ;
- commit unique, fast-forward depuis `main@efe6b78cb3a2baa8d73c3de5dfd963f20beaf21b` ;
- CI GitHub exact-HEAD à confirmer sur la PR.

## Invariants de sécurité

Cette route ne peut pas :

- exécuter du shell ou Drush arbitraire ;
- invoquer `drush cim`, `updb` ou Governed Content ;
- modifier `scripts/deploy-production.sh` ;
- créer une catégorie, un utilisateur ou une permission ;
- publier un autre bundle ou utiliser un autre text format ;
- définir un alias arbitraire ;
- appeler un provider IA ;
- télécharger une image distante arbitraire ;
- modifier un Article existant en v1.

Le workflow trusted devra être **mergé sur `main` avant toute exécution production**. Aucun `inspect`, `dry-run` ou `apply` production ne doit être lancé depuis cette PR.

## Après merge

`#401 -> inspect production -> payload final catégorie -> dry-run -> apply -> image/ALT -> Browser Validation FR/EN -> clôture #401`