### PR TITLE
Issue #634: recover stuck production maintenance safely

### DIFF
--- a/.github/workflows/trusted-production-maintenance-recovery-634.yml
+++ b/.github/workflows/trusted-production-maintenance-recovery-634.yml
@@ -1,0 +1,289 @@
+name: Agency trusted production maintenance recovery 634
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-maintenance-recovery-634:
+    name: Recover stuck Drupal maintenance mode for issue 634
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 634 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-maintenance recover-634'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      group: agency-production-maintenance-recovery-634
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate exact incident request and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-maintenance recover-634' ]]
+          [[ "$ISSUE_NUMBER" == '634' ]] || {
+            echo 'Maintenance recovery v3 is restricted to issue #634.' >&2
+            exit 1
+          }
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/634")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Maintenance recovery must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Execute fixed fail-closed maintenance recovery
+        id: recovery
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p artifacts/production-maintenance-recovery-634
+          raw='artifacts/production-maintenance-recovery-634/recovery.txt'
+
+          set +e
+          ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' > "$raw" 2>&1 <<'REMOTE_RECOVERY'
+          set -u
+          CURRENT='/var/www/agency/current'
+          EXPECTED_PRODUCTION_SHA='b85667be5fdefa55e661d62c9d0688039bb4c401'
+          FR_URL='https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier'
+          EN_URL='https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start'
+
+          emit() {
+            printf '%s=%s\n' "$1" "$2"
+          }
+
+          no_mutation() {
+            emit outcome 'NO_MUTATION'
+            emit reason "$1"
+            exit 42
+          }
+
+          service_state() {
+            state="$(systemctl is-active "$1" 2>/dev/null || true)"
+            printf '%s' "${state:-unavailable}"
+          }
+
+          http_status() {
+            status="$(curl -k -sS --connect-timeout 8 --max-time 20 \
+              -A 'agency-production-maintenance-recovery/3' \
+              -o /dev/null -w '%{http_code}' "$1" 2>/dev/null)"
+            curl_exit="$?"
+            if [[ "$curl_exit" -ne 0 ]]; then
+              status='000'
+            fi
+            printf '%s' "$status"
+          }
+
+          [[ -d "$CURRENT" ]] || no_mutation 'current_release_missing'
+          [[ -x "$CURRENT/vendor/bin/drush" ]] || no_mutation 'drush_missing'
+
+          current_sha="$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || true)"
+          emit current_sha_before "${current_sha:-unavailable}"
+          [[ "$current_sha" == "$EXPECTED_PRODUCTION_SHA" ]] || no_mutation 'unexpected_runtime_sha'
+
+          (cd "$CURRENT" && vendor/bin/drush status --fields=bootstrap >/dev/null 2>&1) || no_mutation 'drupal_bootstrap_failed'
+          emit drupal_bootstrap 'successful'
+
+          maintenance_before="$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n')"
+          emit maintenance_before "$maintenance_before"
+          [[ "$maintenance_before" == '1' ]] || no_mutation 'maintenance_not_stuck'
+
+          deploys_before="$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')"
+          emit active_deploy_processes_before "$deploys_before"
+          [[ "$deploys_before" == '0' ]] || no_mutation 'deploy_active'
+
+          nginx_before="$(service_state nginx)"
+          php_before="$(service_state php8.4-fpm)"
+          emit nginx_state_before "$nginx_before"
+          emit php84_fpm_state_before "$php_before"
+          [[ "$nginx_before" == 'active' ]] || no_mutation 'nginx_not_active'
+          [[ "$php_before" == 'active' ]] || no_mutation 'php_fpm_not_active'
+
+          # Re-check race-sensitive preconditions immediately before mutation.
+          [[ "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || true)" == "$EXPECTED_PRODUCTION_SHA" ]] || no_mutation 'runtime_changed_before_mutation'
+          [[ "$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')" == '0' ]] || no_mutation 'deploy_started_before_mutation'
+          [[ "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n')" == '1' ]] || no_mutation 'maintenance_changed_before_mutation'
+
+          cd "$CURRENT"
+          vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer >/dev/null
+          vendor/bin/drush cr >/dev/null
+          emit mutation_applied '1'
+
+          maintenance_after="$(vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n')"
+          current_sha_after="$(git rev-parse HEAD 2>/dev/null || true)"
+          deploys_after="$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')"
+          fr_status="$(http_status "$FR_URL")"
+          en_status="$(http_status "$EN_URL")"
+
+          emit maintenance_after "$maintenance_after"
+          emit current_sha_after "${current_sha_after:-unavailable}"
+          emit active_deploy_processes_after "$deploys_after"
+          emit public_fr_status "$fr_status"
+          emit public_en_status "$en_status"
+
+          if [[ "$maintenance_after" == '0' &&
+                "$current_sha_after" == "$EXPECTED_PRODUCTION_SHA" &&
+                "$deploys_after" == '0' &&
+                "$fr_status" =~ ^[23][0-9][0-9]$ &&
+                "$en_status" =~ ^[23][0-9][0-9]$ ]]; then
+            emit outcome 'RECOVERED'
+            emit reason 'all_postconditions_passed'
+            exit 0
+          fi
+
+          emit outcome 'RECOVERY_POSTCHECK_FAILED'
+          emit reason 'one_or_more_postconditions_failed'
+          exit 43
+          REMOTE_RECOVERY
+          ssh_status="$?"
+          set -e
+
+          value() {
+            grep -m1 "^$1=" "$raw" | cut -d= -f2- || true
+          }
+
+          outcome="$(value outcome)"
+          reason="$(value reason)"
+          maintenance_before="$(value maintenance_before)"
+          maintenance_after="$(value maintenance_after)"
+          deploys_before="$(value active_deploy_processes_before)"
+          deploys_after="$(value active_deploy_processes_after)"
+          current_sha_before="$(value current_sha_before)"
+          current_sha_after="$(value current_sha_after)"
+          fr_status="$(value public_fr_status)"
+          en_status="$(value public_en_status)"
+
+          [[ -n "$outcome" ]] || outcome='SSH_RECOVERY_FAILED'
+          [[ -n "$reason" ]] || reason='remote_result_missing'
+
+          jq -n \
+            --arg outcome "$outcome" \
+            --arg reason "$reason" \
+            --arg maintenance_before "${maintenance_before:-unknown}" \
+            --arg maintenance_after "${maintenance_after:-unknown}" \
+            --arg active_deploy_processes_before "${deploys_before:-unknown}" \
+            --arg active_deploy_processes_after "${deploys_after:-unknown}" \
+            --arg current_sha_before "${current_sha_before:-unknown}" \
+            --arg current_sha_after "${current_sha_after:-unknown}" \
+            --arg public_fr_status "${fr_status:-unknown}" \
+            --arg public_en_status "${en_status:-unknown}" \
+            --argjson ssh_exit "$ssh_status" \
+            '{schema_version:3, outcome:$outcome, reason:$reason, ssh_exit:$ssh_exit, maintenance_before:$maintenance_before, maintenance_after:$maintenance_after, active_deploy_processes_before:$active_deploy_processes_before, active_deploy_processes_after:$active_deploy_processes_after, current_sha_before:$current_sha_before, current_sha_after:$current_sha_after, public_fr_status:$public_fr_status, public_en_status:$public_en_status}' \
+            > artifacts/production-maintenance-recovery-634/result.json
+
+          echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+          [[ "$ssh_status" -eq 0 && "$outcome" == 'RECOVERED' ]]
+
+      - name: Upload recovery evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-maintenance-recovery-634-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-maintenance-recovery-634
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded recovery result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          RECOVERY_STEP_OUTCOME: ${{ steps.recovery.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-maintenance-recovery-634/result.json'
+          outcome='MISSING'
+          reason='unknown'
+          maintenance_before='unknown'
+          maintenance_after='unknown'
+          deploys_before='unknown'
+          deploys_after='unknown'
+          sha_before='unknown'
+          sha_after='unknown'
+          fr_status='unknown'
+          en_status='unknown'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            outcome="$(jq -r '.outcome' "$result")"
+            reason="$(jq -r '.reason' "$result")"
+            maintenance_before="$(jq -r '.maintenance_before' "$result")"
+            maintenance_after="$(jq -r '.maintenance_after' "$result")"
+            deploys_before="$(jq -r '.active_deploy_processes_before' "$result")"
+            deploys_after="$(jq -r '.active_deploy_processes_after' "$result")"
+            sha_before="$(jq -r '.current_sha_before' "$result")"
+            sha_after="$(jq -r '.current_sha_after' "$result")"
+            fr_status="$(jq -r '.public_fr_status' "$result")"
+            en_status="$(jq -r '.public_en_status' "$result")"
+          fi
+
+          artifact="agency-production-maintenance-recovery-634-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production maintenance recovery v3 ${outcome}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${RECOVERY_STEP_OUTCOME:-unknown}\`
+          reason: \`${reason}\`
+          maintenance_before: \`${maintenance_before}\`
+          maintenance_after: \`${maintenance_after}\`
+          active_deploy_processes_before: \`${deploys_before}\`
+          active_deploy_processes_after: \`${deploys_after}\`
+          production_sha_before: \`${sha_before}\`
+          production_sha_after: \`${sha_after}\`
+          public_fr_status: \`${fr_status}\`
+          public_en_status: \`${en_status}\`
+          artifact: \`${artifact}\`
+
+          This route is pinned to issue #634 and runtime b85667be5fdefa55e661d62c9d0688039bb4c401. It can only disable the already-proven stuck Drupal maintenance mode, rebuild Drupal cache, and verify fixed postconditions.
+          EOF_BODY
+          )"
+          gh issue comment 634 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/trusted-production-maintenance-recovery-634.yml
+++ b/.github/workflows/trusted-production-maintenance-recovery-634.yml
@@ -92,7 +92,7 @@ jobs:
           ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' > "$raw" 2>&1 <<'REMOTE_RECOVERY'
           set -u
           CURRENT='/var/www/agency/current'
-          EXPECTED_PRODUCTION_SHA='b85667be5fdefa55e661d62c9d0688039bb4c401'
+          EXPECTED_PRODUCTION_SHA='0ccadc58c16acdde8297ff5b6902f5406b9efaf9'
           FR_URL='https://emergingdigital.be/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier'
           EN_URL='https://emergingdigital.be/en/blog/website-redesign-checklist-12-things-verify-you-start'
 
@@ -283,7 +283,7 @@ jobs:
           public_en_status: \`${en_status}\`
           artifact: \`${artifact}\`
 
-          This route is pinned to issue #634 and runtime b85667be5fdefa55e661d62c9d0688039bb4c401. It can only disable the already-proven stuck Drupal maintenance mode, rebuild Drupal cache, and verify fixed postconditions.
+          This route is pinned to issue #634 and runtime 0ccadc58c16acdde8297ff5b6902f5406b9efaf9. It can only disable the already-proven stuck Drupal maintenance mode, rebuild Drupal cache, and verify fixed postconditions.
           EOF_BODY
           )"
           gh issue comment 634 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionMaintenanceRecovery634WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionMaintenanceRecovery634WorkflowTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the incident-bound production maintenance recovery for #634.
+ *
+ * @group agency_project_tests
+ * @group production_maintenance_recovery
+ */
+final class ProductionMaintenanceRecovery634WorkflowTest extends TestCase {
+
+  /**
+   * The control surface must stay issue-bound and live-main trusted.
+   */
+  public function testControlSurfaceIsClosed(): void {
+    $workflow = $this->workflow();
+
+    self::assertStringContainsString(
+      '/agency-production-maintenance recover-634',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'github.event.issue.number == 634',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "github.actor == 'E-merging-digital'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "ISSUE_NUMBER\" == '634'",
+      $workflow,
+    );
+    self::assertStringContainsString('currently on live main', $workflow);
+    self::assertStringContainsString('runs-on: ubuntu-24.04', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * Recovery must be pinned to the exact diagnosed runtime.
+   */
+  public function testPreconditionsArePinnedAndRaceChecked(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      "EXPECTED_PRODUCTION_SHA='b85667be5fdefa55e661d62c9d0688039bb4c401'",
+      'unexpected_runtime_sha',
+      'drupal_bootstrap_failed',
+      'maintenance_not_stuck',
+      'deploy_active',
+      'nginx_not_active',
+      'php_fpm_not_active',
+      'runtime_changed_before_mutation',
+      'deploy_started_before_mutation',
+      'maintenance_changed_before_mutation',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringContainsString(
+      "pgrep -af '[d]eploy-production.sh'",
+      $workflow,
+    );
+    self::assertStringContainsString('service_state nginx', $workflow);
+    self::assertStringContainsString('service_state php8.4-fpm', $workflow);
+  }
+
+  /**
+   * Only the two reviewed Drupal mutations may be present.
+   */
+  public function testMutationSurfaceIsMinimal(): void {
+    $workflow = $this->workflow();
+
+    self::assertSame(
+      1,
+      substr_count(
+        $workflow,
+        'vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer',
+      ),
+    );
+    self::assertSame(
+      1,
+      substr_count($workflow, 'vendor/bin/drush cr >/dev/null'),
+    );
+
+    foreach ([
+      'systemctl restart',
+      'systemctl reload',
+      'service nginx restart',
+      'deploy-production.sh main',
+      'drush cim',
+      'drush updb',
+      'drush sql:',
+      'sudo ',
+      'git pull',
+      'git reset',
+      'git checkout',
+      'composer ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Recovery must prove fixed postconditions and persist evidence.
+   */
+  public function testPostconditionsAndEvidenceAreFailClosed(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'maintenance_after',
+      'current_sha_after',
+      'active_deploy_processes_after',
+      'public_fr_status',
+      'public_en_status',
+      "outcome 'RECOVERED'",
+      "outcome 'RECOVERY_POSTCHECK_FAILED'",
+      'production-maintenance-recovery-634/result.json',
+      'production-maintenance-recovery-634/recovery.txt',
+      'gh issue comment 634',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Loads and parses the recovery workflow.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-production-maintenance-recovery-634.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionMaintenanceRecovery634WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionMaintenanceRecovery634WorkflowTest.php
@@ -49,7 +49,7 @@ final class ProductionMaintenanceRecovery634WorkflowTest extends TestCase {
     $workflow = $this->workflow();
 
     foreach ([
-      "EXPECTED_PRODUCTION_SHA='b85667be5fdefa55e661d62c9d0688039bb4c401'",
+      "EXPECTED_PRODUCTION_SHA='0ccadc58c16acdde8297ff5b6902f5406b9efaf9'",
       'unexpected_runtime_sha',
       'drupal_bootstrap_failed',
       'maintenance_not_stuck',


### PR DESCRIPTION
## Incident

Le deploy initial `32563171839` a échoué pendant `Maintenance ON` sur `SQLSTATE 2006 MySQL server has gone away`, puis SSH `Broken pipe`.

Le premier diagnostic trusted #590 (`32563563870`) a confirmé un `MAINTENANCE_STUCK` sur `b85667be…`. Ensuite le merge de #629 a déclenché un nouveau deploy ; à cause du `git pull` pré-déploiement dans `/var/www/agency/current`, le runtime a avancé en place à `0ccadc58c16acdde8297ff5b6902f5406b9efaf9` pendant que le deploy était actif.

Le diagnostic trusted read-only final #590, run `32563972999`, a confirmé après fin du deploy :

- verdict `MAINTENANCE_STUCK` ;
- runtime exact `0ccadc58c16acdde8297ff5b6902f5406b9efaf9` ;
- maintenance=1 ;
- aucun deploy actif ;
- Nginx/PHP-FPM actifs ;
- HTTP FR/EN/local=503 ;
- artifact `agency-production-health-590-32563972999-1`, digest `sha256:c89f0479277360abc01fadf7c6236b8a6e744a56913bea9bfaa648c7fb8e2c4a`.

## Recovery

Cette PR ajoute une route one-shot dédiée à #634 :

- déclencheur exact `/agency-production-maintenance recover-634` ;
- actor/comment author E-merging-digital ;
- workflow revision = live main ;
- runtime exact `0ccadc58c16acdde8297ff5b6902f5406b9efaf9` ;
- maintenance doit être 1 ;
- aucun deploy actif ;
- Nginx/PHP 8.4 FPM actifs ;
- re-check race-sensitive juste avant mutation ;
- mutation maximale : `drush state:set ... 0` + `drush cr` ;
- postchecks runtime inchangé, maintenance=0, aucun deploy, HTTP FR/EN 2xx/3xx ;
- artifact machine-readable.

Le test repository-owned interdit explicitement deploy, git pull/reset/checkout, Composer, updb/cim/sql, sudo et restart/reload services.

La PR ne touche que `.github/**` et `agency_project_tests/**`, donc son merge est exclu du trigger de deploy production actuel.

Closes #634
Refs #590 #592 #600 #632.