### PR TITLE
Issue #608: govern configuration language across Drupal transformations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,37 @@ E-merging Digital. Elle doit rester courte, pratique et alignee avec le code.
   menus.
 - Les textes SEO doivent etre differencies par langue, pas simplement dupliques.
 
+## 6.1 Gouvernance de la langue de configuration
+
+- Pour toute tache qui cree ou modifie de la configuration Drupal, une Recipe,
+  une Config Action, une config entity Canvas ou une configuration materialisee
+  par Drupal AI/agent, lire **obligatoirement**
+  `docs/decisions/ADR-002-configuration-language-governance.md` et
+  `docs/configuration-language-policy.yml`.
+- Invariant : la langue de configuration technique doit etre deterministe,
+  reproductible et verifiable. Elle ne depend jamais accidentellement de la
+  requete HTTP, de l'admin, de la langue d'interface, de la provenance d'une
+  Recipe ou du contexte d'un agent IA.
+- La cible canonique technique Agency est `en`, distincte du
+  `system.site:default_langcode` editorial actuel `fr`.
+- La policy est actuellement `migration_required` : **ne pas normaliser en masse
+  `config/sync` et ne pas pretendre que l'enforcement EN est deja actif**.
+- #609 porte l'audit/migration. `drupal/config_language_lock` 1.0.x est le
+  candidat `USE DRUPAL` privilegie, avec `follow_site_default=false`, mais ne
+  doit pas etre active avec un lock EN avant les preuves prevues par #609.
+- Une Recipe est une transformation reproductible d'etat Drupal : verifier
+  preconditions, configuration/Config Actions, langcodes/traductions,
+  permissions, Canvas/SDC/AI impactes et etat final avant admission.
+- `drupal/language_audit` est au plus un outil DEV/investigation tant qu'il ne
+  dispose pas d'une release stable supportee ; ne pas en faire une dependance
+  production ni recreer son moteur sans gap demontre.
+- Agency expose la policy et les snapshots/diffs ; Preflight peut les verifier
+  independamment mais Agency ne depend pas de l'implementation interne de
+  Preflight.
+- Lorsque Drupal core fournit une primitive suffisante de langue par defaut de
+  configuration, conserver la policy/tests et retirer progressivement le
+  workaround contrib plutot que maintenir une dependance artificielle.
+
 ## 7. Regles de maillage interne
 
 - Les liens internes SEO doivent etre explicites dans les champs HTML quand ils

