### PR TITLE
Issue #614: promote proven configuration language audit baseline

### DIFF
--- a/.github/workflows/trusted-configuration-language-audit.yml
+++ b/.github/workflows/trusted-configuration-language-audit.yml
@@ -172,8 +172,8 @@ jobs:
             repository_by_langcode="$(jq -c '.repository.by_langcode // {}' "$result")"
             active_by_langcode="$(jq -c '.active.by_langcode // {}' "$result")"
             translations="$(jq -c '.translations // []' "$result")"
-            mixed="$(jq -r '.observations.mixed_technical_base_languages // "unknown"' "$result")"
-            uniform="$(jq -r '.observations.canonical_language_already_uniform // "unknown"' "$result")"
+            mixed="$(jq -r 'if (.observations | has("mixed_technical_base_languages")) then .observations.mixed_technical_base_languages else "unknown" end' "$result")"
+            uniform="$(jq -r 'if (.observations | has("canonical_language_already_uniform")) then .observations.canonical_language_already_uniform else "unknown" end' "$result")"
           fi
 
           echo "status=$status" >> "$GITHUB_OUTPUT"

--- a/docs/evidence/configuration-language-baseline-609.yml
+++ b/docs/evidence/configuration-language-baseline-609.yml
@@ -1,0 +1,97 @@
+schema_version: 1
+baseline_id: agency-config-language-609-pre-migration-v1
+captured_at: '2026-08-21'
+policy_id: agency-configuration-language-v1
+policy_status: migration_required
+canonical_configuration_language: en
+source:
+  issue: 609
+  workflow_run: 32528341256
+  trusted_main: c6d77fd109aa40cc6cf5849249d04e3d87bae65e
+  artifact:
+    id: 9463027789
+    name: agency-config-language-609-32528341256-1
+    digest: sha256:d9c008b56175a733b866b3beddd2076c5ac2bb12577fbd64d60ba32835ec854b
+  snapshot_sha256: df4d389eafaad6135fcd7d995354ff433111be62f745208ac0a65ddf8783629d
+canonical_rebuild:
+  site_install_existing_config: pass
+  config_status: clean
+  repository_active_name_match: true
+  repository_active_langcode_match: true
+repository:
+  total: 595
+  by_langcode:
+    no_langcode: 59
+    en: 183
+    fr: 352
+    und: 1
+  by_kind:
+    config_entity: 529
+    simple_config: 66
+  config_entities_by_langcode:
+    en: 183
+    fr: 345
+    und: 1
+  simple_config_by_langcode:
+    no_langcode: 59
+    fr: 7
+translations:
+  en:
+    count: 172
+  fr:
+    count: 2
+migration_analysis:
+  mixed_technical_base_languages: true
+  canonical_language_already_uniform: false
+  fr_base_with_en_override: 171
+  fr_base_without_en_override: 181
+  en_base_with_fr_override: 2
+  fr_simple_config:
+    - agency_ai_translation.settings
+    - llms_txt.settings
+    - system.maintenance
+    - system.site
+    - user.mail
+    - user.settings
+    - webform.settings
+  fr_without_en_override_by_entity_type:
+    base_field_override: 53
+    component: 30
+    language_content_settings: 14
+    folder: 13
+    entity_form_display: 11
+    entity_view_display: 10
+    action: 6
+    field_config: 6
+    field_storage_config: 6
+    media_type: 5
+    filter_format: 3
+    image_style: 3
+    view: 3
+    ai_automator: 2
+    block: 2
+    editor: 2
+    entity_view_mode: 2
+    node_type: 2
+    pathauto_pattern: 2
+    asset_library: 1
+    brand_kit: 1
+    configurable_language: 1
+    entity_form_mode: 1
+    metatag_defaults: 1
+    simple_config: 1
+  canvas:
+    fr_components_without_en_override: 30
+    fr_folders_without_en_override: 13
+classification:
+  migration_required_confirmed: true
+  bulk_langcode_replacement_allowed: false
+  semantic_or_locked_watchlist:
+    - config/sync/language.entity.und.yml
+    - config/sync/language.entity.zxx.yml
+    - system.menu.footer
+  notes:
+    - A base langcode and a configuration translation are different responsibilities.
+    - Existing EN overrides must be preserved or deliberately rematerialized when changing the canonical base language.
+    - Canvas configuration is a first-class migration surface and must be tested before enforcement.
+    - This compact baseline records durable evidence; the full snapshot remains the workflow artifact for detailed inspection.

