### PR TITLE
Issue #588: externalize production browser proof and skip non-runtime deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'tests/**'
+      - 'web/modules/custom/agency_project_tests/**'
+      - '*.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trusted-production-editorial-browser-proof.yml
+++ b/.github/workflows/trusted-production-editorial-browser-proof.yml
@@ -19,12 +19,10 @@ jobs:
         github.event.comment.user.login == 'E-merging-digital' &&
         github.event.comment.body == '/agency-production-browser validate'
       }}
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - agency
-      - browser
+    # This is deliberately GitHub-hosted: the proof is public/read-only and must
+    # observe production from an external network rather than from the managed
+    # Agency executor used for DDEV proofs.
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     concurrency:
       group: agency-production-editorial-browser-${{ github.event.issue.number }}
@@ -172,6 +170,7 @@ jobs:
           body="$(cat <<EOF_BODY
           ${heading}
 
+          executor: \`github-hosted/ubuntu-24.04\`
           trusted_main: \`${TRUSTED_MAIN:-n/a}\`
           run_id: \`${GITHUB_RUN_ID}\`
           route_outcome: \`${PROOF_OUTCOME:-unknown}\`

--- a/docs/operations/production-editorial-browser-proof.md
+++ b/docs/operations/production-editorial-browser-proof.md
@@ -1,7 +1,7 @@
 # Production editorial browser proof
 
 Status: **GOVERNED / READ-ONLY**  
-Owner: #586  
+Owner: #586, execution hardening #588  
 Initial consumer: #401
 
 ## Purpose
@@ -14,6 +14,13 @@ rendering of an editor-owned Article that exists only in production.
 Issue #586 adds a separate, bounded proof for that case. It reuses the existing
 Playwright Test, Chromium, browser audit and machine-readable result primitives,
 but targets the public production origin read-only.
+
+Issue #588 hardens the execution model after three self-hosted proof attempts
+returned the same public HTTP 503 before Playwright (`32484873812`,
+`32485251713`, `32485555392`) while the governed SSH Drupal inspection remained
+healthy (`32485845917`). Public availability evidence must therefore be observed
+from an independent external execution point rather than from the managed
+Agency/DDEV host.
 
 This route complements the DDEV Browser Validation route; it does not replace it.
 
@@ -63,8 +70,7 @@ cannot select an arbitrary contract.
 
 ```text
 owner issue comment
--> job-level actor/command filter
--> agency-browser-runner-01
+-> GitHub-hosted ubuntu-24.04 external observer
 -> verify OPEN owner-created #401 + live main
 -> checkout exact trusted main without persisted credentials
 -> verify immutable #401 contract
