### PR TITLE
Issue #630: add trusted Configuration Language Lock evaluation routes

### DIFF
--- a/.github/workflows/agent-composer-materialization-dispatch.yml
+++ b/.github/workflows/agent-composer-materialization-dispatch.yml
@@ -83,7 +83,12 @@ jobs:
               r'[0-9a-f]{40}', head_sha
           ):
               raise SystemExit('head_sha must be a lowercase 40-character SHA')
-          if profile != 'canvas-ai-agents-530':
+
+          allowed_profiles = {
+              'canvas-ai-agents-530',
+              'config-language-lock-628',
+          }
+          if profile not in allowed_profiles:
               raise SystemExit('Unsupported Composer materialization profile')
 
           print(f'REQUEST_ID={request_id}')
@@ -93,6 +98,21 @@ jobs:
           PY
 
           source /tmp/composer-request.env
+
+          case "$PROFILE" in
+            canvas-ai-agents-530)
+              expected_package='drupal/ai_agents'
+              expected_constraint='^1.3'
+              ;;
+            config-language-lock-628)
+              expected_package='drupal/config_language_lock'
+              expected_constraint='^1.0'
+              ;;
+            *)
+              echo 'Unsupported Composer materialization profile' >&2
+              exit 1
+              ;;
+          esac
 
           pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           test "$(jq -r '.state' <<<"$pr_json")" = 'open'
@@ -122,9 +142,12 @@ jobs:
             --jq '.content' | tr -d '\n' | base64 --decode \
             > /tmp/composer-target.json
 
+          EXPECTED_PACKAGE="$expected_package" \
+          EXPECTED_CONSTRAINT="$expected_constraint" \
           python3 - <<'PY'
           import copy
           import json
+          import os
 
           with open('/tmp/composer-base.json', encoding='utf-8') as handle:
               base = json.load(handle)
@@ -132,11 +155,13 @@ jobs:
               target = json.load(handle)
 
           expected = copy.deepcopy(base)
-          expected.setdefault('require', {})['drupal/ai_agents'] = '^1.3'
+          expected.setdefault('require', {})[os.environ['EXPECTED_PACKAGE']] = (
+              os.environ['EXPECTED_CONSTRAINT']
+          )
           if target != expected:
               raise SystemExit(
-                  'Target composer.json must differ from base only by '
-                  'drupal/ai_agents:^1.3'
+                  'Target composer.json contains changes outside the reviewed '
+                  'Composer profile.'
               )
           PY
 