--- a/docs/configuration-language-governance.md
+++ b/docs/configuration-language-governance.md
@@ -1,0 +1,275 @@
+# Configuration Language Governance
+
+Statut : **SOURCE D’ARCHITECTURE ACTIVE — MIGRATION REQUIRED**  
+Décision : `docs/decisions/ADR-002-configuration-language-governance.md`  
+Policy machine-readable : `docs/configuration-language-policy.yml`  
+Issue d’architecture : #608  
+Adoption / migration : #609
+
+## 1. Objectif
+
+Agency doit pouvoir créer et transformer l’état Drupal par des opérations
+manuelles ou automatisées sans que la langue source de la configuration varie
+selon le contexte d’exécution.
+
+La règle s’applique uniformément à :
+
+- l’administration Drupal ;
+- l’installation de modules ou thèmes ;
+- Drupal Recipes ;
+- Config Actions ;
+- Canvas ;
+- Drupal AI / Canvas AI ;
+- agents automatisés qui passent par les APIs Drupal.
+
+La langue éditoriale du site et la langue canonique de configuration sont deux
+responsabilités distinctes. Agency conserve actuellement `fr` comme langue
+éditoriale par défaut et vise `en` comme langue canonique de configuration.
+
+## 2. État constaté avant migration
+
+Le snapshot versionné de #608 montre une base réellement mixte :
+
+| Surface | État observé |
+| --- | --- |
+| `system.site` | `langcode: fr`, `default_langcode: fr` |
+| `node.type.article` | `langcode: fr` |
+| Canvas folder `Agency governed` | `langcode: fr` |
+| `core.entity_view_mode.user.token` | `langcode: en` |
+| menu `footer` core | `langcode: und` |
+| locked languages | fichiers `language.entity.und.yml` et `language.entity.zxx.yml` présents |
+| config translations | `config/sync/language/fr` et `config/sync/language/en` présents |
+
+Ce tableau n’est pas une liste exhaustive. Il prouve que la normalisation est
+une migration et qu’une simple substitution de tous les `langcode` serait
+incorrecte.
+
+La policy reste donc :
+
+```text
+status: migration_required
+enforce_consistency: false
+canonical_configuration_language: en
+```
+
+jusqu’à #609.
+
+## 3. Modèle de transformation gouvernée
+
+Une transformation de configuration suit conceptuellement :
+
+```text
+état initial
+  |
+  v
+transformation Drupal
+  |
+  +--> module/theme install
+  +--> Recipe
+  +--> Config Action
+  +--> Canvas
+  +--> Drupal AI / agent
+  |
+  v
+état final
+  |
+  +--> structure
+  +--> langcode canonique
+  +--> traductions
+  +--> permissions
+  +--> composants / Canvas
+  +--> configuration exportable
+  |
+  v
+preuve before/after
+```
+
+Le validateur ne doit pas avoir besoin de savoir si l’opération a été déclenchée
+par un humain, une Recipe ou une IA. Il juge l’état final selon la même policy.
+
+## 4. Recipes
+
+Agency considère une Recipe comme une **transformation reproductible de l’état
+Drupal** et non comme un simple raccourci d’installation de modules.
+
+Pour toute Recipe introduite ou consommée, la revue doit couvrir :
+
+- préconditions ;
+- Recipes parentes et dépendances ;
+- modules et thèmes ;
+- configuration créée/importée ;
+- Config Actions ;
+- langcodes de la configuration source ;
+- traductions de configuration ;
+- permissions ;
+- SDC / composants ;
+- Canvas ;
+- Drupal AI ou agents concernés ;
+- état final attendu ;
+- snapshot/diff et preuve indépendante.
+
+Le `langcode` écrit dans un YAML externe n’est pas automatiquement autoritatif
+pour l’état Agency. #609 doit prouver le comportement d’une Recipe contenant un
+langcode différent ou invalide et vérifier que le résultat final ne dérive pas
+silencieusement de la policy.
+
+## 5. Canvas / SDC
+
+SDC reste le contrat de composant natif Drupal défini par ADR-001 et `DESIGN.md`.
+Cette politique n’ajoute aucune abstraction de composant.
+
+En revanche, les **config entities Canvas** font partie de la configuration
+technique et doivent donc respecter la langue canonique lorsqu’elles sont créées
+ou modifiées. La langue d’une Canvas Page ou de son contenu reste une question
+éditoriale distincte.
+
+Le pilote Canvas AI #530 doit être rebasé/revalidé contre ADR-002 avant admission
+finale si sa surface crée ou modifie de la configuration. Il ne doit pas être
+réécrit pour cette politique : l’enforcement doit rester transversal dans
+Drupal.
+
+## 6. Drupal AI et agents
+
+Drupal AI reste l’abstraction IA par défaut. ADR-002 ajoute une contrainte sur
+les **effets Drupal** d’une automatisation, pas sur le provider.
+
+Une IA peut :
+
+- produire du contenu en FR/EN ;
+- proposer une composition Canvas ;
+- déclencher une primitive Drupal autorisée.
+
+Elle ne peut pas :
+
+- choisir implicitement le `langcode` technique parce que le prompt est en FR ;
+- hériter de la langue de l’admin comme politique de configuration ;
+- contourner la policy via une API différente ;
+- produire une seconde convention de langue propre à l’IA.
+
+Les tests #609 doivent donc vérifier le résultat de la primitive Drupal, pas un
+provider précis.
+
+## 7. Configuration Language Lock
+
+Classification actuelle :
+
+```text
+USE DRUPAL — CANDIDATE FOR ADOPTION
+```
+
+La release stable `drupal/config_language_lock` 1.0.0 est le candidat préféré
+parce qu’elle intervient précisément sur les sauvegardes de config entities,
+les installs, les Recipes et les Config Actions.
+
+#608 ne l’installe pas. #609 doit :
+
+1. capturer un snapshot complet avant changement ;
+2. installer/activer d’abord le module sans enforcement ;
+3. comparer son audit au snapshot Agency ;
+4. simuler/observer la normalisation EN ;
+5. vérifier les traductions existantes et les locked languages ;
+6. prouver les cas Recipes/Config Actions/Canvas/IA ;
+7. n’activer `locked_langcode: en` avec `follow_site_default: false` qu’après
+   preuve verte ;
+8. vérifier `cim -> cex` sans drift et `site:install --existing-config`.
+
+Si ces preuves révèlent un blocker, #609 doit échouer fermé plutôt que corriger
+le YAML à la main.
+
+## 8. Language Audit
+
+`drupal/language_audit` est une source d’outillage et d’idées utile pour #609 :
+
+- distribution ;
+- snapshot ;
+- diff ;
+- détails config entity/simple config ;
+- provenance extension/Recipe lorsque détectable.
+
+Il reste classé **DEV / INVESTIGATION** tant qu’une release stable supportée
+n’existe pas. Il ne devient pas une dépendance production par défaut.
+
+Agency ne doit pas développer un clone de Language Audit pour obtenir un rapport
+qui existe déjà upstream. Un petit adaptateur ou export machine-readable n’est
+acceptable que si Preflight a besoin d’un contrat que l’outil upstream n’expose
+pas directement.
+
+## 9. Contrat observable pour Preflight
+
+Agency ne dépend pas de Preflight pour appliquer une Recipe ou rendre Canvas.
+Il expose ce qui est nécessaire à une vérification indépendante :
+
+```text
+docs/configuration-language-policy.yml
++ snapshot avant
++ description de la transformation
++ snapshot après
++ diff
++ éventuelles violations/exceptions
+```
+
+Preflight peut alors vérifier :
+
+- la langue canonique attendue ;
+- les langues éditoriales/translation connues ;
+- l’état `migration_required` ou `enforced` ;
+- les transformations soumises à la policy ;
+- les différences avant/après ;
+- la conformité de l’état final.
+
+La policy ne contient aucun détail d’implémentation interne de Preflight.
+
+## 10. Migration future vers Drupal core
+
+La policy Agency est durable ; le mécanisme d’enforcement ne l’est pas.
+
+Drupal core travaille sur une langue de configuration distincte de la langue par
+défaut du site. Lorsque cette primitive devient stable et couvre les cas Agency :
+
+```text
+policy + tests Agency conservés
+-> bascule enforcement contrib -> core
+-> preuves de non-régression
+-> retrait de config_language_lock si devenu inutile
+```
+
+Aucune API propriétaire Agency ne doit rendre cette simplification difficile.
+
+## 11. Roadmap
+
+### #608 — Architecture et contrat
+
+Statut cible : **P1 / documentation + policy + tests statiques**.
+
+- ADR-002 ;
+- policy machine-readable ;
+- règles agents ;
+- état initial matérialisé ;
+- relation Recipes/Canvas/AI/Preflight ;
+- aucun changement Composer/config runtime.
+
+### #609 — Audit et adoption
+
+Statut : **prochain chantier de configuration après #608**, coordonné avec les
+PR Composer ouvertes.
+
+- snapshot exhaustif ;
+- évaluation `config_language_lock` ;
+- migration dry-run ;
+- tests nominal/multilingue/Recipe/Config Action/Canvas/IA ;
+- décision d’adoption ou rejet fondée sur preuves ;
+- passage de `migration_required` à `enforced` uniquement si l’état est réellement
+  convergé.
+
+### Canvas AI / Recipes futures
+
+Tout chantier futur qui crée de la configuration doit consommer la policy et ne
+pas réinventer l’enforcement. Les idées de provenance/snapshot supplémentaires
+restent dans #609 ou dans un ticket dérivé uniquement lorsqu’un gap concret est
+identifié.
+
+## 12. Critère READY
+
+#609 devient READY après fusion de #608 **et** après rechargement des PR Composer
+ouvertes afin de ne pas créer de conflit de lockfile. Son premier acte est un
+audit/snapshot, pas un `composer require` ni une normalisation.

