### PR TITLE
[P1][Bug] Blog — corriger le backup gzip de la route éditoriale

### DIFF
--- a/scripts/runner/run-editorial-publication.sh
+++ b/scripts/runner/run-editorial-publication.sh
@@ -101,9 +101,10 @@ case "$MODE" in
     backup_file=''
     if [[ "$preapply_verdict" == 'READY' ]]; then
       timestamp="$(date -u +%Y%m%d%H%M%S)"
-      backup_file="/var/www/agency/shared/backups/editorial-issue-${ISSUE_NUMBER}-${timestamp}.sql.gz"
+      backup_stem="/var/www/agency/shared/backups/editorial-issue-${ISSUE_NUMBER}-${timestamp}.sql"
+      backup_file="${backup_stem}.gz"
       ssh "$remote_target" \
-        "set -euo pipefail; cd /var/www/agency/current; mkdir -p /var/www/agency/shared/backups; vendor/bin/drush sql:dump --gzip --result-file='$backup_file' >/dev/null; test -s '$backup_file'"
+        "set -euo pipefail; cd /var/www/agency/current; mkdir -p /var/www/agency/shared/backups; vendor/bin/drush sql:dump --gzip --result-file='$backup_stem' >/dev/null; test -s '$backup_file'"
     fi
 
     remote_run apply "$remote_result"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php
@@ -85,6 +85,14 @@ final class GovernedEditorialPublicationWorkflowTest extends TestCase {
     self::assertStringContainsString('/var/www/agency/current', $shell);
     self::assertStringContainsString('vendor/bin/drush sql:dump', $shell);
     self::assertStringContainsString('vendor/bin/drush php:script', $shell);
+    self::assertStringContainsString(
+      'backup_stem="/var/www/agency/shared/backups/editorial-issue-${ISSUE_NUMBER}-${timestamp}.sql"',
+      $shell,
+    );
+    self::assertStringContainsString('backup_file="${backup_stem}.gz"', $shell);
+    self::assertStringContainsString('--result-file=\'$backup_stem\'', $shell);
+    self::assertStringContainsString('test -s \'$backup_file\'', $shell);
+    self::assertStringNotContainsString('--result-file=\'$backup_file\'', $shell);
     self::assertStringContainsString("private const BUNDLE = 'article'", $php);
     self::assertStringContainsString("private const TEXT_FORMAT = 'basic_html'", $php);
     self::assertStringContainsString("private const AUTHOR_UID = 1", $php);


### PR DESCRIPTION
Closes #580

Bloque la reprise de #401 tant que la route trusted n'est pas réparée.

## Cause démontrée

L'apply #401 run `32428113911` a exécuté son second dry-run serveur en **PASS / READY**, puis Drush a créé :

`/var/www/agency/shared/backups/editorial-issue-401-20260820231905.sql.gz.gz`

Le runner fournissait déjà un `--result-file` suffixé `.sql.gz` avec `--gzip`, puis testait ce chemin `.sql.gz`. Drush ajoute son propre `.gz`, donc la vérification échouait avant `remote_run apply`.

Aucun `result.json` apply n'a été produit ; le preapply attestait encore `operation=create`.

## Correction bornée

- `backup_stem=...sql` ;
- `backup_file=${backup_stem}.gz` ;
- `drush sql:dump --gzip --result-file='$backup_stem'` ;
- `test -s '$backup_file'` ;
- le chemin final `.sql.gz` reste celui reporté dans la preuve apply ;
- test de régression interdisant le retour de `--result-file='$backup_file'`.

## Diff

2 fichiers uniquement :

- `scripts/runner/run-editorial-publication.sh` ;
- `web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPublicationWorkflowTest.php`.

Aucun changement de workflow, PHP applicatif, contenu, Content Sync/Governed Content ou déploiement production.

## Validation attendue

CI exact-HEAD GREEN, puis merge/deploy automatique et reprise #401 avec le payload existant, mais nouveau dry-run obligatoire car `main` aura changé.