### PR TITLE
Issue #401: align production browser proof with public locale URLs

### DIFF
--- a/.github/workflows/trusted-production-editorial-browser-proof.yml
+++ b/.github/workflows/trusted-production-editorial-browser-proof.yml
@@ -86,7 +86,7 @@ jobs:
           jq -e '
             .issue_number == 401 and
             .origin == "https://emergingdigital.be" and
-            .target == "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier" and
+            .target == "/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier" and
             .actor == "anonymous"
           ' "$CONTRACT" >/dev/null
           git diff --check

--- a/docs/operations/production-editorial-browser-proof.md
+++ b/docs/operations/production-editorial-browser-proof.md
@@ -54,17 +54,30 @@ tests/browser/contracts/production-editorial-401.json
 It fixes:
 
 - production origin `https://emergingdigital.be`;
-- FR and EN Article paths;
+- FR and EN public Article paths;
 - expected H1 and document languages;
 - category label;
 - FR and EN image ALT values;
 - canonical URLs;
-- FR/EN/x-default hreflang URLs;
+- FR and EN hreflang URLs;
 - sitemap endpoint;
 - the bounded set of internal links that must resolve.
 
 Adding another Article requires a reviewed repository change. The issue comment
 cannot select an arbitrary contract.
+
+### Public locale URL contract
+
+Drupal stores the Article aliases without a language prefix, but the versioned
+language negotiation uses `path_prefix` with `fr: fr` and `en: en`. The public
+URLs asserted by this proof must therefore include `/fr/...` and `/en/...`.
+An unprefixed Drupal alias is not the public canonical URL.
+
+The production HTML observed for #401 exposes the two translated alternates
+`hreflang="fr"` and `hreflang="en"`. `x-default` is not part of the v1 product
+contract and must not be invented by the proof. If Agency deliberately adds an
+`x-default` policy later, that must be introduced as an explicit reviewed SEO
+change before the Browser Proof starts requiring it.
 
 ## Execution model
 
@@ -102,7 +115,7 @@ For both FR and EN the scenario verifies:
 - category visibility;
 - feature image visibility, successful load and exact translated ALT;
 - canonical URL;
-- FR, EN and x-default hreflang values;
+- FR and EN hreflang values;
 - absence of obvious horizontal overflow;
 - required internal links are present and return below 400;
 - the canonical Article URL is present in the sitemap or one of its bounded

--- a/tests/browser/contracts/production-editorial-401.json
+++ b/tests/browser/contracts/production-editorial-401.json
@@ -1,17 +1,17 @@
 {
   "id": "production-editorial-401",
   "issue_number": 401,
-  "target": "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+  "target": "/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
   "actor": "anonymous",
   "origin": "https://emergingdigital.be",
   "category": "Qualité web / SEO / accessibilité",
   "sitemap": "/sitemap.xml",
   "locales": {
     "fr": {
-      "path": "/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+      "path": "/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
       "lang": "fr",
       "title": "Checklist avant une refonte de site internet : 12 points à vérifier",
-      "canonical": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+      "canonical": "https://emergingdigital.be/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
       "image_alt": "Checklist de préparation avant la refonte d’un site web"
     },
     "en": {
@@ -23,9 +23,8 @@
     }
   },
   "hreflang": {
-    "fr": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
-    "en": "https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start",
-    "x-default": "https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier"
+    "fr": "https://emergingdigital.be/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
+    "en": "https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start"
   },
   "internal_links": [
     "/services",

--- a/tests/browser/production-editorial-article.spec.mjs
+++ b/tests/browser/production-editorial-article.spec.mjs
@@ -31,7 +31,7 @@ assert.equal(contract.issue_number, 401);
 assert.equal(contract.actor, 'anonymous');
 assert.equal(contract.origin, 'https://emergingdigital.be');
 assert.deepEqual(Object.keys(contract.locales).sort(), ['en', 'fr']);
-assert.deepEqual(Object.keys(contract.hreflang).sort(), ['en', 'fr', 'x-default']);
+assert.deepEqual(Object.keys(contract.hreflang).sort(), ['en', 'fr']);
 
 function absoluteUrl(value, baseURL) {
   return new URL(value, `${baseURL}/`).toString();

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
@@ -33,6 +33,10 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
     self::assertStringContainsString('production-editorial-401.json', $workflow);
     self::assertStringContainsString('production-editorial-article.spec.mjs', $workflow);
     self::assertStringContainsString('https://emergingdigital.be', $workflow);
+    self::assertStringContainsString(
+      '.target == "/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier"',
+      $workflow,
+    );
     self::assertStringContainsString('runs-on: ubuntu-24.04', $workflow);
     self::assertStringNotContainsString('self-hosted', $workflow);
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
@@ -68,8 +72,28 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
     self::assertSame(401, $contract['issue_number']);
     self::assertSame('anonymous', $contract['actor']);
     self::assertSame('https://emergingdigital.be', $contract['origin']);
+    self::assertSame(
+      '/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      $contract['target'],
+    );
     self::assertSame(['fr', 'en'], array_keys($contract['locales']));
-    self::assertSame(['fr', 'en', 'x-default'], array_keys($contract['hreflang']));
+    self::assertSame(['fr', 'en'], array_keys($contract['hreflang']));
+    self::assertSame(
+      '/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      $contract['locales']['fr']['path'],
+    );
+    self::assertSame(
+      'https://emergingdigital.be/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      $contract['locales']['fr']['canonical'],
+    );
+    self::assertSame(
+      'https://emergingdigital.be/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      $contract['hreflang']['fr'],
+    );
+    self::assertSame(
+      'https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start',
+      $contract['hreflang']['en'],
+    );
     self::assertSame(
       'Checklist de préparation avant la refonte d’un site web',
       $contract['locales']['fr']['image_alt'],


### PR DESCRIPTION
Aligns the bounded production Browser Proof with the public locale contract observed for #401: French URLs use `/fr/...`, English URLs use `/en/...`, and the page currently exposes FR/EN hreflang alternates. Updates only the Browser Proof contract, its immutable workflow guard, tests, and documentation. No Drupal runtime or config change. #401 and #596 remain open until the final production Browser Proof passes and screenshots are reviewed.

Refs #401 #596.