### PR TITLE
Issue #612: run configuration audit PHP inside DDEV

### DIFF
--- a/.github/workflows/trusted-configuration-language-audit.yml
+++ b/.github/workflows/trusted-configuration-language-audit.yml
@@ -111,7 +111,6 @@ jobs:
           test -f scripts/runner/run-configuration-language-audit.sh
           test -f scripts/runner/configuration-language-audit.php
           bash -n scripts/runner/run-configuration-language-audit.sh
-          php -l scripts/runner/configuration-language-audit.php
           git diff --check
 
       - name: Isolate DDEV project for this audit
@@ -128,6 +127,7 @@ jobs:
         run: |
           set -euo pipefail
           ddev start -y
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php
           ddev composer install --no-interaction --no-progress --prefer-dist
 
           admin_pass="$(openssl rand -hex 24)"
@@ -241,6 +241,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ -z "${REPOSITORY_BY_LANGCODE:-}" ]]; then
+            REPOSITORY_BY_LANGCODE='{}'
+          fi
+          if [[ -z "${ACTIVE_BY_LANGCODE:-}" ]]; then
+            ACTIVE_BY_LANGCODE='{}'
+          fi
+          if [[ -z "${TRANSLATIONS:-}" ]]; then
+            TRANSLATIONS='[]'
+          fi
+
           heading='### Agency configuration language inspect FAIL'
           if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
             heading='### Agency configuration language inspect PASS'
@@ -255,9 +265,9 @@ jobs:
           route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
           verdict: \`${VERDICT:-UNKNOWN}\`
           snapshot_sha256: \`${SNAPSHOT_SHA256:-n/a}\`
-          repository_by_langcode: \`${REPOSITORY_BY_LANGCODE:-{}}\`
-          active_by_langcode: \`${ACTIVE_BY_LANGCODE:-{}}\`
-          translations: \`${TRANSLATIONS:-[]}\`
+          repository_by_langcode: \`${REPOSITORY_BY_LANGCODE}\`
+          active_by_langcode: \`${ACTIVE_BY_LANGCODE}\`
+          translations: \`${TRANSLATIONS}\`
           mixed_technical_base_languages: \`${MIXED:-unknown}\`
           canonical_language_already_uniform: \`${UNIFORM:-unknown}\`
           artifact: \`${artifact}\`

--- a/scripts/runner/run-configuration-language-audit.sh
+++ b/scripts/runner/run-configuration-language-audit.sh
@@ -26,7 +26,7 @@ command -v sha256sum >/dev/null
 test -f docs/configuration-language-policy.yml
 test -f scripts/runner/configuration-language-audit.php
 test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
-php -l scripts/runner/configuration-language-audit.php >/dev/null
+ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php >/dev/null
 git diff --check
 
 config_status="$(ddev drush config:status 2>&1)"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
@@ -43,6 +43,10 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
     self::assertStringContainsString('- self-hosted', $workflow);
     self::assertStringContainsString('- agency', $workflow);
     self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString(
+      'ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php',
+      $workflow,
+    );
 
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
     self::assertStringNotContainsString('SSH_PRIVATE_KEY', $workflow);
@@ -51,6 +55,18 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
     self::assertStringNotContainsString('drush cex', $workflow);
     self::assertStringNotContainsString(
       'emerging:governed-content',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      "\n          php -l scripts/runner/configuration-language-audit.php",
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      'REPOSITORY_BY_LANGCODE:-{}',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      'ACTIVE_BY_LANGCODE:-{}',
       $workflow,
     );
   }
@@ -68,6 +84,10 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
     );
 
     self::assertStringContainsString('drush config:status', $runner);
+    self::assertStringContainsString(
+      'ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php',
+      $runner,
+    );
     self::assertStringContainsString(
       'configuration-language-audit.php',
       $runner,
@@ -91,6 +111,10 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
     ] as $forbiddenMutation) {
       self::assertStringNotContainsString($forbiddenMutation, $runner);
     }
+    self::assertStringNotContainsString(
+      "\nphp -l scripts/runner/configuration-language-audit.php",
+      $runner,
+    );
 
     self::assertStringContainsString(
       "\\Drupal::service('config.storage')",


### PR DESCRIPTION
## Correction

Le premier audit #609 (run `32527869024`) a échoué fermé avant DDEV car le runner Agency n’a pas de PHP host.

Cette PR :
- déplace le lint de `configuration-language-audit.php` dans DDEV ;
- utilise aussi DDEV dans le runner d’audit ;
- corrige les fallbacks JSON `{}` du commentaire de résultat ;
- ajoute des tests empêchant le retour d’une dépendance PHP host.

Aucun changement Composer, `config/sync`, production ou contrat fonctionnel de l’audit.

Closes #612
Refs #609 #611.