### PR TITLE
Issue #401: validate translated production category labels

### DIFF
--- a/docs/operations/production-editorial-browser-proof.md
+++ b/docs/operations/production-editorial-browser-proof.md
@@ -56,7 +56,7 @@ It fixes:
 - production origin `https://emergingdigital.be`;
 - FR and EN public Article paths;
 - expected H1 and document languages;
-- category label;
+- exact translated FR and EN category labels;
 - FR and EN image ALT values;
 - canonical URLs;
 - FR and EN hreflang URLs;
@@ -78,6 +78,10 @@ The production HTML observed for #401 exposes the two translated alternates
 contract and must not be invented by the proof. If Agency deliberately adds an
 `x-default` policy later, that must be introduced as an explicit reviewed SEO
 change before the Browser Proof starts requiring it.
+
+The category is also translated content. The proof must require the exact
+public label for the locale under test rather than applying the French label to
+both language variants.
 
 ## Execution model
 
@@ -112,7 +116,7 @@ For both FR and EN the scenario verifies:
 - initial HTTP response below 400;
 - exact H1 and one-H1 structure;
 - exact `<html lang>`;
-- category visibility;
+- exact translated category visibility;
 - feature image visibility, successful load and exact translated ALT;
 - canonical URL;
 - FR and EN hreflang values;

--- a/tests/browser/contracts/production-editorial-401.json
+++ b/tests/browser/contracts/production-editorial-401.json
@@ -4,7 +4,10 @@
   "target": "/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier",
   "actor": "anonymous",
   "origin": "https://emergingdigital.be",
-  "category": "Qualité web / SEO / accessibilité",
+  "category": {
+    "fr": "Qualité web / SEO / accessibilité",
+    "en": "Web quality / SEO / accessibility"
+  },
   "sitemap": "/sitemap.xml",
   "locales": {
     "fr": {

--- a/tests/browser/production-editorial-article.spec.mjs
+++ b/tests/browser/production-editorial-article.spec.mjs
@@ -30,6 +30,7 @@ assert.equal(contract.id, 'production-editorial-401');
 assert.equal(contract.issue_number, 401);
 assert.equal(contract.actor, 'anonymous');
 assert.equal(contract.origin, 'https://emergingdigital.be');
+assert.deepEqual(Object.keys(contract.category).sort(), ['en', 'fr']);
 assert.deepEqual(Object.keys(contract.locales).sort(), ['en', 'fr']);
 assert.deepEqual(Object.keys(contract.hreflang).sort(), ['en', 'fr']);
 
@@ -86,7 +87,7 @@ async function verifyLocale(page, request, baseURL, locale, expected) {
   })).toBeVisible();
   await expect(page.locator('main')).toBeVisible();
   await expect(page.locator('html')).toHaveAttribute('lang', expected.lang);
-  await expect(page.getByText(contract.category, { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(contract.category[locale], { exact: true }).first()).toBeVisible();
 
   const image = page.locator(`img[alt="${expected.image_alt}"]`).first();
   await image.scrollIntoViewIfNeeded();

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionEditorialBrowserProofWorkflowTest.php
@@ -76,6 +76,15 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
       '/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier',
       $contract['target'],
     );
+    self::assertSame(['fr', 'en'], array_keys($contract['category']));
+    self::assertSame(
+      'Qualité web / SEO / accessibilité',
+      $contract['category']['fr'],
+    );
+    self::assertSame(
+      'Web quality / SEO / accessibility',
+      $contract['category']['en'],
+    );
     self::assertSame(['fr', 'en'], array_keys($contract['locales']));
     self::assertSame(['fr', 'en'], array_keys($contract['hreflang']));
     self::assertSame(
@@ -117,6 +126,7 @@ final class ProductionEditorialBrowserProofWorkflowTest extends TestCase {
     self::assertStringContainsString("link[rel=\"canonical\"]", $scenario);
     self::assertStringContainsString('link[rel="alternate"][hreflang]', $scenario);
     self::assertStringContainsString('<loc>${expectedUrl}</loc>', $scenario);
+    self::assertStringContainsString('contract.category[locale]', $scenario);
     self::assertStringContainsString('image_alt', $scenario);
     self::assertStringContainsString('naturalWidth', $scenario);
     self::assertStringContainsString('hasHorizontalOverflow', $scenario);


### PR DESCRIPTION
The Browser Proof run `32514149850` showed that FR now passes through its screenshot and the remaining failure is the EN category assertion: production correctly renders `Web quality / SEO / accessibility`, while the contract reused the French label for both locales. This PR makes the category contract locale-specific and keeps exact category visibility mandatory in both FR and EN. Changes are limited to tests/docs and do not alter Drupal runtime or production config.

Refs #401 #596.