### PR TITLE
Issue #628: add Configuration Language Lock candidate dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "drupal/ai_provider_openai": "^1.2.3",
         "drupal/ai_search": "1.3.0-alpha4",
         "drupal/canvas": "^1.8",
+        "drupal/config_language_lock": "^1.0",
         "drupal/config_split": "^2.0",
         "drupal/core-composer-scaffold": "^11.4",
         "drupal/core-project-message": "^11.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cc3f6f03981811fb3ac739c8e6a642b",
+    "content-hash": "4503a4a627724812f76b5c8e668745c9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1862,6 +1862,50 @@
             "homepage": "https://www.drupal.org/project/canvas",
             "support": {
                 "source": "https://git.drupalcode.org/project/canvas"
+            }
+        },
+        {
+            "name": "drupal/config_language_lock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_language_lock.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_language_lock-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "2ab9fbd20a15abf2692c883c8699556832e47ae1"
+            },
+            "require": {
+                "drupal/core": "^11.2 || ^12"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1787030477",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "gábor hojtsy",
+                    "homepage": "https://www.drupal.org/user/4166"
+                }
+            ],
+            "description": "Locks configuration language to an independently configured language.",
+            "homepage": "https://www.drupal.org/project/config_language_lock",
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_language_lock"
             }
         },
         {


### PR DESCRIPTION
## Objet

Sous-tâche de #609 : ajouter Configuration Language Lock comme **dépendance contrib disponible**, sans activer le module ni configurer de lock EN dans cette phase.

## Delta produit

Cette PR contient uniquement :

- `composer.json` : `"drupal/config_language_lock": "^1.0"` ;
- le vrai `composer.lock` généré par la route trusted.

Aucune config `config_language_lock.settings`, aucun `core.extension`, aucun export de config et aucune normalisation FR -> EN ne sont introduits.

## Résolution Composer trusted

- profile : `config-language-lock-628` ;
- resolved : `drupal/config_language_lock 1.0.0` stable ;
- run : `32562142545` ;
- lock SHA-256 : `1b445381f71964aef29d11a92ddfea0f8df3e14b765c1a1d055ad54c5c785461` ;
- self-hosted resolver read-only ;
- lock publié uniquement depuis le runner GitHub-hosted après revalidation du HEAD.

## CI exact-head

HEAD final courant : `7027f0680fcf314bd50c489d404b841c5d843211`  
CI #1191 / run `32563216934` : **SUCCESS**.

## Évaluation DDEV non-enforcing

La première preuve a correctement révélé que notre hypothèse « enable sans lock = zéro mutation » était trop stricte : Drupal Locale applique son footprint natif lors de l’installation d’une extension sur le site FR. #632/#633 ont corrigé la preuve sans assouplir le verdict final.

Preuve corrigée :

- run : `32563307409` ;
- artifact : `9473452659` ;
- digest : `sha256:2c396c6581099a546b929efb99dd6dab7ea54d581b578cd2e57930ae3b3167ff` ;
- verdict : **PASS / NON_ENFORCING_BEHAVIOR_PROVEN**.

Observations :

- baseline : 595 configs ;
- module settings éphémères : `locked_langcode=null`, `follow_site_default=false` ;
- 19 hashes existants modifiés par le cycle Drupal Locale ;
- 12 langcodes source `en`/absent -> `fr`, aucune transition vers `en` ;
- aucune config existante supprimée ;
- `system.menu.footer` reste `und` ;
- IDs sémantiques `und` / `zxx` préservés ;
- uninstall retire le module/config module-owned ;
- `cim` canonique final restaure exactement le fingerprint initial `435e955c5dc902c172f61043c07bf74e655fc6a25c7480c19e202fddc3b535cb` ;
- `config:status` final : No differences ;
- Composer audit : 0 advisory / 0 abandoned package ;
- cleanup DDEV/workspace : SUCCESS.

## Décision

La dépendance peut être fusionnée. **Le module doit rester désactivé après merge.**

L’activation persistée, l’export de `config_language_lock.settings`, `locked_langcode: en` et la migration du dépôt restent une future phase distincte de #609 après classification des 181 bases FR sans override EN.

Closes #628
Refs #609 #608 #614 #630 #631 #632 #633 #412.