--- a/docs/configuration-language-policy.yml
+++ b/docs/configuration-language-policy.yml
@@ -1,0 +1,47 @@
+schema_version: 1
+policy_id: agency-configuration-language-v1
+status: migration_required
+canonical_configuration_language: en
+site_default_language: fr
+site_languages:
+  - fr
+  - en
+target_configuration_translation_languages:
+  - fr
+current_configuration_translation_directories:
+  - config/sync/language/fr
+  - config/sync/language/en
+enforce_consistency: false
+enforcement:
+  strategy: use_drupal
+  candidate: drupal/config_language_lock
+  minimum_release: 1.0.0
+  target_locked_langcode: en
+  follow_site_default: false
+  adoption_issue: 609
+transformation_sources:
+  - manual_admin
+  - module_install
+  - theme_install
+  - recipe
+  - config_action
+  - canvas
+  - drupal_ai
+  - automated_agent
+evidence:
+  require_before_snapshot: true
+  require_after_snapshot: true
+  require_diff: true
+  require_independent_verdict: true
+preflight:
+  coupling: none
+  contract: observable_policy_and_snapshots
+migration_watchlist:
+  - config/sync/language.entity.und.yml
+  - config/sync/language.entity.zxx.yml
+  - config/sync/language/fr
+  - config/sync/language/en
+  - config/sync/canvas.folder.0d5d5129-0d2e-41f3-a6d5-0211018bd59f.yml
+core_transition:
+  upstream_issue: 'https://www.drupal.org/project/drupal/issues/3337864'
+  remove_contrib_when_core_sufficient: true

