### PR TITLE
Issue #632: separate native Locale footprint from lock enforcement

### DIFF
--- a/.github/workflows/trusted-config-language-lock-evaluation.yml
+++ b/.github/workflows/trusted-config-language-lock-evaluation.yml
@@ -139,14 +139,14 @@ jobs:
           - trusted main: \`${BASE_SHA}\`
           - target HEAD: \`${HEAD_SHA}\`
           - resolved module: \`${RESOLVED_VERSION}\`
-          - mode: \`ephemeral enable without locked_langcode -> uninstall\`
+          - mode: \`non-enforcing enable -> observe native Locale footprint -> uninstall -> canonical restore\`
 
           No config export, enforcement, production access or provider secret is permitted.
           EOF
           )"
 
   evaluate:
-    name: Prove no-op enable and clean uninstall in fresh DDEV
+    name: Prove non-enforcing behavior and reversible Locale footprint
     needs:
       - validate-target
       - report-start
@@ -208,7 +208,7 @@ jobs:
           ddev utility configyaml \
             | grep -F "agency-config-language-lock-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
-      - name: Rebuild Drupal and capture pre-enable baseline
+      - name: Rebuild Drupal and capture canonical pre-enable baseline
         shell: bash
         run: |
           set -euo pipefail
@@ -240,11 +240,17 @@ jobs:
           ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
             > artifacts/config-language-lock-evaluation/language-before.json
 
-          jq -e '.schema_version == 1 and .total == 595' \
+          jq -e '.schema_version == 2 and .total == 595' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.site_default_language == "fr"' \
             artifacts/config-language-lock-evaluation/state-before.json >/dev/null
           jq -e '.config_language_lock_enabled == false' \
             artifacts/config-language-lock-evaluation/state-before.json >/dev/null
           jq -e '.special.system_menu_footer_langcode == "und"' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.special.language_entity_und_id == "und"' \
+            artifacts/config-language-lock-evaluation/state-before.json >/dev/null
+          jq -e '.special.language_entity_zxx_id == "zxx"' \
             artifacts/config-language-lock-evaluation/state-before.json >/dev/null
           jq -e '.repository_active_comparison.missing_from_active | length == 0' \
             artifacts/config-language-lock-evaluation/language-before.json >/dev/null
@@ -253,7 +259,9 @@ jobs:
           jq -e '.repository_active_comparison.langcode_mismatches | length == 0' \
             artifacts/config-language-lock-evaluation/language-before.json >/dev/null
 
-      - name: Enable module without lock and prove bounded active-config footprint
+      - name: Enable module and capture native Locale footprint
+        id: enable
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -263,7 +271,15 @@ jobs:
             > artifacts/config-language-lock-evaluation/state-enabled.json
           ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
             > artifacts/config-language-lock-evaluation/language-enabled.json
+          test -z "$(git status --short config/sync)"
 
+      - name: Assess non-enforcing semantics against Locale footprint
+        id: semantics
+        if: ${{ always() && steps.enable.outcome == 'success' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
           python3 - <<'PY'
           import json
           from pathlib import Path
@@ -271,9 +287,13 @@ jobs:
           root = Path('artifacts/config-language-lock-evaluation')
           before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
           enabled = json.loads((root / 'state-enabled.json').read_text(encoding='utf-8'))
+          language_enabled = json.loads((root / 'language-enabled.json').read_text(encoding='utf-8'))
 
+          errors = []
           if enabled.get('config_language_lock_enabled') is not True:
-              raise SystemExit('config_language_lock was not enabled')
+              errors.append('config_language_lock was not enabled')
+          if enabled.get('site_default_language') != before.get('site_default_language'):
+              errors.append('site default language changed during enable')
 
           before_entries = before['entries']
           enabled_entries = enabled['entries']
@@ -281,60 +301,98 @@ jobs:
           enabled_names = set(enabled_entries)
           removed = sorted(before_names - enabled_names)
           added = sorted(enabled_names - before_names)
-          changed = sorted(
+          changed_hash = sorted(
               name for name in before_names & enabled_names
               if before_entries[name]['sha256'] != enabled_entries[name]['sha256']
           )
+          langcode_transitions = []
+          for name in sorted(before_names & enabled_names):
+              old = before_entries[name].get('langcode')
+              new = enabled_entries[name].get('langcode')
+              if old != new:
+                  langcode_transitions.append({
+                      'name': name,
+                      'before': old,
+                      'after': new,
+                  })
 
           if removed:
-              raise SystemExit(f'Enable removed existing config: {removed}')
-          if changed != ['core.extension']:
-              raise SystemExit(f'Unexpected existing config mutation: {changed}')
-          if any(not name.startswith('config_language_lock.') for name in added):
-              raise SystemExit(f'Unexpected module-install config: {added}')
+              errors.append(f'enable removed existing config: {removed}')
+          if added != ['config_language_lock.settings']:
+              errors.append(f'unexpected module-install config: {added}')
 
-          if before['special'] != enabled['special']:
-              raise SystemExit('und/zxx/footer special configuration changed during enable')
+          settings = enabled.get('module_owned', {}).get('config_language_lock.settings')
+          if not isinstance(settings, dict):
+              errors.append('config_language_lock.settings was not captured')
+          else:
+              if settings.get('locked_langcode') is not None:
+                  errors.append(
+                      f"locked_langcode is enforcing unexpectedly: {settings.get('locked_langcode')!r}"
+                  )
+              if settings.get('follow_site_default') is not False:
+                  errors.append('follow_site_default must remain false in non-enforcing mode')
 
-          locked_values = []
-          def walk(value):
-              if isinstance(value, dict):
-                  for key, entry in value.items():
-                      if key == 'locked_langcode':
-                          locked_values.append(entry)
-                      walk(entry)
-              elif isinstance(value, list):
-                  for entry in value:
-                      walk(entry)
+          site_default = before.get('site_default_language')
+          for transition in langcode_transitions:
+              old = transition['before']
+              new = transition['after']
+              if old not in ('en', None) or new != site_default:
+                  errors.append(
+                      'non-Locale langcode transition: '
+                      f"{transition['name']} {old!r}->{new!r}"
+                  )
 
-          walk(enabled.get('module_owned', {}))
-          non_empty = [
-              value for value in locked_values
-              if value not in (None, '', False, [])
-          ]
-          if non_empty:
-              raise SystemExit(f'Non-empty locked_langcode detected: {non_empty}')
+          special = enabled.get('special', {})
+          if special.get('system_menu_footer_langcode') != 'und':
+              errors.append('system.menu.footer no longer has langcode und')
+          if special.get('language_entity_und_id') != 'und':
+              errors.append('language.entity.und semantic id changed')
+          if special.get('language_entity_zxx_id') != 'zxx':
+              errors.append('language.entity.zxx semantic id changed')
+
+          mismatch_names = sorted(
+              entry['name']
+              for entry in language_enabled.get(
+                  'repository_active_comparison', {}
+              ).get('langcode_mismatches', [])
+          )
+          transition_names = sorted(entry['name'] for entry in langcode_transitions)
+          if mismatch_names != transition_names:
+              errors.append(
+                  'active/repository langcode mismatches do not equal observed '
+                  f'Locale transitions: mismatches={mismatch_names}, transitions={transition_names}'
+              )
+
+          if language_enabled.get('translations') != json.loads(
+              (root / 'language-before.json').read_text(encoding='utf-8')
+          ).get('translations'):
+              errors.append('versioned translation-directory inventory changed')
 
           comparison = {
+              'classification': 'DRUPAL_LOCALE_EXTENSION_INSTALL_FOOTPRINT',
+              'site_default_language': site_default,
               'removed_existing': removed,
               'added_module_owned': added,
-              'changed_existing': changed,
-              'locked_langcode_values': locked_values,
-              'special_unchanged': True,
+              'changed_existing_hashes': changed_hash,
+              'langcode_transitions': langcode_transitions,
+              'repository_active_langcode_mismatches': mismatch_names,
+              'module_settings': settings,
+              'special': special,
+              'errors': errors,
           }
           (root / 'enable-comparison.json').write_text(
               json.dumps(comparison, indent=2, sort_keys=True) + '\n',
               encoding='utf-8',
           )
+          if errors:
+              raise SystemExit('; '.join(errors))
           PY
 
-          test -z "$(git status --short config/sync)"
-
-      - name: Uninstall module and prove exact active-config restoration
+      - name: Uninstall module and measure post-enable reversibility
+        id: uninstall
+        if: ${{ always() && steps.enable.outcome == 'success' }}
+        continue-on-error: true
         shell: bash
-        env:
-          TARGET_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
-          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
         run: |
           set -euo pipefail
           ddev drush pm:uninstall config_language_lock -y
@@ -344,63 +402,169 @@ jobs:
           ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
             > artifacts/config-language-lock-evaluation/language-after-uninstall.json
 
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-lock-evaluation/config-status-after-uninstall.txt
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('artifacts/config-language-lock-evaluation')
+          enabled = json.loads((root / 'state-enabled.json').read_text(encoding='utf-8'))
+          final = json.loads((root / 'state-after-uninstall.json').read_text(encoding='utf-8'))
+          errors = []
+
+          if final.get('config_language_lock_enabled') is not False:
+              errors.append('config_language_lock remains enabled after uninstall')
+          if final.get('module_owned'):
+              errors.append('module-owned config remains after uninstall')
+
+          enabled_entries = enabled['entries']
+          final_entries = final['entries']
+          expected_names = set(enabled_entries) - {'config_language_lock.settings'}
+          if set(final_entries) != expected_names:
+              errors.append('unexpected config add/remove during uninstall')
+
+          changed = sorted(
+              name for name in set(final_entries) & set(enabled_entries)
+              if final_entries[name]['sha256'] != enabled_entries[name]['sha256']
+          )
+          if changed != ['core.extension']:
+              errors.append(f'unexpected post-enable uninstall mutation: {changed}')
+
+          if final.get('special') != enabled.get('special'):
+              errors.append('semantic language/footer state changed during uninstall')
+
+          comparison = {
+              'changed_existing': changed,
+              'module_owned_removed': not bool(final.get('module_owned')),
+              'errors': errors,
+          }
+          (root / 'uninstall-comparison.json').write_text(
+              json.dumps(comparison, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          if errors:
+              raise SystemExit('; '.join(errors))
+          PY
+          test -z "$(git status --short config/sync)"
+
+      - name: Restore repository canonical config and require exact baseline
+        id: restore
+        if: ${{ always() && steps.uninstall.outcome == 'success' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush php:script /var/www/html/scripts/runner/config-language-lock-state.php \
+            > artifacts/config-language-lock-evaluation/state-restored.json
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-audit.php \
+            > artifacts/config-language-lock-evaluation/language-restored.json
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-lock-evaluation/config-status-restored.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
           python3 - <<'PY'
           import json
           from pathlib import Path
 
           root = Path('artifacts/config-language-lock-evaluation')
           before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
-          final = json.loads((root / 'state-after-uninstall.json').read_text(encoding='utf-8'))
-          if final.get('config_language_lock_enabled') is not False:
-              raise SystemExit('config_language_lock remains enabled after uninstall')
-          if final.get('module_owned'):
-              raise SystemExit('Module-owned config remains after uninstall')
-          if final['entries'] != before['entries']:
-              raise SystemExit('Active configuration did not return exactly to baseline')
-          if final['overall_sha256'] != before['overall_sha256']:
-              raise SystemExit('Final active configuration fingerprint differs from baseline')
+          restored = json.loads((root / 'state-restored.json').read_text(encoding='utf-8'))
+          if restored.get('config_language_lock_enabled') is not False:
+              raise SystemExit('config_language_lock enabled after canonical restore')
+          if restored.get('module_owned'):
+              raise SystemExit('module-owned config remains after canonical restore')
+          if restored['entries'] != before['entries']:
+              raise SystemExit('canonical restore did not return exact active config baseline')
+          if restored['overall_sha256'] != before['overall_sha256']:
+              raise SystemExit('restored active configuration fingerprint differs from baseline')
           PY
 
-          config_status="$(ddev drush config:status 2>&1)"
-          printf '%s\n' "$config_status" \
-            > artifacts/config-language-lock-evaluation/config-status-after-uninstall.txt
-          grep -Fq 'No differences' <<<"$config_status"
+          jq -e '.repository_active_comparison.missing_from_active | length == 0' \
+            artifacts/config-language-lock-evaluation/language-restored.json >/dev/null
+          jq -e '.repository_active_comparison.missing_from_repository | length == 0' \
+            artifacts/config-language-lock-evaluation/language-restored.json >/dev/null
+          jq -e '.repository_active_comparison.langcode_mismatches | length == 0' \
+            artifacts/config-language-lock-evaluation/language-restored.json >/dev/null
           test -z "$(git status --short config/sync)"
 
-          jq -e '.repository_active_comparison.missing_from_active | length == 0' \
-            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
-          jq -e '.repository_active_comparison.missing_from_repository | length == 0' \
-            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
-          jq -e '.repository_active_comparison.langcode_mismatches | length == 0' \
-            artifacts/config-language-lock-evaluation/language-after-uninstall.json >/dev/null
+      - name: Publish machine-readable bounded evaluation result
+        if: ${{ always() }}
+        shell: bash
+        env:
+          TARGET_HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
+          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+          ENABLE_OUTCOME: ${{ steps.enable.outcome }}
+          SEMANTICS_OUTCOME: ${{ steps.semantics.outcome }}
+          UNINSTALL_OUTCOME: ${{ steps.uninstall.outcome }}
+          RESTORE_OUTCOME: ${{ steps.restore.outcome }}
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-lock-evaluation'
+          status='FAIL'
+          verdict='NON_ENFORCING_EVALUATION_FAILED'
+          if [[ "$ENABLE_OUTCOME" == 'success' && \
+                "$SEMANTICS_OUTCOME" == 'success' && \
+                "$UNINSTALL_OUTCOME" == 'success' && \
+                "$RESTORE_OUTCOME" == 'success' ]]; then
+            status='PASS'
+            verdict='NON_ENFORCING_BEHAVIOR_PROVEN'
+          fi
 
-          baseline_sha="$(jq -r '.overall_sha256' artifacts/config-language-lock-evaluation/state-before.json)"
-          added="$(jq -c '.added_module_owned' artifacts/config-language-lock-evaluation/enable-comparison.json)"
-          locked_values="$(jq -c '.locked_langcode_values' artifacts/config-language-lock-evaluation/enable-comparison.json)"
+          locale_transition_count='0'
+          changed_hash_count='0'
+          if [[ -s "$root/enable-comparison.json" ]]; then
+            locale_transition_count="$(jq -r '.langcode_transitions | length' "$root/enable-comparison.json")"
+            changed_hash_count="$(jq -r '.changed_existing_hashes | length' "$root/enable-comparison.json")"
+          fi
+          baseline_sha='n/a'
+          restored_sha='n/a'
+          if [[ -s "$root/state-before.json" ]]; then
+            baseline_sha="$(jq -r '.overall_sha256' "$root/state-before.json")"
+          fi
+          if [[ -s "$root/state-restored.json" ]]; then
+            restored_sha="$(jq -r '.overall_sha256' "$root/state-restored.json")"
+          fi
+
           jq -n \
-            --arg status 'PASS' \
-            --arg verdict 'NON_ENFORCING_ENABLE_IS_REVERSIBLE' \
+            --arg status "$status" \
+            --arg verdict "$verdict" \
             --arg target_head_sha "$TARGET_HEAD_SHA" \
             --arg resolved_version "$RESOLVED_VERSION" \
+            --arg enable_outcome "$ENABLE_OUTCOME" \
+            --arg semantics_outcome "$SEMANTICS_OUTCOME" \
+            --arg uninstall_outcome "$UNINSTALL_OUTCOME" \
+            --arg restore_outcome "$RESTORE_OUTCOME" \
             --arg baseline_sha256 "$baseline_sha" \
-            --argjson added_module_owned "$added" \
-            --argjson locked_langcode_values "$locked_values" \
+            --arg restored_sha256 "$restored_sha" \
+            --argjson locale_transition_count "$locale_transition_count" \
+            --argjson changed_hash_count "$changed_hash_count" \
             '{
               status:$status,
               verdict:$verdict,
               target_head_sha:$target_head_sha,
               resolved_version:$resolved_version,
-              baseline_active_config_sha256:$baseline_sha256,
-              baseline_total:595,
-              existing_config_changes_on_enable:["core.extension"],
-              added_module_owned:$added_module_owned,
-              locked_langcode_values:$locked_langcode_values,
-              special_und_zxx_unchanged:true,
-              repository_config_unchanged:true,
-              uninstall_restored_baseline:true,
-              composer_audit_locked:"PASS"
-            }' > artifacts/config-language-lock-evaluation/result.json
-          jq -e '.status == "PASS"' artifacts/config-language-lock-evaluation/result.json >/dev/null
+              mode:"non_enforcing_with_native_locale_footprint",
+              enable_outcome:$enable_outcome,
+              semantics_outcome:$semantics_outcome,
+              uninstall_outcome:$uninstall_outcome,
+              restore_outcome:$restore_outcome,
+              baseline_sha256:$baseline_sha256,
+              restored_sha256:$restored_sha256,
+              locale_langcode_transition_count:$locale_transition_count,
+              changed_existing_hash_count:$changed_hash_count,
+              locked_langcode:null,
+              follow_site_default:false
+            }' > "$root/result.json"
+
+          cat "$root/result.json"
+          test "$status" = 'PASS'
 
       - name: Upload evaluation evidence
         if: ${{ always() }}
@@ -448,33 +612,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.validate-target.outputs.head_sha }}
-          EVALUATION_RESULT: ${{ needs.evaluate.result }}
           RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
         run: |
           set -euo pipefail
           state='failure'
           verdict='FAIL'
+          description='Config Language Lock non-enforcing evaluation failed'
           if [[ "$EVALUATION_RESULT" == 'success' ]]; then
             state='success'
             verdict='PASS'
+            description='Config Language Lock non-enforcing evaluation passed'
           fi
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
             -f state="$state" \
             -f context='agency/config-language-lock-evaluation' \
-            -f description="Non-enforcing config language lock evaluation ${verdict}" \
+            -f description="$description" \
             -f target_url="$run_url" >/dev/null
           gh pr comment 629 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
           ### #628 Configuration Language Lock evaluation ${verdict}
 
-          - run: \`${GITHUB_RUN_ID}\`
+          - run: \`${GITHUB_RUN_ID}\` attempt \`${GITHUB_RUN_ATTEMPT}\`
           - target HEAD: \`${HEAD_SHA}\`
-          - resolved module: \`${RESOLVED_VERSION}\`
-          - self-hosted evaluation: \`${EVALUATION_RESULT}\`
-          - status: \`agency/config-language-lock-evaluation\`
+          - module: \`${RESOLVED_VERSION}\`
+          - route result: \`${EVALUATION_RESULT}\`
+          - model: \`no lock -> native Locale footprint -> uninstall -> canonical cim restore\`
 
-          The proof is ephemeral and does not export config or enable enforcement.
+          The route is non-enforcing and read-only with respect to Git/production. Inspect the run artifact for the Locale transition and restoration evidence.
           EOF
           )"
           test "$state" = 'success'

--- a/docs/operations/config-language-lock-evaluation.md
+++ b/docs/operations/config-language-lock-evaluation.md
@@ -1,12 +1,12 @@
 # Configuration Language Lock evaluation
 
 Status: **TRUSTED CANDIDATE EVALUATION CONTRACT**  
-Owner issue: #630  
+Owner issues: #630, #632  
 Product candidate: #628 / PR #629
 
 ## Purpose
 
-This route proves whether `drupal/config_language_lock:^1.0` can be introduced into Agency without silently rewriting the existing mixed configuration-language state before Agency explicitly adopts `locked_langcode: en`.
+This route proves whether `drupal/config_language_lock:^1.0` can be introduced into Agency without silently enabling Agency's future `locked_langcode: en` policy before that migration is explicitly reviewed.
 
 The route is an evaluation primitive only. Presence of this workflow on `main` does **not** mean Configuration Language Lock is adopted or enabled in Agency.
 
@@ -20,9 +20,19 @@ enforce_consistency              = false
 
 The baseline captured for #609 remains authoritative for the pre-migration state.
 
+Upstream behavior is also part of the contract. Configuration Language Lock documents that installing the module without selecting a lock preserves Drupal's normal behavior. When Locale is enabled and no lock is set, Locale's extension-install hooks run normally. On a site whose default language is French, that native Drupal behavior can rewrite the **source language of extension-managed active configuration** toward `fr` during module installation.
+
+Upstream reference:
+
+```text
+https://project.pages.drupalcode.org/config_language_lock/
+```
+
+This Locale footprint is not Configuration Language Lock enforcement. The proof must therefore distinguish those two mechanisms rather than treating any active-config hash change as lock enforcement.
+
 ## Composer materialization
 
-The existing governed Composer route receives one new repository-owned profile:
+The governed Composer route owns the repository profile:
 
 ```text
 profile          = config-language-lock-628