--- a/.github/workflows/trusted-config-language-lock-evaluation.yml
+++ b/.github/workflows/trusted-config-language-lock-evaluation.yml
@@ -1,0 +1,480 @@
+name: Agency trusted Configuration Language Lock evaluation
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #628 candidate target
+    if: ${{ github.event.issue.pull_request && github.event.issue.number == 629 && github.event.comment.body == '/agency-config-language-lock evaluate' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+      base_sha: ${{ steps.validate.outputs.base_sha }}
+      resolved_version: ${{ steps.validate.outputs.resolved_version }}
+    steps:
+      - name: Checkout trusted evaluation implementation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate actor, exact PR and resolved candidate
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          test "$PR_NUMBER" = '629'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-lock evaluate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -r '.state' <<<"$pr_json")" = 'open'
+          test "$(jq -r '.draft' <<<"$pr_json")" = 'true'
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = 'main'
+          test "$(jq -r '.head.ref' <<<"$pr_json")" = 'feature/628-config-language-lock-candidate'
+          test "$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
+
+          base_sha="$(jq -r '.base.sha' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          test "$base_sha" = "$EVENT_DEFAULT_SHA" || {
+            echo 'PR #629 must be rebased onto the trusted evaluation revision on main.' >&2
+            exit 1
+          }
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          changed="$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+              --jq '.[].filename' | sort
+          )"
+          expected_changed="$(printf '%s\n' composer.json composer.lock | sort)"
+          if [[ "$changed" != "$expected_changed" ]]; then
+            echo 'Resolved #629 target must change exactly composer.json and composer.lock.' >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
+
+          gh api \
+            "repos/$GITHUB_REPOSITORY/contents/composer.json?ref=$head_sha" \
+            --jq '.content' | tr -d '\n' | base64 --decode > /tmp/composer-target.json
+          gh api \
+            "repos/$GITHUB_REPOSITORY/contents/composer.lock?ref=$head_sha" \
+            --jq '.content' | tr -d '\n' | base64 --decode > /tmp/composer-target.lock
+
+          resolved_version="$(python3 - <<'PY'
+          import json
+          import re
+
+          with open('/tmp/composer-target.json', encoding='utf-8') as handle:
+              composer = json.load(handle)
+          if composer.get('require', {}).get('drupal/config_language_lock') != '^1.0':
+              raise SystemExit('Expected drupal/config_language_lock:^1.0')
+
+          with open('/tmp/composer-target.lock', encoding='utf-8') as handle:
+              lock = json.load(handle)
+          packages = [
+              package for package in lock.get('packages', [])
+              if package.get('name') == 'drupal/config_language_lock'
+          ]
+          if len(packages) != 1:
+              raise SystemExit('Expected exactly one config_language_lock package in lock')
+          version = packages[0].get('version', '').lstrip('v')
+          if not re.fullmatch(r'1\.0\.[0-9]+', version):
+              raise SystemExit(f'Expected stable 1.0.x, got {version!r}')
+          print(version)
+          PY
+          )"
+
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "resolved_version=$resolved_version" >> "$GITHUB_OUTPUT"
+
+  report-start:
+    name: Publish evaluation run locator
+    needs: validate-target
+    runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
+      pull-requests: write
+    steps:
+      - name: Publish pending status and PR locator
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state='pending' \
+            -f context='agency/config-language-lock-evaluation' \
+            -f description='Non-enforcing config language lock evaluation running' \
+            -f target_url="$run_url" >/dev/null
+          gh pr comment 629 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### #628 Configuration Language Lock evaluation — trusted run locator
+
+          - run: \`${GITHUB_RUN_ID}\` attempt \`${GITHUB_RUN_ATTEMPT}\`
+          - trusted main: \`${BASE_SHA}\`
+          - target HEAD: \`${HEAD_SHA}\`
+          - resolved module: \`${RESOLVED_VERSION}\`
+          - mode: \`ephemeral enable without locked_langcode -> uninstall\`
+
+          No config export, enforcement, production access or provider secret is permitted.
+          EOF
+          )"
+
+  evaluate:
+    name: Prove no-op enable and clean uninstall in fresh DDEV
+    needs:
+      - validate-target
+      - report-start
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+          python3 --version
+
+      - name: Checkout exact trusted target read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable target and evaluation scripts
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.validate-target.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -f scripts/runner/config-language-lock-state.php
+          test -f scripts/runner/configuration-language-audit.php
+          test -f docs/evidence/configuration-language-baseline-609.yml
+          git diff --check
+
+          git fetch --no-tags --depth=1 origin "$EXPECTED_BASE_SHA"
+          changed="$(git diff --name-only "$EXPECTED_BASE_SHA" "$EXPECTED_HEAD_SHA" | sort)"
+          expected_changed="$(printf '%s\n' composer.json composer.lock | sort)"
+          test "$changed" = "$expected_changed"
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-lock.yaml <<EOF
+          name: agency-config-language-lock-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-language-lock-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal and capture pre-enable baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/config-language-lock-evaluation
+
+          ddev start -y
+          ddev composer audit --locked --format=json \
+            > artifacts/config-language-lock-evaluation/composer-audit.json
+          jq -e '(.advisories // {}) | length == 0' \
+            artifacts/config-language-lock-evaluation/composer-audit.json >/dev/null
+
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/config-language-lock-state.php >/dev/null
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-lock-evaluation/config-status-before.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script /var/www/html/scripts/runner/config-language-lock-state.php \
+            > artifacts/config-language-lock-evaluation/state-before.json
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
+            > artifacts/config-language-lock-evaluation/language-before.json
+
+          jq -e '.schema_version == 1 and .total == 595' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.config_language_lock_enabled == false' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.special.system_menu_footer_langcode == "und"' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.repository_active_comparison.missing_from_active | length == 0' \
+            artifacts/config-language-lock-evaluation/language-before.json >/dev/null
+          jq -e '.repository_active_comparison.missing_from_repository | length == 0' \
+            artifacts/config-language-lock-evaluation/language-before.json >/dev/null
+          jq -e '.repository_active_comparison.langcode_mismatches | length == 0' \
+            artifacts/config-language-lock-evaluation/language-before.json >/dev/null
+
+      - name: Enable module without lock and prove bounded active-config footprint
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev drush pm:enable config_language_lock -y
+          ddev drush cr
+          ddev drush php:script /var/www/html/scripts/runner/config-language-lock-state.php \
+            > artifacts/config-language-lock-evaluation/state-enabled.json
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
+            > artifacts/config-language-lock-evaluation/language-enabled.json
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('artifacts/config-language-lock-evaluation')
+          before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
+          enabled = json.loads((root / 'state-enabled.json').read_text(encoding='utf-8'))
+
+          if enabled.get('config_language_lock_enabled') is not True:
+              raise SystemExit('config_language_lock was not enabled')
+
+          before_entries = before['entries']
+          enabled_entries = enabled['entries']
+          before_names = set(before_entries)
+          enabled_names = set(enabled_entries)
+          removed = sorted(before_names - enabled_names)
+          added = sorted(enabled_names - before_names)
+          changed = sorted(
+              name for name in before_names & enabled_names
+              if before_entries[name]['sha256'] != enabled_entries[name]['sha256']
+          )
+
+          if removed:
+              raise SystemExit(f'Enable removed existing config: {removed}')
+          if changed != ['core.extension']:
+              raise SystemExit(f'Unexpected existing config mutation: {changed}')
+          if any(not name.startswith('config_language_lock.') for name in added):
+              raise SystemExit(f'Unexpected module-install config: {added}')
+
+          if before['special'] != enabled['special']:
+              raise SystemExit('und/zxx/footer special configuration changed during enable')
+
+          locked_values = []
+          def walk(value):
+              if isinstance(value, dict):
+                  for key, entry in value.items():
+                      if key == 'locked_langcode':
+                          locked_values.append(entry)
+                      walk(entry)
+              elif isinstance(value, list):
+                  for entry in value:
+                      walk(entry)
+
+          walk(enabled.get('module_owned', {}))
+          non_empty = [
+              value for value in locked_values
+              if value not in (None, '', False, [])
+          ]
+          if non_empty:
+              raise SystemExit(f'Non-empty locked_langcode detected: {non_empty}')
+
+          comparison = {
+              'removed_existing': removed,
+              'added_module_owned': added,
+              'changed_existing': changed,
+              'locked_langcode_values': locked_values,
+              'special_unchanged': True,
+          }
+          (root / 'enable-comparison.json').write_text(
+              json.dumps(comparison, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+          test -z "$(git status --short config/sync)"
+
+      - name: Uninstall module and prove exact active-config restoration
+        shell: bash
+        env:
+          TARGET_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+        run: |
+          set -euo pipefail
+          ddev drush pm:uninstall config_language_lock -y
+          ddev drush cr
+          ddev drush php:script /var/www/html/scripts/runner/config-language-lock-state.php \
+            > artifacts/config-language-lock-evaluation/state-after-uninstall.json
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
+            > artifacts/config-language-lock-evaluation/language-after-uninstall.json
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('artifacts/config-language-lock-evaluation')
+          before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
+          final = json.loads((root / 'state-after-uninstall.json').read_text(encoding='utf-8'))
+          if final.get('config_language_lock_enabled') is not False:
+              raise SystemExit('config_language_lock remains enabled after uninstall')
+          if final.get('module_owned'):
+              raise SystemExit('Module-owned config remains after uninstall')
+          if final['entries'] != before['entries']:
+              raise SystemExit('Active configuration did not return exactly to baseline')
+          if final['overall_sha256'] != before['overall_sha256']:
+              raise SystemExit('Final active configuration fingerprint differs from baseline')
+          PY
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-lock-evaluation/config-status-after-uninstall.txt
+          grep -Fq 'No differences' <<<"$config_status"
+          test -z "$(git status --short config/sync)"
+
+          jq -e '.repository_active_comparison.missing_from_active | length == 0' \
+            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
+          jq -e '.repository_active_comparison.missing_from_repository | length == 0' \
+            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
+          jq -e '.repository_active_comparison.langcode_mismatches | length == 0' \
+            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
+
+          baseline_sha="$(jq -r '.overall_sha256' artifacts/config-language-lock-evaluation/state-before.json)"
+          added="$(jq -c '.added_module_owned' artifacts/config-language-lock-evaluation/enable-comparison.json)"
+          locked_values="$(jq -c '.locked_langcode_values' artifacts/config-language-lock-evaluation/enable-comparison.json)"
+          jq -n \
+            --arg status 'PASS' \
+            --arg verdict 'NON_ENFORCING_ENABLE_IS_REVERSIBLE' \
+            --arg target_head_sha "$TARGET_HEAD_SHA" \
+            --arg resolved_version "$RESOLVED_VERSION" \
+            --arg baseline_sha256 "$baseline_sha" \
+            --argjson added_module_owned "$added" \
+            --argjson locked_langcode_values "$locked_values" \
+            '{
+              status:$status,
+              verdict:$verdict,
+              target_head_sha:$target_head_sha,
+              resolved_version:$resolved_version,
+              baseline_active_config_sha256:$baseline_sha256,
+              baseline_total:595,
+              existing_config_changes_on_enable:["core.extension"],
+              added_module_owned:$added_module_owned,
+              locked_langcode_values:$locked_langcode_values,
+              special_und_zxx_unchanged:true,
+              repository_config_unchanged:true,
+              uninstall_restored_baseline:true,
+              composer_audit_locked:"PASS"
+            }' > artifacts/config-language-lock-evaluation/result.json
+          jq -e '.status == "PASS"' artifacts/config-language-lock-evaluation/result.json >/dev/null
+
+      - name: Upload evaluation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-lock-evaluation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-lock-evaluation
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-language-lock-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-lock.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-lock-evaluation
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish evaluation verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - report-start
+      - evaluate
+    runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
+      pull-requests: write
+    steps:
+      - name: Publish final status and PR verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+        run: |
+          set -euo pipefail
+          state='failure'
+          verdict='FAIL'
+          if [[ "$EVALUATION_RESULT" == 'success' ]]; then
+            state='success'
+            verdict='PASS'
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context='agency/config-language-lock-evaluation' \
+            -f description="Non-enforcing config language lock evaluation ${verdict}" \
+            -f target_url="$run_url" >/dev/null
+          gh pr comment 629 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### #628 Configuration Language Lock evaluation ${verdict}
+
+          - run: \`${GITHUB_RUN_ID}\`
+          - target HEAD: \`${HEAD_SHA}\`
+          - resolved module: \`${RESOLVED_VERSION}\`
+          - self-hosted evaluation: \`${EVALUATION_RESULT}\`
+          - status: \`agency/config-language-lock-evaluation\`
+
+          The proof is ephemeral and does not export config or enable enforcement.
+          EOF
+          )"
+          test "$state" = 'success'

--- a/docs/operations/config-language-lock-evaluation.md
+++ b/docs/operations/config-language-lock-evaluation.md
@@ -1,0 +1,142 @@
+# Configuration Language Lock evaluation
+
+Status: **TRUSTED CANDIDATE EVALUATION CONTRACT**  
+Owner issue: #630  
+Product candidate: #628 / PR #629
+
+## Purpose
+
+This route proves whether `drupal/config_language_lock:^1.0` can be introduced into Agency without silently rewriting the existing mixed configuration-language state before Agency explicitly adopts `locked_langcode: en`.
+
+The route is an evaluation primitive only. Presence of this workflow on `main` does **not** mean Configuration Language Lock is adopted or enabled in Agency.
+
+The canonical policy remains:
+
+```text
+status                           = migration_required
+canonical configuration language= en
+enforce_consistency              = false
+```
+
+The baseline captured for #609 remains authoritative for the pre-migration state.
+
+## Composer materialization
+
+The existing governed Composer route receives one new repository-owned profile:
+
+```text
+profile          = config-language-lock-628
+package          = drupal/config_language_lock
+constraint       = ^1.0
+resolved version = stable 1.0.x
+owner issue      = #628
+```
+
+The control request still exposes only:
+
+```text
+request_id
+pr_number
+head_sha
+profile
+```
+
+Package names, constraints, Composer commands and shell arguments are not request inputs. The gateway explicitly allowlists `canvas-ai-agents-530` and `config-language-lock-628`; every other profile fails closed.
+
+Before materialization, PR #629 must differ from its base by exactly `composer.json`, and semantic validation proves that the only change is:
+
+```json
+"drupal/config_language_lock": "^1.0"
+```
+
+The self-hosted resolver remains `contents: read` and `persist-credentials: false`. It publishes only a bounded `composer.lock` artifact. The GitHub-hosted publisher alone can fast-forward the validated lock to the PR branch after a live HEAD recheck.
+
+## DDEV evaluation route
+
+Trigger, after the real lock has been materialized:
+
+```text
+/agency-config-language-lock evaluate
+```
+
+The trigger is accepted only on PR #629, from `E-merging-digital`, while the PR is OPEN, draft, same-repository, based on live `main`, and uses branch:
+
+```text
+feature/628-config-language-lock-candidate
+```
+
+The target diff must be exactly:
+
+```text
+composer.json
+composer.lock
+```
+
+The lock must resolve `drupal/config_language_lock` to stable `1.0.x`.
+
+## Evaluation sequence
+
+```text
+trusted main workflow
+-> exact PR HEAD read-only checkout
+-> isolated DDEV
+-> composer install from exact lock
+-> composer audit --locked
+-> site:install --existing-config
+-> cim / cr / config:status
+-> fingerprint entire active configuration
+-> enable config_language_lock with no lock configured
+-> fingerprint active configuration again
+-> validate bounded enable delta
+-> uninstall config_language_lock
+-> fingerprint active configuration again
+-> require exact baseline restoration
+-> config:status clean
+-> workspace/config sync unchanged
+-> artifact + cleanup
+```
+
+`scripts/runner/config-language-lock-state.php` reads every active configuration object, canonicalizes nested map ordering, records a SHA-256 per object and a global SHA-256, and exposes the semantic watch values used by #609.
+
+## Accepted enable delta
+
+Existing active configuration may not be silently rewritten.
+
+After module enable:
+
+- no pre-existing object may disappear;
+- the only pre-existing object allowed to change is `core.extension`;
+- newly created objects, if any, must be owned by the `config_language_lock.*` namespace;
+- module-owned configuration may not contain a non-empty `locked_langcode` anywhere;
+- `system.menu.footer` must remain `langcode: und`;
+- `language.entity.und` and `language.entity.zxx` must remain present and unchanged.
+
+The route performs no `cex` and does not materialize `locked_langcode: en` or `follow_site_default: false`.
+
+## Reversibility requirement
+
+After uninstall, the entire active-configuration fingerprint must exactly equal the baseline captured immediately before enable. `config:status` must report no differences, and `config/sync` must remain untouched.
+
+A failure at any point is evidence against adoption, not permission to normalize configuration manually.
+
+## Security boundaries
+
+The route provides no:
+
+- arbitrary PR or branch selection;
+- arbitrary package/constraint/Composer arguments;
+- arbitrary shell input;
+- self-hosted repository write credentials;
+- provider/API secret;
+- production SSH/access;
+- Content Sync mutation;
+- config export;
+- automatic Configuration Language Lock enforcement.
+
+## Evidence
+
+The workflow uploads `artifacts/config-language-lock-evaluation` with machine-readable fingerprints, enable delta, Composer audit and a bounded result. The result becomes authoritative only after the route has executed successfully on the exact #629 HEAD.
+
+Until then the capability itself is **CANDIDATE** and #609 remains in its non-enforcing evaluation phase.
+
+Refs #609 #608 #614 #628 #629 #531 #412.

--- a/docs/operations/execution-capabilities.md
+++ b/docs/operations/execution-capabilities.md
@@ -3,7 +3,7 @@
 Status: **AUTHORITATIVE CAPABILITY REGISTRY**  
 Repository: `E-merging-digital/agency-website-drupal`  
 Registry owner: #421  
-Last materialized: 2026-08-21
+Last materialized: 2026-08-22
 
 ## 1. Purpose
 
@@ -497,4 +497,48 @@ Full route contract:
 
 ```text
 docs/operations/configuration-language-audit.md