--- a/docs/decisions/ADR-002-configuration-language-governance.md
+++ b/docs/decisions/ADR-002-configuration-language-governance.md
@@ -1,0 +1,337 @@
+# ADR-002 — Configuration Language Governance
+
+- **Statut : ACCEPTED**
+- **Date : 2026-08-21**
+- **Issue : #608**
+- **Follow-up d’adoption : #609**
+- **Complète : ADR-001 — Governed AI Experience**
+- **Supersède : aucune décision**
+
+## 1. Contexte
+
+Agency évolue vers une plateforme Drupal où de plus en plus d’état peut être
+créé ou transformé par des primitives automatisées : modules, Drupal Recipes,
+Config Actions, Canvas, Drupal AI et agents. Cette automatisation reste
+compatible avec la gouvernance Agency seulement si l’état produit est
+déterministe, reproductible et vérifiable.
+
+La langue de configuration est aujourd’hui un point de dérive réel dans Drupal.
+Une configuration peut hériter de la langue d’une requête, de l’utilisateur
+administrateur, de la langue de l’interface, de la langue fournie par une
+extension ou une Recipe, ou du contexte d’exécution d’un outil automatisé.
+
+L’état Agency observé sur `main` au 21 août 2026 confirme que le problème n’est
+pas théorique :
+
+- `system.site:default_langcode` vaut `fr` ;
+- la configuration de base exportée contient des `langcode` `fr`, `en` et
+  `und` ;
+- `language.entity.zxx` porte naturellement aussi la valeur `zxx` ;
+- des traductions de configuration sont exportées sous
+  `config/sync/language/fr` et `config/sync/language/en` ;
+- des objets Canvas déjà versionnés, par exemple le dossier `Agency governed`,
+  ont été créés avec `langcode: fr` ;
+- d’autres configurations provenant de core/contrib sont en `en` ou `und`.
+
+Cette distribution historique ne doit pas être interprétée comme une politique.
+Elle constitue un état de migration à comprendre avant normalisation.
+
+## 2. Décision fondamentale
+
+Agency adopte l’invariant suivant :
+
+> Toute configuration créée ou modifiée par Agency, Drupal core/contrib, une
+> Recipe, Config Actions, Canvas, Drupal AI ou un agent automatisé doit avoir un
+> comportement linguistique déterministe, reproductible et vérifiable.
+
+Le `langcode` d’une configuration technique ne doit jamais dépendre
+accidentellement :
+
+- de la langue de la requête HTTP ;
+- de la langue de l’utilisateur administrateur ;
+- de la langue active de l’interface ;
+- de la provenance ou de la langue source d’une Recipe ;
+- du contexte d’exécution d’un workflow IA ou d’un agent ;
+- de l’ordre dans lequel des modules, thèmes ou transformations ont été
+  appliqués.
+
+Cet invariant complète `COMPOSE BEFORE CREATE` : une composition gouvernée doit
+produire non seulement des composants autorisés, mais aussi un état Drupal dont
+la langue technique est gouvernée.
+
+## 3. Langue canonique cible
+
+Agency sépare désormais explicitement :
+
+```text
+langue éditoriale/site par défaut
+!=
+langue canonique de configuration technique
+```
+
+Pour le repository Agency actuel :
+
+```text
+site/default éditorial = fr
+configuration technique canonique cible = en
+langues du site = fr, en
+traduction cible de la configuration canonique = fr lorsque nécessaire
+```
+
+Le choix de `en` est motivé par :
+
+- Drupal core et la majorité des extensions fournissent leur configuration de
+  base en anglais ;
+- Agency vise des transformations réutilisables indépendantes d’un site
+  principalement FR, NL, DE ou EN ;
+- une base technique EN rend la configuration source indépendante de la langue
+  éditoriale courante ;
+- les mécanismes Drupal de traduction de configuration restent responsables des
+  libellés traduits.
+
+Ce choix **ne modifie pas** `system.site:default_langcode`, qui reste `fr` tant
+qu’un ticket éditorial distinct n’en décide pas autrement.
+
+## 4. État de transition : `migration_required`
+
+`en` est une cible d’architecture ACCEPTED, mais **l’enforcement n’est pas activé
+dans #608**.
+
+Le dépôt actuel contient déjà une base mixte et des overrides de traduction des
+deux côtés. Une réécriture globale immédiate pourrait déplacer la langue source
+d’objets traduisibles et donc modifier ce que Drupal considère comme original
+ou traduction.
+
+La policy machine-readable porte donc :
+
+```text
+status = migration_required
+enforce_consistency = false
+```
+
+jusqu’à la preuve de migration #609.
+
+#609 doit établir un snapshot avant/après, vérifier les traductions existantes,
+les objets Canvas, les locked languages `und`/`zxx`, l’installation
+`--existing-config` et la stabilité `cim -> cex` avant de faire passer la policy
+en mode enforced.
+
+## 5. Configuration Language Lock
+
+`drupal/config_language_lock` `1.0.0`, publié le 18 août 2026, est retenu comme
+**candidat `USE DRUPAL` privilégié** pour #609.
+
+La release stable est couverte par la Drupal Security Team et compatible avec
+Drupal `^11.2 || ^12`. Le module répond directement aux gaps identifiés :
+
+- config entities sauvegardées via UI/API ;
+- installation de modules et thèmes ;
+- configuration importée par Recipes ;
+- Config Actions ;
+- visualisation de la distribution des langues ;
+- normalisation vers une langue explicitement verrouillée.
+
+Décision Agency :
+
+```text
+candidat = drupal/config_language_lock ^1.0
+locked_langcode cible = en
+follow_site_default = false
+activation = uniquement après #609 vert
+```
+
+`follow_site_default` doit rester `false` : l’objectif est précisément de ne pas
+coupler la langue technique canonique au défaut éditorial du site.
+
+L’installation du module sans lock est acceptable comme étape de preuve sous
+#609 parce que le module documente ce mode comme opt-in et non intrusif. Son
+activation avec `en` ne doit cependant intervenir qu’après revue du diff de
+normalisation.
+
+## 6. Language Audit
+
+`drupal/language_audit` est classé :
+
+```text
+DEVELOPMENT / INVESTIGATION TOOL
+```
+
+Au 21 août 2026, le projet ne dispose pas d’une release stable supportée. Il est
+utile conceptuellement et potentiellement en DDEV pour :
+
+- distribution des langcodes ;
+- snapshots ;
+- diff avant/après ;
+- détail des config entities et simple config ;
+- recherche de provenance module/thème/Recipe.
+
+Il n’est pas ajouté comme dépendance production par #608. Agency ne doit pas
+réimplémenter son interface ou son moteur de provenance. #609 peut l’utiliser
+temporairement en développement si cela réduit le travail et si sa maturité est
+revalidée au moment de l’usage.
+
+## 7. Recipes = transformations gouvernées
+
+Une Recipe Agency n’est pas seulement une liste de modules à installer. Elle est
+une **transformation reproductible de l’état Drupal**.
+
+Toute adoption ou création de Recipe doit pouvoir décrire et vérifier au
+minimum :
+
+```text
+préconditions
+-> dépendances / recipes parentes
+-> modules / thèmes
+-> configuration importée
+-> Config Actions
+-> langcodes source
+-> traductions
+-> permissions
+-> SDC / Canvas concernés
+-> interactions Drupal AI éventuelles
+-> état final attendu
+-> preuve indépendante
+```
+
+Une Recipe contenant du YAML avec un autre `langcode`, ou un langcode invalide,
+ne peut pas introduire silencieusement un drift. Après la migration #609, l’état
+actif résultant doit respecter la langue canonique Agency, quelle que soit la
+langue source du fichier de Recipe.
+
+Une Recipe externe est donc évaluée sur **l’état final produit**, pas uniquement
+sur la validité syntaxique de son `recipe.yml`.
+
+## 8. Canvas, SDC et Drupal AI
+
+### SDC
+
+Les fichiers de composants SDC ne deviennent pas des traductions de
+configuration par eux-mêmes. Lorsqu’un SDC est matérialisé ou référencé par une
+config entity Canvas, cette config entity relève de cette ADR.
+
+### Canvas
+
+Canvas est déjà la primitive de composition visuelle Agency. Toute config entity
+Canvas créée ou modifiée manuellement ou par Canvas AI doit converger vers le
+`langcode` canonique, indépendamment de la langue de l’éditeur ou de la page
+candidate.
+
+La langue du contenu d’une Canvas Page reste une propriété éditoriale de
+l’entité de contenu et ne doit pas être confondue avec la langue de ses objets de
+configuration technique.
+
+### Drupal AI / agents
+
+Un workflow IA ne reçoit aucune exception à la politique parce qu’il est
+automatisé. S’il produit indirectement une configuration via une API Drupal, la
+même politique s’applique que pour une action manuelle, une Recipe ou une Config
+Action.
+
+L’IA peut choisir du contenu dans une langue demandée ; elle ne choisit pas
+implicitement la langue source de la configuration technique.
+
+## 9. Contrat Agency -> Preflight
+
+Agency expose la politique sans importer de logique Preflight.
+
+La source machine-readable est :
+
+```text
+docs/configuration-language-policy.yml
+```
+
+Elle exprime au minimum :
+
+- langue canonique cible ;
+- langue éditoriale par défaut actuelle ;
+- langues actives du site ;
+- langues de traduction cible de la configuration ;
+- état `migration_required` ou `enforced` ;
+- mécanisme d’enforcement prévu ;
+- transformations soumises à la politique ;
+- exigences de snapshot/diff ;
+- watchlist de migration ;
+- transition future vers Drupal core.
+
+Preflight peut lire cette policy et comparer un snapshot avant/après sans
+connaître l’implémentation de `config_language_lock`, Canvas ou Drupal AI.
+
+Le contrat cible est :
+
+```text
+état initial
+-> transformation Drupal
+-> snapshot/diff
+-> policy check
+-> verdict indépendant
+```
+
+## 10. Drupal core comme destination
+
+Configuration Language Lock est une solution de transition, pas une dépendance
+métier permanente.
+
+Drupal core travaille sur des guardrails de langue de configuration, notamment :
+
+- #3608533 — surface centralisée « Configuration language » ;
+- #3337864 — langue par défaut de configuration distincte de la langue par
+  défaut du site.
+
+Agency doit éviter toute API propriétaire qui empêcherait une migration vers la
+primitive core. Lorsque core fournit une couverture suffisante et stable :
+
+```text
+policy Agency inchangée
+-> remplacer l’enforcement contrib par core
+-> conserver les tests et preuves
+-> retirer progressivement le workaround contrib
+```
+
+La politique est donc plus durable que son mécanisme d’implémentation.
+
+## 11. Tests obligatoires pour l’adoption #609
+
+Au minimum :
+
+1. création nominale d’une config entity -> `en` ;
+2. frontend FR + admin FR -> config technique toujours `en` ;
+3. Config Action -> état final `en` ;
+4. Recipe avec `langcode` différent/incorrect -> pas de drift silencieux ;
+5. installation module/thème -> état final `en` ;
+6. création/modification d’un objet Canvas -> `en` ;
+7. workflow Drupal AI/agent matérialisant une config via Drupal -> même
+   invariant ;
+8. traductions de configuration FR préservées ;
+9. `site:install --existing-config` reproductible ;
+10. locked languages `und`/`zxx` de #412 non cassées ;
+11. `cim` puis `cex` sans drift ;
+12. preuve before/after exploitable indépendamment par Preflight.
+
+#608 n’ajoute qu’un test du **contrat de gouvernance** et du snapshot déclaré ;
+il n’émule pas `Language Audit` et ne prétend pas prouver l’enforcement runtime.
+
+## 12. Conséquences
+
+### Positives
+
+- comportement reproductible des transformations ;
+- séparation nette contenu/configuration ;
+- Recipes et Canvas AI deviennent auditables selon la même règle ;
+- moins de dérive liée à la langue de l’admin ;
+- contrat consommable par Preflight ;
+- trajectoire claire vers Drupal core.
+
+### Coûts assumés
+
+- migration initiale de la configuration historique ;
+- revue des traductions avant normalisation ;
+- tests supplémentaires sur Recipes/Canvas/AI ;
+- maintien temporaire d’un mécanisme contrib si #609 l’adopte.
+
+## 13. Règle de supersession
+
+Cette ADR complète ADR-001 et est autoritative pour la langue de configuration.
+
+Elle ne peut être remplacée que par une nouvelle ADR explicite. Une évolution de
+Drupal core peut changer le **mécanisme** d’enforcement sans remettre en cause
+l’invariant ni la séparation entre langue éditoriale et langue technique.

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageGovernanceTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageGovernanceTest.php
@@ -139,30 +139,25 @@ final class ConfigurationLanguageGovernanceTest extends TestCase {
     $root = dirname(DRUPAL_ROOT);
     $agents = (string) file_get_contents($root . '/AGENTS.md');
     $architecture = (string) file_get_contents(
-      $root . '/docs/governed-ai-experience.md',
-    );
-    $aiArchitecture = (string) file_get_contents(
-      $root . '/docs/drupal-ai-architecture.md',
+      $root . '/docs/configuration-language-governance.md',
     );
     $adr = (string) file_get_contents(
       $root . '/docs/decisions/ADR-002-configuration-language-governance.md',
     );
 
-    foreach ([$agents, $architecture, $aiArchitecture, $adr] as $document) {
+    foreach ([$agents, $architecture, $adr] as $document) {
       self::assertStringContainsString(
         'docs/configuration-language-policy.yml',
         $document,
       );
     }
 
-    self::assertStringContainsString(
-      'migration_required',
-      $adr,
-    );
-    self::assertStringContainsString(
-      'drupal/config_language_lock',
-      $adr,
-    );
+    foreach (['Recipes', 'Canvas', 'Drupal AI', 'Preflight'] as $surface) {
+      self::assertStringContainsString($surface, $architecture);
+    }
+
+    self::assertStringContainsString('migration_required', $adr);
+    self::assertStringContainsString('drupal/config_language_lock', $adr);
     self::assertStringContainsString('Preflight', $adr);
   }
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageGovernanceTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageGovernanceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the durable Agency configuration-language policy.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageGovernanceTest extends TestCase {
+
+  /**
+   * The machine-readable policy must stay explicit and Preflight-observable.
+   */
+  public function testPolicyContractIsExplicit(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $policy = Yaml::parseFile($root . '/docs/configuration-language-policy.yml');
+
+    self::assertSame(1, $policy['schema_version'] ?? NULL);
+    self::assertSame(
+      'agency-configuration-language-v1',
+      $policy['policy_id'] ?? NULL,
+    );
+    self::assertSame('migration_required', $policy['status'] ?? NULL);
+    self::assertSame('en', $policy['canonical_configuration_language'] ?? NULL);
+    self::assertSame('fr', $policy['site_default_language'] ?? NULL);
+    self::assertSame(['fr', 'en'], $policy['site_languages'] ?? NULL);
+    self::assertSame(
+      ['fr'],
+      $policy['target_configuration_translation_languages'] ?? NULL,
+    );
+    self::assertFalse($policy['enforce_consistency'] ?? TRUE);
+
+    self::assertSame(
+      'use_drupal',
+      $policy['enforcement']['strategy'] ?? NULL,
+    );
+    self::assertSame(
+      'drupal/config_language_lock',
+      $policy['enforcement']['candidate'] ?? NULL,
+    );
+    self::assertSame(
+      '1.0.0',
+      $policy['enforcement']['minimum_release'] ?? NULL,
+    );
+    self::assertSame(
+      'en',
+      $policy['enforcement']['target_locked_langcode'] ?? NULL,
+    );
+    self::assertFalse($policy['enforcement']['follow_site_default'] ?? TRUE);
+    self::assertSame(609, $policy['enforcement']['adoption_issue'] ?? NULL);
+
+    self::assertSame([
+      'manual_admin',
+      'module_install',
+      'theme_install',
+      'recipe',
+      'config_action',
+      'canvas',
+      'drupal_ai',
+      'automated_agent',
+    ], $policy['transformation_sources'] ?? NULL);
+
+    foreach ([
+      'require_before_snapshot',
+      'require_after_snapshot',
+      'require_diff',
+      'require_independent_verdict',
+    ] as $requirement) {
+      self::assertTrue($policy['evidence'][$requirement] ?? FALSE);
+    }
+
+    self::assertSame('none', $policy['preflight']['coupling'] ?? NULL);
+    self::assertSame(
+      'observable_policy_and_snapshots',
+      $policy['preflight']['contract'] ?? NULL,
+    );
+    self::assertTrue(
+      $policy['core_transition']['remove_contrib_when_core_sufficient'] ?? FALSE,
+    );
+  }
+
+  /**
+   * Current repository state must remain visibly classified as a migration.
+   */
+  public function testCurrentMixedSnapshotRequiresMigration(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $policy = Yaml::parseFile($root . '/docs/configuration-language-policy.yml');
+
+    self::assertSame('migration_required', $policy['status'] ?? NULL);
+    self::assertFalse($policy['enforce_consistency'] ?? TRUE);
+
+    $site = Yaml::parseFile($root . '/config/sync/system.site.yml');
+    self::assertSame('fr', $site['langcode'] ?? NULL);
+    self::assertSame('fr', $site['default_langcode'] ?? NULL);
+
+    $canvasFolder = Yaml::parseFile(
+      $root
+      . '/config/sync/canvas.folder.'
+      . '0d5d5129-0d2e-41f3-a6d5-0211018bd59f.yml',
+    );
+    self::assertSame('fr', $canvasFolder['langcode'] ?? NULL);
+
+    $coreViewMode = Yaml::parseFile(
+      $root . '/config/sync/core.entity_view_mode.user.token.yml',
+    );
+    self::assertSame('en', $coreViewMode['langcode'] ?? NULL);
+
+    $footerMenu = Yaml::parseFile(
+      $root . '/config/sync/system.menu.footer.yml',
+    );
+    self::assertSame('und', $footerMenu['langcode'] ?? NULL);
+
+    foreach ([
+      '/config/sync/language/fr',
+      '/config/sync/language/en',
+    ] as $translationDirectory) {
+      self::assertDirectoryExists($root . $translationDirectory);
+    }
+
+    foreach ([
+      '/config/sync/language.entity.und.yml',
+      '/config/sync/language.entity.zxx.yml',
+    ] as $lockedLanguage) {
+      self::assertFileExists($root . $lockedLanguage);
+    }
+  }
+
+  /**
+   * Policy ownership must be discoverable from durable agent documentation.
+   */
+  public function testDurableDocumentationOwnsTheInvariant(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $agents = (string) file_get_contents($root . '/AGENTS.md');
+    $architecture = (string) file_get_contents(
+      $root . '/docs/governed-ai-experience.md',
+    );
+    $aiArchitecture = (string) file_get_contents(
+      $root . '/docs/drupal-ai-architecture.md',
+    );
+    $adr = (string) file_get_contents(
+      $root . '/docs/decisions/ADR-002-configuration-language-governance.md',
+    );
+
+    foreach ([$agents, $architecture, $aiArchitecture, $adr] as $document) {
+      self::assertStringContainsString(
+        'docs/configuration-language-policy.yml',
+        $document,
+      );
+    }
+
+    self::assertStringContainsString(
+      'migration_required',
+      $adr,
+    );
+    self::assertStringContainsString(
+      'drupal/config_language_lock',
+      $adr,
+    );
+    self::assertStringContainsString('Preflight', $adr);
+  }
+
+}


### PR DESCRIPTION
## Objet

Matérialise durablement la gouvernance de langue de configuration demandée pour Agency, sans activer prématurément un module ni réécrire la configuration existante.

## Décisions

- `ADR-002` accepte la séparation langue éditoriale / langue technique ;
- cible canonique technique : `en` ;
- état courant explicitement `migration_required` ;
- `drupal/config_language_lock` 1.0.x classé `USE DRUPAL — candidate for adoption`, adoption bornée dans #609 ;
- `drupal/language_audit` reste DEV/investigation tant qu’il n’a pas de release stable supportée ;
- Recipes sont traitées comme transformations reproductibles d’état Drupal ;
- Canvas / Drupal AI / agents sont soumis au même invariant ;
- Preflight consomme une policy et des snapshots/diffs observables, sans couplage interne.

## Fichiers

- `docs/decisions/ADR-002-configuration-language-governance.md`
- `docs/configuration-language-governance.md`
- `docs/configuration-language-policy.yml`
- `AGENTS.md`
- `ConfigurationLanguageGovernanceTest.php`

## Garde-fous

Aucun changement de `composer.json`, `composer.lock`, `config/sync`, runtime Drupal ou workflow GitHub. La migration/adoption réelle est réservée à #609 après audit et coordination avec les PR Composer ouvertes.

Closes #608
Refs #609 #530 #387 #412 #518 #526.