### PR TITLE
Issue #596: deepen production AVIF generation diagnostics

### DIFF
--- a/.github/workflows/trusted-production-image-diagnostic.yml
+++ b/.github/workflows/trusted-production-image-diagnostic.yml
@@ -121,18 +121,62 @@ jobs:
           bool gd_avif_support "$(php -r '$i=function_exists("gd_info") ? gd_info() : []; echo !empty($i["AVIF Support"]) ? 1 : 0;' 2>/dev/null || echo 0)"
           bool gd_webp_support "$(php -r '$i=function_exists("gd_info") ? gd_info() : []; echo !empty($i["WebP Support"]) ? 1 : 0;' 2>/dev/null || echo 0)"
           scalar memory_limit "$(php -r 'echo ini_get("memory_limit");' 2>/dev/null || echo unavailable)"
+          scalar php_fpm_workers "$(ps -eo user=,group=,comm= 2>/dev/null | awk '$3 ~ /^php-fpm/ && $1 != "root" {print $1 ":" $2}' | sort -u | paste -sd, - || true)"
 
           if [[ -f "$SOURCE" ]]; then
             scalar source_exists true
             scalar source_bytes "$(stat -c '%s' "$SOURCE" 2>/dev/null || echo unavailable)"
             scalar source_dimensions "$(php -r '$i=@getimagesize($argv[1]); echo $i ? $i[0]."x".$i[1] : "unreadable";' "$SOURCE" 2>/dev/null || echo unavailable)"
             scalar source_mime "$(php -r '$i=@getimagesize($argv[1]); echo $i["mime"] ?? "unknown";' "$SOURCE" 2>/dev/null || echo unavailable)"
+            scalar cli_avif_encode "$(php -r '$i=@imagecreatefrompng($argv[1]); if (!$i) { echo "decode_failed"; exit; } ob_start(); $ok=@imageavif($i, NULL, 75); $data=ob_get_clean(); echo ($ok && strlen($data) > 0) ? "ok:" . strlen($data) : "failed:" . strlen($data);' "$SOURCE" 2>/dev/null || echo execution_failed)"
+            scalar cli_webp_encode "$(php -r '$i=@imagecreatefrompng($argv[1]); if (!$i) { echo "decode_failed"; exit; } ob_start(); $ok=@imagewebp($i, NULL, 75); $data=ob_get_clean(); echo ($ok && strlen($data) > 0) ? "ok:" . strlen($data) : "failed:" . strlen($data);' "$SOURCE" 2>/dev/null || echo execution_failed)"
           else
             scalar source_exists false
             scalar source_bytes unavailable
             scalar source_dimensions unavailable
             scalar source_mime unavailable
+            scalar cli_avif_encode source_missing
+            scalar cli_webp_encode source_missing
           fi
+
+          echo 'php_fpm_capabilities_begin'
+          if command -v php-fpm8.4 >/dev/null 2>&1; then
+            php-fpm8.4 -i 2>&1 | grep -Ei 'Server API|GD Support|GD Version|AVIF Support|WebP Support|memory_limit' | head -n 30 || true
+          elif [[ -x /usr/sbin/php-fpm8.4 ]]; then
+            /usr/sbin/php-fpm8.4 -i 2>&1 | grep -Ei 'Server API|GD Support|GD Version|AVIF Support|WebP Support|memory_limit' | head -n 30 || true
+          else
+            echo 'php-fpm8.4-info-unavailable'
+          fi
+          echo 'php_fpm_capabilities_end'
+
+          echo 'path_permissions_begin'
+          for target_path in \
+            "$FILES" \
+            "$FILES/articles" \
+            "$FILES/styles" \
+            "$FILES/styles/large" \
+            "$FILES/styles/large/public" \
+            "$FILES/styles/large/public/articles" \
+            "$SOURCE"; do
+            if [[ -e "$target_path" || -L "$target_path" ]]; then
+              stat -Lc '%A|%a|%U|%G|%s|%n' "$target_path" 2>&1 || true
+            else
+              printf 'missing|||||%s\n' "$target_path"
+            fi
+          done
+          echo 'namei_derivative_begin'
+          namei -l "$DERIVATIVE" 2>&1 || true
+          echo 'namei_derivative_end'
+          echo 'path_permissions_end'
+
+          echo 'disk_space_begin'
+          df -Pk "$FILES" 2>&1 || true
+          df -Pi "$FILES" 2>&1 || true
+          echo 'disk_space_end'
+
+          echo 'existing_large_derivatives_begin'
+          find "$FILES/styles/large" -maxdepth 5 -type f -printf '%m|%u|%g|%s|%p\n' 2>/dev/null | head -n 20 || true
+          echo 'existing_large_derivatives_end'
 
           if [[ -f "$DERIVATIVE" ]]; then
             scalar derivative_exists true
