### PR TITLE
Issue #626: bind self-hosted browser proof to public Blog profile

### DIFF
--- a/.github/workflows/self-hosted-browser-validation.yml
+++ b/.github/workflows/self-hosted-browser-validation.yml
@@ -174,6 +174,8 @@ jobs:
           test -f .ddev/config.yaml
           test -f package.json
           test -f scripts/run-browser-validation.mjs
+          test -f tests/browser/contracts/public-blog.json
+          test -f tests/browser/public-blog.spec.mjs
           test -f scripts/runner/prove-governed-content-cli-facade.sh
 
           if [[ -f package-lock.json ]]; then
@@ -295,9 +297,10 @@ jobs:
         shell: bash
         env:
           CI: 'true'
+          BROWSER_VALIDATION_CONTRACT: tests/browser/contracts/public-blog.json
         run: |
           set -euo pipefail
-          npm run browser:validate
+          npm run browser:validate -- tests/browser/public-blog.spec.mjs
 
       - name: Upload browser and config evidence
         if: ${{ always() }}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/SelfHostedBrowserValidationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/SelfHostedBrowserValidationWorkflowTest.php
@@ -44,7 +44,9 @@ final class SelfHostedBrowserValidationWorkflowTest extends TestCase {
       $workflow,
       'ddev drush emerging:governed-content --all',
     );
-    $browserPosition = strpos($workflow, 'npm run browser:validate');
+    $browserCommand =
+      'npm run browser:validate -- tests/browser/public-blog.spec.mjs';
+    $browserPosition = strpos($workflow, $browserCommand);
 
     self::assertIsInt($installPosition);
     self::assertIsInt($siteInstallPosition);
@@ -64,6 +66,23 @@ final class SelfHostedBrowserValidationWorkflowTest extends TestCase {
     self::assertStringContainsString('ddev drush config:status', $workflow);
     self::assertStringContainsString(
       'bash scripts/runner/prove-governed-content-cli-facade.sh',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test -f tests/browser/contracts/public-blog.json',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test -f tests/browser/public-blog.spec.mjs',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'BROWSER_VALIDATION_CONTRACT: tests/browser/contracts/public-blog.json',
+      $workflow,
+    );
+    self::assertSame(1, substr_count($workflow, 'npm run browser:validate'));
+    self::assertStringNotContainsString(
+      'production-editorial-article.spec.mjs',
       $workflow,
     );
     self::assertStringContainsString(


### PR DESCRIPTION
## Contexte

Le run Browser exact-head #563 `32534978065` a validé tout le rebuild DDEV puis a échoué avant toute navigation Playwright, car la route self-hosted lançait toute la suite alors que son contrat est `public-blog`.

## Correction

- vérifie explicitement `tests/browser/contracts/public-blog.json` et `tests/browser/public-blog.spec.mjs` ;
- fixe `BROWSER_VALIDATION_CONTRACT` sur ce contrat ;
- lance uniquement `npm run browser:validate -- tests/browser/public-blog.spec.mjs` ;
- renforce le test repository-owned pour protéger le bornage et interdire le spec production #401 dans cette route.

Le workflow production #401 et `production-editorial-article.spec.mjs` ne sont pas modifiés.

Aucun package, lockfile, config Drupal, contenu, secret ou production n’est modifié.

Closes #626
Refs #562 #563 #624 #625 #401.