### PR TITLE
Issue #624: run database updates in exact-head browser proof

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -276,6 +276,8 @@ jobs:
           ddev drush site:install --existing-config -y --account-pass="$admin_pass"
           unset admin_pass
 
+          ddev drush updb -y
+
           # Module/profile install hooks can mutate active configuration after the
           # initial install-time import. Re-import the repository-owned sync
           # directory so the browser proof always starts from canonical config.

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/SelfHostedBrowserValidationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/SelfHostedBrowserValidationWorkflowTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the exact-head self-hosted browser validation contract.
+ *
+ * @group agency_project_tests
+ * @group governed_browser
+ */
+final class SelfHostedBrowserValidationWorkflowTest extends TestCase {
+
+  /**
+   * Database, config, governed content and browser gates stay ordered.
+   */
+  public function testDrupalRebuildRunsMaintenanceGatesBeforeBrowser(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/self-hosted-browser-validation.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+
+    $installPosition = strpos(
+      $workflow,
+      'ddev composer install --no-interaction --no-progress --prefer-dist',
+    );
+    $siteInstallPosition = strpos(
+      $workflow,
+      'ddev drush site:install --existing-config -y',
+    );
+    $updbPosition = strpos($workflow, 'ddev drush updb -y');
+    $cimPosition = strpos($workflow, 'ddev drush cim -y');
+    $cachePosition = strpos($workflow, 'ddev drush cr');
+    $governedPosition = strpos(
+      $workflow,
+      'ddev drush emerging:governed-content --all',
+    );
+    $browserPosition = strpos($workflow, 'npm run browser:validate');
+
+    self::assertIsInt($installPosition);
+    self::assertIsInt($siteInstallPosition);
+    self::assertIsInt($updbPosition);
+    self::assertIsInt($cimPosition);
+    self::assertIsInt($cachePosition);
+    self::assertIsInt($governedPosition);
+    self::assertIsInt($browserPosition);
+
+    self::assertGreaterThan($installPosition, $siteInstallPosition);
+    self::assertGreaterThan($siteInstallPosition, $updbPosition);
+    self::assertGreaterThan($updbPosition, $cimPosition);
+    self::assertGreaterThan($cimPosition, $cachePosition);
+    self::assertGreaterThan($cachePosition, $governedPosition);
+    self::assertGreaterThan($governedPosition, $browserPosition);
+
+    self::assertStringContainsString('ddev drush config:status', $workflow);
+    self::assertStringContainsString(
+      'bash scripts/runner/prove-governed-content-cli-facade.sh',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "context='agency/browser-validation'",
+      $workflow,
+    );
+  }
+
+}


### PR DESCRIPTION
## Contexte

Le DoD #562 exige explicitement `drush updb -y` en plus de l'installation du lock, de la convergence config, de Governed Content et de Browser Validation.

## Correction

- exécute `ddev drush updb -y` après `site:install --existing-config` et avant `cim` ;
- conserve la route self-hosted read-only et le nettoyage existant ;
- ajoute un test repository-owned protégeant l'ordre install -> site install -> updb -> cim -> cache -> Governed Content -> Playwright.

Aucun package, lockfile, config Drupal, contenu, permission ou production n'est modifié.

Closes #624
Refs #562 #563 #622 #623.