### PR TITLE
[P1][Bug] Blog — matérialiser les catégories éditoriales initiales

### DIFF
--- a/web/modules/custom/emerging_digital_content/content/taxonomy_term/5d072809-6653-42a5-a404-bb6bb18a465e.yml
+++ b/web/modules/custom/emerging_digital_content/content/taxonomy_term/5d072809-6653-42a5-a404-bb6bb18a465e.yml
@@ -1,0 +1,30 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: 5d072809-6653-42a5-a404-bb6bb18a465e
+  bundle: blog_categories
+  default_langcode: fr
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'Drupal comme expertise forte'
+  weight:
+    -
+      value: 2
+  revision_translation_affected:
+    -
+      value: true
+translations:
+  en:
+    status:
+      -
+        value: true
+    name:
+      -
+        value: 'Drupal expertise'
+    revision_translation_affected:
+      -
+        value: true

--- a/web/modules/custom/emerging_digital_content/content/taxonomy_term/d4390eaa-6097-4aee-89f8-eeed57401508.yml
+++ b/web/modules/custom/emerging_digital_content/content/taxonomy_term/d4390eaa-6097-4aee-89f8-eeed57401508.yml
@@ -1,0 +1,30 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: d4390eaa-6097-4aee-89f8-eeed57401508
+  bundle: blog_categories
+  default_langcode: fr
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'Décisions web / agence senior'
+  weight:
+    -
+      value: 0
+  revision_translation_affected:
+    -
+      value: true
+translations:
+  en:
+    status:
+      -
+        value: true
+    name:
+      -
+        value: 'Web decisions / senior agency'
+    revision_translation_affected:
+      -
+        value: true

--- a/web/modules/custom/emerging_digital_content/content/taxonomy_term/e7610b1c-2723-491e-837f-b0eff435f507.yml
+++ b/web/modules/custom/emerging_digital_content/content/taxonomy_term/e7610b1c-2723-491e-837f-b0eff435f507.yml
@@ -1,0 +1,30 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: e7610b1c-2723-491e-837f-b0eff435f507
+  bundle: blog_categories
+  default_langcode: fr
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'PHP / architecture / frameworks'
+  weight:
+    -
+      value: 1
+  revision_translation_affected:
+    -
+      value: true
+translations:
+  en:
+    status:
+      -
+        value: true
+    name:
+      -
+        value: 'PHP / architecture / frameworks'
+    revision_translation_affected:
+      -
+        value: true

--- a/web/modules/custom/emerging_digital_content/content/taxonomy_term/f2f77a08-e528-4ac7-9d78-24464bc99f21.yml
+++ b/web/modules/custom/emerging_digital_content/content/taxonomy_term/f2f77a08-e528-4ac7-9d78-24464bc99f21.yml
@@ -1,0 +1,30 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: f2f77a08-e528-4ac7-9d78-24464bc99f21
+  bundle: blog_categories
+  default_langcode: fr
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'Qualité web / SEO / accessibilité'
+  weight:
+    -
+      value: 4
+  revision_translation_affected:
+    -
+      value: true
+translations:
+  en:
+    status:
+      -
+        value: true
+    name:
+      -
+        value: 'Web quality / SEO / accessibility'
+    revision_translation_affected:
+      -
+        value: true

--- a/web/modules/custom/emerging_digital_content/content/taxonomy_term/fc8248c8-015b-4215-9354-ef554a16416d.yml
+++ b/web/modules/custom/emerging_digital_content/content/taxonomy_term/fc8248c8-015b-4215-9354-ef554a16416d.yml
@@ -1,0 +1,30 @@
+_meta:
+  version: '1.0'
+  entity_type: taxonomy_term
+  uuid: fc8248c8-015b-4215-9354-ef554a16416d
+  bundle: blog_categories
+  default_langcode: fr
+default:
+  status:
+    -
+      value: true
+  name:
+    -
+      value: 'IA encadrée'
+  weight:
+    -
+      value: 3
+  revision_translation_affected:
+    -
+      value: true
+translations:
+  en:
+    status:
+      -
+        value: true
+    name:
+      -
+        value: 'Governed AI'
+    revision_translation_affected:
+      -
+        value: true

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
@@ -14,6 +14,7 @@ dependencies:
   - drupal:paragraphs
   - drupal:serialization
   - drupal:hal
+  - drupal:taxonomy
 default_content:
   menu_link_content:
     - 0160a2d4-d1fa-48e3-94e4-06159373cbe6
@@ -22,6 +23,12 @@ default_content:
     - ff24fa4f-99d3-4e46-91ab-22f6aac0b42e
     - 4220d840-7314-4726-955a-2ca1c9f6cde5
     - 6f2663ee-2902-4e9f-887e-3e14a53026c6