--- a/docs/operations/configuration-language-audit.md
+++ b/docs/operations/configuration-language-audit.md
@@ -1,13 +1,15 @@
 # Configuration Language Audit — trusted read-only route
 
-Statut : **CANDIDATE — à prouver sur main avant promotion dans le registre global**  
+Statut : **PROUVÉE / AVAILABLE**  
 Owner : #609  
+Promotion : #614  
 Architecture : `docs/decisions/ADR-002-configuration-language-governance.md`  
-Policy : `docs/configuration-language-policy.yml`
+Policy : `docs/configuration-language-policy.yml`  
+Baseline durable : `docs/evidence/configuration-language-baseline-609.yml`
 
 ## 1. Objectif
 
-Cette route capture le snapshot initial exigé par #609 avant toute adoption de
+Cette route capture le snapshot exigé par #609 avant toute adoption de
 `drupal/config_language_lock`.
 
 Elle répond à une seule question : **quel est l’état linguistique réel d’une
@@ -15,7 +17,94 @@ installation Drupal fraîche reconstruite depuis la configuration versionnée ?*
 
 Elle ne normalise rien et ne prend aucune décision d’adoption à elle seule.
 
-## 2. Surface de contrôle
+## 2. Preuve d’admission
+
+La route a été exercée avec succès sur le `main` live le 21 août 2026 :
+
+```text
+run                  = 32528341256
+trusted main         = c6d77fd109aa40cc6cf5849249d04e3d87bae65e
+verdict              = PASS / SNAPSHOT_CAPTURED
+snapshot SHA-256     = df4d389eafaad6135fcd7d995354ff433111be62f745208ac0a65ddf8783629d
+artifact             = agency-config-language-609-32528341256-1
+artifact id          = 9463027789
+artifact digest      = sha256:d9c008b56175a733b866b3beddd2076c5ac2bb12577fbd64d60ba32835ec854b
+```
+
+Les trois jobs — validation hosted, reconstruction/audit self-hosted et report
+hosted — ont terminé `SUCCESS`, y compris le cleanup DDEV/workspace.
+
+La reconstruction a prouvé :
+
+```text
+site:install --existing-config = PASS
+cim                            = PASS
+config:status                  = No differences
+repository config count        = 595
+active config count            = 595
+missing names                  = 0
+langcode mismatches            = 0
+```
+
+Le premier essai `32527869024` avait échoué fermé avant DDEV parce que PHP
+n’existe pas sur l’hôte du runner. #612/#613 a déplacé le lint PHP dans DDEV.
+Cet échec historique ne constitue pas un échec Drupal ni une donnée de baseline.
+
+## 3. Baseline pré-migration
+
+Distribution exacte observée :
+
+| Surface | FR | EN | sans `langcode` | `und` |
+| --- | ---: | ---: | ---: | ---: |
+| Toutes configs | 352 | 183 | 59 | 1 |
+| Config entities | 345 | 183 | 0 | 1 |
+| Simple config | 7 | 0 | 59 | 0 |
+
+Traductions de configuration exportées :
+
+```text
+config/sync/language/en = 172 overrides
+config/sync/language/fr = 2 overrides
+```
+
+Analyse initiale :
+
+```text
+FR base avec override EN     = 171
+FR base sans override EN     = 181
+EN base avec override FR     = 2
+mixed technical base         = true
+canonical EN already uniform = false
+```
+
+Parmi les 181 bases FR sans override EN figurent notamment :
+
+- 53 `base_field_override` ;
+- 30 config entities Canvas `component` ;
+- 13 dossiers Canvas ;
+- 14 `language_content_settings` ;
+- 11 form displays et 10 view displays ;
+- champs/storages, media types, filtres, image styles, Views et autres surfaces.
+
+Les sept simple configs FR sont :
+
+- `agency_ai_translation.settings` ;
+- `llms_txt.settings` ;
+- `system.maintenance` ;
+- `system.site` ;
+- `user.mail` ;
+- `user.settings` ;
+- `webform.settings`.
+
+Cette distribution confirme `status: migration_required`. Elle interdit une
+réécriture globale `fr -> en`. Base canonique, configuration traduisible,
+overrides de traduction et valeurs sémantiques/locked doivent être distingués.
+
+Le détail compact et les identifiants de preuve sont versionnés dans
+`docs/evidence/configuration-language-baseline-609.yml`. Le snapshot complet
+reste l’artifact de run pour l’investigation détaillée.
+
+## 4. Surface de contrôle
 
 La seule commande admise est un commentaire propriétaire exact sur l’issue
 ouverte #609 :
