### PR TITLE
Issue #609: capture trusted configuration language baseline

### DIFF
--- a/.github/workflows/trusted-configuration-language-audit.yml
+++ b/.github/workflows/trusted-configuration-language-audit.yml
@@ -1,0 +1,268 @@
+name: Agency trusted configuration language audit
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate configuration language audit request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language inspect'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '609' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language inspect' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Configuration language audit must execute the workflow revision on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  audit:
+    name: Rebuild Drupal and capture configuration language snapshot
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      snapshot_sha256: ${{ steps.summary.outputs.snapshot_sha256 }}
+      repository_by_langcode: ${{ steps.summary.outputs.repository_by_langcode }}
+      active_by_langcode: ${{ steps.summary.outputs.active_by_langcode }}
+      translations: ${{ steps.summary.outputs.translations }}
+      mixed_technical_base_languages: ${{ steps.summary.outputs.mixed_technical_base_languages }}
+      canonical_language_already_uniform: ${{ steps.summary.outputs.canonical_language_already_uniform }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable audit implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f AGENTS.md
+          test -f .ddev/config.yaml
+          test -f docs/configuration-language-policy.yml
+          test -f scripts/runner/run-configuration-language-audit.sh
+          test -f scripts/runner/configuration-language-audit.php
+          bash -n scripts/runner/run-configuration-language-audit.sh
+          php -l scripts/runner/configuration-language-audit.php
+          git diff --check
+
+      - name: Isolate DDEV project for this audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-ci.yaml <<EOF
+          name: agency-config-language-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-config-language-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Capture bounded read-only configuration language snapshot
+        id: route
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-audit
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-audit.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-audit/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          snapshot_sha256='n/a'
+          repository_by_langcode='{}'
+          active_by_langcode='{}'
+          translations='[]'
+          mixed='unknown'
+          uniform='unknown'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            snapshot_sha256="$(jq -r '.snapshot_sha256 // "n/a"' "$result")"
+            repository_by_langcode="$(jq -c '.repository.by_langcode // {}' "$result")"
+            active_by_langcode="$(jq -c '.active.by_langcode // {}' "$result")"
+            translations="$(jq -c '.translations // []' "$result")"
+            mixed="$(jq -r '.observations.mixed_technical_base_languages // "unknown"' "$result")"
+            uniform="$(jq -r '.observations.canonical_language_already_uniform // "unknown"' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "snapshot_sha256=$snapshot_sha256" >> "$GITHUB_OUTPUT"
+          echo "repository_by_langcode=$repository_by_langcode" >> "$GITHUB_OUTPUT"
+          echo "active_by_langcode=$active_by_langcode" >> "$GITHUB_OUTPUT"
+          echo "translations=$translations" >> "$GITHUB_OUTPUT"
+          echo "mixed_technical_base_languages=$mixed" >> "$GITHUB_OUTPUT"
+          echo "canonical_language_already_uniform=$uniform" >> "$GITHUB_OUTPUT"
+
+      - name: Upload configuration language evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-609-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-audit
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-ci.yaml
+          rm -rf artifacts/configuration-language-audit
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish bounded configuration language audit result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - audit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment audit result on #609
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.audit.result }}
+          STATUS: ${{ needs.audit.outputs.status }}
+          VERDICT: ${{ needs.audit.outputs.verdict }}
+          SNAPSHOT_SHA256: ${{ needs.audit.outputs.snapshot_sha256 }}
+          REPOSITORY_BY_LANGCODE: ${{ needs.audit.outputs.repository_by_langcode }}
+          ACTIVE_BY_LANGCODE: ${{ needs.audit.outputs.active_by_langcode }}
+          TRANSLATIONS: ${{ needs.audit.outputs.translations }}
+          MIXED: ${{ needs.audit.outputs.mixed_technical_base_languages }}
+          UNIFORM: ${{ needs.audit.outputs.canonical_language_already_uniform }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration language inspect FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration language inspect PASS'
+          fi
+
+          artifact="agency-config-language-609-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          snapshot_sha256: \`${SNAPSHOT_SHA256:-n/a}\`
+          repository_by_langcode: \`${REPOSITORY_BY_LANGCODE:-{}}\`
+          active_by_langcode: \`${ACTIVE_BY_LANGCODE:-{}}\`
+          translations: \`${TRANSLATIONS:-[]}\`
+          mixed_technical_base_languages: \`${MIXED:-unknown}\`
+          canonical_language_already_uniform: \`${UNIFORM:-unknown}\`
+          artifact: \`${artifact}\`
+
+          Read-only fresh-DDEV audit only. No Composer mutation, config export, Content Sync, production access or arbitrary shell input is permitted by this route.
+          EOF_BODY
+          )"
+          gh issue comment 609 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/docs/operations/configuration-language-audit.md
+++ b/docs/operations/configuration-language-audit.md
@@ -1,0 +1,159 @@
+# Configuration Language Audit — trusted read-only route
+
+Statut : **CANDIDATE — à prouver sur main avant promotion dans le registre global**  
+Owner : #609  
+Architecture : `docs/decisions/ADR-002-configuration-language-governance.md`  
+Policy : `docs/configuration-language-policy.yml`
+
+## 1. Objectif
+
+Cette route capture le snapshot initial exigé par #609 avant toute adoption de
+`drupal/config_language_lock`.
+
+Elle répond à une seule question : **quel est l’état linguistique réel d’une
+installation Drupal fraîche reconstruite depuis la configuration versionnée ?**
+
+Elle ne normalise rien et ne prend aucune décision d’adoption à elle seule.
+
+## 2. Surface de contrôle
+
+La seule commande admise est un commentaire propriétaire exact sur l’issue
+ouverte #609 :
+
+```text
+/agency-config-language inspect
+```
+
+Le gateway GitHub-hosted refuse la demande si :
+
+- l’acteur ou l’auteur du commentaire n’est pas `E-merging-digital` ;
+- le ticket n’est pas exactement #609 ;
+- l’issue n’est plus ouverte ou a été créée par un autre compte ;
+- le commentaire n’est pas exactement la commande ci-dessus ;
+- la révision de workflow exécutée n’est pas le `main` live.
+
+Aucun argument, chemin, package, commande shell ou cible runtime n’est fourni par
+le commentaire.
+
+## 3. Séparation de privilèges
+
+```text
+issue comment #609
+-> gateway GitHub-hosted
+   - valide acteur / issue / commande / live main
+-> runner self-hosted Agency
+   - contents: read
+   - checkout exact main
+   - DDEV isolé
+   - reconstruction Drupal fraîche
+   - audit read-only
+-> artifact
+-> job GitHub-hosted
+   - issues: write
+   - publie seulement le résumé borné
+```
+
+Le runner self-hosted ne reçoit aucun token repository write et utilise
+`persist-credentials: false`.
+
+La route ne reçoit aucun secret de production, provider IA ou utilisateur
+Drupal.
+
+## 4. Reconstruction canonique
+
+Le job self-hosted réutilise les invariants déjà éprouvés par Browser Validation :
+
+```text
+checkout exact main
+-> DDEV isolé
+-> composer install depuis composer.lock
+-> drush site:install --existing-config
+-> drush cim -y
+-> drush cr
+-> config:status
+-> snapshot
+-> artifact
+-> suppression DDEV
+-> workspace propre
+```
+
+`config:status` doit indiquer `No differences` avant l’audit. Si la configuration
+active et `config/sync` ne sont pas convergées, le verdict est
+`CONFIGURATION_NOT_CANONICAL` et aucun snapshot n’est admis comme baseline.
+
+## 5. Snapshot machine-readable
+
+L’artifact a la forme :
+
+```text
+agency-config-language-609-<run_id>-<attempt>
+```
+
+Il contient au minimum :
+
+```text
+result.json
+snapshot.json
+config-status.txt
+```
+
+`snapshot.json` contient :
+
+- policy Agency effectivement observée ;
+- version Drupal et langue par défaut active ;
+- inventaire de tous les YAML de base de `config/sync` ;
+- classification simple config / config entity lorsque Drupal la connaît ;
+- distribution des `langcode` ;
+- inventaire équivalent de la configuration active ;
+- comparaison nom par nom entre repository et active config ;
+- répertoires et noms des traductions sous `config/sync/language/*` ;
+- watchlist de migration ADR-002 ;
+- observation du caractère mixte ou uniforme des langues techniques.
+
+Le snapshot conserve les entrées individuelles, pas uniquement des compteurs,
+afin qu’un futur diff avant/après puisse identifier précisément les objets
+transformés.
+
+## 6. Critères PASS
+
+Le premier audit est `PASS / SNAPSHOT_CAPTURED` uniquement si :
+
+- la policy est `agency-configuration-language-v1` ;
+- son état est encore `migration_required` ;
+- sa cible canonique est `en` ;
+- `enforce_consistency` est encore `false` ;
+- la reconstruction `--existing-config` réussit ;
+- `config:status` est propre ;
+- aucun nom de configuration ne manque entre dépôt et active config ;
+- aucun `langcode` ne diffère entre dépôt et active config ;
+- tous les éléments de la migration watchlist existent.
+
+Un PASS ne signifie **pas** que la configuration est déjà normalisée EN. Il
+signifie seulement que le baseline pré-migration a été capturé de manière
+reproductible.
+
+## 7. Interdictions
+
+Cette route ne doit jamais :
+
+- exécuter `composer require` ou modifier `composer.json` / `composer.lock` ;
+- activer `config_language_lock` ;
+- exécuter `drush cex` ;
+- écrire de configuration via `config:set` ou Entity API ;
+- appliquer Governed Content / Content Sync ;
+- utiliser le canal SSH production ;
+- accepter du shell ou des chemins fournis par l’utilisateur ;
+- faire passer `migration_required` à `enforced`.
+
+## 8. Suite après première preuve
+
+Après un run PASS réellement observé sur `main` :
+
+1. conserver le SHA-256 du snapshot comme baseline #609 ;
+2. documenter la distribution réelle et les catégories de drift ;
+3. promouvoir la route dans `docs/operations/execution-capabilities.md` ;
+4. recharger les PR Composer #563/#566 ;
+5. seulement ensuite préparer l’évaluation de `config_language_lock` sans
+enforcement ;
+6. comparer le snapshot après activation du module au baseline initial ;
+7. ne préparer la migration EN qu’après preuve d’absence de perte de traduction.

--- a/scripts/runner/configuration-language-audit.php
+++ b/scripts/runner/configuration-language-audit.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$policyPath = $projectRoot . '/docs/configuration-language-policy.yml';
+$configDirectory = $projectRoot . '/config/sync';
+
+if (!is_file($policyPath) || !is_dir($configDirectory)) {
+  throw new RuntimeException('Configuration language policy or config/sync is missing.');
+}
+
+$policy = Yaml::parseFile($policyPath);
+if (!is_array($policy)) {
+  throw new RuntimeException('Configuration language policy must be a YAML mapping.');
+}
+if (($policy['policy_id'] ?? NULL) !== 'agency-configuration-language-v1') {
+  throw new RuntimeException('Unexpected configuration language policy id.');
+}
+if (($policy['status'] ?? NULL) !== 'migration_required') {
+  throw new RuntimeException('Initial audit is restricted to migration_required policy state.');
+}
+if (($policy['canonical_configuration_language'] ?? NULL) !== 'en') {
+  throw new RuntimeException('Initial audit expects canonical configuration language en.');
+}
+if (($policy['enforce_consistency'] ?? TRUE) !== FALSE) {
+  throw new RuntimeException('Initial audit must run before configuration-language enforcement.');
+}
+
+$configManager = \Drupal::service('config.manager');
+$activeStorage = \Drupal::service('config.storage');
+
+$increment = static function (array &$counts, string $key): void {
+  $counts[$key] = ($counts[$key] ?? 0) + 1;
+};
+
+$classify = static function (string $name) use ($configManager): array {
+  try {
+    $entityTypeId = $configManager->getEntityTypeIdByName($name);
+  }
+  catch (Throwable) {
+    $entityTypeId = NULL;
+  }
+
+  return [
+    'kind' => $entityTypeId === NULL ? 'simple_config' : 'config_entity',
+    'entity_type' => $entityTypeId,
+  ];
+};
+
+$normaliseLangcode = static function (array $data): string {
+  if (!array_key_exists('langcode', $data)) {
+    return '__none__';
+  }
+  $value = $data['langcode'];
+  if (!is_string($value) || $value === '') {
+    return '__invalid__';
+  }
+  return $value;
+};
+
+$buildSummary = static function (array $entries): array {
+  $byLangcode = [];
+  $byKind = [];
+  $byKindAndLangcode = [];
+
+  foreach ($entries as $entry) {
+    $langcode = (string) $entry['langcode'];
+    $kind = (string) $entry['kind'];
+    $byLangcode[$langcode] = ($byLangcode[$langcode] ?? 0) + 1;
+    $byKind[$kind] = ($byKind[$kind] ?? 0) + 1;
+    $byKindAndLangcode[$kind][$langcode] = ($byKindAndLangcode[$kind][$langcode] ?? 0) + 1;
+  }
+
+  ksort($byLangcode);
+  ksort($byKind);
+  ksort($byKindAndLangcode);
+  foreach ($byKindAndLangcode as &$counts) {
+    ksort($counts);
+  }
+  unset($counts);
+
+  return [
+    'total' => count($entries),
+    'by_langcode' => $byLangcode,
+    'by_kind' => $byKind,
+    'by_kind_and_langcode' => $byKindAndLangcode,
+  ];
+};
+
+$repositoryEntries = [];
+$repositoryByName = [];
+$repositoryFiles = glob($configDirectory . '/*.yml');
+if ($repositoryFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate repository configuration.');
+}
+sort($repositoryFiles, SORT_STRING);
+
+foreach ($repositoryFiles as $path) {
+  $data = Yaml::parseFile($path);
+  if (!is_array($data)) {
+    $data = [];
+  }
+  $name = basename($path, '.yml');
+  $classification = $classify($name);
+  $entry = [
+    'name' => $name,
+    'langcode' => $normaliseLangcode($data),
+    'kind' => $classification['kind'],
+    'entity_type' => $classification['entity_type'],
+  ];
+  $repositoryEntries[] = $entry;
+  $repositoryByName[$name] = $entry;
+}
+
+$activeEntries = [];
+$activeByName = [];
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    $data = [];
+  }
+  $classification = $classify($name);
+  $entry = [
+    'name' => $name,
+    'langcode' => $normaliseLangcode($data),
+    'kind' => $classification['kind'],
+    'entity_type' => $classification['entity_type'],
+  ];
+  $activeEntries[] = $entry;
+  $activeByName[$name] = $entry;
+}
+
+$missingActive = array_values(array_diff(array_keys($repositoryByName), array_keys($activeByName)));
+$missingRepository = array_values(array_diff(array_keys($activeByName), array_keys($repositoryByName)));
+sort($missingActive, SORT_STRING);
+sort($missingRepository, SORT_STRING);
+
+$langcodeMismatches = [];
+foreach (array_intersect(array_keys($repositoryByName), array_keys($activeByName)) as $name) {
+  $repositoryLangcode = $repositoryByName[$name]['langcode'];
+  $activeLangcode = $activeByName[$name]['langcode'];
+  if ($repositoryLangcode !== $activeLangcode) {
+    $langcodeMismatches[] = [
+      'name' => $name,
+      'repository' => $repositoryLangcode,
+      'active' => $activeLangcode,
+    ];
+  }
+}
+usort($langcodeMismatches, static fn(array $left, array $right): int => $left['name'] <=> $right['name']);
+
+$translationDirectories = [];
+$languageDirectories = glob($configDirectory . '/language/*', GLOB_ONLYDIR);
+if ($languageDirectories === FALSE) {
+  throw new RuntimeException('Unable to enumerate configuration translation directories.');
+}
+sort($languageDirectories, SORT_STRING);
+foreach ($languageDirectories as $directory) {
+  $files = glob($directory . '/*.yml');
+  if ($files === FALSE) {
+    throw new RuntimeException('Unable to enumerate configuration translation files.');
+  }
+  sort($files, SORT_STRING);
+  $translationDirectories[] = [
+    'language' => basename($directory),
+    'count' => count($files),
+    'config_names' => array_map(
+      static fn(string $path): string => basename($path, '.yml'),
+      $files,
+    ),
+  ];
+}
+
+$watchlist = [];
+foreach (($policy['migration_watchlist'] ?? []) as $relativePath) {
+  if (!is_string($relativePath) || $relativePath === '') {
+    continue;
+  }
+  $absolutePath = $projectRoot . '/' . ltrim($relativePath, '/');
+  $entry = [
+    'path' => $relativePath,
+    'exists' => file_exists($absolutePath),
+    'type' => is_dir($absolutePath) ? 'directory' : (is_file($absolutePath) ? 'file' : 'missing'),
+  ];
+  if (is_file($absolutePath) && str_ends_with($absolutePath, '.yml')) {
+    $data = Yaml::parseFile($absolutePath);
+    if (!is_array($data)) {
+      $data = [];
+    }
+    $entry['langcode'] = $normaliseLangcode($data);
+  }
+  $watchlist[] = $entry;
+}
+
+$repositorySummary = $buildSummary($repositoryEntries);
+$activeSummary = $buildSummary($activeEntries);
+$observedBaseLangcodes = array_keys($repositorySummary['by_langcode']);
+$technicalBaseLangcodes = array_values(array_filter(
+  $observedBaseLangcodes,
+  static fn(string $langcode): bool => !in_array($langcode, ['__none__', 'und', 'zxx'], TRUE),
+));
+sort($technicalBaseLangcodes, SORT_STRING);
+
+$snapshot = [
+  'schema_version' => 1,
+  'policy' => [
+    'policy_id' => $policy['policy_id'],
+    'status' => $policy['status'],
+    'canonical_configuration_language' => $policy['canonical_configuration_language'],
+    'site_default_language' => $policy['site_default_language'] ?? NULL,
+    'site_languages' => $policy['site_languages'] ?? [],
+    'enforce_consistency' => $policy['enforce_consistency'],
+  ],
+  'drupal' => [
+    'version' => \Drupal::VERSION,
+    'site_default_language' => \Drupal::languageManager()->getDefaultLanguage()->getId(),
+  ],
+  'repository' => [
+    'summary' => $repositorySummary,
+    'entries' => $repositoryEntries,
+  ],
+  'active' => [
+    'summary' => $activeSummary,
+    'entries' => $activeEntries,
+  ],
+  'repository_active_comparison' => [
+    'missing_from_active' => $missingActive,
+    'missing_from_repository' => $missingRepository,
+    'langcode_mismatches' => $langcodeMismatches,
+  ],
+  'translations' => $translationDirectories,
+  'migration_watchlist' => $watchlist,
+  'observations' => [
+    'observed_base_langcodes' => $observedBaseLangcodes,
+    'technical_base_langcodes' => $technicalBaseLangcodes,
+    'mixed_technical_base_languages' => count($technicalBaseLangcodes) > 1,
+    'canonical_language_already_uniform' => $technicalBaseLangcodes === ['en'],
+  ],
+];
+
+echo json_encode(
+  $snapshot,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-audit.sh
+++ b/scripts/runner/run-configuration-language-audit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-audit'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+command -v sha256sum >/dev/null
+
+test -f docs/configuration-language-policy.yml
+test -f scripts/runner/configuration-language-audit.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+php -l scripts/runner/configuration-language-audit.php >/dev/null
+git diff --check
+
+config_status="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status" > "$ARTIFACT_DIR/config-status.txt"
+if ! grep -Fq 'No differences' <<<"$config_status"; then
+  jq -n \
+    --arg status 'FAIL' \
+    --arg verdict 'CONFIGURATION_NOT_CANONICAL' \
+    --arg trusted_main "$TRUSTED_MAIN" \
+    '{status:$status,verdict:$verdict,trusted_main:$trusted_main}' \
+    > "$ARTIFACT_DIR/result.json"
+  echo 'Configuration must be converged before language audit.' >&2
+  exit 1
+fi
+
+ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
+  > "$ARTIFACT_DIR/snapshot.json"
+
+jq -e '.schema_version == 1' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.policy.policy_id == "agency-configuration-language-v1"' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.policy.status == "migration_required"' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.policy.canonical_configuration_language == "en"' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.policy.enforce_consistency == false' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.repository_active_comparison.missing_from_active | length == 0' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.repository_active_comparison.missing_from_repository | length == 0' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.repository_active_comparison.langcode_mismatches | length == 0' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+jq -e '.migration_watchlist | all(.exists == true)' "$ARTIFACT_DIR/snapshot.json" >/dev/null
+
+snapshot_sha256="$(sha256sum "$ARTIFACT_DIR/snapshot.json" | awk '{print $1}')"
+repo_total="$(jq -r '.repository.summary.total' "$ARTIFACT_DIR/snapshot.json")"
+active_total="$(jq -r '.active.summary.total' "$ARTIFACT_DIR/snapshot.json")"
+repo_langcodes="$(jq -c '.repository.summary.by_langcode' "$ARTIFACT_DIR/snapshot.json")"
+active_langcodes="$(jq -c '.active.summary.by_langcode' "$ARTIFACT_DIR/snapshot.json")"
+translation_counts="$(jq -c '[.translations[] | {language,count}]' "$ARTIFACT_DIR/snapshot.json")"
+mixed="$(jq -r '.observations.mixed_technical_base_languages' "$ARTIFACT_DIR/snapshot.json")"
+uniform="$(jq -r '.observations.canonical_language_already_uniform' "$ARTIFACT_DIR/snapshot.json")"
+
+jq -n \
+  --arg status 'PASS' \
+  --arg verdict 'SNAPSHOT_CAPTURED' \
+  --arg trusted_main "$TRUSTED_MAIN" \
+  --arg snapshot_sha256 "$snapshot_sha256" \
+  --argjson repository_total "$repo_total" \
+  --argjson active_total "$active_total" \
+  --argjson repository_by_langcode "$repo_langcodes" \
+  --argjson active_by_langcode "$active_langcodes" \
+  --argjson translations "$translation_counts" \
+  --argjson mixed_technical_base_languages "$mixed" \
+  --argjson canonical_language_already_uniform "$uniform" \
+  '{
+    status:$status,
+    verdict:$verdict,
+    trusted_main:$trusted_main,
+    snapshot_sha256:$snapshot_sha256,
+    policy_status:"migration_required",
+    canonical_configuration_language:"en",
+    repository:{total:$repository_total,by_langcode:$repository_by_langcode},
+    active:{total:$active_total,by_langcode:$active_by_langcode},
+    translations:$translations,
+    observations:{
+      mixed_technical_base_languages:$mixed_technical_base_languages,
+      canonical_language_already_uniform:$canonical_language_already_uniform
+    }
+  }' > "$ARTIFACT_DIR/result.json"
+
+jq -e '.status == "PASS" and .verdict == "SNAPSHOT_CAPTURED"' "$ARTIFACT_DIR/result.json" >/dev/null

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded configuration-language audit route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
+
+  /**
+   * The issue-comment gateway must remain owner-bound and read-only.
+   */
+  public function testTrustedAuditGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-audit.yml',
+    );
+
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language inspect'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'609\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('SSH_PRIVATE_KEY', $workflow);
+    self::assertStringNotContainsString('SERVER_HOST', $workflow);
+    self::assertStringNotContainsString('composer require', $workflow);
+    self::assertStringNotContainsString('drush cex', $workflow);
+    self::assertStringNotContainsString(
+      'emerging:governed-content',
+      $workflow,
+    );
+  }
+
+  /**
+   * The runner captures repository and active state without changing either.
+   */
+  public function testAuditRunnerCapturesReadOnlyEvidence(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runner = (string) file_get_contents(
+      $root . '/scripts/runner/run-configuration-language-audit.sh',
+    );
+    $snapshotter = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-audit.php',
+    );
+
+    self::assertStringContainsString('drush config:status', $runner);
+    self::assertStringContainsString(
+      'configuration-language-audit.php',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.repository_active_comparison.missing_from_active | length == 0',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.repository_active_comparison.langcode_mismatches | length == 0',
+      $runner,
+    );
+    self::assertStringContainsString('SNAPSHOT_CAPTURED', $runner);
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush cim',
+      'drush en',
+      'config:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    self::assertStringContainsString(
+      "\\Drupal::service('config.storage')",
+      $snapshotter,
+    );
+    self::assertStringContainsString(
+      'getEntityTypeIdByName',
+      $snapshotter,
+    );
+    self::assertStringContainsString(
+      'repository_active_comparison',
+      $snapshotter,
+    );
+    self::assertStringContainsString(
+      'mixed_technical_base_languages',
+      $snapshotter,
+    );
+    self::assertStringContainsString(
+      "glob(\$configDirectory . '/language/*', GLOB_ONLYDIR)",
+      $snapshotter,
+    );
+    self::assertStringNotContainsString('->save(', $snapshotter);
+    self::assertStringNotContainsString('config.factory', $snapshotter);
+  }
+
+  /**
+   * Durable documentation must expose the command and evidence contract.
+   */
+  public function testDocumentationExposesAuditRoute(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $architecture = (string) file_get_contents(
+      $root . '/docs/configuration-language-governance.md',
+    );
+    $capabilities = (string) file_get_contents(
+      $root . '/docs/operations/execution-capabilities.md',
+    );
+
+    foreach ([$architecture, $capabilities] as $document) {
+      self::assertStringContainsString(
+        '/agency-config-language inspect',
+        $document,
+      );
+      self::assertStringContainsString(
+        'agency-config-language-609-',
+        $document,
+      );
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
@@ -117,27 +117,28 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
   }
 
   /**
-   * Durable documentation must expose the command and evidence contract.
+   * The candidate route must be documented before its first trusted proof.
    */
-  public function testDocumentationExposesAuditRoute(): void {
+  public function testCandidateRunbookExposesAuditContract(): void {
     $root = dirname(DRUPAL_ROOT);
-    $architecture = (string) file_get_contents(
-      $root . '/docs/configuration-language-governance.md',
-    );
-    $capabilities = (string) file_get_contents(
-      $root . '/docs/operations/execution-capabilities.md',
+    $runbook = (string) file_get_contents(
+      $root . '/docs/operations/configuration-language-audit.md',
     );
 
-    foreach ([$architecture, $capabilities] as $document) {
-      self::assertStringContainsString(
-        '/agency-config-language inspect',
-        $document,
-      );
-      self::assertStringContainsString(
-        'agency-config-language-609-',
-        $document,
-      );
-    }
+    self::assertStringContainsString(
+      'CANDIDATE — à prouver sur main avant promotion',
+      $runbook,
+    );
+    self::assertStringContainsString(
+      '/agency-config-language inspect',
+      $runbook,
+    );
+    self::assertStringContainsString(
+      'agency-config-language-609-',
+      $runbook,
+    );
+    self::assertStringContainsString('SNAPSHOT_CAPTURED', $runbook);
+    self::assertStringContainsString('No Composer mutation', $runbook);
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
@@ -138,7 +138,7 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
       $runbook,
     );
     self::assertStringContainsString('SNAPSHOT_CAPTURED', $runbook);
-    self::assertStringContainsString('No Composer mutation', $runbook);
+    self::assertStringContainsString('`composer require`', $runbook);
   }
 
 }


### PR DESCRIPTION
## Objet

Premier incrément de #609 : capturer le baseline pré-migration de langue de configuration sur un Drupal fraîchement reconstruit, sans modifier Composer ni la configuration.

## Route

Commande propriétaire unique sur #609 : `/agency-config-language inspect`.

Le gateway GitHub-hosted valide acteur, issue et live `main`, puis le runner Agency reconstruit DDEV depuis `--existing-config`, converge par `cim`, exige `config:status` propre et produit un snapshot JSON dépôt + active config + traductions + watchlist.

## Garde-fous

- runner self-hosted en `contents: read` et `persist-credentials: false` ;
- aucun SSH/production/provider secret ;
- aucun `composer require`, `cex`, Content Sync ou shell arbitraire ;
- aucune activation de `config_language_lock` ;
- aucune transition `migration_required -> enforced`.

Après CI + merge, un premier `/agency-config-language inspect` sur #609 devra prouver la route et fournir le SHA-256 du snapshot avant la phase d’évaluation du module.

Refs #608 #412 #563 #566. Partial #609.