+```
+
+## 14. Configuration Language Lock non-enforcing evaluation
+
+Issue #630 adds a bounded **candidate** evaluation route for #628 / PR #629.
+It does not adopt or enforce Configuration Language Lock merely by existing on
+`main`.
+
+Composer materialization gains one explicit reviewed profile:
+
+```text
+config-language-lock-628
+-> drupal/config_language_lock:^1.0
+-> stable 1.0.x only
+```
+
+The generic Composer gateway remains closed to arbitrary packages and explicitly
+allowlists only repository-owned profiles. The #629 product PR must be
+`composer.json`-only before lock resolution.
+
+After the true lock is published, the DDEV proof is triggered only by:
+
+```text
+/agency-config-language-lock evaluate
+```
+
+on exact draft PR #629. The self-hosted runner then rebuilds the exact HEAD,
+audits the lock, fingerprints every active config object, enables
+`config_language_lock` with no language lock configured, permits no pre-existing
+config mutation except `core.extension`, then uninstalls the module and requires
+an exact return to the pre-enable active-config fingerprint.
+
+The proof also requires `system.menu.footer` to remain `und`, preserves
+`language.entity.und` and `language.entity.zxx`, performs no `cex`, and leaves
+`config/sync` untouched. No production SSH, provider secret or repository write
+credential is available to the self-hosted job.
+
+This capability remains **CANDIDATE / NOT YET PROVEN** until it executes
+successfully on the exact #629 HEAD after #630 has been merged.
+
+Full route contract:
+
+```text
+docs/operations/config-language-lock-evaluation.md
 ```

--- a/docs/operations/governed-composer-materialization.md
+++ b/docs/operations/governed-composer-materialization.md
@@ -65,7 +65,7 @@ Schema:
 The gateway accepts exactly these four keys. `request_id` and `head_sha` have
 strict formats, `pr_number` must identify an open same-repository PR targeting
 `main`, and `profile` must be present in the trusted repository-owned profile
-registry.
+registry **and** in the explicit gateway allowlist.
 
 Before dispatch, the PR must differ from its base by exactly `composer.json`.
 The gateway then compares parsed JSON and proves that the target differs from
@@ -85,7 +85,7 @@ A profile owns all executable inputs: package, expected constraint, accepted
 resolved-version pattern and product issue. Callers provide only the profile
 identifier.
 
-Initial profile:
+Reviewed profiles:
 
 ```text
 canvas-ai-agents-530