@@ -35,7 +124,7 @@ Le gateway GitHub-hosted refuse la demande si :
 Aucun argument, chemin, package, commande shell ou cible runtime n’est fourni par
 le commentaire.
 
-## 3. Séparation de privilèges
+## 5. Séparation de privilèges
 
 ```text
 issue comment #609
@@ -57,15 +146,15 @@ Le runner self-hosted ne reçoit aucun token repository write et utilise
 `persist-credentials: false`.
 
 La route ne reçoit aucun secret de production, provider IA ou utilisateur
-Drupal.
+Drupal. PHP n’est pas requis sur l’hôte : les contrôles PHP s’exécutent dans le
+runtime DDEV du projet.
 
-## 4. Reconstruction canonique
-
-Le job self-hosted réutilise les invariants déjà éprouvés par Browser Validation :
+## 6. Reconstruction canonique
 
 ```text
 checkout exact main
 -> DDEV isolé
+-> lint PHP dans DDEV
 -> composer install depuis composer.lock
 -> drush site:install --existing-config
 -> drush cim -y
@@ -81,7 +170,7 @@ checkout exact main
 active et `config/sync` ne sont pas convergées, le verdict est
 `CONFIGURATION_NOT_CANONICAL` et aucun snapshot n’est admis comme baseline.
 
-## 5. Snapshot machine-readable
+## 7. Snapshot machine-readable
 
 L’artifact a la forme :
 
@@ -110,13 +199,12 @@ config-status.txt
 - watchlist de migration ADR-002 ;
 - observation du caractère mixte ou uniforme des langues techniques.
 
-Le snapshot conserve les entrées individuelles, pas uniquement des compteurs,
-afin qu’un futur diff avant/après puisse identifier précisément les objets
-transformés.
+Le snapshot conserve les entrées individuelles afin qu’un futur diff
+avant/après puisse identifier les objets transformés.
 
-## 6. Critères PASS
+## 8. Critères PASS
 
-Le premier audit est `PASS / SNAPSHOT_CAPTURED` uniquement si :
+Un audit est `PASS / SNAPSHOT_CAPTURED` uniquement si :
 
 - la policy est `agency-configuration-language-v1` ;
 - son état est encore `migration_required` ;
@@ -128,11 +216,10 @@ Le premier audit est `PASS / SNAPSHOT_CAPTURED` uniquement si :
 - aucun `langcode` ne diffère entre dépôt et active config ;
 - tous les éléments de la migration watchlist existent.
 
-Un PASS ne signifie **pas** que la configuration est déjà normalisée EN. Il
-signifie seulement que le baseline pré-migration a été capturé de manière
-reproductible.
+Un PASS ne signifie **pas** que la configuration est normalisée EN. Il signifie
+que l’état pré-migration est reproductible et mesuré.
 
-## 7. Interdictions
+## 9. Interdictions
 
 Cette route ne doit jamais :
 
@@ -145,15 +232,16 @@ Cette route ne doit jamais :
 - accepter du shell ou des chemins fournis par l’utilisateur ;
 - faire passer `migration_required` à `enforced`.
 
-## 8. Suite après première preuve
+## 10. Suite #609
 
-Après un run PASS réellement observé sur `main` :
+Après cette preuve :
 
-1. conserver le SHA-256 du snapshot comme baseline #609 ;
-2. documenter la distribution réelle et les catégories de drift ;
-3. promouvoir la route dans `docs/operations/execution-capabilities.md` ;
-4. recharger les PR Composer #563/#566 ;
-5. seulement ensuite préparer l’évaluation de `config_language_lock` sans
-enforcement ;
-6. comparer le snapshot après activation du module au baseline initial ;
-7. ne préparer la migration EN qu’après preuve d’absence de perte de traduction.
+1. recharger les PR Composer #563/#566 ;
+2. ne pas introduire `config_language_lock` tant qu’une mutation Composer
+   concurrente n’est pas convergée ;
+3. lorsque la voie Composer est libre, évaluer le module d’abord sans enforcement ;
+4. capturer un nouveau snapshot dans le même environnement ;
+5. comparer au baseline durable ;
+6. seulement ensuite préparer une migration EN ;
+7. n’activer l’enforcement qu’après preuve d’absence de perte ou dérive des
+   traductions, Recipes, Config Actions, Canvas et workflows IA.