+  taxonomy_term:
+    - d4390eaa-6097-4aee-89f8-eeed57401508
+    - e7610b1c-2723-491e-837f-b0eff435f507
+    - 5d072809-6653-42a5-a404-bb6bb18a465e
+    - fc8248c8-015b-4215-9354-ef554a16416d
+    - f2f77a08-e528-4ac7-9d78-24464bc99f21
   paragraph:
     - 11c3e2e1-78c9-491d-814c-b204bc2f5338
     - 25892a5a-3c09-4f64-86d7-cda8058e1875

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_schema().
@@ -87,6 +88,186 @@ function emerging_digital_content_update_11003(array &$sandbox): string {
   $changed = _emerging_digital_content_ensure_blog_navigation_position();
 
   return sprintf('%d Blog navigation values were normalized.', $changed);
+}
+
+/**
+ * Materializes the initial bilingual Blog categories on existing sites.
+ */
+function emerging_digital_content_update_11004(array &$sandbox): string {
+  unset($sandbox);
+
+  $result = _emerging_digital_content_ensure_initial_blog_categories();
+
+  return sprintf(
+    'Initial Blog categories ensured: %d created, %d updated.',
+    $result['created'],
+    $result['updated'],
+  );
+}
+
+/**
+ * Ensures the five editorial Blog categories defined by issue #397.
+ *
+ * @return array{created: int, updated: int}
+ *   Counts of created and updated taxonomy terms.
+ */
+function _emerging_digital_content_ensure_initial_blog_categories(): array {
+  $vocabulary = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_vocabulary')
+    ->load('blog_categories');
+  if ($vocabulary === NULL) {
+    throw new \RuntimeException('Required blog_categories vocabulary does not exist.');
+  }
+
+  $manifest = [
+    'd4390eaa-6097-4aee-89f8-eeed57401508' => [
+      'fr' => 'Décisions web / agence senior',
+      'en' => 'Web decisions / senior agency',
+      'weight' => 0,
+    ],
+    'e7610b1c-2723-491e-837f-b0eff435f507' => [
+      'fr' => 'PHP / architecture / frameworks',
+      'en' => 'PHP / architecture / frameworks',
+      'weight' => 1,
+    ],
+    '5d072809-6653-42a5-a404-bb6bb18a465e' => [
+      'fr' => 'Drupal comme expertise forte',
+      'en' => 'Drupal expertise',
+      'weight' => 2,
+    ],
+    'fc8248c8-015b-4215-9354-ef554a16416d' => [
+      'fr' => 'IA encadrée',
+      'en' => 'Governed AI',
+      'weight' => 3,
+    ],
+    'f2f77a08-e528-4ac7-9d78-24464bc99f21' => [
+      'fr' => 'Qualité web / SEO / accessibilité',
+      'en' => 'Web quality / SEO / accessibility',
+      'weight' => 4,
+    ],
+  ];
+
+  $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  $created = 0;
+  $updated = 0;
+
+  foreach ($manifest as $uuid => $definition) {
+    $uuid_matches = array_values($storage->loadByProperties(['uuid' => $uuid]));
+    if (count($uuid_matches) > 1) {
+      throw new \RuntimeException(sprintf(
+        'Multiple taxonomy terms use packaged Blog category UUID %s.',
+        $uuid,
+      ));
+    }
+
+    $term = $uuid_matches[0] ?? NULL;
+    if ($term instanceof TermInterface && $term->bundle() !== 'blog_categories') {
+      throw new \RuntimeException(sprintf(
+        'Packaged Blog category UUID %s already belongs to vocabulary %s.',
+        $uuid,
+        $term->bundle(),
+      ));
+    }
+
+    if (!$term instanceof TermInterface) {
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('vid', 'blog_categories')
+        ->condition('langcode', 'fr')
+        ->condition('name', $definition['fr'])
+        ->execute();
+
+      if (count($ids) > 1) {
+        throw new \RuntimeException(sprintf(
+          'Multiple Blog categories already use the FR label "%s".',
+          $definition['fr'],
+        ));
+      }
+
+      if ($ids !== []) {
+        $term = $storage->load((int) reset($ids));
+      }
+    }
+
+    $is_new = !$term instanceof TermInterface;
+    if ($is_new) {
+      $term = $storage->create([
+        'vid' => 'blog_categories',
+        'uuid' => $uuid,
+        'langcode' => 'fr',
+        'name' => $definition['fr'],
+        'weight' => $definition['weight'],
+        'status' => TRUE,
+      ]);
+    }
+
+    if (!$term instanceof TermInterface) {
+      throw new \RuntimeException(sprintf(
+        'Unable to load or create Blog category "%s".',
+        $definition['fr'],
+      ));
+    }
+    if ($term->bundle() !== 'blog_categories') {
+      throw new \RuntimeException(sprintf(
+        'Blog category "%s" resolved outside blog_categories.',
+        $definition['fr'],
+      ));
+    }
+    if ($term->language()->getId() !== 'fr') {
+      throw new \RuntimeException(sprintf(
+        'Blog category "%s" does not use FR as its source language.',
+        $definition['fr'],
+      ));
+    }
+
+    $changed = FALSE;
+    if ((string) $term->label() !== $definition['fr']) {
+      $term->set('name', $definition['fr']);
+      $changed = TRUE;
+    }
+    if ((int) $term->get('weight')->value !== $definition['weight']) {
+      $term->set('weight', $definition['weight']);
+      $changed = TRUE;
+    }
+    if (!(bool) $term->get('status')->value) {
+      $term->set('status', TRUE);
+      $changed = TRUE;
+    }
+
+    if ($term->hasTranslation('en')) {
+      $translation = $term->getTranslation('en');
+      if ((string) $translation->label() !== $definition['en']) {
+        $translation->set('name', $definition['en']);
+        $changed = TRUE;
+      }
+      if (!(bool) $translation->get('status')->value) {
+        $translation->set('status', TRUE);
+        $changed = TRUE;
+      }
+    }
+    else {
+      $term->addTranslation('en', [
+        'name' => $definition['en'],
+        'status' => TRUE,
+      ]);
+      $changed = TRUE;
+    }
+
+    if ($is_new || $changed) {
+      $term->save();
+      if ($is_new) {
+        $created++;
+      }
+      else {
+        $updated++;
+      }
+    }
+  }
+
+  return [
+    'created' => $created,
+    'updated' => $updated,
+  ];
 }
 
 /**

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -263,6 +263,7 @@ function _emerging_digital_content_ensure_initial_blog_categories(): array {
     'updated' => $updated,
   ];
 }
+
 /**
  * Ensures Blog immediately precedes Contact without reweighting other links.
  */

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.install
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.install
@@ -201,12 +201,6 @@ function _emerging_digital_content_ensure_initial_blog_categories(): array {
       ]);
     }
 