@@ -93,11 +93,23 @@ package            = drupal/ai_agents
 constraint         = ^1.3
 resolved version   = stable 1.3.x
 product issue      = #530
+
+config-language-lock-628
+package            = drupal/config_language_lock
+constraint         = ^1.0
+resolved version   = stable 1.0.x
+product issue      = #628
 ```
 
+The second profile exists only to materialize the dependency candidate evaluated
+by #609/#628. It does not configure, enable or enforce Configuration Language
+Lock. Runtime evaluation remains a separate trusted route documented in
+`docs/operations/config-language-lock-evaluation.md`.
+
 Adding another dependency requires a reviewed repository change adding another
-explicit profile. Never extend the request schema with package names, Composer
-arguments or shell commands.
+explicit profile **and** gateway semantic validation for that profile. Never
+extend the request schema with package names, Composer arguments or shell
+commands.
 
 ## Resolver behavior
 
@@ -149,7 +161,7 @@ difference. The target commit then receives:
 ```text
 context    = agency/composer-materialization
 state      = pending
- target_url = exact trusted workflow run
+target_url = exact trusted workflow run
 ```
 
 The gateway remains on GitHub-hosted infrastructure while it observes that exact
@@ -177,6 +189,8 @@ This route does **not** provide:
 - self-hosted GitHub write credentials;
 - provider/API secrets;
 - product configuration generation;
+- automatic module enablement;
+- automatic Configuration Language Lock enforcement;
 - automatic merge authority.
 
 Those remain separate capabilities and require their own governed owner when

--- a/scripts/runner/composer-materialization-profiles.sh
+++ b/scripts/runner/composer-materialization-profiles.sh
@@ -16,6 +16,15 @@ case "${COMPOSER_PROFILE:-}" in
     COMPOSER_REQUIRED_FIELD_VALIDATION_VERSION=''
     COMPOSER_OWNER_ISSUE='530'
     ;;
+  config-language-lock-628)
+    COMPOSER_PACKAGE='drupal/config_language_lock'
+    COMPOSER_CONSTRAINT='^1.0'
+    COMPOSER_VERSION_REGEX='^1\.0\.[0-9]+$'
+    COMPOSER_UPDATE_SELECTOR='drupal/config_language_lock'
+    COMPOSER_REQUIRED_AI_SEARCH_VERSION=''
+    COMPOSER_REQUIRED_FIELD_VALIDATION_VERSION=''
+    COMPOSER_OWNER_ISSUE='628'
+    ;;
   drupal-maintenance-ai-1.5-rc1)
     COMPOSER_PACKAGE='drupal/ai'
     COMPOSER_CONSTRAINT='1.5.0-rc1'

--- a/scripts/runner/config-language-lock-state.php
+++ b/scripts/runner/config-language-lock-state.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Emits a deterministic fingerprint of Drupal active configuration.
+ *
+ * This script is intentionally read-only. It is executed through Drush inside
+ * the isolated DDEV proof for Configuration Language Lock.
+ */
+
+$storage = \Drupal::service('config.storage');
+
+$canonicalize = static function (mixed $value) use (&$canonicalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+
+  if (array_is_list($value)) {
+    return array_map($canonicalize, $value);
+  }
+
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $entry) {
+    $value[$key] = $canonicalize($entry);
+  }
+  return $value;
+};
+
+$names = $storage->listAll();
+sort($names, SORT_STRING);
+
+$entries = [];
+$moduleOwned = [];
+foreach ($names as $name) {
+  $data = $storage->read($name);
+  if (!is_array($data)) {
+    $data = [];
+  }
+  $canonical = $canonicalize($data);
+  $encoded = json_encode(
+    $canonical,
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  );
+  $entry = [
+    'sha256' => hash('sha256', $encoded),
+    'langcode' => array_key_exists('langcode', $canonical)
+      ? $canonical['langcode']
+      : NULL,
+  ];
+  $entries[$name] = $entry;
+
+  if (str_starts_with($name, 'config_language_lock.')) {
+    $moduleOwned[$name] = $canonical;
+  }
+}
+
+$overall = json_encode(
+  array_map(
+    static fn(array $entry): string => $entry['sha256'],
+    $entries,
+  ),
+  JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+);
+
+$coreExtension = $storage->read('core.extension');
+if (!is_array($coreExtension)) {
+  $coreExtension = [];
+}
+
+$output = [
+  'schema_version' => 1,
+  'total' => count($entries),
+  'overall_sha256' => hash('sha256', $overall),
+  'entries' => $entries,
+  'module_owned' => $moduleOwned,
+  'special' => [
+    'system_menu_footer_langcode' => $entries['system.menu.footer']['langcode'] ?? NULL,
+    'language_entity_und_sha256' => $entries['language.entity.und']['sha256'] ?? NULL,
+    'language_entity_zxx_sha256' => $entries['language.entity.zxx']['sha256'] ?? NULL,
+  ],
+  'config_language_lock_enabled' => array_key_exists(
+    'config_language_lock',
+    $coreExtension['module'] ?? [],
+  ),
+];
+
+echo json_encode(
+  $output,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded Configuration Language Lock evaluation route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
+
+  /**
+   * The workflow stays tied to the reviewed #628 candidate.
+   */
+  public function testTargetAndTriggerAreFixed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-config-language-lock-evaluation.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString('github.event.issue.number == 629', $workflow);
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-lock evaluate'",
+      $workflow,
+    );
+    self::assertStringContainsString("test \"$PR_NUMBER\" = '629'", $workflow);
+    self::assertStringContainsString(
+      "test \"$(jq -r '.draft' <<<\"$pr_json\")\" = 'true'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "test \"$(jq -r '.head.ref' <<<\"$pr_json\")\" = 'feature/628-config-language-lock-candidate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "Expected drupal/config_language_lock:^1.0",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "Expected stable 1.0.x",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'composer.json and composer.lock',
+      $workflow,
+    );
+  }
+
+  /**
+   * The self-hosted proof is read-only, reversible and non-enforcing.
+   */
+  public function testEvaluationIsReadOnlyAndReversible(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-config-language-lock-evaluation.yml';
+    $workflow = (string) file_get_contents($path);
+
+    $evaluateStart = strpos($workflow, "  evaluate:\n");
+    $reportStart = strpos($workflow, "  report-result:\n");
+    self::assertIsInt($evaluateStart);
+    self::assertIsInt($reportStart);
+    $evaluate = substr($workflow, $evaluateStart, $reportStart - $evaluateStart);
+
+    self::assertStringContainsString('contents: read', $evaluate);
+    self::assertStringNotContainsString('contents: write', $evaluate);
+    self::assertStringContainsString('persist-credentials: false', $evaluate);
+    self::assertStringContainsString('ddev composer audit --locked', $evaluate);
+    self::assertStringContainsString('site:install --existing-config', $evaluate);
+    self::assertStringContainsString('ddev drush cim -y', $evaluate);
+    self::assertStringContainsString(
+      'ddev drush pm:enable config_language_lock -y',
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      'ddev drush pm:uninstall config_language_lock -y',
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "changed != ['core.extension']",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "name.startswith('config_language_lock.')",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "if key == 'locked_langcode'",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      'Active configuration did not return exactly to baseline',
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      '.special.system_menu_footer_langcode == "und"',
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      'test -z "$(git status --short config/sync)"',
+      $evaluate,
+    );
+    self::assertStringNotContainsString('drush cex', $evaluate);
+    self::assertStringNotContainsString('OPENAI_API_KEY', $workflow);
+    self::assertStringNotContainsString('deploy-production', $workflow);
+    self::assertStringNotContainsString('ssh ', $workflow);
+  }
+
+  /**
+   * The active-configuration fingerprint helper performs reads only.
+   */
+  public function testFingerprintHelperIsDeterministicAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/runner/config-language-lock-state.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("$storage->listAll()", $script);
+    self::assertStringContainsString("$storage->read($name)", $script);
+    self::assertStringContainsString("ksort($value, SORT_STRING)", $script);
+    self::assertStringContainsString("hash('sha256'", $script);
+    self::assertStringContainsString("'module_owned'", $script);
+    self::assertStringContainsString("'config_language_lock_enabled'", $script);
+    self::assertStringNotContainsString('->write(', $script);
+    self::assertStringNotContainsString('->save(', $script);
+    self::assertStringNotContainsString('->delete(', $script);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
@@ -31,23 +31,20 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
       "github.event.comment.body == '/agency-config-language-lock evaluate'",
       $workflow,
     );
-    self::assertStringContainsString("test \"$PR_NUMBER\" = '629'", $workflow);
+    self::assertStringContainsString("test \"\$PR_NUMBER\" = '629'", $workflow);
     self::assertStringContainsString(
-      "test \"$(jq -r '.draft' <<<\"$pr_json\")\" = 'true'",
+      "test \"\$(jq -r '.draft' <<<\"\$pr_json\")\" = 'true'",
       $workflow,
     );
     self::assertStringContainsString(
-      "test \"$(jq -r '.head.ref' <<<\"$pr_json\")\" = 'feature/628-config-language-lock-candidate'",
+      "test \"\$(jq -r '.head.ref' <<<\"\$pr_json\")\" = 'feature/628-config-language-lock-candidate'",
       $workflow,
     );
     self::assertStringContainsString(
-      "Expected drupal/config_language_lock:^1.0",
+      'Expected drupal/config_language_lock:^1.0',
       $workflow,
     );
-    self::assertStringContainsString(
-      "Expected stable 1.0.x",
-      $workflow,
-    );
+    self::assertStringContainsString('Expected stable 1.0.x', $workflow);
     self::assertStringContainsString(
       'composer.json and composer.lock',
       $workflow,
@@ -122,9 +119,9 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
     self::assertFileExists($path);
 
     $script = (string) file_get_contents($path);
-    self::assertStringContainsString("$storage->listAll()", $script);
-    self::assertStringContainsString("$storage->read($name)", $script);
-    self::assertStringContainsString("ksort($value, SORT_STRING)", $script);
+    self::assertStringContainsString('$storage->listAll()', $script);
+    self::assertStringContainsString('$storage->read($name)', $script);
+    self::assertStringContainsString('ksort($value, SORT_STRING)', $script);
     self::assertStringContainsString("hash('sha256'", $script);
     self::assertStringContainsString("'module_owned'", $script);
     self::assertStringContainsString("'config_language_lock_enabled'", $script);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GovernedComposerMaterializationWorkflowTest.php
@@ -42,14 +42,31 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
       "changed\" != 'composer.json'",
       $workflow,
     );
+    self::assertStringContainsString('canvas-ai-agents-530', $workflow);
+    self::assertStringContainsString('config-language-lock-628', $workflow);
     self::assertStringContainsString(
-      "['drupal/ai_agents'] = '^1.3'",
+      "expected_package='drupal/ai_agents'",
       $workflow,
     );
-    self::assertStringNotContainsString(
-      'composer require $',
+    self::assertStringContainsString(
+      "expected_constraint='^1.3'",
       $workflow,
     );
+    self::assertStringContainsString(
+      "expected_package='drupal/config_language_lock'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "expected_constraint='^1.0'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "expected.setdefault('require', {})[os.environ['EXPECTED_PACKAGE']]",
+      $workflow,
+    );
+    self::assertStringNotContainsString('composer require $', $workflow);
+    self::assertStringNotContainsString('package_name', $workflow);
+    self::assertStringNotContainsString('composer_args', $workflow);
   }
 
   /**
@@ -205,7 +222,7 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
   /**
    * Profile data must remain repository-owned and fail closed.
    */
-  public function testInitialProfileIsFixedAndFailClosed(): void {
+  public function testProfilesAreFixedAndFailClosed(): void {
     $root = dirname(DRUPAL_ROOT);
     $path = $root . '/scripts/runner/composer-materialization-profiles.sh';
     self::assertFileExists($path);
@@ -218,6 +235,23 @@ final class GovernedComposerMaterializationWorkflowTest extends TestCase {
     );
     self::assertStringContainsString(
       "COMPOSER_CONSTRAINT='^1.3'",
+      $profiles,
+    );
+    self::assertStringContainsString('config-language-lock-628)', $profiles);
+    self::assertStringContainsString(
+      "COMPOSER_PACKAGE='drupal/config_language_lock'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_CONSTRAINT='^1.0'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_VERSION_REGEX='^1\\.0\\.[0-9]+$'",
+      $profiles,
+    );
+    self::assertStringContainsString(
+      "COMPOSER_OWNER_ISSUE='628'",
       $profiles,
     );
     self::assertStringContainsString(


### PR DESCRIPTION
## Objet

Matérialise les capacités trusted nécessaires à #609/#628 avant toute activation ou adoption de Configuration Language Lock.

### Composer

- ajoute le profil repository-owned `config-language-lock-628` ;
- package fixe `drupal/config_language_lock` ;
- contrainte fixe `^1.0` ;
- résolution acceptée uniquement en stable `1.0.x` ;
- étend le gateway existant avec une allowlist fermée de deux profils ;
- conserve le target `composer.json`-only, le self-hosted read-only et le publisher hosted lock-only.

### Évaluation DDEV #629

Ajoute `/agency-config-language-lock evaluate`, borné à la PR draft #629 et à sa branche exacte. La preuve :

- installe le lock exact et exécute `composer audit --locked` ;
- reconstruit Drupal depuis `--existing-config` ;
- fingerprint toute l’active config ;
- active `config_language_lock` sans verrou ;
- interdit toute mutation existante hors `core.extension` et toute nouvelle config hors namespace module-owned ;
- refuse tout `locked_langcode` non vide ;
- préserve `und` / `zxx` ;
- désinstalle le module ;
- exige le retour exact au fingerprint initial et un `config:status` propre ;
- ne fait aucun `cex`, aucun accès production, aucun secret/provider.

### Mémoire durable

- runbook dédié `docs/operations/config-language-lock-evaluation.md` ;
- registre `execution-capabilities.md` mis à jour ;
- route explicitement marquée **CANDIDATE / NOT YET PROVEN** jusqu’à son exécution sur #629 ;
- documentation Composer mise à jour pour le second profil.

Aucune dépendance produit, aucun `composer.json`/lock, aucune config Drupal ni production n’est modifiée dans cette PR.

Closes #630
Refs #609 #628 #629 #531 #614 #412.