--- a/docs/operations/execution-capabilities.md
+++ b/docs/operations/execution-capabilities.md
@@ -64,6 +64,10 @@ Node for browser jobs = 24 via actions/setup-node
 Chromium              = Playwright-managed
 ```
 
+The host account is not required to expose a standalone PHP binary. PHP checks
+for Drupal/runtime routes must use DDEV unless a workflow explicitly provisions
+host PHP.
+
 The repository `.ddev/config.yaml` also targets MariaDB 11.8. Any older
 reference to MariaDB 10.11 in DDEV documentation is historical debt, not the
 current Agency DDEV runtime.
@@ -377,12 +381,16 @@ Governed editorial publisher
 
 Governed editorial feature-image publisher
   -> bounded repository-owned field_feature_image inspect/dry-run/apply via trusted main
+
+Configuration language audit
+  -> fresh-DDEV read-only repository/active config snapshot and langcode evidence
 ```
 
 MCP is not a replacement for deterministic tests, and deterministic tests are
 not a replacement for visual inspection. The Composer materializer is not a
 generic command executor. The editorial publisher and feature-image publisher
-are not generic production content, upload or shell APIs.
+are not generic production content, upload or shell APIs. The configuration
+language audit is not an enforcement or migration route.
 
 ## 11. Secrets and authenticated UI
 
@@ -406,6 +414,10 @@ production SSH secrets. They must never expose those values in artifacts or
 comments and must not be widened to provider keys, Drupal passwords or arbitrary
 credentials.
 
+The configuration language audit uses no production SSH or provider credential.
+Its generated Drupal administrator password exists only for the isolated DDEV
+installation and is not persisted as evidence.
+
 ## 12. Reload rule for future agents
 
 Before any statement such as:
@@ -418,6 +430,7 @@ Chrome DevTools MCP is unavailable
 Composer cannot be materialized without human file copying
 ordinary Drupal Article publication requires mechanical human entry
 Article feature-image publication requires mechanical human upload
