### PR TITLE
[P1][Bug] Editorial route — finaliser les aliases Pathauto FR/EN

### DIFF
--- a/scripts/runner/editorial-publication-pathauto.php
+++ b/scripts/runner/editorial-publication-pathauto.php
@@ -2,276 +2,116 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\State\StateInterface;
-use Drupal\node\NodeInterface;
-use Drupal\path_alias\AliasManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\emerging_digital_content\Service\EditorialPathautoFinalizer;
 
-/**
- * Finalizes Pathauto aliases for the governed editor-owned Article route.
- */
-final class AgencyEditorialPathautoFinalizer {
+$mode = getenv('AGENCY_EDITORIAL_MODE') ?: '';
+$issueRaw = getenv('AGENCY_EDITORIAL_ISSUE') ?: '';
+$payloadSha = getenv('AGENCY_EDITORIAL_PAYLOAD_SHA') ?: '';
+$payloadPath = getenv('AGENCY_EDITORIAL_PAYLOAD_PATH') ?: '';
+$resultPath = getenv('AGENCY_EDITORIAL_RESULT_PATH') ?: '';
+$libraryPath = getenv('AGENCY_EDITORIAL_LIBRARY_PATH') ?: '';
 
-  private const BUNDLE = 'article';
-  private const SOURCE_LANGCODE = 'fr';
-  private const TRANSLATION_LANGCODE = 'en';
-  private const STATE_PREFIX = 'agency_editorial.issue.';
-  private const ALIAS_PREFIX = '/blog/';
+$writeResult = static function (array $result) use ($resultPath): void {
+  if ($resultPath === '') {
+    throw new RuntimeException('AGENCY_EDITORIAL_RESULT_PATH is required.');
+  }
+  file_put_contents(
+    $resultPath,
+    json_encode(
+      $result,
+      JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+    ) . PHP_EOL,
+  );
+};
 
-  public function __construct(
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly StateInterface $state,
-    private readonly AliasManagerInterface $aliasManager,
-    private readonly object $pathautoGenerator,
-  ) {
-    if (!method_exists($this->pathautoGenerator, 'updateEntityAlias')) {
-      throw new RuntimeException('Pathauto generator does not expose updateEntityAlias().');
-    }
+try {
+  if (!preg_match('/^[1-9][0-9]*$/', $issueRaw)) {
+    throw new InvalidArgumentException('AGENCY_EDITORIAL_ISSUE must be positive numeric.');
+  }
+  $issueNumber = (int) $issueRaw;
+  if (!in_array($mode, ['inspect', 'dry-run', 'apply'], TRUE)) {
+    throw new InvalidArgumentException('Unsupported AGENCY_EDITORIAL_MODE.');
+  }
+  if ($libraryPath === '' || !is_file($libraryPath)) {
+    throw new RuntimeException('Trusted editorial publication library is missing.');
   }
 
-  public static function fromContainer(ContainerInterface $container): self {
-    return new self(
-      $container->get('entity_type.manager'),
-      $container->get('state'),
-      $container->get('path_alias.manager'),
-      $container->get('pathauto.generator'),
-    );
+  if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
+    define('AGENCY_EDITORIAL_LIBRARY_ONLY', TRUE);
   }
+  require_once $libraryPath;
 
-  /**
-   * Reports whether the mapped Article needs derived alias repair.
-   */
-  public function inspect(int $issueNumber, string $payloadSha): array {
-    $node = $this->loadMappedNode($issueNumber, $payloadSha);
-    $aliases = $this->aliases($node);
-    $source = '/node/' . $node->id();
-    $needsRepair = [];
+  $publisher = AgencyEditorialPublication::fromContainer(\Drupal::getContainer());
+  $finalizer = EditorialPathautoFinalizer::fromContainer(\Drupal::getContainer());
 
-    foreach ([self::SOURCE_LANGCODE, self::TRANSLATION_LANGCODE] as $langcode) {
-      $alias = $aliases[$langcode];
-      if ($alias === $source || !str_starts_with($alias, self::ALIAS_PREFIX)) {
-        $needsRepair[] = $langcode;
-      }
-    }
-
-    return [
-      'status' => 'PASS',
-      'verdict' => $needsRepair === [] ? 'IDEMPOTENT' : 'REPAIR_REQUIRED',
-      'mode' => 'dry-run',
-      'issue_number' => $issueNumber,
-      'payload_sha256' => $payloadSha,
-      'aliases_to_repair' => $needsRepair,
-      'node' => $this->nodeResult($node, $aliases),
-    ];
-  }
-
-  /**
-   * Regenerates only missing/invalid derived aliases without saving the node.
-   */
-  public function apply(int $issueNumber, string $payloadSha): array {
-    $before = $this->inspect($issueNumber, $payloadSha);
-    if ($before['verdict'] === 'IDEMPOTENT') {
-      $before['mode'] = 'apply';
-      return $before;
-    }
-
-    $node = $this->loadMappedNode($issueNumber, $payloadSha);
-    $revisionId = (int) $node->getRevisionId();
-
-    foreach ($before['aliases_to_repair'] as $langcode) {
-      $translation = $node->getTranslation($langcode);
-      $this->pathautoGenerator->updateEntityAlias(
-        $translation,
-        'bulkupdate',
-        ['force' => TRUE],
+  if ($mode === 'inspect') {
+    $result = $publisher->inspect($issueNumber);
+    if (is_array($result['runtime']['mapping'] ?? NULL)) {
+      $aliasResult = $finalizer->inspect(
+        $issueNumber,
+        (string) $result['runtime']['mapping']['payload_sha256'],
       );
+      $result['runtime']['alias_finalization'] = [
+        'verdict' => $aliasResult['verdict'],
+        'aliases_to_repair' => $aliasResult['aliases_to_repair'],
+        'node' => $aliasResult['node'],
+      ];
     }
-
-    $this->entityTypeManager->getStorage('node')->resetCache([(int) $node->id()]);
-    $reloaded = $this->loadMappedNode($issueNumber, $payloadSha);
-    if ((int) $reloaded->getRevisionId() !== $revisionId) {
-      throw new RuntimeException('Pathauto alias repair unexpectedly created a node revision.');
-    }
-
-    $after = $this->inspect($issueNumber, $payloadSha);
-    if ($after['verdict'] !== 'IDEMPOTENT') {
-      throw new RuntimeException('Pathauto alias repair did not converge for FR and EN.');
-    }
-
-    $after['verdict'] = 'REPAIRED';
-    $after['mode'] = 'apply';
-    $after['aliases_to_repair'] = [];
-    return $after;
   }
-
-  private function loadMappedNode(int $issueNumber, string $payloadSha): NodeInterface {
-    $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
-    if (!is_array($mapping)) {
-      throw new RuntimeException('Editorial alias finalization requires an existing issue mapping.');
+  else {
+    if (!preg_match('/^[0-9a-f]{64}$/', $payloadSha)) {
+      throw new InvalidArgumentException('AGENCY_EDITORIAL_PAYLOAD_SHA must be SHA-256.');
     }
-
-    $nodeId = $mapping['node_id'] ?? NULL;
-    $mappedHash = $mapping['payload_sha256'] ?? NULL;
-    if (!is_int($nodeId) || !is_string($mappedHash)) {
-      throw new RuntimeException('Editorial alias finalization mapping is incomplete.');
+    if ($payloadPath === '' || !is_file($payloadPath)) {
+      throw new InvalidArgumentException('Editorial payload file is missing.');
     }
-    if (!hash_equals($mappedHash, $payloadSha)) {
-      throw new RuntimeException('Editorial alias finalization payload hash mismatch.');
+    $actualHash = hash_file('sha256', $payloadPath);
+    if (!is_string($actualHash) || !hash_equals($payloadSha, $actualHash)) {
+      throw new RuntimeException('Editorial payload hash mismatch on production.');
     }
-
-    $node = $this->entityTypeManager->getStorage('node')->load($nodeId);
-    if (!$node instanceof NodeInterface || $node->bundle() !== self::BUNDLE) {
-      throw new RuntimeException('Editorial alias finalization mapping points to an invalid Article.');
-    }
-    if (!$node->hasTranslation(self::TRANSLATION_LANGCODE)) {
-      throw new RuntimeException('Editorial alias finalization requires the EN translation.');
-    }
-
-    return $node;
-  }
-
-  private function aliases(NodeInterface $node): array {
-    $source = '/node/' . $node->id();
-    $this->aliasManager->cacheClear($source);
-
-    return [
-      self::SOURCE_LANGCODE => $this->aliasManager->getAliasByPath(
-        $source,
-        self::SOURCE_LANGCODE,
-      ),
-      self::TRANSLATION_LANGCODE => $this->aliasManager->getAliasByPath(
-        $source,
-        self::TRANSLATION_LANGCODE,
-      ),
-    ];
-  }
-
-  private function nodeResult(NodeInterface $node, array $aliases): array {
-    return [
-      'id' => (int) $node->id(),
-      'uuid' => $node->uuid(),
-      'revision_id' => (int) $node->getRevisionId(),
-      'published' => $node->isPublished(),
-      'title_fr' => $node->label(),
-      'title_en' => $node->getTranslation(self::TRANSLATION_LANGCODE)->label(),
-      'category_tid' => (int) $node->get('field_blog_category')->target_id,
-      'aliases' => $aliases,
-    ];
-  }
-
-}
-
-if (!defined('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY')) {
-  $mode = getenv('AGENCY_EDITORIAL_MODE') ?: '';
-  $issueRaw = getenv('AGENCY_EDITORIAL_ISSUE') ?: '';
-  $payloadSha = getenv('AGENCY_EDITORIAL_PAYLOAD_SHA') ?: '';
-  $payloadPath = getenv('AGENCY_EDITORIAL_PAYLOAD_PATH') ?: '';
-  $resultPath = getenv('AGENCY_EDITORIAL_RESULT_PATH') ?: '';
-  $libraryPath = getenv('AGENCY_EDITORIAL_LIBRARY_PATH') ?: '';
-
-  $writeResult = static function (array $result) use ($resultPath): void {
-    if ($resultPath === '') {
-      throw new RuntimeException('AGENCY_EDITORIAL_RESULT_PATH is required.');
-    }
-    file_put_contents(
-      $resultPath,
-      json_encode(
-        $result,
-        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-      ) . PHP_EOL,
+    $payload = json_decode(
+      (string) file_get_contents($payloadPath),
+      TRUE,
+      32,
+      JSON_THROW_ON_ERROR,
     );
-  };
-
-  try {
-    if (!preg_match('/^[1-9][0-9]*$/', $issueRaw)) {
-      throw new InvalidArgumentException('AGENCY_EDITORIAL_ISSUE must be positive numeric.');
-    }
-    $issueNumber = (int) $issueRaw;
-    if (!in_array($mode, ['inspect', 'dry-run', 'apply'], TRUE)) {
-      throw new InvalidArgumentException('Unsupported AGENCY_EDITORIAL_MODE.');
-    }
-    if ($libraryPath === '' || !is_file($libraryPath)) {
-      throw new RuntimeException('Trusted editorial publication library is missing.');
+    if (!is_array($payload)) {
+      throw new InvalidArgumentException('Editorial payload must decode to an object.');
     }
 
-    if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
-      define('AGENCY_EDITORIAL_LIBRARY_ONLY', TRUE);
-    }
-    require_once $libraryPath;
-
-    $publisher = AgencyEditorialPublication::fromContainer(\Drupal::getContainer());
-    $finalizer = AgencyEditorialPathautoFinalizer::fromContainer(\Drupal::getContainer());
-
-    if ($mode === 'inspect') {
-      $result = $publisher->inspect($issueNumber);
-      if (is_array($result['runtime']['mapping'] ?? NULL)) {
-        $aliasResult = $finalizer->inspect(
-          $issueNumber,
-          (string) $result['runtime']['mapping']['payload_sha256'],
-        );
-        $result['runtime']['alias_finalization'] = [
-          'verdict' => $aliasResult['verdict'],
-          'aliases_to_repair' => $aliasResult['aliases_to_repair'],
-          'node' => $aliasResult['node'],
-        ];
-      }
-    }
-    else {
-      if (!preg_match('/^[0-9a-f]{64}$/', $payloadSha)) {
-        throw new InvalidArgumentException('AGENCY_EDITORIAL_PAYLOAD_SHA must be SHA-256.');
-      }
-      if ($payloadPath === '' || !is_file($payloadPath)) {
-        throw new InvalidArgumentException('Editorial payload file is missing.');
-      }
-      $actualHash = hash_file('sha256', $payloadPath);
-      if (!is_string($actualHash) || !hash_equals($payloadSha, $actualHash)) {
-        throw new RuntimeException('Editorial payload hash mismatch on production.');
-      }
-      $payload = json_decode(
-        (string) file_get_contents($payloadPath),
-        TRUE,
-        32,
-        JSON_THROW_ON_ERROR,
-      );
-      if (!is_array($payload)) {
-        throw new InvalidArgumentException('Editorial payload must decode to an object.');
-      }
-
-      if ($mode === 'dry-run') {
-        $result = $publisher->dryRun($payload, $issueNumber, $payloadSha);
-        if ($result['verdict'] === 'IDEMPOTENT') {
-          $aliasResult = $finalizer->inspect($issueNumber, $payloadSha);
-          if ($aliasResult['verdict'] === 'REPAIR_REQUIRED') {
-            $result['verdict'] = 'REPAIR_REQUIRED';
-          }
-          $result['alias_finalization'] = $aliasResult['verdict'];
-          $result['aliases_to_repair'] = $aliasResult['aliases_to_repair'];
-          $result['node'] = $aliasResult['node'];
-        }
-      }
-      else {
-        $result = $publisher->apply($payload, $issueNumber, $payloadSha);
-        $aliasResult = $finalizer->apply($issueNumber, $payloadSha);
-        if ($result['verdict'] === 'IDEMPOTENT' && $aliasResult['verdict'] === 'REPAIRED') {
-          $result['verdict'] = 'REPAIRED';
+    if ($mode === 'dry-run') {
+      $result = $publisher->dryRun($payload, $issueNumber, $payloadSha);
+      if ($result['verdict'] === 'IDEMPOTENT') {
+        $aliasResult = $finalizer->inspect($issueNumber, $payloadSha);
+        if ($aliasResult['verdict'] === 'REPAIR_REQUIRED') {
+          $result['verdict'] = 'REPAIR_REQUIRED';
         }
         $result['alias_finalization'] = $aliasResult['verdict'];
         $result['aliases_to_repair'] = $aliasResult['aliases_to_repair'];
         $result['node'] = $aliasResult['node'];
       }
     }
+    else {
+      $result = $publisher->apply($payload, $issueNumber, $payloadSha);
+      $aliasResult = $finalizer->apply($issueNumber, $payloadSha);
+      if ($result['verdict'] === 'IDEMPOTENT' && $aliasResult['verdict'] === 'REPAIRED') {
+        $result['verdict'] = 'REPAIRED';
+      }
+      $result['alias_finalization'] = $aliasResult['verdict'];
+      $result['aliases_to_repair'] = $aliasResult['aliases_to_repair'];
+      $result['node'] = $aliasResult['node'];
+    }
+  }
 
-    $writeResult($result);
-  }
-  catch (Throwable $exception) {
-    $writeResult([
-      'status' => 'FAIL',
-      'verdict' => 'FAIL_CLOSED',
-      'mode' => $mode,
-      'issue_number' => ctype_digit($issueRaw) ? (int) $issueRaw : NULL,
-      'message' => $exception->getMessage(),
-    ]);
-    exit(1);
-  }
+  $writeResult($result);
+}
+catch (Throwable $exception) {
+  $writeResult([
+    'status' => 'FAIL',
+    'verdict' => 'FAIL_CLOSED',
+    'mode' => $mode,
+    'issue_number' => ctype_digit($issueRaw) ? (int) $issueRaw : NULL,
+    'message' => $exception->getMessage(),
+  ]);
+  exit(1);
 }

--- a/scripts/runner/editorial-publication-pathauto.php
+++ b/scripts/runner/editorial-publication-pathauto.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Finalizes Pathauto aliases for the governed editor-owned Article route.
+ */
+final class AgencyEditorialPathautoFinalizer {
+
+  private const BUNDLE = 'article';
+  private const SOURCE_LANGCODE = 'fr';
+  private const TRANSLATION_LANGCODE = 'en';
+  private const STATE_PREFIX = 'agency_editorial.issue.';
+  private const ALIAS_PREFIX = '/blog/';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly StateInterface $state,
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly object $pathautoGenerator,
+  ) {
+    if (!method_exists($this->pathautoGenerator, 'updateEntityAlias')) {
+      throw new RuntimeException('Pathauto generator does not expose updateEntityAlias().');
+    }
+  }
+
+  public static function fromContainer(ContainerInterface $container): self {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('state'),
+      $container->get('path_alias.manager'),
+      $container->get('pathauto.generator'),
+    );
+  }
+
+  /**
+   * Reports whether the mapped Article needs derived alias repair.
+   */
+  public function inspect(int $issueNumber, string $payloadSha): array {
+    $node = $this->loadMappedNode($issueNumber, $payloadSha);
+    $aliases = $this->aliases($node);
+    $source = '/node/' . $node->id();
+    $needsRepair = [];
+
+    foreach ([self::SOURCE_LANGCODE, self::TRANSLATION_LANGCODE] as $langcode) {
+      $alias = $aliases[$langcode];
+      if ($alias === $source || !str_starts_with($alias, self::ALIAS_PREFIX)) {
+        $needsRepair[] = $langcode;
+      }
+    }
+
+    return [
+      'status' => 'PASS',
+      'verdict' => $needsRepair === [] ? 'IDEMPOTENT' : 'REPAIR_REQUIRED',
+      'mode' => 'dry-run',
+      'issue_number' => $issueNumber,
+      'payload_sha256' => $payloadSha,
+      'aliases_to_repair' => $needsRepair,
+      'node' => $this->nodeResult($node, $aliases),
+    ];
+  }
+
+  /**
+   * Regenerates only missing/invalid derived aliases without saving the node.
+   */
+  public function apply(int $issueNumber, string $payloadSha): array {
+    $before = $this->inspect($issueNumber, $payloadSha);
+    if ($before['verdict'] === 'IDEMPOTENT') {
+      $before['mode'] = 'apply';
+      return $before;
+    }
+
+    $node = $this->loadMappedNode($issueNumber, $payloadSha);
+    $revisionId = (int) $node->getRevisionId();
+
+    foreach ($before['aliases_to_repair'] as $langcode) {
+      $translation = $node->getTranslation($langcode);
+      $this->pathautoGenerator->updateEntityAlias(
+        $translation,
+        'bulkupdate',
+        ['force' => TRUE],
+      );
+    }
+
+    $this->entityTypeManager->getStorage('node')->resetCache([(int) $node->id()]);
+    $reloaded = $this->loadMappedNode($issueNumber, $payloadSha);
+    if ((int) $reloaded->getRevisionId() !== $revisionId) {
+      throw new RuntimeException('Pathauto alias repair unexpectedly created a node revision.');
+    }
+
+    $after = $this->inspect($issueNumber, $payloadSha);
+    if ($after['verdict'] !== 'IDEMPOTENT') {
+      throw new RuntimeException('Pathauto alias repair did not converge for FR and EN.');
+    }
+
+    $after['verdict'] = 'REPAIRED';
+    $after['mode'] = 'apply';
+    $after['aliases_to_repair'] = [];
+    return $after;
+  }
+
+  private function loadMappedNode(int $issueNumber, string $payloadSha): NodeInterface {
+    $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
+    if (!is_array($mapping)) {
+      throw new RuntimeException('Editorial alias finalization requires an existing issue mapping.');
+    }
+
+    $nodeId = $mapping['node_id'] ?? NULL;
+    $mappedHash = $mapping['payload_sha256'] ?? NULL;
+    if (!is_int($nodeId) || !is_string($mappedHash)) {
+      throw new RuntimeException('Editorial alias finalization mapping is incomplete.');
+    }
+    if (!hash_equals($mappedHash, $payloadSha)) {
+      throw new RuntimeException('Editorial alias finalization payload hash mismatch.');
+    }
+
+    $node = $this->entityTypeManager->getStorage('node')->load($nodeId);
+    if (!$node instanceof NodeInterface || $node->bundle() !== self::BUNDLE) {
+      throw new RuntimeException('Editorial alias finalization mapping points to an invalid Article.');
+    }
+    if (!$node->hasTranslation(self::TRANSLATION_LANGCODE)) {
+      throw new RuntimeException('Editorial alias finalization requires the EN translation.');
+    }
+
+    return $node;
+  }
+
+  private function aliases(NodeInterface $node): array {
+    $source = '/node/' . $node->id();
+    $this->aliasManager->cacheClear($source);
+
+    return [
+      self::SOURCE_LANGCODE => $this->aliasManager->getAliasByPath(
+        $source,
+        self::SOURCE_LANGCODE,
+      ),
+      self::TRANSLATION_LANGCODE => $this->aliasManager->getAliasByPath(
+        $source,
+        self::TRANSLATION_LANGCODE,
+      ),
+    ];
+  }
+
+  private function nodeResult(NodeInterface $node, array $aliases): array {
+    return [
+      'id' => (int) $node->id(),
+      'uuid' => $node->uuid(),
+      'revision_id' => (int) $node->getRevisionId(),
+      'published' => $node->isPublished(),
+      'title_fr' => $node->label(),
+      'title_en' => $node->getTranslation(self::TRANSLATION_LANGCODE)->label(),
+      'category_tid' => (int) $node->get('field_blog_category')->target_id,
+      'aliases' => $aliases,
+    ];
+  }
+
+}
+
+if (!defined('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY')) {
+  $mode = getenv('AGENCY_EDITORIAL_MODE') ?: '';
+  $issueRaw = getenv('AGENCY_EDITORIAL_ISSUE') ?: '';
+  $payloadSha = getenv('AGENCY_EDITORIAL_PAYLOAD_SHA') ?: '';
+  $payloadPath = getenv('AGENCY_EDITORIAL_PAYLOAD_PATH') ?: '';
+  $resultPath = getenv('AGENCY_EDITORIAL_RESULT_PATH') ?: '';
+  $libraryPath = getenv('AGENCY_EDITORIAL_LIBRARY_PATH') ?: '';
+
+  $writeResult = static function (array $result) use ($resultPath): void {
+    if ($resultPath === '') {
+      throw new RuntimeException('AGENCY_EDITORIAL_RESULT_PATH is required.');
+    }
+    file_put_contents(
+      $resultPath,
+      json_encode(
+        $result,
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+      ) . PHP_EOL,
+    );
+  };
+
+  try {
+    if (!preg_match('/^[1-9][0-9]*$/', $issueRaw)) {
+      throw new InvalidArgumentException('AGENCY_EDITORIAL_ISSUE must be positive numeric.');
+    }
+    $issueNumber = (int) $issueRaw;
+    if (!in_array($mode, ['inspect', 'dry-run', 'apply'], TRUE)) {
+      throw new InvalidArgumentException('Unsupported AGENCY_EDITORIAL_MODE.');
+    }
+    if ($libraryPath === '' || !is_file($libraryPath)) {
+      throw new RuntimeException('Trusted editorial publication library is missing.');
+    }
+
+    if (!defined('AGENCY_EDITORIAL_LIBRARY_ONLY')) {
+      define('AGENCY_EDITORIAL_LIBRARY_ONLY', TRUE);
+    }
+    require_once $libraryPath;
+
+    $publisher = AgencyEditorialPublication::fromContainer(\Drupal::getContainer());
+    $finalizer = AgencyEditorialPathautoFinalizer::fromContainer(\Drupal::getContainer());
+
+    if ($mode === 'inspect') {
+      $result = $publisher->inspect($issueNumber);
+      if (is_array($result['runtime']['mapping'] ?? NULL)) {
+        $aliasResult = $finalizer->inspect(
+          $issueNumber,
+          (string) $result['runtime']['mapping']['payload_sha256'],
+        );
+        $result['runtime']['alias_finalization'] = [
+          'verdict' => $aliasResult['verdict'],
+          'aliases_to_repair' => $aliasResult['aliases_to_repair'],
+          'node' => $aliasResult['node'],
+        ];
+      }
+    }
+    else {
+      if (!preg_match('/^[0-9a-f]{64}$/', $payloadSha)) {
+        throw new InvalidArgumentException('AGENCY_EDITORIAL_PAYLOAD_SHA must be SHA-256.');
+      }
+      if ($payloadPath === '' || !is_file($payloadPath)) {
+        throw new InvalidArgumentException('Editorial payload file is missing.');
+      }
+      $actualHash = hash_file('sha256', $payloadPath);
+      if (!is_string($actualHash) || !hash_equals($payloadSha, $actualHash)) {
+        throw new RuntimeException('Editorial payload hash mismatch on production.');
+      }
+      $payload = json_decode(
+        (string) file_get_contents($payloadPath),
+        TRUE,
+        32,
+        JSON_THROW_ON_ERROR,
+      );
+      if (!is_array($payload)) {
+        throw new InvalidArgumentException('Editorial payload must decode to an object.');
+      }
+
+      if ($mode === 'dry-run') {
+        $result = $publisher->dryRun($payload, $issueNumber, $payloadSha);
+        if ($result['verdict'] === 'IDEMPOTENT') {
+          $aliasResult = $finalizer->inspect($issueNumber, $payloadSha);
+          if ($aliasResult['verdict'] === 'REPAIR_REQUIRED') {
+            $result['verdict'] = 'REPAIR_REQUIRED';
+          }
+          $result['alias_finalization'] = $aliasResult['verdict'];
+          $result['aliases_to_repair'] = $aliasResult['aliases_to_repair'];
+          $result['node'] = $aliasResult['node'];
+        }
+      }
+      else {
+        $result = $publisher->apply($payload, $issueNumber, $payloadSha);
+        $aliasResult = $finalizer->apply($issueNumber, $payloadSha);
+        if ($result['verdict'] === 'IDEMPOTENT' && $aliasResult['verdict'] === 'REPAIRED') {
+          $result['verdict'] = 'REPAIRED';
+        }
+        $result['alias_finalization'] = $aliasResult['verdict'];
+        $result['aliases_to_repair'] = $aliasResult['aliases_to_repair'];
+        $result['node'] = $aliasResult['node'];
+      }
+    }
+
+    $writeResult($result);
+  }
+  catch (Throwable $exception) {
+    $writeResult([
+      'status' => 'FAIL',
+      'verdict' => 'FAIL_CLOSED',
+      'mode' => $mode,
+      'issue_number' => ctype_digit($issueRaw) ? (int) $issueRaw : NULL,
+      'message' => $exception->getMessage(),
+    ]);
+    exit(1);
+  }
+}

--- a/scripts/runner/run-editorial-publication.sh
+++ b/scripts/runner/run-editorial-publication.sh
@@ -42,13 +42,17 @@ if [[ "$MODE" != 'inspect' ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PHP_SCRIPT="$SCRIPT_DIR/editorial-publication.php"
+LIBRARY_SCRIPT="$SCRIPT_DIR/editorial-publication.php"
+PHP_SCRIPT="$SCRIPT_DIR/editorial-publication-pathauto.php"
+[[ -f "$LIBRARY_SCRIPT" ]]
 [[ -f "$PHP_SCRIPT" ]]
+php -l "$LIBRARY_SCRIPT" >/dev/null
 php -l "$PHP_SCRIPT" >/dev/null
 mkdir -p "$ARTIFACT_DIR"
 
 remote_stem="/tmp/agency-editorial-${ISSUE_NUMBER}-${RUN_ID}-${RUN_ATTEMPT}"
 remote_script="${remote_stem}.php"
+remote_library="${remote_stem}-library.php"
 remote_payload="${remote_stem}.json"
 remote_result="${remote_stem}-result.json"
 remote_preapply="${remote_stem}-preapply.json"
@@ -57,12 +61,13 @@ remote_target="${SERVER_USER}@${SERVER_HOST}"
 cleanup_remote() {
   set +e
   ssh "$remote_target" \
-    "rm -f '$remote_script' '$remote_payload' '$remote_result' '$remote_preapply'" \
+    "rm -f '$remote_script' '$remote_library' '$remote_payload' '$remote_result' '$remote_preapply'" \
     >/dev/null 2>&1
 }
 trap cleanup_remote EXIT
 
 scp "$PHP_SCRIPT" "$remote_target:$remote_script" >/dev/null
+scp "$LIBRARY_SCRIPT" "$remote_target:$remote_library" >/dev/null
 if [[ "$MODE" != 'inspect' ]]; then
   scp "$PAYLOAD_FILE" "$remote_target:$remote_payload" >/dev/null
 fi
@@ -79,7 +84,7 @@ remote_run() {
   fi
 
   ssh "$remote_target" \
-    "set -euo pipefail; cd /var/www/agency/current; test -x vendor/bin/drush; vendor/bin/drush status --fields=bootstrap >/dev/null; AGENCY_EDITORIAL_MODE='$run_mode' AGENCY_EDITORIAL_ISSUE='$ISSUE_NUMBER' AGENCY_EDITORIAL_PAYLOAD_SHA='$payload_sha' AGENCY_EDITORIAL_PAYLOAD_PATH='$payload_path' AGENCY_EDITORIAL_RESULT_PATH='$remote_output' vendor/bin/drush php:script '$remote_script'"
+    "set -euo pipefail; cd /var/www/agency/current; test -x vendor/bin/drush; vendor/bin/drush status --fields=bootstrap >/dev/null; AGENCY_EDITORIAL_MODE='$run_mode' AGENCY_EDITORIAL_ISSUE='$ISSUE_NUMBER' AGENCY_EDITORIAL_PAYLOAD_SHA='$payload_sha' AGENCY_EDITORIAL_PAYLOAD_PATH='$payload_path' AGENCY_EDITORIAL_RESULT_PATH='$remote_output' AGENCY_EDITORIAL_LIBRARY_PATH='$remote_library' vendor/bin/drush php:script '$remote_script'"
 }
 
 case "$MODE" in
@@ -94,12 +99,12 @@ case "$MODE" in
   apply)
     remote_run dry-run "$remote_preapply"
     scp "$remote_target:$remote_preapply" "$ARTIFACT_DIR/preapply.json" >/dev/null
-    jq -e '.status == "PASS" and (.verdict == "READY" or .verdict == "IDEMPOTENT")' \
+    jq -e '.status == "PASS" and (.verdict == "READY" or .verdict == "REPAIR_REQUIRED" or .verdict == "IDEMPOTENT")' \
       "$ARTIFACT_DIR/preapply.json" >/dev/null
 
     preapply_verdict="$(jq -r '.verdict' "$ARTIFACT_DIR/preapply.json")"
     backup_file=''
-    if [[ "$preapply_verdict" == 'READY' ]]; then
+    if [[ "$preapply_verdict" == 'READY' || "$preapply_verdict" == 'REPAIR_REQUIRED' ]]; then
       timestamp="$(date -u +%Y%m%d%H%M%S)"
       backup_stem="/var/www/agency/shared/backups/editorial-issue-${ISSUE_NUMBER}-${timestamp}.sql"
       backup_file="${backup_stem}.gz"

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -35,6 +35,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'text',
     'node',
     'taxonomy',
     'language',

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -130,6 +130,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
       'alias' => '/blog/checklist-avant-une-refonte',
       'langcode' => 'fr',
     ])->save();
+    $this->container->get('path_alias.manager')->cacheClear();
 
     $hash = str_repeat('a', 64);
     $this->container->get('state')->set('agency_editorial.issue.401', [

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Kernel;
 
+use Drupal\emerging_digital_content\Service\EditorialPathautoFinalizer;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
 use Drupal\path_alias\Entity\PathAlias;
+use Drupal\pathauto\PathautoGeneratorInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\user\Entity\User;
@@ -38,6 +41,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     'content_translation',
     'path',
     'path_alias',
+    'emerging_digital_content',
   ];
 
   /**
@@ -132,42 +136,29 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
       'payload_sha256' => $hash,
     ]);
 
-    if (!defined('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY')) {
-      define('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY', TRUE);
-    }
-    require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication-pathauto.php';
+    $langcodes = [];
+    $generator = $this->createMock(PathautoGeneratorInterface::class);
+    $generator
+      ->method('updateEntityAlias')
+      ->willReturnCallback(
+        static function (NodeInterface $entity, string $op, array $options) use (&$langcodes): void {
+          self::assertSame('bulkupdate', $op);
+          self::assertSame(['force' => TRUE], $options);
+          $langcode = $entity->language()->getId();
+          $langcodes[] = $langcode;
+          $alias = $langcode === 'en'
+            ? '/blog/website-redesign-checklist'
+            : '/blog/checklist-avant-une-refonte';
 
-    $generator = new class() {
+          PathAlias::create([
+            'path' => '/node/' . $entity->id(),
+            'alias' => $alias,
+            'langcode' => $langcode,
+          ])->save();
+        },
+      );
 
-      /**
-       * Languages for which alias generation was requested.
-       *
-       * @var string[]
-       */
-      public array $langcodes = [];
-
-      /**
-       * Creates the deterministic test alias for the requested translation.
-       */
-      public function updateEntityAlias(object $entity, string $op, array $options = []): void {
-        unset($op, $options);
-        $langcode = $entity->language()->getId();
-        $this->langcodes[] = $langcode;
-        $nodeId = (int) $entity->id();
-        $alias = $langcode === 'en'
-          ? '/blog/website-redesign-checklist'
-          : '/blog/checklist-avant-une-refonte';
-
-        PathAlias::create([
-          'path' => '/node/' . $nodeId,
-          'alias' => $alias,
-          'langcode' => $langcode,
-        ])->save();
-      }
-
-    };
-
-    $finalizer = new \AgencyEditorialPathautoFinalizer(
+    $finalizer = new EditorialPathautoFinalizer(
       $this->container->get('entity_type.manager'),
       $this->container->get('state'),
       $this->container->get('path_alias.manager'),
@@ -182,7 +173,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     self::assertSame('REPAIRED', $applied['verdict']);
     self::assertSame('/blog/checklist-avant-une-refonte', $applied['node']['aliases']['fr']);
     self::assertSame('/blog/website-redesign-checklist', $applied['node']['aliases']['en']);
-    self::assertSame(['en'], $generator->langcodes);
+    self::assertSame(['en'], $langcodes);
 
     $reloaded = Node::load($nodeId);
     self::assertNotNull($reloaded);

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -54,6 +54,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('path_alias');
     $this->installSchema('node', ['node_access']);
+    $this->container->get('state')->set('router.path_roots', ['node']);
 
     foreach (['fr', 'en'] as $langcode) {
       if (ConfigurableLanguage::load($langcode) === NULL) {

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -137,7 +137,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     }
     require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication-pathauto.php';
 
-    $generator = new class {
+    $generator = new class() {
 
       /**
        * Languages for which alias generation was requested.

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\path_alias\Entity\PathAlias;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Covers alias-only repair for an already mapped editorial Article.
+ *
+ * @group agency_project_tests
+ * @group governed_editorial_publication
+ */
+#[Group('governed_editorial_publication')]
+final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'node',
+    'taxonomy',
+    'language',
+    'content_translation',
+    'path',
+    'path_alias',
+  ];
+
+  public function testMissingEnglishAliasIsRepairedWithoutNodeRevision(): void {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+
+    foreach (['fr', 'en'] as $langcode) {
+      if (ConfigurableLanguage::load($langcode) === NULL) {
+        ConfigurableLanguage::createFromLangcode($langcode)->save();
+      }
+    }
+
+    NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+      'new_revision' => TRUE,
+    ])->save();
+    $this->container
+      ->get('content_translation.manager')
+      ->setEnabled('node', 'article', TRUE);
+
+    Vocabulary::create([
+      'vid' => 'blog_categories',
+      'name' => 'Blog categories',
+    ])->save();
+    $category = Term::create([
+      'vid' => 'blog_categories',
+      'langcode' => 'fr',
+      'name' => 'Qualité web / SEO / accessibilité',
+    ]);
+    $category->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_blog_category',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'taxonomy_term'],
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_blog_category',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Blog category',
+      'translatable' => TRUE,
+      'settings' => [
+        'handler' => 'default:taxonomy_term',
+        'handler_settings' => [
+          'target_bundles' => ['blog_categories' => 'blog_categories'],
+        ],
+      ],
+    ])->save();
+
+    User::create([
+      'uid' => 1,
+      'name' => 'agency-editorial-test-admin',
+      'status' => 1,
+    ])->save();
+
+    $node = Node::create([
+      'type' => 'article',
+      'langcode' => 'fr',
+      'title' => 'Checklist avant une refonte',
+      'uid' => 1,
+      'status' => 1,
+      'field_blog_category' => [['target_id' => (int) $category->id()]],
+    ]);
+    $node->addTranslation('en', [
+      'title' => 'Website redesign checklist',
+      'status' => 1,
+      'field_blog_category' => [['target_id' => (int) $category->id()]],
+    ]);
+    $node->save();
+    $nodeId = (int) $node->id();
+    $revisionId = (int) $node->getRevisionId();
+
+    PathAlias::create([
+      'path' => '/node/' . $nodeId,
+      'alias' => '/blog/checklist-avant-une-refonte',
+      'langcode' => 'fr',
+    ])->save();
+
+    $hash = str_repeat('a', 64);
+    $this->container->get('state')->set('agency_editorial.issue.401', [
+      'node_id' => $nodeId,
+      'payload_sha256' => $hash,
+    ]);
+
+    if (!defined('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY')) {
+      define('AGENCY_EDITORIAL_PATHAUTO_LIBRARY_ONLY', TRUE);
+    }
+    require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication-pathauto.php';
+
+    $generator = new class($this->container->get('entity_type.manager')) {
+      public array $langcodes = [];
+
+      public function __construct(private readonly object $entityTypeManager) {}
+
+      public function updateEntityAlias(object $entity, string $op, array $options = []): void {
+        unset($op, $options);
+        $langcode = $entity->language()->getId();
+        $this->langcodes[] = $langcode;
+        $nodeId = (int) $entity->id();
+        $alias = $langcode === 'en'
+          ? '/blog/website-redesign-checklist'
+          : '/blog/checklist-avant-une-refonte';
+
+        PathAlias::create([
+          'path' => '/node/' . $nodeId,
+          'alias' => $alias,
+          'langcode' => $langcode,
+        ])->save();
+      }
+    };
+
+    $finalizer = new \AgencyEditorialPathautoFinalizer(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('state'),
+      $this->container->get('path_alias.manager'),
+      $generator,
+    );
+
+    $dryRun = $finalizer->inspect(401, $hash);
+    self::assertSame('REPAIR_REQUIRED', $dryRun['verdict']);
+    self::assertSame(['en'], $dryRun['aliases_to_repair']);
+
+    $applied = $finalizer->apply(401, $hash);
+    self::assertSame('REPAIRED', $applied['verdict']);
+    self::assertSame('/blog/checklist-avant-une-refonte', $applied['node']['aliases']['fr']);
+    self::assertSame('/blog/website-redesign-checklist', $applied['node']['aliases']['en']);
+    self::assertSame(['en'], $generator->langcodes);
+
+    $reloaded = Node::load($nodeId);
+    self::assertNotNull($reloaded);
+    self::assertSame($revisionId, (int) $reloaded->getRevisionId());
+    self::assertSame('Checklist avant une refonte', $reloaded->label());
+    self::assertSame('Website redesign checklist', $reloaded->getTranslation('en')->label());
+
+    $idempotent = $finalizer->inspect(401, $hash);
+    self::assertSame('IDEMPOTENT', $idempotent['verdict']);
+    self::assertSame([], $idempotent['aliases_to_repair']);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -25,6 +25,9 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('governed_editorial_publication')]
 final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'system',
     'user',
@@ -37,6 +40,9 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     'path_alias',
   ];
 
+  /**
+   * Missing EN alias is repaired without touching the Article revision.
+   */
   public function testMissingEnglishAliasIsRepairedWithoutNodeRevision(): void {
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -132,12 +138,24 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication-pathauto.php';
 
     $generator = new class($this->container->get('entity_type.manager')) {
+
+      /**
+       * Languages for which alias generation was requested.
+       *
+       * @var string[]
+       */
       public array $langcodes = [];
 
+      /**
+       * Constructs the bounded fake Pathauto generator.
+       */
       public function __construct(private readonly object $entityTypeManager) {}
 
+      /**
+       * Creates the deterministic test alias for the requested translation.
+       */
       public function updateEntityAlias(object $entity, string $op, array $options = []): void {
-        unset($op, $options);
+        unset($op, $options, $this->entityTypeManager);
         $langcode = $entity->language()->getId();
         $this->langcodes[] = $langcode;
         $nodeId = (int) $entity->id();
@@ -151,6 +169,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
           'langcode' => $langcode,
         ])->save();
       }
+
     };
 
     $finalizer = new \AgencyEditorialPathautoFinalizer(

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/GovernedEditorialPathautoKernelTest.php
@@ -137,7 +137,7 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
     }
     require_once dirname(DRUPAL_ROOT) . '/scripts/runner/editorial-publication-pathauto.php';
 
-    $generator = new class($this->container->get('entity_type.manager')) {
+    $generator = new class {
 
       /**
        * Languages for which alias generation was requested.
@@ -147,15 +147,10 @@ final class GovernedEditorialPathautoKernelTest extends KernelTestBase {
       public array $langcodes = [];
 
       /**
-       * Constructs the bounded fake Pathauto generator.
-       */
-      public function __construct(private readonly object $entityTypeManager) {}
-
-      /**
        * Creates the deterministic test alias for the requested translation.
        */
       public function updateEntityAlias(object $entity, string $op, array $options = []): void {
-        unset($op, $options, $this->entityTypeManager);
+        unset($op, $options);
         $langcode = $entity->language()->getId();
         $this->langcodes[] = $langcode;
         $nodeId = (int) $entity->id();

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
@@ -21,19 +21,28 @@ final class GovernedEditorialPathautoWorkflowTest extends TestCase {
     $root = dirname(DRUPAL_ROOT);
     $runner = (string) file_get_contents($root . '/scripts/runner/run-editorial-publication.sh');
     $wrapper = (string) file_get_contents($root . '/scripts/runner/editorial-publication-pathauto.php');
+    $finalizer = (string) file_get_contents(
+      DRUPAL_ROOT . '/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php',
+    );
+    $moduleInfo = (string) file_get_contents(
+      DRUPAL_ROOT . '/modules/custom/emerging_digital_content/emerging_digital_content.info.yml',
+    );
 
     self::assertStringContainsString('editorial-publication-pathauto.php', $runner);
     self::assertStringContainsString('AGENCY_EDITORIAL_LIBRARY_PATH', $runner);
     self::assertStringContainsString('.verdict == "REPAIR_REQUIRED"', $runner);
     self::assertStringContainsString('$preapply_verdict" == \'REPAIR_REQUIRED\'', $runner);
-    self::assertStringContainsString('$container->get(\'pathauto.generator\')', $wrapper);
-    self::assertStringContainsString('updateEntityAlias(', $wrapper);
-    self::assertStringContainsString("'bulkupdate'", $wrapper);
-    self::assertStringContainsString("['force' => TRUE]", $wrapper);
-    self::assertStringContainsString("private const ALIAS_PREFIX = '/blog/'", $wrapper);
-    self::assertStringNotContainsString('->save()', $wrapper);
-    self::assertStringNotContainsString('PathAlias::create', $wrapper);
-    self::assertStringNotContainsString('->delete(', $wrapper);
+    self::assertStringContainsString('EditorialPathautoFinalizer::fromContainer', $wrapper);
+    self::assertStringContainsString("$container->get('pathauto.generator')", $finalizer);
+    self::assertStringContainsString('PathautoGeneratorInterface', $finalizer);
+    self::assertStringContainsString('updateEntityAlias(', $finalizer);
+    self::assertStringContainsString("'bulkupdate'", $finalizer);
+    self::assertStringContainsString("['force' => TRUE]", $finalizer);
+    self::assertStringContainsString("private const ALIAS_PREFIX = '/blog/'", $finalizer);
+    self::assertStringContainsString('- drupal:pathauto', $moduleInfo);
+    self::assertStringNotContainsString('->save()', $finalizer);
+    self::assertStringNotContainsString('PathAlias::create', $finalizer);
+    self::assertStringNotContainsString('->delete(', $finalizer);
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded Pathauto finalization layered onto editorial publication.
+ *
+ * @group agency_project_tests
+ * @group governed_editorial_publication
+ */
+final class GovernedEditorialPathautoWorkflowTest extends TestCase {
+
+  public function testRunnerTreatsAliasRepairAsGuardedMutation(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runner = (string) file_get_contents($root . '/scripts/runner/run-editorial-publication.sh');
+    $wrapper = (string) file_get_contents($root . '/scripts/runner/editorial-publication-pathauto.php');
+
+    self::assertStringContainsString('editorial-publication-pathauto.php', $runner);
+    self::assertStringContainsString('AGENCY_EDITORIAL_LIBRARY_PATH', $runner);
+    self::assertStringContainsString('.verdict == "REPAIR_REQUIRED"', $runner);
+    self::assertStringContainsString('$preapply_verdict" == \'REPAIR_REQUIRED\'', $runner);
+    self::assertStringContainsString('$container->get(\'pathauto.generator\')', $wrapper);
+    self::assertStringContainsString('updateEntityAlias(', $wrapper);
+    self::assertStringContainsString("'bulkupdate'", $wrapper);
+    self::assertStringContainsString("['force' => TRUE]", $wrapper);
+    self::assertStringContainsString("private const ALIAS_PREFIX = '/blog/'", $wrapper);
+    self::assertStringNotContainsString('->save()', $wrapper);
+    self::assertStringNotContainsString('PathAlias::create', $wrapper);
+    self::assertStringNotContainsString('->delete(', $wrapper);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
@@ -33,7 +33,7 @@ final class GovernedEditorialPathautoWorkflowTest extends TestCase {
     self::assertStringContainsString('.verdict == "REPAIR_REQUIRED"', $runner);
     self::assertStringContainsString('$preapply_verdict" == \'REPAIR_REQUIRED\'', $runner);
     self::assertStringContainsString('EditorialPathautoFinalizer::fromContainer', $wrapper);
-    self::assertStringContainsString("$container->get('pathauto.generator')", $finalizer);
+    self::assertStringContainsString('$container->get(\'pathauto.generator\')', $finalizer);
     self::assertStringContainsString('PathautoGeneratorInterface', $finalizer);
     self::assertStringContainsString('updateEntityAlias(', $finalizer);
     self::assertStringContainsString("'bulkupdate'", $finalizer);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
@@ -7,8 +7,7 @@ namespace Drupal\Tests\agency_project_tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Protects the bounded Pathauto finalization layered onto editorial
- * publication.
+ * Protects bounded Pathauto finalization for editorial publication.
  *
  * @group agency_project_tests
  * @group governed_editorial_publication

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedEditorialPathautoWorkflowTest.php
@@ -7,13 +7,17 @@ namespace Drupal\Tests\agency_project_tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Protects the bounded Pathauto finalization layered onto editorial publication.
+ * Protects the bounded Pathauto finalization layered onto editorial
+ * publication.
  *
  * @group agency_project_tests
  * @group governed_editorial_publication
  */
 final class GovernedEditorialPathautoWorkflowTest extends TestCase {
 
+  /**
+   * Alias-only repair must remain a guarded, Pathauto-owned mutation.
+   */
   public function testRunnerTreatsAliasRepairAsGuardedMutation(): void {
     $root = dirname(DRUPAL_ROOT);
     $runner = (string) file_get_contents($root . '/scripts/runner/run-editorial-publication.sh');

--- a/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
+++ b/web/modules/custom/emerging_digital_content/emerging_digital_content.info.yml
@@ -11,6 +11,7 @@ dependencies:
   - drupal:node
   - drupal:path
   - drupal:path_alias
+  - drupal:pathauto
   - drupal:paragraphs
   - drupal:serialization
   - drupal:hal

--- a/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
+++ b/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\emerging_digital_content\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\pathauto\PathautoGeneratorInterface;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Finalizes derived Pathauto aliases for governed editor-owned Articles.
+ */
+final class EditorialPathautoFinalizer {
+
+  private const BUNDLE = 'article';
+  private const SOURCE_LANGCODE = 'fr';
+  private const TRANSLATION_LANGCODE = 'en';
+  private const STATE_PREFIX = 'agency_editorial.issue.';
+  private const ALIAS_PREFIX = '/blog/';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly StateInterface $state,
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly PathautoGeneratorInterface $pathautoGenerator,
+  ) {
+  }
+
+  /**
+   * Builds the finalizer from Drupal's existing public services.
+   */
+  public static function fromContainer(ContainerInterface $container): self {
+    $pathautoGenerator = $container->get('pathauto.generator');
+    if (!$pathautoGenerator instanceof PathautoGeneratorInterface) {
+      throw new RuntimeException('Pathauto generator service is unavailable.');
+    }
+
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('state'),
+      $container->get('path_alias.manager'),
+      $pathautoGenerator,
+    );
+  }
+
+  /**
+   * Reports whether the mapped Article needs derived alias repair.
+   *
+   * @return array<string, mixed>
+   *   Structured alias-finalization evidence.
+   */
+  public function inspect(int $issueNumber, string $payloadSha): array {
+    $node = $this->loadMappedNode($issueNumber, $payloadSha);
+    $aliases = $this->aliases($node);
+    $source = '/node/' . $node->id();
+    $needsRepair = [];
+
+    foreach ([self::SOURCE_LANGCODE, self::TRANSLATION_LANGCODE] as $langcode) {
+      $alias = $aliases[$langcode];
+      if ($alias === $source || !str_starts_with($alias, self::ALIAS_PREFIX)) {
+        $needsRepair[] = $langcode;
+      }
+    }
+
+    return [
+      'status' => 'PASS',
+      'verdict' => $needsRepair === [] ? 'IDEMPOTENT' : 'REPAIR_REQUIRED',
+      'mode' => 'dry-run',
+      'issue_number' => $issueNumber,
+      'payload_sha256' => $payloadSha,
+      'aliases_to_repair' => $needsRepair,
+      'node' => $this->nodeResult($node, $aliases),
+    ];
+  }
+
+  /**
+   * Regenerates only missing derived aliases without saving the Article.
+   *
+   * @return array<string, mixed>
+   *   Structured alias-finalization evidence.
+   */
+  public function apply(int $issueNumber, string $payloadSha): array {
+    $before = $this->inspect($issueNumber, $payloadSha);
+    if ($before['verdict'] === 'IDEMPOTENT') {
+      $before['mode'] = 'apply';
+      return $before;
+    }
+
+    $node = $this->loadMappedNode($issueNumber, $payloadSha);
+    $revisionId = (int) $node->getRevisionId();
+
+    foreach ($before['aliases_to_repair'] as $langcode) {
+      $translation = $node->getTranslation($langcode);
+      $this->pathautoGenerator->updateEntityAlias(
+        $translation,
+        'bulkupdate',
+        ['force' => TRUE],
+      );
+    }
+
+    $this->entityTypeManager->getStorage('node')->resetCache([(int) $node->id()]);
+    $reloaded = $this->loadMappedNode($issueNumber, $payloadSha);
+    if ((int) $reloaded->getRevisionId() !== $revisionId) {
+      throw new RuntimeException('Pathauto alias repair unexpectedly created a node revision.');
+    }
+
+    $after = $this->inspect($issueNumber, $payloadSha);
+    if ($after['verdict'] !== 'IDEMPOTENT') {
+      throw new RuntimeException('Pathauto alias repair did not converge for FR and EN.');
+    }
+
+    $after['verdict'] = 'REPAIRED';
+    $after['mode'] = 'apply';
+    $after['aliases_to_repair'] = [];
+    return $after;
+  }
+
+  /**
+   * Loads the Article bound to the exact issue and payload hash.
+   */
+  private function loadMappedNode(int $issueNumber, string $payloadSha): NodeInterface {
+    $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
+    if (!is_array($mapping)) {
+      throw new RuntimeException('Editorial alias finalization requires an existing issue mapping.');
+    }
+
+    $nodeId = $mapping['node_id'] ?? NULL;
+    $mappedHash = $mapping['payload_sha256'] ?? NULL;
+    if (!is_int($nodeId) || !is_string($mappedHash)) {
+      throw new RuntimeException('Editorial alias finalization mapping is incomplete.');
+    }
+    if (!hash_equals($mappedHash, $payloadSha)) {
+      throw new RuntimeException('Editorial alias finalization payload hash mismatch.');
+    }
+
+    $node = $this->entityTypeManager->getStorage('node')->load($nodeId);
+    if (!$node instanceof NodeInterface || $node->bundle() !== self::BUNDLE) {
+      throw new RuntimeException('Editorial alias finalization mapping points to an invalid Article.');
+    }
+    if (!$node->hasTranslation(self::TRANSLATION_LANGCODE)) {
+      throw new RuntimeException('Editorial alias finalization requires the EN translation.');
+    }
+
+    return $node;
+  }
+
+  /**
+   * Returns current FR and EN aliases for the mapped Article.
+   *
+   * @return array<string, string>
+   *   Aliases keyed by language code.
+   */
+  private function aliases(NodeInterface $node): array {
+    $source = '/node/' . $node->id();
+    $this->aliasManager->cacheClear($source);
+
+    return [
+      self::SOURCE_LANGCODE => $this->aliasManager->getAliasByPath(
+        $source,
+        self::SOURCE_LANGCODE,
+      ),
+      self::TRANSLATION_LANGCODE => $this->aliasManager->getAliasByPath(
+        $source,
+        self::TRANSLATION_LANGCODE,
+      ),
+    ];
+  }
+
+  /**
+   * Builds immutable Article evidence for the route result.
+   *
+   * @param array<string, string> $aliases
+   *   Current aliases keyed by language code.
+   *
+   * @return array<string, mixed>
+   *   Node evidence without editorial mutation.
+   */
+  private function nodeResult(NodeInterface $node, array $aliases): array {
+    return [
+      'id' => (int) $node->id(),
+      'uuid' => $node->uuid(),
+      'revision_id' => (int) $node->getRevisionId(),
+      'published' => $node->isPublished(),
+      'title_fr' => $node->label(),
+      'title_en' => $node->getTranslation(self::TRANSLATION_LANGCODE)->label(),
+      'category_tid' => (int) $node->get('field_blog_category')->target_id,
+      'aliases' => $aliases,
+    ];
+  }
+
+}

--- a/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
+++ b/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
@@ -34,16 +34,11 @@ final class EditorialPathautoFinalizer {
    * Builds the finalizer from Drupal's existing public services.
    */
   public static function fromContainer(ContainerInterface $container): self {
-    $pathautoGenerator = $container->get('pathauto.generator');
-    if (!$pathautoGenerator instanceof PathautoGeneratorInterface) {
-      throw new \RuntimeException('Pathauto generator service is unavailable.');
-    }
-
     return new self(
       $container->get('entity_type.manager'),
       $container->get('state'),
       $container->get('path_alias.manager'),
-      $pathautoGenerator,
+      $container->get('pathauto.generator'),
     );
   }
 

--- a/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
+++ b/web/modules/custom/emerging_digital_content/src/Service/EditorialPathautoFinalizer.php
@@ -9,7 +9,6 @@ use Drupal\Core\State\StateInterface;
 use Drupal\node\NodeInterface;
 use Drupal\path_alias\AliasManagerInterface;
 use Drupal\pathauto\PathautoGeneratorInterface;
-use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -37,7 +36,7 @@ final class EditorialPathautoFinalizer {
   public static function fromContainer(ContainerInterface $container): self {
     $pathautoGenerator = $container->get('pathauto.generator');
     if (!$pathautoGenerator instanceof PathautoGeneratorInterface) {
-      throw new RuntimeException('Pathauto generator service is unavailable.');
+      throw new \RuntimeException('Pathauto generator service is unavailable.');
     }
 
     return new self(
@@ -106,12 +105,12 @@ final class EditorialPathautoFinalizer {
     $this->entityTypeManager->getStorage('node')->resetCache([(int) $node->id()]);
     $reloaded = $this->loadMappedNode($issueNumber, $payloadSha);
     if ((int) $reloaded->getRevisionId() !== $revisionId) {
-      throw new RuntimeException('Pathauto alias repair unexpectedly created a node revision.');
+      throw new \RuntimeException('Pathauto alias repair unexpectedly created a node revision.');
     }
 
     $after = $this->inspect($issueNumber, $payloadSha);
     if ($after['verdict'] !== 'IDEMPOTENT') {
-      throw new RuntimeException('Pathauto alias repair did not converge for FR and EN.');
+      throw new \RuntimeException('Pathauto alias repair did not converge for FR and EN.');
     }
 
     $after['verdict'] = 'REPAIRED';
@@ -126,24 +125,24 @@ final class EditorialPathautoFinalizer {
   private function loadMappedNode(int $issueNumber, string $payloadSha): NodeInterface {
     $mapping = $this->state->get(self::STATE_PREFIX . $issueNumber);
     if (!is_array($mapping)) {
-      throw new RuntimeException('Editorial alias finalization requires an existing issue mapping.');
+      throw new \RuntimeException('Editorial alias finalization requires an existing issue mapping.');
     }
 
     $nodeId = $mapping['node_id'] ?? NULL;
     $mappedHash = $mapping['payload_sha256'] ?? NULL;
     if (!is_int($nodeId) || !is_string($mappedHash)) {
-      throw new RuntimeException('Editorial alias finalization mapping is incomplete.');
+      throw new \RuntimeException('Editorial alias finalization mapping is incomplete.');
     }
     if (!hash_equals($mappedHash, $payloadSha)) {
-      throw new RuntimeException('Editorial alias finalization payload hash mismatch.');
+      throw new \RuntimeException('Editorial alias finalization payload hash mismatch.');
     }
 
     $node = $this->entityTypeManager->getStorage('node')->load($nodeId);
     if (!$node instanceof NodeInterface || $node->bundle() !== self::BUNDLE) {
-      throw new RuntimeException('Editorial alias finalization mapping points to an invalid Article.');
+      throw new \RuntimeException('Editorial alias finalization mapping points to an invalid Article.');
     }
     if (!$node->hasTranslation(self::TRANSLATION_LANGCODE)) {
-      throw new RuntimeException('Editorial alias finalization requires the EN translation.');
+      throw new \RuntimeException('Editorial alias finalization requires the EN translation.');
     }
 
     return $node;
@@ -174,6 +173,8 @@ final class EditorialPathautoFinalizer {
   /**
    * Builds immutable Article evidence for the route result.
    *
+   * @param \Drupal\node\NodeInterface $node
+   *   The mapped Article.
    * @param array<string, string> $aliases
    *   Current aliases keyed by language code.
    *


### PR DESCRIPTION
## Résumé

Corrige #582, reproduit à partir de #401 : un Article bilingue peut être correctement publié et mappé par la route gouvernée tout en conservant `/node/{nid}` pour une traduction dont Pathauto n'a pas finalisé l'alias.

## Implémentation

- ajoute un finalizer borné `editorial-publication-pathauto.php` autour de la route v1 existante ;
- réutilise le mapping issue/hash/node et le validateur éditorial existants ;
- détecte `REPAIR_REQUIRED` en dry-run lorsque FR/EN n'ont pas tous deux un alias `/blog/...` ;
- régénère uniquement les aliases dérivés via le service Drupal `pathauto.generator` et `updateEntityAlias(..., 'bulkupdate', ['force' => TRUE])` ;
- ne sauvegarde pas le node et vérifie que la révision ne change pas ;
- étend le runner pour sauvegarder la DB avant une réparation d'alias, comme avant une création ;
- conserve les patterns Pathauto versionnés comme seule source de vérité : aucun alias libre/hardcodé en production.

## Tests

- contrat unitaire du runner/wrapper ;
- Kernel : node FR+EN déjà mappé, alias FR existant, alias EN manquant ;
- dry-run => `REPAIR_REQUIRED` ;
- apply => réparation EN uniquement ;
- révision et titres inchangés ;
- second inspect => `IDEMPOTENT`.

## Preuve exacte

- HEAD : `72b4650177cd1ea2342ffd86334c3af9be27f661` ;
- CI #1089 / run `32466611236` : SUCCESS ;
- trusted runner syntax/profiles : PASS ;
- Composer validate/install : PASS ;
- PHPCS / PHPStan / drupal-check : PASS ;
- custom PHPUnit suite (56 tests) : PASS ;
- aucune review ni thread ouvert ;
- `main` de base : `f31b48b87178c9c6ef94658df0210850c09bb6f0`.

## Hors scope

- image/ALT #401 ;
- Browser Validation production ;
- contenu éditorial/payload v1 ;
- workflow de déploiement.

La clôture de #582 reste volontairement différée jusqu’au déploiement et à la preuve #401 exigés par l’issue.

Refs #582