@@ -149,7 +193,7 @@ jobs:
           headers="$(mktemp)"
           body="$(mktemp)"
           derivative_status="$(curl -k -sS --connect-timeout 8 --max-time 20 \
-            -A 'agency-production-image-diagnostic/1' \
+            -A 'agency-production-image-diagnostic/2' \
             -D "$headers" -o "$body" -w '%{http_code}' "$DERIVATIVE_URL" 2>/dev/null)"
           curl_exit="$?"
           if [[ "$curl_exit" -ne 0 ]]; then
@@ -161,9 +205,23 @@ jobs:
           scalar derivative_http_hint "$(tr '\n' ' ' < "$body" | grep -Eio -m1 'service unavailable|image|avif|gd|memory|permission|error' || true)"
           rm -f "$headers" "$body"
 
-          echo 'drupal_error_log_begin'
-          (cd "$CURRENT" && vendor/bin/drush watchdog:show --count=30 --severity=Error --format=table 2>&1 | tail -n 80) || true
-          echo 'drupal_error_log_end'
+          if [[ -f "$DERIVATIVE" ]]; then
+            scalar derivative_exists_after_get true
+            scalar derivative_bytes_after_get "$(stat -c '%s' "$DERIVATIVE" 2>/dev/null || echo unavailable)"
+            scalar derivative_mime_after_get "$(php -r '$i=@getimagesize($argv[1]); echo $i["mime"] ?? "unknown";' "$DERIVATIVE" 2>/dev/null || echo unavailable)"
+          else
+            scalar derivative_exists_after_get false
+            scalar derivative_bytes_after_get unavailable
+            scalar derivative_mime_after_get unavailable
+          fi
+
+          echo 'drupal_php_error_log_begin'
+          (cd "$CURRENT" && vendor/bin/drush watchdog:show --count=100 --type=php --severity=Error --extended --format=table 2>&1 | tail -n 160) || true
+          echo 'drupal_php_error_log_end'
+
+          echo 'drupal_image_error_log_begin'
+          (cd "$CURRENT" && vendor/bin/drush watchdog:show --count=200 --severity=Error --extended --filter='message~=#(image|avif|gd|permission|write|file)#i' --format=table 2>&1 | tail -n 160) || true
+          echo 'drupal_image_error_log_end'
 
           echo 'nginx_error_log_begin'
           tail -n 50 /var/log/nginx/error.log 2>&1 || true
@@ -182,13 +240,16 @@ jobs:
 
           status="$(value derivative_http_status)"
           source_exists="$(value source_exists)"
-          derivative_exists="$(value derivative_exists)"
+          derivative_exists="$(value derivative_exists_after_get)"
           gd_avif="$(value gd_avif_support)"
           imageavif="$(value imageavif_function)"
           gd_webp="$(value gd_webp_support)"
+          cli_avif="$(value cli_avif_encode)"
+          cli_webp="$(value cli_webp_encode)"
           toolkit="$(value image_toolkit)"
           current_sha="$(value current_sha)"
           maintenance="$(value maintenance_mode)"
