### PR TITLE
Issue #620: audit generated Composer lock with --locked

### DIFF
--- a/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
+++ b/.github/workflows/trusted-drupal-maintenance-ai-1-5-rc1.yml
@@ -250,7 +250,7 @@ jobs:
             --no-scripts
 
           mkdir -p ../drupal-maintenance-artifact
-          ddev composer audit --format=json > ../drupal-maintenance-artifact/composer-audit.json
+          ddev composer audit --format=json --locked > ../drupal-maintenance-artifact/composer-audit.json
 
           rm -f .ddev/config.gate-drupal-maintenance.yaml
           test -z "$(git ls-files --others --exclude-standard)"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedDrupalMaintenanceWorkflowTest.php
@@ -148,10 +148,14 @@ final class GovernedDrupalMaintenanceWorkflowTest extends TestCase {
       'resolved_field_validation',
       $resolver,
     );
+    self::assertStringContainsString(
+      'ddev composer audit --format=json --locked',
+      $resolver,
+    );
 
     $auditPosition = strpos(
       $resolver,
-      'ddev composer audit --format=json',
+      'ddev composer audit --format=json --locked',
     );
     $gateRemovalPosition = strpos(
       $resolver,


### PR DESCRIPTION
## Correction

Le run trusted #562 `32532303562` résout correctement le lock mais échoue ensuite parce que le resolver exécute volontairement `composer update --no-install` puis lance `composer audit` sans préciser qu'il doit auditer le lock.

Cette PR :
- remplace l'audit par `ddev composer audit --format=json --locked` ;
- conserve `--no-install` et l'identité DDEV isolée jusqu'à la fin de l'audit ;
- renforce le test de contrat pour exiger `--locked` et préserver l'ordre audit -> suppression du gate DDEV -> contrôles Git.

Aucun package, profil Composer, permission, configuration Drupal ou production n'est modifié.

Closes #620
Refs #562 #563 #618 #619.