### PR TITLE
Issue #622: keep strict Composer validation for bounded prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Validate composer.json
-        run: composer validate --strict
+        run: composer validate --strict --no-check-all
 
       - name: Install dependencies (with require-dev)
         run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ComposerValidationCiTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ComposerValidationCiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects strict Composer validation for governed prerelease constraints.
+ *
+ * @group agency_project_tests
+ * @group governed_composer
+ */
+final class ComposerValidationCiTest extends TestCase {
+
+  /**
+   * CI ignores only Composer's overly-strict constraint warning class.
+   */
+  public function testStrictValidationKeepsLockAndPublishChecksEnabled(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/ci.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'composer validate --strict --no-check-all',
+      $workflow,
+    );
+    self::assertStringNotContainsString('--no-check-lock', $workflow);
+    self::assertStringNotContainsString('--no-check-publish', $workflow);
+    self::assertStringNotContainsString(
+      'composer validate --no-check-all',
+      $workflow,
+    );
+  }
+
+}


### PR DESCRIPTION
## Contexte

La CI #1173 sur le lock #562 confirme que `composer.json` est valide mais `composer validate --strict` échoue uniquement sur les trois contraintes exactes volontairement bornées de la maintenance AI RC1.

## Correction

- CI : `composer validate --strict --no-check-all` ;
- `--strict` reste actif ;
- les vérifications du lock et de publication ne sont pas désactivées ;
- test repository-owned interdisant `--no-check-lock` et `--no-check-publish`.

Aucune dépendance, contrainte, lockfile ou configuration Drupal n'est modifiée.

Composer documente `--no-check-all` comme l'option qui supprime uniquement les warnings sur les contraintes non bornées ou trop strictes.

Closes #622
Refs #562 #563 #616 #620 #621.