+          fpm_workers="$(value php_fpm_workers)"
 
           verdict='UNKNOWN'
           if [[ "$ssh_status" -ne 0 ]]; then
@@ -199,6 +260,8 @@ jobs:
             verdict='DERIVATIVE_HEALTHY'
           elif [[ "$status" == '500' && ( "$gd_avif" != 'true' || "$imageavif" != 'true' ) ]]; then
             verdict='AVIF_CAPABILITY_MISMATCH'
+          elif [[ "$status" == '500' && "$cli_avif" != ok:* ]]; then
+            verdict='CLI_AVIF_ENCODER_FAILED'
           elif [[ "$status" == '500' && "$derivative_exists" != 'true' ]]; then
             verdict='DERIVATIVE_GENERATION_FAILED'
           elif [[ "$status" == '500' ]]; then
@@ -213,6 +276,9 @@ jobs:
             --arg gd_avif_support "${gd_avif:-unknown}" \
             --arg imageavif_function "${imageavif:-unknown}" \
             --arg gd_webp_support "${gd_webp:-unknown}" \
+            --arg cli_avif_encode "${cli_avif:-unknown}" \
+            --arg cli_webp_encode "${cli_webp:-unknown}" \
+            --arg php_fpm_workers "${fpm_workers:-unknown}" \
             --arg source_exists "${source_exists:-unknown}" \
             --arg source_dimensions "$(value source_dimensions)" \
             --arg derivative_exists "${derivative_exists:-unknown}" \
@@ -220,7 +286,7 @@ jobs:
             --arg derivative_http_status "${status:-unknown}" \
             --arg derivative_http_content_type "$(value derivative_http_content_type)" \
             --argjson ssh_exit "$ssh_status" \
-            '{schema_version:1, verdict:$verdict, ssh_exit:$ssh_exit, current_sha:$current_sha, maintenance_mode:$maintenance_mode, image_toolkit:$image_toolkit, gd_avif_support:$gd_avif_support, imageavif_function:$imageavif_function, gd_webp_support:$gd_webp_support, source_exists:$source_exists, source_dimensions:$source_dimensions, derivative_exists:$derivative_exists, derivative_dimensions:$derivative_dimensions, derivative_http_status:$derivative_http_status, derivative_http_content_type:$derivative_http_content_type}' \
+            '{schema_version:2, verdict:$verdict, ssh_exit:$ssh_exit, current_sha:$current_sha, maintenance_mode:$maintenance_mode, image_toolkit:$image_toolkit, gd_avif_support:$gd_avif_support, imageavif_function:$imageavif_function, gd_webp_support:$gd_webp_support, cli_avif_encode:$cli_avif_encode, cli_webp_encode:$cli_webp_encode, php_fpm_workers:$php_fpm_workers, source_exists:$source_exists, source_dimensions:$source_dimensions, derivative_exists:$derivative_exists, derivative_dimensions:$derivative_dimensions, derivative_http_status:$derivative_http_status, derivative_http_content_type:$derivative_http_content_type}' \
             > artifacts/production-image-diagnostic/result.json
 
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
@@ -252,6 +318,9 @@ jobs:
           gd_avif='unknown'
           imageavif='unknown'
           gd_webp='unknown'
+          cli_avif='unknown'
+          cli_webp='unknown'
+          fpm_workers='unknown'
           source_exists='unknown'
           source_dimensions='unknown'
           derivative_exists='unknown'
@@ -267,6 +336,9 @@ jobs:
             gd_avif="$(jq -r '.gd_avif_support' "$result")"
             imageavif="$(jq -r '.imageavif_function' "$result")"
             gd_webp="$(jq -r '.gd_webp_support' "$result")"