-    if (!$term instanceof TermInterface) {
-      throw new \RuntimeException(sprintf(
-        'Unable to load or create Blog category "%s".',
-        $definition['fr'],
-      ));
-    }
     if ($term->bundle() !== 'blog_categories') {
       throw new \RuntimeException(sprintf(
         'Blog category "%s" resolved outside blog_categories.',
@@ -269,7 +263,6 @@ function _emerging_digital_content_ensure_initial_blog_categories(): array {
     'updated' => $updated,
   ];
 }
-
 /**
  * Ensures Blog immediately precedes Contact without reweighting other links.
  */

--- a/web/modules/custom/emerging_digital_content/tests/src/Kernel/BlogCategoriesUpdateTest.php
+++ b/web/modules/custom/emerging_digital_content/tests/src/Kernel/BlogCategoriesUpdateTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emerging_digital_content\Kernel;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Tests materialization of the initial bilingual Blog categories.
+ *
+ * @group emerging_digital_content
+ */
+final class BlogCategoriesUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'taxonomy',
+    'language',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['system', 'language', 'taxonomy']);
+
+    if (ConfigurableLanguage::load('fr') === NULL) {
+      ConfigurableLanguage::createFromLangcode('fr')->save();
+    }
+
+    Vocabulary::create([
+      'vid' => 'blog_categories',
+      'name' => 'Blog categories',
+    ])->save();
+
+    require_once DRUPAL_ROOT . '/modules/custom/emerging_digital_content/emerging_digital_content.install';
+  }
+
+  /**
+   * Ensures creation, translations, idempotence and unrelated-term safety.
+   */
+  public function testInitialBlogCategoriesAreMaterializedIdempotently(): void {
+    $sentinel = Term::create([
+      'vid' => 'blog_categories',
+      'langcode' => 'fr',
+      'name' => 'Catégorie éditoriale supplémentaire',
+      'weight' => 99,
+    ]);
+    $sentinel->save();
+    $sentinel_id = (int) $sentinel->id();
+
+    $first = _emerging_digital_content_ensure_initial_blog_categories();
+    self::assertSame(['created' => 5, 'updated' => 0], $first);
+
+    $expected = [
+      'd4390eaa-6097-4aee-89f8-eeed57401508' => [
+        'Décisions web / agence senior',
+        'Web decisions / senior agency',
+        0,
+      ],
+      'e7610b1c-2723-491e-837f-b0eff435f507' => [
+        'PHP / architecture / frameworks',
+        'PHP / architecture / frameworks',
+        1,
+      ],
+      '5d072809-6653-42a5-a404-bb6bb18a465e' => [
+        'Drupal comme expertise forte',
+        'Drupal expertise',
+        2,
+      ],
+      'fc8248c8-015b-4215-9354-ef554a16416d' => [
+        'IA encadrée',
+        'Governed AI',
+        3,
+      ],
+      'f2f77a08-e528-4ac7-9d78-24464bc99f21' => [
+        'Qualité web / SEO / accessibilité',
+        'Web quality / SEO / accessibility',
+        4,
+      ],
+    ];
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('taxonomy_term');
+    foreach ($expected as $uuid => [$fr, $en, $weight]) {
+      $matches = array_values($storage->loadByProperties(['uuid' => $uuid]));
+      self::assertCount(1, $matches);
+      $term = $matches[0];
+
+      self::assertSame('blog_categories', $term->bundle());
+      self::assertSame('fr', $term->language()->getId());
+      self::assertSame($fr, $term->label());
+      self::assertSame($weight, (int) $term->get('weight')->value);
+      self::assertTrue($term->isPublished());
+      self::assertTrue($term->hasTranslation('en'));
+      self::assertSame($en, $term->getTranslation('en')->label());
+    }
+
+    $second = _emerging_digital_content_ensure_initial_blog_categories();
+    self::assertSame(['created' => 0, 'updated' => 0], $second);
+
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('vid', 'blog_categories')
+      ->execute();
+    self::assertCount(6, $ids);
+
+    $sentinel_reloaded = $storage->load($sentinel_id);
+    self::assertNotNull($sentinel_reloaded);
+    self::assertSame('Catégorie éditoriale supplémentaire', $sentinel_reloaded->label());
+    self::assertSame(99, (int) $sentinel_reloaded->get('weight')->value);
+  }
+
+  /**
+   * Ensures an absent vocabulary fails closed instead of being recreated.
+   */
+  public function testMissingVocabularyFailsClosed(): void {
+    $vocabulary = Vocabulary::load('blog_categories');
+    self::assertNotNull($vocabulary);
+    $vocabulary->delete();
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Required blog_categories vocabulary does not exist.');
+
+    _emerging_digital_content_ensure_initial_blog_categories();
+  }
+
+  /**
+   * Ensures duplicate matching source labels fail closed.
+   */
+  public function testAmbiguousExistingLabelFailsClosed(): void {
+    foreach ([10, 11] as $weight) {
+      Term::create([
+        'vid' => 'blog_categories',
+        'langcode' => 'fr',
+        'name' => 'Décisions web / agence senior',
+        'weight' => $weight,
+      ])->save();
+    }
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage(
+      'Multiple Blog categories already use the FR label "Décisions web / agence senior".',
+    );
+
+    _emerging_digital_content_ensure_initial_blog_categories();
+  }
+
+}

