### PR TITLE
Issue #596: preserve production image repair failure evidence

### DIFF
--- a/.github/workflows/trusted-production-image-source-repair.yml
+++ b/.github/workflows/trusted-production-image-source-repair.yml
@@ -159,8 +159,23 @@ jobs:
               "set -euo pipefail; cd /var/www/agency/current; test -x vendor/bin/drush; vendor/bin/drush status --fields=bootstrap >/dev/null; AGENCY_IMAGE_REPAIR_MODE='$mode' AGENCY_IMAGE_REPAIR_PROFILE_PATH='$remote_profile' AGENCY_IMAGE_REPAIR_ASSET_PATH='$remote_asset' AGENCY_IMAGE_REPAIR_RESULT_PATH='$output' timeout 120s vendor/bin/drush php:script '$remote_script'"
           }
 
+          set +e
           remote_run dry-run "$remote_preapply"
-          scp "${ssh_opts[@]}" "$remote_target:$remote_preapply" "$artifact_dir/preapply.json" >/dev/null
+          dry_run_status="$?"
+          set -e
+          if ! scp "${ssh_opts[@]}" "$remote_target:$remote_preapply" "$artifact_dir/preapply.json" >/dev/null; then
+            echo "Dry-run result is missing after remote exit $dry_run_status." >&2
+            exit 1
+          fi
+          if ! jq -e . "$artifact_dir/preapply.json" >/dev/null; then
+            echo 'Dry-run result is not valid JSON.' >&2
+            exit 1
+          fi
+          if [[ "$dry_run_status" -ne 0 ]]; then
+            cp "$artifact_dir/preapply.json" "$artifact_dir/result.json"
+            echo "Remote dry-run failed after preserving bounded result evidence." >&2
+            exit "$dry_run_status"
+          fi
           jq -e '.status == "PASS" and (.verdict == "REPLACE_REQUIRED" or .verdict == "IDEMPOTENT")' "$artifact_dir/preapply.json" >/dev/null
           verdict="$(jq -r '.verdict' "$artifact_dir/preapply.json")"
           backup_file=''
@@ -172,13 +187,27 @@ jobs:
               "set -euo pipefail; cd /var/www/agency/current; mkdir -p /var/www/agency/shared/backups; timeout 120s vendor/bin/drush sql:dump --gzip --result-file='$backup_stem' >/dev/null; test -s '$backup_file'"
           fi
 
+          set +e
           remote_run apply "$remote_result"
-          scp "${ssh_opts[@]}" "$remote_target:$remote_result" "$artifact_dir/result.json" >/dev/null
-          jq -e '.status == "PASS" and (.verdict == "REPLACED" or .verdict == "IDEMPOTENT")' "$artifact_dir/result.json" >/dev/null
+          apply_status="$?"
+          set -e
+          if ! scp "${ssh_opts[@]}" "$remote_target:$remote_result" "$artifact_dir/result.json" >/dev/null; then
+            echo "Apply result is missing after remote exit $apply_status." >&2
+            exit 1
+          fi
+          if ! jq -e . "$artifact_dir/result.json" >/dev/null; then
+            echo 'Apply result is not valid JSON.' >&2
+            exit 1
+          fi
           jq --arg backup_file "$backup_file" \
             '. + {backup_file:(if $backup_file == "" then null else $backup_file end)}' \
             "$artifact_dir/result.json" > "$artifact_dir/result.tmp.json"
           mv "$artifact_dir/result.tmp.json" "$artifact_dir/result.json"
+          if [[ "$apply_status" -ne 0 ]]; then
+            echo "Remote apply failed after preserving bounded result evidence." >&2
+            exit "$apply_status"
+          fi
+          jq -e '.status == "PASS" and (.verdict == "REPLACED" or .verdict == "IDEMPOTENT")' "$artifact_dir/result.json" >/dev/null
 
       - name: Upload bounded repair evidence
         if: ${{ always() }}
@@ -204,12 +233,14 @@ jobs:
           revision='n/a'
           fid='n/a'
           uri='n/a'
+          message='n/a'
           if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
             status="$(jq -r '.status // "UNKNOWN"' "$result")"
             verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
             revision="$(jq -r '.node.revision_id // "n/a"' "$result")"
             fid="$(jq -r '.node.image.fid // "n/a"' "$result")"
             uri="$(jq -r '.node.image.uri // "n/a"' "$result")"
+            message="$(jq -r '.message // "n/a"' "$result" | tr '\r\n' ' ' | cut -c1-300)"
           fi
           artifact="agency-production-image-source-repair-596-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           body="$(cat <<EOF_BODY
@@ -223,6 +254,7 @@ jobs:
           revision_id: \`${revision}\`
           fid: \`${fid}\`
           uri: \`${uri}\`
+          message: \`${message}\`
           artifact: \`${artifact}\`
 
           This one-shot route accepts only issue #596 and the exact legacy #401 URI/SHA -> exact deterministic replacement transition. It does not delete the legacy File entity or accept arbitrary URLs, paths, commands or image bytes.

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialImageSourceRepairWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialImageSourceRepairWorkflowTest.php
@@ -43,6 +43,36 @@ final class ProductionEditorialImageSourceRepairWorkflowTest extends TestCase {
   }
 
   /**
+   * A remote fail-close must preserve the helper JSON before the job fails.
+   */
+  public function testRepairWorkflowPreservesRemoteFailureEvidence(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-image-source-repair.yml';
+    $workflow = (string) file_get_contents($path);
+
+    foreach ([
+      'dry_run_status="$?"',
+      'apply_status="$?"',
+      'cp "$artifact_dir/preapply.json" "$artifact_dir/result.json"',
+      'Remote dry-run failed after preserving bounded result evidence.',
+      'Remote apply failed after preserving bounded result evidence.',
+      'message="$(jq -r',
+      'message: \\`${message}\\`',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertMatchesRegularExpression(
+      '/set \+e\s+remote_run dry-run .*?dry_run_status="\$\?"\s+set -e\s+if ! scp/s',
+      $workflow,
+    );
+    self::assertMatchesRegularExpression(
+      '/set \+e\s+remote_run apply .*?apply_status="\$\?"\s+set -e\s+if ! scp/s',
+      $workflow,
+    );
+  }
+
+  /**
    * Pins the exact legacy-to-replacement transition and fail-close.
    */
   public function testRepairHelperPinsExactLegacyAndReplacementBytes(): void {


### PR DESCRIPTION
Fixes the bounded #596 one-shot repair telemetry without changing production runtime behavior.

- preserve remote helper JSON when dry-run/apply exits non-zero;
- keep the workflow fail-closed after evidence capture;
- surface a bounded exception message in the issue result;
- add regression coverage for evidence capture ordering.

Both changed paths are excluded from Deploy Production, so merging this PR must not deploy the site.

Refs #596 #599 #401.