+            cli_avif="$(jq -r '.cli_avif_encode' "$result")"
+            cli_webp="$(jq -r '.cli_webp_encode' "$result")"
+            fpm_workers="$(jq -r '.php_fpm_workers' "$result")"
             source_exists="$(jq -r '.source_exists' "$result")"
             source_dimensions="$(jq -r '.source_dimensions' "$result")"
             derivative_exists="$(jq -r '.derivative_exists' "$result")"
@@ -288,15 +360,18 @@ jobs:
           gd_avif_support: \`${gd_avif}\`
           imageavif_function: \`${imageavif}\`
           gd_webp_support: \`${gd_webp}\`
+          cli_avif_encode: \`${cli_avif}\`
+          cli_webp_encode: \`${cli_webp}\`
+          php_fpm_workers: \`${fpm_workers}\`
           source_exists: \`${source_exists}\`
           source_dimensions: \`${source_dimensions}\`
-          derivative_exists: \`${derivative_exists}\`
+          derivative_exists_after_get: \`${derivative_exists}\`
           derivative_dimensions: \`${derivative_dimensions}\`
           derivative_http_status: \`${http_status}\`
           derivative_content_type: \`${content_type}\`
           artifact: \`${artifact}\`
 
-          Read-only incident diagnostic. No image derivative is generated or deleted, no Drupal state/config/content is changed, and no service/deployment command is executed.
+          Incident diagnostic only. The route performs no explicit derivative generation, deletion, flush, Drupal mutation, service change or deployment; its single fixed public GET may exercise Drupal's normal derivative-cache path exactly as Browser Validation does.
           EOF_BODY
           )"
           gh issue comment 596 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/docs/operations/production-image-diagnostic.md
+++ b/docs/operations/production-image-diagnostic.md
@@ -47,10 +47,18 @@ Through the existing production SSH channel, the route records:
 - `imageavif()` and `imagewebp()` availability;
 - GD AVIF and WebP support flags;
 - source file existence, size, dimensions and MIME type;
-- derivative existence, size, dimensions and MIME type;
+- in-memory AVIF and WebP encoding of the exact source through PHP CLI;
+- PHP-FPM worker identity and available FPM capability output;
+- permissions and ownership along the shared `files/styles` path;
+- filesystem free space and inode availability;
+- a bounded sample of existing `large` derivatives and their ownership/mode;
+- derivative existence, size, dimensions and MIME type before/after the GET;
 - the HTTP status/content type/body hash for the exact failing derivative;
-- bounded Drupal error log output;
+- bounded Drupal `php` errors plus image/AVIF/GD/file-related errors;
 - bounded Nginx and PHP-FPM log tails when readable by the deployment user.
+
+The encoder probes capture encoder output in memory and discard it. They do not
+write a diagnostic AVIF/WebP file.
 
 The fixed HTTP GET exercises the same public derivative endpoint already
 exercised by Browser Validation. Drupal may attempt its normal derivative-cache
@@ -75,11 +83,17 @@ The machine-readable result distinguishes:
 
 - `SOURCE_MISSING`;
 - `AVIF_CAPABILITY_MISMATCH`;
+- `CLI_AVIF_ENCODER_FAILED`;
 - `DERIVATIVE_GENERATION_FAILED`;
 - `DERIVATIVE_SERVING_FAILED`;
 - `DERIVATIVE_HEALTHY`;
 - `SSH_DIAGNOSTIC_FAILED`;
 - `UNKNOWN`.
+
+`CLI_AVIF_ENCODER_FAILED` means GD advertises AVIF but cannot encode the exact
+source even through the isolated in-memory CLI probe. If the CLI probe succeeds
+while the Drupal derivative still fails, permissions, FPM/runtime differences
+and the targeted Drupal error evidence become the next discriminators.
 
 Raw evidence stays in the 30-day workflow artifact; the issue comment publishes
 only bounded fields required for the next decision.

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionImageDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionImageDiagnosticWorkflowTest.php
@@ -52,12 +52,39 @@ final class ProductionImageDiagnosticWorkflowTest extends TestCase {
       '["AVIF Support"]',
       '["WebP Support"]',
       'getimagesize',
-      'watchdog:show --count=30 --severity=Error',
+      'imagecreatefrompng',
+      'imageavif($i, NULL, 75)',
+      'imagewebp($i, NULL, 75)',
+      'php_fpm_workers',
+      'php-fpm8.4 -i',
+      'namei -l "$DERIVATIVE"',
+      'df -Pk "$FILES"',
+      'df -Pi "$FILES"',
+      'existing_large_derivatives_begin',
+      'watchdog:show --count=100 --type=php --severity=Error --extended',
+      "message~=#(image|avif|gd|permission|write|file)#i",
       '/var/log/nginx/error.log',
       '/var/log/php8.4-fpm.log',
     ] as $required) {
       self::assertStringContainsString($required, $workflow);
     }
+  }
+
+  /**
+   * In-memory encoder probes may not create a diagnostic output file.
+   */
+  public function testEncoderProbesStayInMemory(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-production-image-diagnostic.yml',
+    );
+
+    self::assertStringContainsString('ob_start()', $workflow);
+    self::assertStringContainsString('ob_get_clean()', $workflow);
+    self::assertStringContainsString('cli_avif_encode', $workflow);
+    self::assertStringContainsString('cli_webp_encode', $workflow);
+    self::assertStringNotContainsString('imageavif($i, $', $workflow);
+    self::assertStringNotContainsString('imagewebp($i, $', $workflow);
   }
 
   /**
@@ -106,13 +133,16 @@ final class ProductionImageDiagnosticWorkflowTest extends TestCase {
 
     foreach ([
       'AVIF_CAPABILITY_MISMATCH',
+      'CLI_AVIF_ENCODER_FAILED',
       'DERIVATIVE_GENERATION_FAILED',
       'DERIVATIVE_SERVING_FAILED',
       'DERIVATIVE_HEALTHY',
       'SOURCE_MISSING',
+      'schema_version:2',
       'artifacts/production-image-diagnostic/result.json',
       'artifacts/production-image-diagnostic/diagnostic.txt',
       'derivative_http_content_type',
+      'derivative_exists_after_get',
     ] as $required) {
       self::assertStringContainsString($required, $workflow);
     }


### PR DESCRIPTION
## Contexte

Le diagnostic #596 run `32494829039` a prouvé `DERIVATIVE_GENERATION_FAILED` : GD/AVIF/WebP sont annoncés disponibles, la source #401 est lisible (1200×630), mais la dérivée reste absente et le GET retourne HTTP 500.

Les logs généraux étaient noyés par des erreurs mail et les logs Nginx/PHP-FPM ne sont pas lisibles par l’utilisateur SSH.

## Renforcement read-only

Cette PR garde exactement le même contrôle `/agency-production-image diagnose` et ajoute :

- encodage AVIF/WebP de la source **en mémoire** via output buffering, sans fichier écrit ;
- identité des workers PHP-FPM ;
- capacités `php-fpm8.4 -i` si disponibles ;
- permissions/ownership du chemin partagé `files/styles` + `namei` ;
- espace disque + inodes ;
- échantillon borné de dérivées `large` existantes ;
- existence de la dérivée avant/après le GET fixe ;
- watchdog `php` ciblé ;
- watchdog filtré image/AVIF/GD/permission/write/file ;
- verdict supplémentaire `CLI_AVIF_ENCODER_FAILED`.

Aucune génération explicite, suppression, flush, config/state/content mutation, restart, deploy ou commande arbitraire n’est introduite. Le GET fixe reste exactement l’endpoint déjà exercé par Browser Validation.

Diff exclusivement `.github/**`, docs et module de tests : aucun déploiement production attendu au merge grâce à #588.

Refs #596 #597 #401.