### PR TITLE
Issue #618: preserve DDEV identity through Composer audit

### DIFF
--- a/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
+++ b/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
@@ -249,6 +249,9 @@ jobs:
             --no-progress \
             --no-scripts
 
+          mkdir -p ../drupal-maintenance-artifact
+          ddev composer audit --format=json > ../drupal-maintenance-artifact/composer-audit.json
+
           rm -f .ddev/config.gate-drupal-maintenance.yaml
           test -z "$(git ls-files --others --exclude-standard)"
           test -z "$(git diff --cached --name-only)"
@@ -259,9 +262,7 @@ jobs:
             exit 1
           fi
 
-          mkdir -p ../drupal-maintenance-artifact
           cp composer.lock ../drupal-maintenance-artifact/composer.lock
-          ddev composer audit --format=json > ../drupal-maintenance-artifact/composer-audit.json
 
           EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA" python3 - <<'PY'
           import hashlib

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
@@ -149,6 +149,24 @@ final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
       $resolver,
     );
 
+    $auditPosition = strpos(
+      $resolver,
+      'ddev composer audit --format=json',
+    );
+    $gateRemovalPosition = strpos(
+      $resolver,
+      'rm -f .ddev/config.gate-drupal-maintenance.yaml',
+    );
+    $gitCheckPosition = strpos(
+      $resolver,
+      'git ls-files --others --exclude-standard',
+    );
+    self::assertIsInt($auditPosition);
+    self::assertIsInt($gateRemovalPosition);
+    self::assertIsInt($gitCheckPosition);
+    self::assertGreaterThan($auditPosition, $gateRemovalPosition);
+    self::assertGreaterThan($gateRemovalPosition, $gitCheckPosition);
+
     self::assertStringContainsString('contents: write', $publisher);
     self::assertStringContainsString(
       "test \"$(git diff --cached --name-only)\" = 'composer.lock'",


### PR DESCRIPTION
## Correction

Le solver #562 run `32531846439` a résolu les dépendances avec succès mais a échoué avant artifact/publisher parce que le gate DDEV était supprimé avant le dernier appel `ddev composer audit`.

Cette PR :
- exécute `composer audit` tant que l'identité DDEV isolée du run est encore active ;
- supprime ensuite le gate avant les contrôles Git ;
- ajoute un test imposant l'ordre audit -> suppression du gate -> contrôle des fichiers non suivis.

Aucun package, profil Composer, permission, config Drupal ou production n'est modifié.

Closes #618
Refs #562 #563 #616 #617.