@@ -32,7 +42,7 @@ resolved version = stable 1.0.x
 owner issue      = #628
 ```
 
-The control request still exposes only:
+The control request exposes only:
 
 ```text
 request_id
@@ -41,7 +51,7 @@ head_sha
 profile
 ```
 
-Package names, constraints, Composer commands and shell arguments are not request inputs. The gateway explicitly allowlists `canvas-ai-agents-530` and `config-language-lock-628`; every other profile fails closed.
+Package names, constraints, Composer commands and shell arguments are not request inputs. The gateway explicitly allowlists repository-owned profiles and fails closed for every other value.
 
 Before materialization, PR #629 must differ from its base by exactly `composer.json`, and semantic validation proves that the only change is:
 
@@ -50,6 +60,14 @@ Before materialization, PR #629 must differ from its base by exactly `composer.j
 ```
 
 The self-hosted resolver remains `contents: read` and `persist-credentials: false`. It publishes only a bounded `composer.lock` artifact. The GitHub-hosted publisher alone can fast-forward the validated lock to the PR branch after a live HEAD recheck.
+
+The first real resolution for #628 produced:
+
+```text
+resolved package = drupal/config_language_lock 1.0.0
+trusted run      = 32562142545
+lock SHA-256     = 1b445381f71964aef29d11a92ddfea0f8df3e14b765c1a1d055ad54c5c785461
+```
 
 ## DDEV evaluation route
 
@@ -74,50 +92,105 @@ composer.lock
 
 The lock must resolve `drupal/config_language_lock` to stable `1.0.x`.
 
+## First evaluation and corrected model
+
+Run `32562350246` was intentionally fail-closed and produced the evidence that refined this contract.
+
+The fresh baseline was clean at 595 active/repository objects. Enabling `config_language_lock 1.0.0` without a lock created only `config_language_lock.settings`, with:
+
+```text
+locked_langcode      = null
+follow_site_default  = false
+```
+
+During the same extension install, Locale imported the module's French translations and reported 43 configuration objects updated. The fingerprint observed 19 existing objects with changed hashes and 12 source-langcode transitions. Every transition was toward the Drupal site default `fr`; there was no normalization toward Agency's future canonical `en` lock.
+
+Observed distribution:
+
+```text
+before enable : none=59, en=183, fr=352, und=1
+after enable  : none=59, en=172, fr=364, und=1
+```
+
+`system.menu.footer` remained `langcode: und`. `language.entity.und` and `language.entity.zxx` remained the semantic language entities `und` and `zxx`, while the source language of those configuration objects was among the Locale `en -> fr` transitions. These concepts must not be conflated.
+
+First evaluation artifact:
+
+```text
+artifact = 9473184700
+SHA-256 = 82407f130c6b457bff50976378ec098fac48ca2bce6e76536c15bb5dfcd2f17b
+```
+
+The first workflow stopped before uninstall because its old intermediate gate was too strict. Issue #632 corrects that proof design; it does not weaken the product invariant.
+
 ## Evaluation sequence
 
 ```text
 trusted main workflow
 -> exact PR HEAD read-only checkout
 -> isolated DDEV