@@ -77,6 +83,11 @@ owner issue comment
 -> bounded bot comment
 -> workspace cleanup
 ```
+
+The public proof deliberately does **not** use `agency-browser-runner-01`.
+That self-hosted runner remains the correct executor for fresh-DDEV Browser
+Validation and project-local MCP/browser work, but it is not an independent
+observer of the public production route.
 
 No DDEV, Drupal CLI, SSH, deployment or production secret is needed. The route
 performs only public HTTP(S) reads against the fixed production origin.
@@ -129,6 +140,35 @@ production-editorial-401-mobile-en.png
 The issue bot comment publishes the run ID, exact trusted `main`, machine result,
 functional/DOM/visual verdicts and console/network counters.
 
+## Production deployment trigger invariant
+
+The production deploy workflow places Drupal in maintenance mode while the new
+release is prepared, switched and converged. A repository change that cannot
+alter the deployed runtime must therefore not cause that maintenance window.
+
+`deploy-production.yml` ignores a push when **all** changed files are confined
+to these reviewed non-runtime areas:
+
+```text
+.github/**
+docs/**
+tests/**
+web/modules/custom/agency_project_tests/**
+*.md                     # repository-root Markdown
+```
+
+This is only a push filter. `workflow_dispatch` remains available for an
+explicit deployment.
+
+Runtime-bearing paths such as `scripts/**`, `web/**` outside the test module,
+`config/**`, `composer.json` and `composer.lock` are intentionally **not** in
+`paths-ignore`. Consequently a mixed commit containing any runtime file still
+triggers the normal production deployment.
+
+Do not widen the ignore set merely to suppress a deployment failure. A path may
+be ignored only when changes under that path cannot affect the deployed Agency
+runtime.
+
 ## Security invariants
 
 The route must remain:
@@ -144,6 +184,7 @@ selector-input free
 shell-input free
 secret free
 mutation free
+external-observer execution
 ```
 
 Do not generalize it into a public crawler or arbitrary Playwright executor.
@@ -153,6 +194,7 @@ A new production proof target must be admitted through repository review.
 
 ```text
 canonical Browser Validation
+  -> managed self-hosted runner
   -> fresh DDEV / repository-owned state
 
 Governed editorial publication
@@ -162,6 +204,7 @@ Governed editorial feature image
   -> bounded production field_feature_image mutation
 
 Production editorial browser proof
+  -> GitHub-hosted external observer
   -> bounded public read-only proof of the final editor-owned Article
 ```
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
@@ -33,6 +33,8 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
     self::assertStringContainsString('production-editorial-401.json', $workflow);
     self::assertStringContainsString('production-editorial-article.spec.mjs', $workflow);
     self::assertStringContainsString('https://emergingdigital.be', $workflow);
+    self::assertStringContainsString('runs-on: ubuntu-24.04', $workflow);
+    self::assertStringNotContainsString('self-hosted', $workflow);
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
   }
 
@@ -127,6 +129,41 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
       'npm run browser:validate -- tests/browser/production-editorial-article.spec.mjs',
       $workflow,
     );
+  }
+
+  /**
+   * Documentation/test-only pushes must not put production in maintenance.
+   */
+  public function testProductionDeployIgnoresOnlyKnownNonRuntimePaths(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/deploy-production.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    foreach ([
+      "- '.github/**'",
+      "- 'docs/**'",
+      "- 'tests/**'",
+      "- 'web/modules/custom/agency_project_tests/**'",
+      "- '*.md'",
+    ] as $ignoredPath) {
+      self::assertStringContainsString($ignoredPath, $workflow);
+    }
+
+    // Runtime-bearing areas must remain deploy-triggering by omission from
+    // paths-ignore. A mixed commit therefore still deploys.
+    foreach ([
+      "- 'scripts/**'",
+      "- 'web/**'",
+      "- 'config/**'",
+      "- 'composer.json'",
+      "- 'composer.lock'",
+    ] as $forbiddenIgnore) {
+      self::assertStringNotContainsString($forbiddenIgnore, $workflow);
+    }
+
+    self::assertStringContainsString('workflow_dispatch:', $workflow);
   }
 
 }


### PR DESCRIPTION
## Résumé

Closes #588.

Cette PR durcit le chemin final de validation de #401 sans affaiblir les assertions existantes :

- exécute la preuve publique production sur `ubuntu-24.04` GitHub-hosted au lieu du runner Agency ;
- conserve le contrat #401 fermé, l'origine fixe et toutes les assertions FR/EN desktop/mobile ;
- empêche `deploy-production.yml` de déclencher un déploiement/maintenance lorsque **tous** les changements sont confinés à `.github/**`, `docs/**`, `tests/**`, `web/modules/custom/agency_project_tests/**` ou au Markdown racine ;
- conserve le déploiement pour tout commit mixte contenant un fichier runtime ;
- ajoute des tests de gouvernance pour l'exécuteur externe et les filtres de déploiement ;
- documente la séparation self-hosted DDEV vs observateur public externe.

## Contexte observé

Trois preuves #401 depuis `agency-browser-runner-01` ont donné `NOT_RUN` sur HTTP 503 avant Playwright : `32484873812`, `32485251713`, `32485555392`. En parallèle, l'inspection Drupal production via SSH gouverné est restée `PASS/READY` (`32485845917`).

## Invariants

- aucun secret ajouté à la preuve publique ;
- aucune URL/selector/shell/argument Playwright fourni par le commentaire ;
- aucune assertion SEO/image/console/réseau supprimée ;
- `workflow_dispatch` de déploiement reste disponible ;
- `scripts/**`, `config/**`, `composer.json`, `composer.lock` et le runtime `web/**` restent deploy-triggering.

Base autoritative au démarrage : `37214cb0913339829b97e3576443712e8a6a24f9`.