### PR TITLE
Issue #594: wait for lazy production image before asserting load

### DIFF
--- a/tests/browser/production-editorial-article.spec.mjs
+++ b/tests/browser/production-editorial-article.spec.mjs
@@ -89,7 +89,19 @@ async function verifyLocale(page, request, baseURL, locale, expected) {
   await expect(page.getByText(contract.category, { exact: true }).first()).toBeVisible();
 
   const image = page.locator(`img[alt="${expected.image_alt}"]`).first();
+  await image.scrollIntoViewIfNeeded();
   await expect(image).toBeVisible();
+  await expect.poll(
+    () => image.evaluate((element) => (
+      element.complete
+      && element.naturalWidth > 0
+      && element.naturalHeight > 0
+    )),
+    {
+      message: `${locale} feature image did not finish loading.`,
+      timeout: 10_000,
+    },
+  ).toBe(true);
   const imageState = await image.evaluate((element) => ({
     complete: element.complete,
     naturalHeight: element.naturalHeight,

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
@@ -101,6 +101,25 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
   }
 
   /**
+   * Lazy feature images must be awaited, not accepted before loading completes.
+   */
+  public function testScenarioWaitsForLazyFeatureImageWithoutFixedSleep(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $scenario = (string) file_get_contents(
+      $root . '/tests/browser/production-editorial-article.spec.mjs',
+    );
+
+    self::assertStringContainsString('scrollIntoViewIfNeeded()', $scenario);
+    self::assertStringContainsString('expect.poll(', $scenario);
+    self::assertStringContainsString('element.complete', $scenario);
+    self::assertStringContainsString('element.naturalWidth > 0', $scenario);
+    self::assertStringContainsString('element.naturalHeight > 0', $scenario);
+    self::assertStringContainsString('timeout: 10_000', $scenario);
+    self::assertStringContainsString('feature image did not finish loading', $scenario);
+    self::assertStringNotContainsString('waitForTimeout(', $scenario);
+  }
+
+  /**
    * The production route is public and must not gain secret or mutation inputs.
    */
   public function testWorkflowIsReadOnlyAndSecretFree(): void {


### PR DESCRIPTION
## Résumé

Corrige la fausse négative révélée par la Browser Validation #401 run `32493249236` : l’image de couverture est `loading="lazy"` et le test vérifiait `element.complete` immédiatement après `toBeVisible()`, alors que la requête venait seulement de démarrer.

### Changement

- `scrollIntoViewIfNeeded()` pour déclencher explicitement le lazy-load ;
- `expect.poll` borné à 10 s sur `complete && naturalWidth > 0 && naturalHeight > 0` ;
- conservation de toutes les assertions existantes (ALT exact, visible, dimensions > 0, same-origin, canonical, hreflang, sitemap, liens, DOM, console/réseau) ;
- aucun `waitForTimeout`, aucun fallback et aucun relâchement du contrat ;
- test unitaire pour protéger ce comportement.

Diff exclusivement `tests/**` et `agency_project_tests/**` : aucun runtime production et aucun déploiement attendu au merge grâce au filtre #588.

Closes #594. Refs #401 #586 #588 #590 #592.