### PR TITLE
[P1][Infra] Browser Validation — preuve production bornée Article editor-owned

### DIFF
--- a/.github/workflows/trusted-production-editorial-browser-proof.yml
+++ b/.github/workflows/trusted-production-editorial-browser-proof.yml
@@ -1,0 +1,207 @@
+name: Agency trusted production editorial browser proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-editorial-browser-proof:
+    name: Validate editor-owned Article in production
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-browser validate'
+      }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - browser
+    timeout-minutes: 15
+    concurrency:
+      group: agency-production-editorial-browser-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate actor, issue and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-browser validate' ]]
+          [[ "$ISSUE_NUMBER" == '401' ]] || {
+            echo 'Production editorial browser proof v1 is restricted to issue #401.' >&2
+            exit 1
+          }
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Production browser proof must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+          echo 'contract=tests/browser/contracts/production-editorial-401.json' >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable production profile and implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.request.outputs.main_sha }}
+          CONTRACT: ${{ steps.request.outputs.contract }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          [[ "$CONTRACT" == 'tests/browser/contracts/production-editorial-401.json' ]]
+          test -f "$CONTRACT"
+          test -f tests/browser/production-editorial-article.spec.mjs
+          test -f scripts/run-browser-validation.mjs
+          test -f tests/browser/support/browser-audit.mjs
+          jq -e '
+            .issue_number == 401 and
+            .origin == "https://emergingdigital.be" and
+            .target == "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier" and
+            .actor == "anonymous"
+          ' "$CONTRACT" >/dev/null
+          git diff --check
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install exact browser dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install chromium
+
+      - name: Run read-only production proof
+        id: proof
+        shell: bash
+        env:
+          CI: 'true'
+          BROWSER_VALIDATION_BASE_URL: https://emergingdigital.be
+          BROWSER_VALIDATION_CONTRACT: ${{ steps.request.outputs.contract }}
+        run: |
+          set -euo pipefail
+          npm run browser:validate -- tests/browser/production-editorial-article.spec.mjs
+
+      - name: Upload production browser evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-editorial-browser-${{ github.event.issue.number }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/browser-validation
+            playwright-report
+            test-results
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          PROOF_OUTCOME: ${{ steps.proof.outcome }}
+        run: |
+          set -euo pipefail
+          result_file='artifacts/browser-validation/result.json'
+          result='MISSING'
+          functional='NOT_RUN'
+          dom='NOT_RUN'
+          visual_desktop='NOT_RUN'
+          visual_mobile='NOT_RUN'
+          console_errors='n/a'
+          page_errors='n/a'
+          unexpected_http_4xx='n/a'
+          http_5xx='n/a'
+          failed_requests='n/a'
+
+          if [[ -s "$result_file" ]] && jq -e . "$result_file" >/dev/null 2>&1; then
+            result="$(jq -r '.result // "UNKNOWN"' "$result_file")"
+            functional="$(jq -r '.functional // "NOT_RUN"' "$result_file")"
+            dom="$(jq -r '.dom // "NOT_RUN"' "$result_file")"
+            visual_desktop="$(jq -r '.visual_desktop // "NOT_RUN"' "$result_file")"
+            visual_mobile="$(jq -r '.visual_mobile // "NOT_RUN"' "$result_file")"
+            console_errors="$(jq -r '.console_errors // "n/a"' "$result_file")"
+            page_errors="$(jq -r '.page_errors // "n/a"' "$result_file")"
+            unexpected_http_4xx="$(jq -r '.unexpected_http_4xx // "n/a"' "$result_file")"
+            http_5xx="$(jq -r '.http_5xx // "n/a"' "$result_file")"
+            failed_requests="$(jq -r '.failed_requests // "n/a"' "$result_file")"
+          fi
+
+          heading="### Agency production browser ${result}"
+          if [[ "$PROOF_OUTCOME" == 'success' && "$result" == 'PASS' ]]; then
+            heading='### Agency production browser PASS'
+          fi
+          artifact="agency-production-editorial-browser-${ISSUE_NUMBER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${PROOF_OUTCOME:-unknown}\`
+          result: \`${result}\`
+          functional: \`${functional}\`
+          dom: \`${dom}\`
+          visual_desktop: \`${visual_desktop}\`
+          visual_mobile: \`${visual_mobile}\`
+          console_errors: \`${console_errors}\`
+          page_errors: \`${page_errors}\`
+          unexpected_http_4xx: \`${unexpected_http_4xx}\`
+          http_5xx: \`${http_5xx}\`
+          failed_requests: \`${failed_requests}\`
+          artifact: \`${artifact}\`
+
+          This route is read-only and restricted to the repository-owned public production profile for issue #401. It accepts no URL, selector, shell, Playwright argument, credential or mutation input.
+          EOF_BODY
+          )"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"
+
+      - name: Clean browser artifacts and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          rm -rf artifacts/browser-validation playwright-report test-results
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi

--- a/docs/operations/production-editorial-browser-proof.md
+++ b/docs/operations/production-editorial-browser-proof.md
@@ -1,0 +1,169 @@
+# Production editorial browser proof
+
+Status: **GOVERNED / READ-ONLY**  
+Owner: #586  
+Initial consumer: #401
+
+## Purpose
+
+Ordinary Blog Articles are editor-owned in Drupal and intentionally outside
+Content Sync. The canonical self-hosted Browser Validation route rebuilds a
+fresh DDEV site from repository-owned state, so it cannot prove the final public
+rendering of an editor-owned Article that exists only in production.
+
+Issue #586 adds a separate, bounded proof for that case. It reuses the existing
+Playwright Test, Chromium, browser audit and machine-readable result primitives,
+but targets the public production origin read-only.
+
+This route complements the DDEV Browser Validation route; it does not replace it.
+
+## Control surface
+
+The only v1 command is an exact issue comment:
+
+```text
+/agency-production-browser validate
+```
+
+The workflow accepts the command only when all of the following are true:
+
+- the event belongs to an issue, not a pull request;
+- the actor and comment author are exactly `E-merging-digital`;
+- the issue is OPEN and owner-created;
+- the issue number is exactly `401`;
+- the workflow revision is the current live `main` revision.
+
+No URL, selector, path, shell command, Playwright argument, credential or
+mutation flag comes from the comment.
+
+## Repository-owned profile
+
+The v1 profile is:
+
+```text
+tests/browser/contracts/production-editorial-401.json
+```
+
+It fixes:
+
+- production origin `https://emergingdigital.be`;
+- FR and EN Article paths;
+- expected H1 and document languages;
+- category label;
+- FR and EN image ALT values;
+- canonical URLs;
+- FR/EN/x-default hreflang URLs;
+- sitemap endpoint;
+- the bounded set of internal links that must resolve.
+
+Adding another Article requires a reviewed repository change. The issue comment
+cannot select an arbitrary contract.
+
+## Execution model
+
+```text
+owner issue comment
+-> job-level actor/command filter
+-> agency-browser-runner-01
+-> verify OPEN owner-created #401 + live main
+-> checkout exact trusted main without persisted credentials
+-> verify immutable #401 contract
+-> Node 24 + npm ci + Playwright Chromium
+-> BROWSER_VALIDATION_BASE_URL=https://emergingdigital.be
+-> existing browser validation runner
+-> production editorial Playwright scenario
+-> desktop + mobile evidence
+-> artifact upload
+-> bounded bot comment
+-> workspace cleanup
+```
+
+No DDEV, Drupal CLI, SSH, deployment or production secret is needed. The route
+performs only public HTTP(S) reads against the fixed production origin.
+
+## Browser checks
+
+For both FR and EN the scenario verifies:
+
+- initial HTTP response below 400;
+- exact H1 and one-H1 structure;
+- exact `<html lang>`;
+- category visibility;
+- feature image visibility, successful load and exact translated ALT;
+- canonical URL;
+- FR, EN and x-default hreflang values;
+- absence of obvious horizontal overflow;
+- required internal links are present and return below 400;
+- the canonical Article URL is present in the sitemap or one of its bounded
+  same-origin child sitemaps.
+
+Across the complete desktop/mobile run the existing browser audit also fails on:
+
+- console errors;
+- uncaught page errors;
+- same-origin unexpected 4xx responses;
+- same-origin 5xx responses;
+- failed same-origin browser requests.
+
+## Evidence
+
+The route uploads the existing Browser Validation evidence format:
+
+```text
+artifacts/browser-validation/result.json
+artifacts/browser-validation/evidence/desktop.json
+artifacts/browser-validation/evidence/mobile.json
+artifacts/browser-validation/screenshots/
+artifacts/browser-validation/test-results/
+```
+
+Four success screenshots are expected for #401:
+
+```text
+production-editorial-401-desktop-fr.png
+production-editorial-401-desktop-en.png
+production-editorial-401-mobile-fr.png
+production-editorial-401-mobile-en.png
+```
+
+The issue bot comment publishes the run ID, exact trusted `main`, machine result,
+functional/DOM/visual verdicts and console/network counters.
+
+## Security invariants
+
+The route must remain:
+
+```text
+public only
+read-only
+live-main only
+owner-command only
+profile-owned
+URL-input free
+selector-input free
+shell-input free
+secret free
+mutation free
+```
+
+Do not generalize it into a public crawler or arbitrary Playwright executor.
+A new production proof target must be admitted through repository review.
+
+## Relationship to other Agency routes
+
+```text
+canonical Browser Validation
+  -> fresh DDEV / repository-owned state
+
+Governed editorial publication
+  -> bounded production Article mutation
+
+Governed editorial feature image
+  -> bounded production field_feature_image mutation
+
+Production editorial browser proof
+  -> bounded public read-only proof of the final editor-owned Article
+```
+
+The last route is the appropriate final UI/SEO evidence after the two production
+mutation routes have converged.

--- a/tests/browser/contracts/production-editorial-401.json
+++ b/tests/browser/contracts/production-editorial-401.json
@@ -1,0 +1,37 @@
+{
+  "id": "production-editorial-401",
+  "issue_number": 401,
+  "target": "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+  "actor": "anonymous",
+  "origin": "https://emergingdigital.be",
+  "category": "Qualité web / SEO / accessibilité",
+  "sitemap": "/sitemap.xml",
+  "locales": {
+    "fr": {
+      "path": "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+      "lang": "fr",
+      "title": "Checklist avant une refonte de site internet : 12 points à vérifier",
+      "canonical": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+      "image_alt": "Checklist de préparation avant la refonte d’un site web"
+    },
+    "en": {
+      "path": "/en/blog/website-redesign-checklist-12-things-verify-you-start",
+      "lang": "en",
+      "title": "Website redesign checklist: 12 things to verify before you start",
+      "canonical": "https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start",
+      "image_alt": "Website redesign preparation checklist"
+    }
+  },
+  "hreflang": {
+    "fr": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+    "en": "https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start",
+    "x-default": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier"
+  },
+  "internal_links": [
+    "/services",
+    "/refonte-site-drupal",
+    "/audit-drupal",
+    "/accessibilite-seo-optimisation",
+    "/contact"
+  ]
+}

--- a/tests/browser/production-editorial-article.spec.mjs
+++ b/tests/browser/production-editorial-article.spec.mjs
@@ -1,0 +1,201 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { test, expect } from './support/browser-audit.mjs';
+
+const contractPath = process.env.BROWSER_VALIDATION_CONTRACT;
+if (!contractPath) {
+  throw new Error('BROWSER_VALIDATION_CONTRACT is required.');
+}
+
+const contract = JSON.parse(
+  await readFile(path.resolve(contractPath), 'utf8'),
+);
+
+const requiredTopLevelKeys = [
+  'actor',
+  'category',
+  'hreflang',
+  'id',
+  'internal_links',
+  'issue_number',
+  'locales',
+  'origin',
+  'sitemap',
+  'target',
+];
+
+expect(Object.keys(contract).sort()).toEqual(requiredTopLevelKeys.sort());
+expect(contract.id).toBe('production-editorial-401');
+expect(contract.issue_number).toBe(401);
+expect(contract.actor).toBe('anonymous');
+expect(contract.origin).toBe('https://emergingdigital.be');
+expect(Object.keys(contract.locales).sort()).toEqual(['en', 'fr']);
+expect(Object.keys(contract.hreflang).sort()).toEqual(['en', 'fr', 'x-default']);
+
+function absoluteUrl(value, baseURL) {
+  return new URL(value, `${baseURL}/`).toString();
+}
+
+async function verifySitemapContains(request, baseURL, sitemapPath, expectedUrl) {
+  const sitemapUrl = absoluteUrl(sitemapPath, baseURL);
+  const response = await request.get(sitemapUrl);
+  expect(response.status(), `Unexpected sitemap status for ${sitemapUrl}`).toBeLessThan(400);
+
+  const xml = await response.text();
+  if (xml.includes(`<loc>${expectedUrl}</loc>`)) {
+    return;
+  }
+
+  const childUrls = [...xml.matchAll(/<loc>(https?:\/\/[^<]+)<\/loc>/g)]
+    .map((match) => match[1])
+    .filter((url) => {
+      try {
+        return new URL(url).origin === new URL(baseURL).origin;
+      }
+      catch {
+        return false;
+      }
+    })
+    .slice(0, 20);
+
+  for (const childUrl of childUrls) {
+    const childResponse = await request.get(childUrl);
+    if (childResponse.status() >= 400) {
+      continue;
+    }
+    if ((await childResponse.text()).includes(`<loc>${expectedUrl}</loc>`)) {
+      return;
+    }
+  }
+
+  throw new Error(`${expectedUrl} is absent from ${sitemapUrl} and its bounded child sitemaps.`);
+}
+
+async function verifyLocale(page, request, baseURL, locale, expected) {
+  const response = await page.goto(expected.path, {
+    waitUntil: 'domcontentloaded',
+  });
+  expect(response, `Navigation must return a response for ${locale}.`).not.toBeNull();
+  expect(response.status(), `Unexpected HTTP status for ${expected.path}`).toBeLessThan(400);
+
+  await expect(page.getByRole('heading', {
+    name: expected.title,
+    level: 1,
+    exact: true,
+  })).toBeVisible();
+  await expect(page.locator('main')).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', expected.lang);
+  await expect(page.getByText(contract.category, { exact: true }).first()).toBeVisible();
+
+  const image = page.locator(`img[alt="${expected.image_alt}"]`).first();
+  await expect(image).toBeVisible();
+  const imageState = await image.evaluate((element) => ({
+    complete: element.complete,
+    naturalHeight: element.naturalHeight,
+    naturalWidth: element.naturalWidth,
+    src: element.currentSrc || element.src,
+  }));
+  expect(imageState.complete).toBeTruthy();
+  expect(imageState.naturalWidth).toBeGreaterThan(0);
+  expect(imageState.naturalHeight).toBeGreaterThan(0);
+  expect(new URL(imageState.src).origin).toBe(new URL(baseURL).origin);
+
+  const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+  expect(canonical, `Canonical is required for ${locale}.`).not.toBeNull();
+  expect(absoluteUrl(canonical, baseURL)).toBe(expected.canonical);
+
+  const alternates = await page.locator('link[rel="alternate"][hreflang]').evaluateAll(
+    (links) => Object.fromEntries(
+      links.map((link) => [
+        link.getAttribute('hreflang'),
+        link.getAttribute('href'),
+      ]),
+    ),
+  );
+  for (const [hreflang, expectedUrl] of Object.entries(contract.hreflang)) {
+    expect(alternates[hreflang], `Missing hreflang=${hreflang} on ${locale}.`).toBeTruthy();
+    expect(absoluteUrl(alternates[hreflang], baseURL)).toBe(expectedUrl);
+  }
+
+  const dom = await page.evaluate(() => ({
+    h1Count: document.querySelectorAll('h1').length,
+    hasHorizontalOverflow:
+      document.documentElement.scrollWidth > window.innerWidth + 1,
+    scrollWidth: document.documentElement.scrollWidth,
+    viewportWidth: window.innerWidth,
+  }));
+  expect(dom.h1Count, `${locale} must expose exactly one H1.`).toBe(1);
+  expect(
+    dom.hasHorizontalOverflow,
+    `${locale} horizontal overflow detected (${dom.scrollWidth}px > ${dom.viewportWidth}px).`,
+  ).toBeFalsy();
+
+  for (const href of contract.internal_links) {
+    await expect(page.locator(`main a[href="${href}"]`).first()).toBeVisible();
+    const linkResponse = await request.get(absoluteUrl(href, baseURL));
+    expect(linkResponse.status(), `Broken internal link ${href} from ${locale}.`).toBeLessThan(400);
+  }
+
+  await verifySitemapContains(request, baseURL, contract.sitemap, expected.canonical);
+}
+
+test.describe('Governed production editorial browser proof', () => {
+  test(`${contract.id}: #401 is valid in production`, async ({
+    page,
+    request,
+    baseURL,
+    audit,
+  }, testInfo) => {
+    expect(baseURL).toBe(contract.origin);
+
+    await verifyLocale(page, request, baseURL, 'fr', contract.locales.fr);
+    audit.checks.functional = 'PASS';
+    audit.checks.dom = 'PASS';
+
+    const screenshotDirectory = path.resolve(
+      'artifacts/browser-validation/screenshots',
+    );
+    await mkdir(screenshotDirectory, { recursive: true });
+
+    const frScreenshot = path.join(
+      screenshotDirectory,
+      `production-editorial-401-${testInfo.project.name}-fr.png`,
+    );
+    await page.screenshot({ path: frScreenshot, fullPage: true });
+    await testInfo.attach(`production-editorial-401-${testInfo.project.name}-fr`, {
+      path: frScreenshot,
+      contentType: 'image/png',
+    });
+
+    await verifyLocale(page, request, baseURL, 'en', contract.locales.en);
+
+    const enScreenshot = path.join(
+      screenshotDirectory,
+      `production-editorial-401-${testInfo.project.name}-en.png`,
+    );
+    await page.screenshot({ path: enScreenshot, fullPage: true });
+    await testInfo.attach(`production-editorial-401-${testInfo.project.name}-en`, {
+      path: enScreenshot,
+      contentType: 'image/png',
+    });
+
+    audit.screenshot = `screenshots/production-editorial-401-${testInfo.project.name}-fr.png`;
+    audit.checks.visual = 'PASS';
+    audit.checks.console =
+      audit.consoleErrors.length === 0 && audit.pageErrors.length === 0
+        ? 'PASS'
+        : 'FAIL';
+    audit.checks.network =
+      audit.http5xx.length === 0
+      && audit.unexpectedHttp4xx.length === 0
+      && audit.failedRequests.length === 0
+        ? 'PASS'
+        : 'FAIL';
+
+    expect(audit.consoleErrors, 'No browser console error is allowed.').toEqual([]);
+    expect(audit.pageErrors, 'No uncaught browser page error is allowed.').toEqual([]);
+    expect(audit.http5xx, 'No same-origin HTTP 5xx is allowed.').toEqual([]);
+    expect(audit.unexpectedHttp4xx, 'No same-origin HTTP 4xx is allowed.').toEqual([]);
+    expect(audit.failedRequests, 'No same-origin request may fail.').toEqual([]);
+  });
+});

--- a/tests/browser/production-editorial-article.spec.mjs
+++ b/tests/browser/production-editorial-article.spec.mjs
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import { mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { test, expect } from './support/browser-audit.mjs';
@@ -24,13 +25,13 @@ const requiredTopLevelKeys = [
   'target',
 ];
 
-expect(Object.keys(contract).sort()).toEqual(requiredTopLevelKeys.sort());
-expect(contract.id).toBe('production-editorial-401');
-expect(contract.issue_number).toBe(401);
-expect(contract.actor).toBe('anonymous');
-expect(contract.origin).toBe('https://emergingdigital.be');
-expect(Object.keys(contract.locales).sort()).toEqual(['en', 'fr']);
-expect(Object.keys(contract.hreflang).sort()).toEqual(['en', 'fr', 'x-default']);
+assert.deepEqual(Object.keys(contract).sort(), requiredTopLevelKeys.sort());
+assert.equal(contract.id, 'production-editorial-401');
+assert.equal(contract.issue_number, 401);
+assert.equal(contract.actor, 'anonymous');
+assert.equal(contract.origin, 'https://emergingdigital.be');
+assert.deepEqual(Object.keys(contract.locales).sort(), ['en', 'fr']);
+assert.deepEqual(Object.keys(contract.hreflang).sort(), ['en', 'fr', 'x-default']);
 
 function absoluteUrl(value, baseURL) {
   return new URL(value, `${baseURL}/`).toString();
@@ -149,8 +150,6 @@ test.describe('Governed production editorial browser proof', () => {
     expect(baseURL).toBe(contract.origin);
 
     await verifyLocale(page, request, baseURL, 'fr', contract.locales.fr);
-    audit.checks.functional = 'PASS';
-    audit.checks.dom = 'PASS';
 
     const screenshotDirectory = path.resolve(
       'artifacts/browser-validation/screenshots',
@@ -179,6 +178,8 @@ test.describe('Governed production editorial browser proof', () => {
       contentType: 'image/png',
     });
 
+    audit.checks.functional = 'PASS';
+    audit.checks.dom = 'PASS';
     audit.screenshot = `screenshots/production-editorial-401-${testInfo.project.name}-fr.png`;
     audit.checks.visual = 'PASS';
     audit.checks.console =

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded production browser proof for editor-owned Articles.
+ *
+ * @group agency_project_tests
+ * @group production_editorial_browser_proof
+ */
+final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
+
+  /**
+   * The workflow must stay issue-bound, actor-bound and main-trusted.
+   */
+  public function testWorkflowControlSurfaceIsClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-editorial-browser-proof.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString('/agency-production-browser validate', $workflow);
+    self::assertStringContainsString("github.actor == 'E-merging-digital'", $workflow);
+    self::assertStringContainsString("ISSUE_NUMBER\" == '401'", $workflow);
+    self::assertStringContainsString('currently on live main', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('production-editorial-401.json', $workflow);
+    self::assertStringContainsString('production-editorial-article.spec.mjs', $workflow);
+    self::assertStringContainsString('https://emergingdigital.be', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * The repository-owned production contract must remain exact and narrow.
+   */
+  public function testProductionContractIsClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/tests/browser/contracts/production-editorial-401.json';
+    self::assertFileExists($path);
+
+    $contract = json_decode(
+      (string) file_get_contents($path),
+      TRUE,
+      16,
+      JSON_THROW_ON_ERROR,
+    );
+    self::assertSame([
+      'id',
+      'issue_number',
+      'target',
+      'actor',
+      'origin',
+      'category',
+      'sitemap',
+      'locales',
+      'hreflang',
+      'internal_links',
+    ], array_keys($contract));
+    self::assertSame('production-editorial-401', $contract['id']);
+    self::assertSame(401, $contract['issue_number']);
+    self::assertSame('anonymous', $contract['actor']);
+    self::assertSame('https://emergingdigital.be', $contract['origin']);
+    self::assertSame(['fr', 'en'], array_keys($contract['locales']));
+    self::assertSame(['fr', 'en', 'x-default'], array_keys($contract['hreflang']));
+    self::assertSame(
+      'Checklist de préparation avant la refonte d’un site web',
+      $contract['locales']['fr']['image_alt'],
+    );
+    self::assertSame(
+      'Website redesign preparation checklist',
+      $contract['locales']['en']['image_alt'],
+    );
+  }
+
+  /**
+   * The proof must reuse the existing Playwright audit primitives.
+   */
+  public function testScenarioReusesExistingBrowserAudit(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/tests/browser/production-editorial-article.spec.mjs';
+    self::assertFileExists($path);
+
+    $scenario = (string) file_get_contents($path);
+    self::assertStringContainsString("from './support/browser-audit.mjs'", $scenario);
+    self::assertStringContainsString("link[rel=\"canonical\"]", $scenario);
+    self::assertStringContainsString('link[rel="alternate"][hreflang]', $scenario);
+    self::assertStringContainsString('<loc>${expectedUrl}</loc>', $scenario);
+    self::assertStringContainsString('image_alt', $scenario);
+    self::assertStringContainsString('naturalWidth', $scenario);
+    self::assertStringContainsString('hasHorizontalOverflow', $scenario);
+    self::assertStringContainsString('audit.consoleErrors', $scenario);
+    self::assertStringContainsString('audit.failedRequests', $scenario);
+  }
+
+  /**
+   * The production route is public and must not gain secret or mutation inputs.
+   */
+  public function testWorkflowIsReadOnlyAndSecretFree(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-production-editorial-browser-proof.yml',
+    );
+
+    foreach ([
+      'secrets.',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'SERVER_USER',
+      'drush ',
+      'ddev ',
+      'deploy-production.sh',
+      'composer require',
+      'curl ',
+      'wget ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+
+    self::assertStringContainsString('BROWSER_VALIDATION_BASE_URL: https://emergingdigital.be', $workflow);
+    self::assertStringContainsString(
+      'npm run browser:validate -- tests/browser/production-editorial-article.spec.mjs',
+      $workflow,
+    );
+  }
+
+}


### PR DESCRIPTION
## Objectif

Implémente #586 : une preuve navigateur production publique, read-only et bornée pour l’Article editor-owned #401, sans détourner la Browser Validation DDEV canonique.

## Contrat

- commande exacte `/agency-production-browser validate` sur #401 uniquement ;
- acteur propriétaire exact et issue OPEN owner-created ;
- workflow exécuté depuis live `main` ;
- runner `agency-browser-runner-01` existant ;
- origin fixe `https://emergingdigital.be` ;
- contrat repository-owned `production-editorial-401.json` ;
- aucun URL/selector/shell/Playwright argument runtime ;
- aucune authentification, aucun secret, aucune mutation production ;
- réutilisation de `run-browser-validation.mjs`, `playwright.config.mjs` et `browser-audit.mjs` ;
- FR/EN, desktop/mobile, image + ALT, catégorie, canonical, hreflang, sitemap, maillage interne, console et réseau ;
- screenshots et résultat JSON comme artifacts.

## État

PR draft tant que la CI exacte n’est pas verte. Après merge, la route doit être exercée sur #401 et ses artifacts examinés avant fermeture de #401.

Closes #586
Refs #401 #398 #584 #585