--- a/web/modules/custom/emerging_digital_content/tests/src/Unit/BlogCategoriesDefaultContentTest.php
+++ b/web/modules/custom/emerging_digital_content/tests/src/Unit/BlogCategoriesDefaultContentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emerging_digital_content\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Validates the repository-owned initial Blog category package.
+ *
+ * @group emerging_digital_content
+ */
+final class BlogCategoriesDefaultContentTest extends TestCase {
+
+  /**
+   * Ensures the five packaged categories match issue #397.
+   */
+  public function testBlogCategoriesDefaultContentContract(): void {
+    $module_path = dirname(__DIR__, 3);
+    $info = Yaml::parseFile($module_path . '/emerging_digital_content.info.yml');
+
+    $expected = [
+      'd4390eaa-6097-4aee-89f8-eeed57401508' => [
+        'Décisions web / agence senior',
+        'Web decisions / senior agency',
+        0,
+      ],
+      'e7610b1c-2723-491e-837f-b0eff435f507' => [
+        'PHP / architecture / frameworks',
+        'PHP / architecture / frameworks',
+        1,
+      ],
+      '5d072809-6653-42a5-a404-bb6bb18a465e' => [
+        'Drupal comme expertise forte',
+        'Drupal expertise',
+        2,
+      ],
+      'fc8248c8-015b-4215-9354-ef554a16416d' => [
+        'IA encadrée',
+        'Governed AI',
+        3,
+      ],
+      'f2f77a08-e528-4ac7-9d78-24464bc99f21' => [
+        'Qualité web / SEO / accessibilité',
+        'Web quality / SEO / accessibility',
+        4,
+      ],
+    ];
+
+    self::assertContains('drupal:taxonomy', $info['dependencies'] ?? []);
+    self::assertSame(
+      array_keys($expected),
+      $info['default_content']['taxonomy_term'] ?? [],
+    );
+
+    foreach ($expected as $uuid => [$fr, $en, $weight]) {
+      $definition = Yaml::parseFile(
+        $module_path . '/content/taxonomy_term/' . $uuid . '.yml',
+      );
+
+      self::assertSame('1.0', $definition['_meta']['version'] ?? NULL);
+      self::assertSame('taxonomy_term', $definition['_meta']['entity_type'] ?? NULL);
+      self::assertSame($uuid, $definition['_meta']['uuid'] ?? NULL);
+      self::assertSame('blog_categories', $definition['_meta']['bundle'] ?? NULL);
+      self::assertSame('fr', $definition['_meta']['default_langcode'] ?? NULL);
+      self::assertTrue($definition['default']['status'][0]['value'] ?? FALSE);
+      self::assertSame($fr, $definition['default']['name'][0]['value'] ?? NULL);
+      self::assertSame($weight, $definition['default']['weight'][0]['value'] ?? NULL);
+      self::assertSame($en, $definition['translations']['en']['name'][0]['value'] ?? NULL);
+      self::assertTrue($definition['translations']['en']['status'][0]['value'] ?? FALSE);
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #578

Bloque #401 jusqu'à matérialisation des catégories en production.

## Cause démontrée

Le premier `/agency-editorial inspect` de #401 sur `main@ba01d122e7fa6871a80b44df6ea60f13effec905` (run `32425208372`) confirme que le runtime Article est prêt mais que `blog_categories` ne contient aucun terme (`runtime.categories = []`).

## Correction

- package les 5 piliers éditoriaux déjà décidés dans #397 comme `taxonomy_term` Default Content ;
- source FR + traduction EN ;
- UUID et poids stables ;
- ajoute `drupal:taxonomy` comme dépendance explicite du package ;
- ajoute `emerging_digital_content_update_11004()` pour les environnements déjà installés ;
- update idempotent et fail-closed sur vocabulaire absent, UUID hors vocabulaire ou doublon de label FR ;
- préserve les termes éditoriaux supplémentaires ;
- ne modifie aucun Article et n'intègre pas les Articles à Content Sync / Governed Content.

## Catégories

1. Décisions web / agence senior
2. PHP / architecture / frameworks
3. Drupal comme expertise forte
4. IA encadrée
5. Qualité web / SEO / accessibilité

#401 utilisera la cinquième catégorie après déploiement et nouvel inspect.

## Diff

9 fichiers uniquement :

- 5 fichiers `content/taxonomy_term/*.yml` ;
- `emerging_digital_content.info.yml` ;
- `emerging_digital_content.install` ;
- `BlogCategoriesDefaultContentTest.php` ;
- `BlogCategoriesUpdateTest.php`.

## Validation exact-HEAD

HEAD : `885db24cfa147321048ddf616a463eace8aef099`.

CI #1069 / run `32427009116` : **SUCCESS**.

- trusted runner syntax/profiles : PASS ;
- Composer validate/install : PASS ;
- PHPCS / PHPStan / drupal-check : PASS ;
- custom PHPUnit suite : PASS ;
- aucune review/thread en attente ;
- PR mergeable ;
- aucune mutation production effectuée.

## Décision sur le mécanisme de migration

#578 formulait initialement le backfill comme un post-update dans `emerging_digital_content.post_update.php`. L'implémentation finale utilise `emerging_digital_content_update_11004()` dans `.install` avec un helper idempotent/fail-closed.

Cette variation est volontairement acceptée : le déploiement autoritatif exécute déjà `drush updb -y`, qui exécute ce hook ; elle maintient l'ordre avec les updates `11001`–`11003`, tandis que les fresh installs utilisent les 5 entités `taxonomy_term` de Default Content. Le contrat métier reste inchangé : vocabulaire préexistant obligatoire, pas de création d'Article, pas de Content Sync/Governed Content pour les Articles, préservation des termes tiers, FR/EN déterministes.

## Déploiement

Aucun changement de `scripts/deploy-production.sh`. Le chemin existant `drush updb -y` doit exécuter l'update `11004`, puis le déploiement poursuit sa séquence habituelle.

Après merge + déploiement autorisé : nouvel inspect #401 -> TID réel -> payload -> dry-run -> apply -> image/ALT -> Browser Validation FR/EN.