--> composer install from exact lock
 -> composer audit --locked
+-> composer install from exact lock
 -> site:install --existing-config
--> cim / cr / config:status
+-> canonical cim / cr / config:status
 -> fingerprint entire active configuration
 -> enable config_language_lock with no lock configured
 -> fingerprint active configuration again
--> validate bounded enable delta
--> uninstall config_language_lock
--> fingerprint active configuration again
--> require exact baseline restoration
--> config:status clean
+-> classify native Locale footprint vs lock enforcement
+-> uninstall config_language_lock even if semantic assessment failed
+-> fingerprint post-uninstall state
+-> record any surviving native Locale drift
+-> canonical cim in ephemeral DDEV
+-> require exact pre-enable fingerprint restoration
+-> clean config:status
 -> workspace/config sync unchanged
 -> artifact + cleanup
 ```
 
-`scripts/runner/config-language-lock-state.php` reads every active configuration object, canonicalizes nested map ordering, records a SHA-256 per object and a global SHA-256, and exposes the semantic watch values used by #609.
+`scripts/runner/config-language-lock-state.php` reads every active configuration object, canonicalizes nested map ordering, records a SHA-256 per object and globally, records each object's source `langcode` and semantic `id`, and exposes the semantic watch values used by #609.
 
-## Accepted enable delta
+## Accepted non-enforcing enable footprint
 
-Existing active configuration may not be silently rewritten.
+The route remains fail-closed.
 
 After module enable:
 
-- no pre-existing object may disappear;
-- the only pre-existing object allowed to change is `core.extension`;
-- newly created objects, if any, must be owned by the `config_language_lock.*` namespace;
-- module-owned configuration may not contain a non-empty `locked_langcode` anywhere;
-- `system.menu.footer` must remain `langcode: und`;
-- `language.entity.und` and `language.entity.zxx` must remain present and unchanged.
+- no pre-existing configuration object may disappear;
+- the only new configuration object must be `config_language_lock.settings`;
+- `locked_langcode` must be `null`;
+- `follow_site_default` must remain `false`;
+- all source-langcode transitions must be native-Locale shaped: previous value `en` or absent, new value equal to Drupal's site default `fr`;
+- no object may transition toward Agency's future canonical `en` lock;
+- every active/repository langcode mismatch after enable must correspond exactly to one observed Locale transition;
+- `system.menu.footer` must remain source `langcode: und`;
+- `language.entity.und` must retain semantic `id: und`;
+- `language.entity.zxx` must retain semantic `id: zxx`;
+- versioned translation-directory inventory and `config/sync` must not change.
 
-The route performs no `cex` and does not materialize `locked_langcode: en` or `follow_site_default: false`.
+Changes to full config hashes are recorded, not silently ignored. They are classified separately from source-langcode transitions so Locale translation updates remain observable.
 
-## Reversibility requirement
+## Uninstall and reversibility requirement
 
-After uninstall, the entire active-configuration fingerprint must exactly equal the baseline captured immediately before enable. `config:status` must report no differences, and `config/sync` must remain untouched.
+Uninstall is executed whenever module enable itself succeeded, even if the semantic gate reports a failure. This guarantees that every evaluation gathers rollback evidence.
 
-A failure at any point is evidence against adoption, not permission to normalize configuration manually.
+Immediately after uninstall:
+
+- the module must be disabled;
+- module-owned configuration must be absent;
+- compared with the post-enable state, only `core.extension` and removal of the module-owned settings are expected; no additional existing config mutation is accepted;
+- Locale-originated source-language drift may still exist because Drupal does not reverse extension-install translation processing merely by uninstalling the extension.
+
+The route records `config:status` at this point instead of pretending uninstall alone restores repository canonical state.
+
+Then, inside the ephemeral DDEV only, the route performs repository-owned `drush cim -y`. After that canonical restore:
+
+- all 595 active configuration fingerprints must exactly equal the pre-enable baseline;
+- overall SHA-256 must equal the pre-enable SHA-256;
+- repository/active langcode mismatches must be zero;
+- `config:status` must report no differences;
+- `config/sync` remains untouched.
+
+There is still no `cex`. Canonical restoration is from repository state to disposable active state, never the reverse.
 
 ## Security boundaries
 
@@ -133,10 +206,29 @@ The route provides no:
 - config export;
 - automatic Configuration Language Lock enforcement.
 
-## Evidence
+## Evidence and decision rule
 
-The workflow uploads `artifacts/config-language-lock-evaluation` with machine-readable fingerprints, enable delta, Composer audit and a bounded result. The result becomes authoritative only after the route has executed successfully on the exact #629 HEAD.
+The workflow uploads `artifacts/config-language-lock-evaluation` with:
 
-Until then the capability itself is **CANDIDATE** and #609 remains in its non-enforcing evaluation phase.
+```text
+composer-audit.json
+state-before.json
+language-before.json
+state-enabled.json
+language-enabled.json
+enable-comparison.json
+state-after-uninstall.json
+language-after-uninstall.json
+uninstall-comparison.json
+config-status-after-uninstall.txt
+state-restored.json
+language-restored.json
+config-status-restored.txt
+result.json
+```
 
-Refs #609 #608 #614 #628 #629 #531 #412.
+A PASS means only that **non-enforcing mode is understood and reversible in Agency's fresh-DDEV model**. It does not authorize `locked_langcode: en`, bulk migration, production enablement or adoption.
+
+#609 remains `migration_required` until the later EN migration dry-run and transformation tests are separately green.
+
+Refs #609 #608 #614 #628 #629 #630 #632 #531 #412.

--- a/scripts/runner/config-language-lock-state.php
+++ b/scripts/runner/config-language-lock-state.php
@@ -47,6 +47,9 @@ foreach ($names as $name) {
     'langcode' => array_key_exists('langcode', $canonical)
       ? $canonical['langcode']
       : NULL,
+    'id' => isset($canonical['id']) && is_string($canonical['id'])
+      ? $canonical['id']
+      : NULL,
   ];
   $entries[$name] = $entry;
 
@@ -69,15 +72,20 @@ if (!is_array($coreExtension)) {
 }
 
 $output = [
-  'schema_version' => 1,
+  'schema_version' => 2,
   'total' => count($entries),
   'overall_sha256' => hash('sha256', $overall),
+  'site_default_language' => \Drupal::languageManager()
+    ->getDefaultLanguage()
+    ->getId(),
   'entries' => $entries,
   'module_owned' => $moduleOwned,
   'special' => [
     'system_menu_footer_langcode' => $entries['system.menu.footer']['langcode'] ?? NULL,
-    'language_entity_und_sha256' => $entries['language.entity.und']['sha256'] ?? NULL,
-    'language_entity_zxx_sha256' => $entries['language.entity.zxx']['sha256'] ?? NULL,
+    'language_entity_und_id' => $entries['language.entity.und']['id'] ?? NULL,
+    'language_entity_und_source_langcode' => $entries['language.entity.und']['langcode'] ?? NULL,
+    'language_entity_zxx_id' => $entries['language.entity.zxx']['id'] ?? NULL,
+    'language_entity_zxx_source_langcode' => $entries['language.entity.zxx']['langcode'] ?? NULL,
   ],
   'config_language_lock_enabled' => array_key_exists(
     'config_language_lock',

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockEvaluationWorkflowTest.php
@@ -52,9 +52,9 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
   }
 
   /**
-   * The self-hosted proof is read-only, reversible and non-enforcing.
+   * The proof distinguishes native Locale drift from lock enforcement.
    */
-  public function testEvaluationIsReadOnlyAndReversible(): void {
+  public function testEvaluationIsLocaleAwareReadOnlyAndReversible(): void {
     $root = dirname(DRUPAL_ROOT);
     $path = $root
       . '/.github/workflows/trusted-config-language-lock-evaluation.yml';
@@ -71,7 +71,6 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
     self::assertStringContainsString('persist-credentials: false', $evaluate);
     self::assertStringContainsString('ddev composer audit --locked', $evaluate);
     self::assertStringContainsString('site:install --existing-config', $evaluate);
-    self::assertStringContainsString('ddev drush cim -y', $evaluate);
     self::assertStringContainsString(
       'ddev drush pm:enable config_language_lock -y',
       $evaluate,
@@ -80,30 +79,68 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
       'ddev drush pm:uninstall config_language_lock -y',
       $evaluate,
     );
+
+    self::assertStringContainsString(
+      "added != ['config_language_lock.settings']",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "settings.get('locked_langcode') is not None",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "settings.get('follow_site_default') is not False",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "old not in ('en', None) or new != site_default",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "'classification': 'DRUPAL_LOCALE_EXTENSION_INSTALL_FOOTPRINT'",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "special.get('system_menu_footer_langcode') != 'und'",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "special.get('language_entity_und_id') != 'und'",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "special.get('language_entity_zxx_id') != 'zxx'",
+      $evaluate,
+    );
+
+    self::assertStringContainsString('continue-on-error: true', $evaluate);
+    self::assertStringContainsString(
+      "if: \${{ always() && steps.enable.outcome == 'success' }}",
+      $evaluate,
+    );
+    self::assertStringContainsString(
+      "if: \${{ always() && steps.uninstall.outcome == 'success' }}",
+      $evaluate,
+    );
     self::assertStringContainsString(
       "changed != ['core.extension']",
       $evaluate,
     );
     self::assertStringContainsString(
-      "name.startswith('config_language_lock.')",
+      'canonical restore did not return exact active config baseline',
       $evaluate,
     );
     self::assertStringContainsString(
-      "if key == 'locked_langcode'",
-      $evaluate,
-    );
-    self::assertStringContainsString(
-      'Active configuration did not return exactly to baseline',
-      $evaluate,
-    );
-    self::assertStringContainsString(
-      '.special.system_menu_footer_langcode == "und"',
+      'grep -Fq \'No differences\' <<<"$config_status"',
       $evaluate,
     );
     self::assertStringContainsString(
       'test -z "$(git status --short config/sync)"',
       $evaluate,
     );
+
+    $cimCount = substr_count($evaluate, 'ddev drush cim -y');
+    self::assertGreaterThanOrEqual(2, $cimCount);
     self::assertStringNotContainsString('drush cex', $evaluate);
     self::assertStringNotContainsString('OPENAI_API_KEY', $workflow);
     self::assertStringNotContainsString('deploy-production', $workflow);
@@ -113,7 +150,7 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
   /**
    * The active-configuration fingerprint helper performs reads only.
    */
-  public function testFingerprintHelperIsDeterministicAndReadOnly(): void {
+  public function testFingerprintHelperIsDeterministicSemanticAndReadOnly(): void {
     $root = dirname(DRUPAL_ROOT);
     $path = $root . '/scripts/runner/config-language-lock-state.php';
     self::assertFileExists($path);
@@ -123,8 +160,13 @@ final class ConfigurationLanguageLockEvaluationWorkflowTest extends TestCase {
     self::assertStringContainsString('$storage->read($name)', $script);
     self::assertStringContainsString('ksort($value, SORT_STRING)', $script);
     self::assertStringContainsString("hash('sha256'", $script);
+    self::assertStringContainsString("'schema_version' => 2", $script);
+    self::assertStringContainsString("'site_default_language'", $script);
     self::assertStringContainsString("'module_owned'", $script);
     self::assertStringContainsString("'config_language_lock_enabled'", $script);
+    self::assertStringContainsString("'language_entity_und_id'", $script);
+    self::assertStringContainsString("'language_entity_zxx_id'", $script);
+    self::assertStringContainsString("'system_menu_footer_langcode'", $script);
     self::assertStringNotContainsString('->write(', $script);
     self::assertStringNotContainsString('->save(', $script);
     self::assertStringNotContainsString('->delete(', $script);


### PR DESCRIPTION
## Cause

Le premier run #628 `32562350246` a démontré que notre gate « aucun objet actif existant ne change à l’activation » testait en réalité le comportement natif de Drupal Locale.

Upstream documente qu’en l’absence de `locked_langcode`, Configuration Language Lock est opt-in et délègue aux hooks d’installation Locale. Sur Agency (`default_langcode=fr`), l’installation peut donc faire évoluer la langue source de config d’extension `en`/absent -> `fr` sans que le lock EN soit actif.

## Correction

- fingerprint v2 : hash complet + source `langcode` + `id` sémantique + langue site ;
- distingue `language.entity.und:id=und` / `zxx:id=zxx` de la langue source de leur config ;
- capture l’activation avant de statuer ;
- exige exactement `config_language_lock.settings`, `locked_langcode=null`, `follow_site_default=false` ;
- n’accepte que les transitions source `en`/absent -> langue site `fr` ;
- interdit toute transition vers le futur canonique `en` ;
- enregistre tous les hashes modifiés et exige que les mismatches repository/active correspondent aux transitions observées ;
- exécute toujours l’uninstall si l’enable a réussi, même si le gate sémantique échoue ;
- exige qu’après uninstall aucune mutation supplémentaire n’apparaisse hors `core.extension` / suppression module-owned ;
- enregistre le drift Locale post-uninstall ;
- exécute ensuite `cim` dans le DDEV éphémère et exige le retour exact au fingerprint initial des 595 objets + `config:status` clean ;
- aucun `cex`, aucun secret/provider, aucune production.

Le runbook conserve l’évidence du premier FAIL et la référence upstream afin que ce comportement ne soit plus interprété comme de l’enforcement.

Aucun `composer.json`, lockfile, config Drupal versionnée ni code produit n’est modifié.

Closes #632
Refs #609 #628 #629 #630 #631 #614 #412.