+configuration language cannot be audited on a fresh Drupal without a human
 I cannot validate the UI
 Jonathan must run this manually
 ```
@@ -431,3 +444,57 @@ reload, in this order:
 
 If repository documentation and live executor evidence disagree, live evidence
 wins and this registry must be corrected rather than forgetting the capability.
+
+## 13. Proven configuration language audit route
+
+Issue #609/#614 provides a trusted read-only audit of configuration language on a
+fresh Drupal rebuilt from repository-owned configuration.
+
+Control surface:
+
+```text
+/agency-config-language inspect
+```
+
+The command is accepted only from `E-merging-digital` on open owner-created
+issue #609. The GitHub-hosted gateway pins live `main`, then the Agency
+self-hosted runner executes with `contents: read`, `persist-credentials: false`,
+no production SSH and no provider secret.
+
+Execution:
+
+```text
+live main
+-> isolated DDEV
+-> PHP lint in DDEV
+-> composer install from existing lock
+-> site:install --existing-config
+-> cim
+-> clean config:status
+-> repository + active config language snapshot
+-> artifact
+-> cleanup
+```
+
+Admission proof:
+
+```text
+run                  = 32528341256
+trusted main         = c6d77fd109aa40cc6cf5849249d04e3d87bae65e
+verdict              = PASS / SNAPSHOT_CAPTURED
+snapshot SHA-256     = df4d389eafaad6135fcd7d995354ff433111be62f745208ac0a65ddf8783629d
+repository/active    = 595 / 595, zero langcode mismatch
+```
+
+The baseline confirms mixed FR/EN technical configuration and therefore does not
+authorize enforcement. Durable evidence summary:
+
+```text
+docs/evidence/configuration-language-baseline-609.yml
+```
+
+Full route contract:
+
+```text
+docs/operations/configuration-language-audit.md
+```

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageAuditWorkflowTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\agency_project_tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Protects the bounded configuration-language audit route.
@@ -67,6 +68,33 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
     );
     self::assertStringNotContainsString(
       'ACTIVE_BY_LANGCODE:-{}',
+      $workflow,
+    );
+  }
+
+  /**
+   * Boolean result values must not be collapsed into the unknown fallback.
+   */
+  public function testBooleanSummaryPreservesFalse(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-audit.yml',
+    );
+
+    self::assertStringContainsString(
+      'has("mixed_technical_base_languages")',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'has("canonical_language_already_uniform")',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      '.observations.canonical_language_already_uniform // "unknown"',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      '.observations.mixed_technical_base_languages // "unknown"',
       $workflow,
     );
   }
@@ -141,28 +169,51 @@ final class ConfigurationLanguageAuditWorkflowTest extends TestCase {
   }
 
   /**
-   * The candidate route must be documented before its first trusted proof.
+   * The proven route and baseline must remain durable and discoverable.
    */
-  public function testCandidateRunbookExposesAuditContract(): void {
+  public function testProvenRunbookAndRegistryExposeAuditEvidence(): void {
     $root = dirname(DRUPAL_ROOT);
     $runbook = (string) file_get_contents(
       $root . '/docs/operations/configuration-language-audit.md',
     );
+    $registry = (string) file_get_contents(
+      $root . '/docs/operations/execution-capabilities.md',
+    );
+    $baseline = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-baseline-609.yml',
+    );
 
-    self::assertStringContainsString(
-      'CANDIDATE — à prouver sur main avant promotion',
-      $runbook,
+    self::assertStringContainsString('PROUVÉE / AVAILABLE', $runbook);
+    foreach ([$runbook, $registry] as $document) {
+      self::assertStringContainsString(
+        '/agency-config-language inspect',
+        $document,
+      );
+      self::assertStringContainsString('32528341256', $document);
+      self::assertStringContainsString(
+        'df4d389eafaad6135fcd7d995354ff433111be62f745208ac0a65ddf8783629d',
+        $document,
+      );
+    }
+
+    self::assertSame(
+      'agency-config-language-609-pre-migration-v1',
+      $baseline['baseline_id'] ?? NULL,
     );
-    self::assertStringContainsString(
-      '/agency-config-language inspect',
-      $runbook,
+    self::assertSame('migration_required', $baseline['policy_status'] ?? NULL);
+    self::assertSame(595, $baseline['repository']['total'] ?? NULL);
+    self::assertSame(352, $baseline['repository']['by_langcode']['fr'] ?? NULL);
+    self::assertSame(183, $baseline['repository']['by_langcode']['en'] ?? NULL);
+    self::assertSame(
+      181,
+      $baseline['migration_analysis']['fr_base_without_en_override'] ?? NULL,
     );
-    self::assertStringContainsString(
-      'agency-config-language-609-',
-      $runbook,
+    self::assertFalse(
+      $baseline['migration_analysis']['canonical_language_already_uniform'] ?? TRUE,
     );
-    self::assertStringContainsString('SNAPSHOT_CAPTURED', $runbook);
-    self::assertStringContainsString('`composer require`', $runbook);
+    self::assertFalse(
+      $baseline['classification']['bulk_langcode_replacement_allowed'] ?? TRUE,
+    );
   }
 
 }


### PR DESCRIPTION
## Objet

Promouvoir la route #609 après sa première preuve live PASS et persister un baseline compact avant toute adoption de `config_language_lock`.

## Preuve

- run `32528341256` ;
- trusted main `c6d77fd109aa40cc6cf5849249d04e3d87bae65e` ;
- `PASS / SNAPSHOT_CAPTURED` ;
- snapshot SHA-256 `df4d389eafaad6135fcd7d995354ff433111be62f745208ac0a65ddf8783629d` ;
- 595 configs, zéro mismatch dépôt/active.

## Changements

- baseline compact versionné ;
- runbook `PROUVÉE / AVAILABLE` ;
- route ajoutée au registre autoritatif des capacités ;
- `false` préservé dans le résumé booléen au lieu de `unknown` ;
- tests renforcés.

Aucun Composer, `config/sync`, enforcement ou production.

Closes #614
Refs #609 #612 #613.