### PR TITLE
Issue #590: add bounded production HTTP 503 diagnostic

### DIFF
--- a/.github/workflows/trusted-production-health-diagnostic.yml
+++ b/.github/workflows/trusted-production-health-diagnostic.yml
@@ -1,0 +1,251 @@
+name: Agency trusted production health diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-health-diagnostic:
+    name: Diagnose production HTTP 503
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-health diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      group: agency-production-health-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate actor, incident and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-health diagnose' ]]
+          [[ "$ISSUE_NUMBER" == '590' ]] || {
+            echo 'Production health diagnostic v1 is restricted to issue #590.' >&2
+            exit 1
+          }
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Production health diagnostic must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Run fixed read-only production diagnostic
+        id: diagnostic
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p artifacts/production-health
+          raw='artifacts/production-health/diagnostic.txt'
+
+          set +e
+          ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' > "$raw" 2>&1 <<'REMOTE_DIAGNOSTIC'
+          set -u
+          CURRENT='/var/www/agency/current'
+          TARGET='https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier'
+          EN_TARGET='https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start'
+
+          scalar() {
+            printf '%s=%s\n' "$1" "$2"
+          }
+
+          probe() {
+            label="$1"
+            url="$2"
+            shift 2
+            body="$(mktemp)"
+            status="$(curl -k -sS --connect-timeout 8 --max-time 15 \
+              -A 'agency-production-health-diagnostic/1' \
+              "$@" -o "$body" -w '%{http_code}' "$url" 2>/dev/null)"
+            curl_exit="$?"
+            if [[ "$curl_exit" -ne 0 ]]; then
+              status='000'
+            fi
+            body_sha='empty'
+            if [[ -s "$body" ]]; then
+              body_sha="$(sha256sum "$body" | awk '{print $1}')"
+            fi
+            hint="$(tr '\n' ' ' < "$body" | grep -Eio -m1 'maintenance|service unavailable|temporarily unavailable|bad gateway|gateway timeout' || true)"
+            scalar "${label}_status" "$status"
+            scalar "${label}_body_sha256" "$body_sha"
+            scalar "${label}_hint" "${hint:-none}"
+            rm -f "$body"
+          }
+
+          scalar current_release "$(readlink -f "$CURRENT" 2>/dev/null || echo unavailable)"
+          scalar current_sha "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+          scalar drupal_bootstrap "$(cd "$CURRENT" && vendor/bin/drush status --field=bootstrap --format=string 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          scalar maintenance_mode "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          scalar active_deploy_processes "$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')"
+          scalar nginx_state "$(systemctl is-active nginx 2>/dev/null || echo unavailable)"
+          scalar php84_fpm_state "$(systemctl is-active php8.4-fpm 2>/dev/null || echo unavailable)"
+
+          probe public_fr "$TARGET"
+          probe public_en "$EN_TARGET"
+          probe local_fr "$TARGET" --resolve 'emergingdigital.be:443:127.0.0.1'
+
+          echo 'deploy_log_begin'
+          tail -n 12 /var/www/agency/shared/deployments.log 2>/dev/null || echo 'deploy_log_unavailable'
+          echo 'deploy_log_end'
+          REMOTE_DIAGNOSTIC
+          ssh_status="$?"
+          set -e
+
+          value() {
+            grep -m1 "^$1=" "$raw" | cut -d= -f2- || true
+          }
+
+          maintenance="$(value maintenance_mode)"
+          deploys="$(value active_deploy_processes)"
+          public_fr="$(value public_fr_status)"
+          public_en="$(value public_en_status)"
+          local_fr="$(value local_fr_status)"
+          nginx="$(value nginx_state)"
+          php_fpm="$(value php84_fpm_state)"
+          release="$(value current_release)"
+          current_sha="$(value current_sha)"
+          bootstrap="$(value drupal_bootstrap)"
+
+          verdict='UNKNOWN'
+          if [[ "$ssh_status" -ne 0 ]]; then
+            verdict='SSH_DIAGNOSTIC_FAILED'
+          elif [[ "$maintenance" == '1' && "${deploys:-0}" == '0' ]]; then
+            verdict='MAINTENANCE_STUCK'
+          elif [[ "$maintenance" == '1' ]]; then
+            verdict='MAINTENANCE_WITH_DEPLOY_ACTIVE'
+          elif [[ "$public_fr" == '503' && "$local_fr" == '503' ]]; then
+            verdict='HTTP_503_LOCAL_AND_EXTERNAL'
+          elif [[ "$public_fr" == '503' && "$local_fr" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='HTTP_503_EXTERNAL_ONLY'
+          elif [[ "$public_fr" =~ ^[23][0-9][0-9]$ && "$public_en" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='PUBLIC_HTTP_HEALTHY'
+          fi
+
+          jq -n \
+            --arg verdict "$verdict" \
+            --arg maintenance_mode "${maintenance:-unknown}" \
+            --arg active_deploy_processes "${deploys:-unknown}" \
+            --arg public_fr_status "${public_fr:-unknown}" \
+            --arg public_en_status "${public_en:-unknown}" \
+            --arg local_fr_status "${local_fr:-unknown}" \
+            --arg nginx_state "${nginx:-unknown}" \
+            --arg php84_fpm_state "${php_fpm:-unknown}" \
+            --arg current_release "${release:-unknown}" \
+            --arg current_sha "${current_sha:-unknown}" \
+            --arg drupal_bootstrap "${bootstrap:-unknown}" \
+            --argjson ssh_exit "$ssh_status" \
+            '{schema_version:1, verdict:$verdict, ssh_exit:$ssh_exit, maintenance_mode:$maintenance_mode, active_deploy_processes:$active_deploy_processes, public_fr_status:$public_fr_status, public_en_status:$public_en_status, local_fr_status:$local_fr_status, nginx_state:$nginx_state, php84_fpm_state:$php84_fpm_state, current_release:$current_release, current_sha:$current_sha, drupal_bootstrap:$drupal_bootstrap}' \
+            > artifacts/production-health/result.json
+
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          test "$ssh_status" -eq 0
+
+      - name: Upload diagnostic evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-health-590-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-health
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded diagnostic result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-health/result.json'
+          verdict='MISSING'
+          maintenance='unknown'
+          deploys='unknown'
+          public_fr='unknown'
+          public_en='unknown'
+          local_fr='unknown'
+          nginx='unknown'
+          php_fpm='unknown'
+          current_sha='unknown'
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            verdict="$(jq -r '.verdict' "$result")"
+            maintenance="$(jq -r '.maintenance_mode' "$result")"
+            deploys="$(jq -r '.active_deploy_processes' "$result")"
+            public_fr="$(jq -r '.public_fr_status' "$result")"
+            public_en="$(jq -r '.public_en_status' "$result")"
+            local_fr="$(jq -r '.local_fr_status' "$result")"
+            nginx="$(jq -r '.nginx_state' "$result")"
+            php_fpm="$(jq -r '.php84_fpm_state' "$result")"
+            current_sha="$(jq -r '.current_sha' "$result")"
+          fi
+          artifact="agency-production-health-590-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production health diagnostic ${verdict}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${DIAGNOSTIC_OUTCOME:-unknown}\`
+          maintenance_mode: \`${maintenance}\`
+          active_deploy_processes: \`${deploys}\`
+          public_fr_status: \`${public_fr}\`
+          public_en_status: \`${public_en}\`
+          local_fr_status: \`${local_fr}\`
+          nginx_state: \`${nginx}\`
+          php84_fpm_state: \`${php_fpm}\`
+          production_current_sha: \`${current_sha}\`
+          artifact: \`${artifact}\`
+
+          Read-only diagnostic only. No deployment, service restart, Drupal state mutation or arbitrary shell input is permitted by this route.
+          EOF_BODY
+          )"
+          gh issue comment 590 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/trusted-production-health-diagnostic.yml
+++ b/.github/workflows/trusted-production-health-diagnostic.yml
@@ -121,13 +121,18 @@ jobs:
             rm -f "$body"
           }
 
+          service_state() {
+            state="$(systemctl is-active "$1" 2>/dev/null || true)"
+            scalar "$2" "${state:-unavailable}"
+          }
+
           scalar current_release "$(readlink -f "$CURRENT" 2>/dev/null || echo unavailable)"
           scalar current_sha "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
           scalar drupal_bootstrap "$(cd "$CURRENT" && vendor/bin/drush status --field=bootstrap --format=string 2>/dev/null | tr -d '\r\n' || echo unavailable)"
           scalar maintenance_mode "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
           scalar active_deploy_processes "$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')"
-          scalar nginx_state "$(systemctl is-active nginx 2>/dev/null || echo unavailable)"
-          scalar php84_fpm_state "$(systemctl is-active php8.4-fpm 2>/dev/null || echo unavailable)"
+          service_state nginx nginx_state
+          service_state php8.4-fpm php84_fpm_state
 
           probe public_fr "$TARGET"
           probe public_en "$EN_TARGET"

--- a/docs/operations/production-health-diagnostic.md
+++ b/docs/operations/production-health-diagnostic.md
@@ -1,0 +1,68 @@
+# Production health diagnostic
+
+Status: **INCIDENT-BOUND / READ-ONLY**  
+Owner: #590
+
+## Purpose
+
+This route diagnoses the persistent public HTTP 503 blocking the final Browser
+Validation of Article #401. It is deliberately separate from deployment,
+editorial mutation and the public Playwright proof.
+
+Control command, restricted to OPEN owner-created issue #590:
+
+```text
+/agency-production-health diagnose
+```
+
+The workflow executes from live `main` on GitHub-hosted Ubuntu and reuses only
+the existing production SSH channel. The comment cannot provide a host, URL,
+command, path or shell argument.
+
+## Fixed evidence
+
+The remote diagnostic records only bounded read-only evidence:
+
+- `/var/www/agency/current` release and Git SHA;
+- Drupal bootstrap status;
+- `system.maintenance_mode` through a fixed read-only Drush evaluation;
+- count of active `deploy-production.sh` processes;
+- `systemctl is-active` for Nginx and PHP 8.4 FPM;
+- HTTP status for the fixed FR and EN #401 public URLs;
+- HTTP status for the FR URL resolved locally to `127.0.0.1` with the canonical
+  hostname/SNI;
+- SHA-256 and a small classification hint for the public response bodies;
+- the last 12 lines of `/var/www/agency/shared/deployments.log`.
+
+The route may create only ephemeral temporary files for response hashing and the
+GitHub Actions evidence artifact. It does not alter Drupal state, deployment
+state, services, releases, configuration or content.
+
+## Verdicts
+
+```text
+MAINTENANCE_STUCK
+MAINTENANCE_WITH_DEPLOY_ACTIVE
+HTTP_503_LOCAL_AND_EXTERNAL
+HTTP_503_EXTERNAL_ONLY
+PUBLIC_HTTP_HEALTHY
+SSH_DIAGNOSTIC_FAILED
+UNKNOWN
+```
+
+A mutation is never inferred from a verdict. If `MAINTENANCE_STUCK` is proven,
+a separate reviewed and bounded recovery route is required before changing
+`system.maintenance_mode`.
+
+## Forbidden widening
+
+Do not add runtime command input, `sudo`, service restart/reload, deployment,
+`drush state:set`, cache rebuild, config import, database update, git mutation or
+arbitrary URL input to this route.
+
+Evidence is uploaded as:
+
+```text
+artifacts/production-health/result.json
+artifacts/production-health/diagnostic.txt
+```

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionHealthDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionHealthDiagnosticWorkflowTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the issue-bound read-only production health diagnostic.
+ *
+ * @group agency_project_tests
+ * @group production_health_diagnostic
+ */
+final class ProductionHealthDiagnosticWorkflowTest extends TestCase {
+
+  /**
+   * The diagnostic control surface must remain closed to issue #590.
+   */
+  public function testControlSurfaceIsIssueAndActorBound(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-health-diagnostic.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString('/agency-production-health diagnose', $workflow);
+    self::assertStringContainsString("github.actor == 'E-merging-digital'", $workflow);
+    self::assertStringContainsString("ISSUE_NUMBER\" == '590'", $workflow);
+    self::assertStringContainsString('currently on live main', $workflow);
+    self::assertStringContainsString('runs-on: ubuntu-24.04', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * Only the existing SSH secrets may cross the trusted GitHub-hosted boundary.
+   */
+  public function testUsesExistingProductionSshChannelOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-production-health-diagnostic.yml',
+    );
+
+    self::assertStringContainsString('secrets.SSH_PRIVATE_KEY', $workflow);
+    self::assertStringContainsString('secrets.SERVER_HOST', $workflow);
+    self::assertStringContainsString('secrets.SERVER_USER', $workflow);
+    self::assertStringNotContainsString('secrets.OPENAI', $workflow);
+    self::assertStringNotContainsString('secrets.DRUPAL', $workflow);
+  }
+
+  /**
+   * The remote command set must remain diagnostic and non-mutating.
+   */
+  public function testRemoteDiagnosticRemainsReadOnlyAndFixed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-production-health-diagnostic.yml',
+    );
+
+    foreach ([
+      'system.maintenance_mode',
+      "pgrep -af '[d]eploy-production.sh'",
+      'systemctl is-active nginx',
+      'systemctl is-active php8.4-fpm',
+      "--resolve 'emergingdigital.be:443:127.0.0.1'",
+      '/var/www/agency/shared/deployments.log',
+      'https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      'https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'state:set',
+      'systemctl restart',
+      'systemctl reload',
+      'service nginx restart',
+      'service php',
+      'deploy-production.sh main',
+      'drush cr',
+      'drush cim',
+      'drush updb',
+      'sudo ',
+      'git pull',
+      'git reset',
+      'git checkout',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The workflow must preserve evidence and publish only bounded fields.
+   */
+  public function testDiagnosticEvidenceIsMachineReadable(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-production-health-diagnostic.yml',
+    );
+
+    self::assertStringContainsString('artifacts/production-health/result.json', $workflow);
+    self::assertStringContainsString('artifacts/production-health/diagnostic.txt', $workflow);
+    self::assertStringContainsString('MAINTENANCE_STUCK', $workflow);
+    self::assertStringContainsString('HTTP_503_LOCAL_AND_EXTERNAL', $workflow);
+    self::assertStringContainsString('HTTP_503_EXTERNAL_ONLY', $workflow);
+    self::assertStringContainsString('PUBLIC_HTTP_HEALTHY', $workflow);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionHealthDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionHealthDiagnosticWorkflowTest.php
@@ -61,8 +61,8 @@ final class ProductionHealthDiagnosticWorkflowTest extends TestCase {
     foreach ([
       'system.maintenance_mode',
       "pgrep -af '[d]eploy-production.sh'",
-      'systemctl is-active nginx',
-      'systemctl is-active php8.4-fpm',
+      'service_state nginx nginx_state',
+      'service_state php8.4-fpm php84_fpm_state',
       "--resolve 'emergingdigital.be:443:127.0.0.1'",
       '/var/www/agency/shared/deployments.log',
       'https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',


### PR DESCRIPTION
## Résumé

Cette PR ajoute une route **read-only, incident-bound** pour diagnostiquer le HTTP 503 public qui bloque #401.

Commande unique :

`/agency-production-health diagnose`

La route est limitée à l'issue OPEN owner-created #590, acteur `E-merging-digital`, live `main`, et réutilise uniquement le canal SSH production existant.

### Evidence fixe

- release et SHA de `/var/www/agency/current` ;
- bootstrap Drupal ;
- `system.maintenance_mode` en lecture ;
- processus de déploiement actifs ;
- état Nginx / PHP 8.4 FPM ;
- HTTP FR/EN externe #401 ;
- HTTP FR résolu localement vers 127.0.0.1 avec hostname/SNI canonique ;
- empreinte/classification minimale des réponses ;
- 12 dernières lignes du journal de déploiement.

### Invariants

- aucun host/URL/path/commande fourni par le commentaire ;
- aucun `sudo`, restart/reload, `state:set`, `drush cr/cim/updb`, déploiement ou mutation Git ;
- aucun changement runtime ;
- verdict de diagnostic uniquement, jamais de recovery automatique ;
- un éventuel `MAINTENANCE_STUCK` nécessitera une route de correction séparée et revue.

Refs #590 #401 #588.