### PR TITLE
Issue #636: make production deploy atomic and maintenance-safe

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,15 +12,27 @@ on:
       - '*.md'
   workflow_dispatch:
 
+concurrency:
+  group: agency-production-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout exact deployment source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Configure SSH key
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
@@ -30,17 +42,21 @@ jobs:
         env:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
           ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Run deployment script on production server
+      - name: Run exact deployment script on production server
         env:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
           SERVER_USER: ${{ secrets.SERVER_USER }}
+          EXPECTED_SHA: ${{ github.sha }}
         run: |
-          ssh "$SERVER_USER@$SERVER_HOST" <<'EOF'
-          cd /var/www/agency/current
-          git pull
-          bash scripts/deploy-production.sh main
-          EOF
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          ssh "$SERVER_USER@$SERVER_HOST" \
+            bash -s -- main "$EXPECTED_SHA" < scripts/deploy-production.sh

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 BRANCH="${1:-main}"
+EXPECTED_SHA="${2:-}"
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 
 PROJECT_ROOT="/var/www/agency"
@@ -17,6 +18,7 @@ DEPLOY_USER="$(id -un)"
 FILES_OWNER="deploy"
 GIT_COMMIT="unknown"
 MAINTENANCE_ENABLED=0
+SWITCH_COMPLETED=0
 SHARED_FILES_DIR="$SHARED_DIR/files"
 RELEASE_FILES_LINK="$NEW_RELEASE/web/sites/default/files"
 
@@ -40,17 +42,31 @@ log_file() {
 fail_trap() {
   local exit_code="$?"
   local line_no="${1:-unknown}"
+  trap - ERR
+  set +e
 
   log "[deploy] ERROR at line ${line_no} (exit ${exit_code})"
   log_file "FAILURE" "Deployment failed at line ${line_no} (exit ${exit_code})"
 
-  if [[ "$MAINTENANCE_ENABLED" -eq 1 ]] && [[ -x "$CURRENT_LINK/vendor/bin/drush" ]]; then
-    log "[deploy] Attempting Maintenance OFF after failure"
-    "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer || true
-    "$CURRENT_LINK/vendor/bin/drush" cr || true
+  if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
+    if [[ -n "$ACTIVE_RELEASE" ]] && [[ -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
+      log "[deploy] Attempting Maintenance OFF through previous absolute release ${ACTIVE_RELEASE}"
+      (
+        cd "$ACTIVE_RELEASE"
+        vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer
+        vendor/bin/drush cr
+      ) || true
+    else
+      log "[deploy] WARNING: maintenance may remain enabled; previous absolute release is unavailable"
+    fi
   fi
 
-  log "Deployment failed. Previous release kept intact."
+  if [[ "$SWITCH_COMPLETED" -eq 0 ]]; then
+    log "Deployment failed before release switch. Active release was not switched."
+  else
+    log "Deployment failed after release switch. Previous release remains at ${ACTIVE_RELEASE}; automatic database rollback is not attempted."
+  fi
+
   exit "$exit_code"
 }
 
@@ -115,11 +131,16 @@ if [[ -z "$REPO_URL" ]] || [[ "$REPO_URL" == *"<org>/<repo>"* ]]; then
   exit 1
 fi
 
+if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "EXPECTED_SHA must be an exact 40-character lowercase Git commit SHA." >&2
+  exit 1
+fi
+
 mkdir -p "$RELEASES_DIR" "$SHARED_DIR" "$BACKUPS_DIR" "$(dirname "$LOG_FILE")"
 touch "$LOG_FILE"
 
-log "[deploy] START branch=${BRANCH}"
-log_file "START" "Deployment started"
+log "[deploy] START branch=${BRANCH} expected_sha=${EXPECTED_SHA}"
+log_file "START" "Deployment started for exact SHA ${EXPECTED_SHA}"
 log "[deploy] Prepare release ${NEW_RELEASE}"
 
 if [[ -e "$NEW_RELEASE" ]]; then
@@ -131,8 +152,14 @@ mkdir -p "$NEW_RELEASE"
 
 log "[deploy] Clone"
 git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$NEW_RELEASE"
+git -C "$NEW_RELEASE" cat-file -e "${EXPECTED_SHA}^{commit}"
+git -C "$NEW_RELEASE" checkout --detach "$EXPECTED_SHA"
 GIT_COMMIT="$(git -C "$NEW_RELEASE" rev-parse HEAD)"
-log "Repository cloned at commit ${GIT_COMMIT}."
+if [[ "$GIT_COMMIT" != "$EXPECTED_SHA" ]]; then
+  log "ERROR: cloned release is ${GIT_COMMIT}, expected ${EXPECTED_SHA}."
+  exit 1
+fi
+log "Repository prepared at exact commit ${GIT_COMMIT}."
 
 log "[deploy] Composer"
 composer --working-dir="$NEW_RELEASE" install --no-dev --optimize-autoloader
@@ -146,11 +173,11 @@ if [[ -L "$CURRENT_LINK" ]]; then
   ACTIVE_RELEASE="$(readlink -f "$CURRENT_LINK")"
   log "Active release detected: ${ACTIVE_RELEASE}"
 
-  if [[ -x "$CURRENT_LINK/vendor/bin/drush" ]]; then
+  if [[ -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
     DB_BACKUP="$BACKUPS_DIR/db-${TIMESTAMP}.sql.gz"
     log "[deploy] Backup DB"
     (
-      cd "$CURRENT_LINK"
+      cd "$ACTIVE_RELEASE"
       vendor/bin/drush sql:dump --gzip --result-file="$DB_BACKUP"
     )
     log "Database backup created: ${DB_BACKUP}"
@@ -158,11 +185,25 @@ if [[ -L "$CURRENT_LINK" ]]; then
     log "WARNING: Drush not available on active release. Skipping DB backup."
   fi
 
-  if [[ -x "$CURRENT_LINK/vendor/bin/drush" ]]; then
+  if [[ -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
+    log "[deploy] Preflight active Drupal and database"
+    (
+      cd "$ACTIVE_RELEASE"
+      vendor/bin/drush status --fields=bootstrap >/dev/null
+      vendor/bin/drush sql:query 'SELECT 1' >/dev/null
+    )
+    test "$(git -C "$NEW_RELEASE" rev-parse HEAD)" = "$EXPECTED_SHA"
+
     log "[deploy] Maintenance ON"
-    "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 1 --input-format=integer
-    "$CURRENT_LINK/vendor/bin/drush" cr
+    (
+      cd "$ACTIVE_RELEASE"
+      vendor/bin/drush state:set system.maintenance_mode 1 --input-format=integer
+    )
     MAINTENANCE_ENABLED=1
+    (
+      cd "$ACTIVE_RELEASE"
+      vendor/bin/drush cr
+    )
   fi
 else
   log "No current release detected."
@@ -170,11 +211,21 @@ else
 fi
 
 if [[ -x "$NEW_RELEASE/vendor/bin/drush" ]]; then
-  "$NEW_RELEASE/vendor/bin/drush" status >/dev/null
+  (
+    cd "$NEW_RELEASE"
+    vendor/bin/drush status --fields=bootstrap >/dev/null
+  )
 fi
+
+test "$(git -C "$NEW_RELEASE" rev-parse HEAD)" = "$EXPECTED_SHA"
 
 log "[deploy] Switch release"
 ln -sfn "$NEW_RELEASE" "$CURRENT_LINK"
+SWITCH_COMPLETED=1
+if [[ "$(readlink -f "$CURRENT_LINK")" != "$(readlink -f "$NEW_RELEASE")" ]]; then
+  log "ERROR: current release did not switch to ${NEW_RELEASE}."
+  exit 1
+fi
 
 "$CURRENT_LINK/vendor/bin/drush" updb -y
 "$CURRENT_LINK/vendor/bin/drush" cim -y
@@ -190,10 +241,12 @@ log "[deploy] Governed Content"
 "$CURRENT_LINK/vendor/bin/drush" cr
 log "Drupal update, config import, production config split import, Governed Content and cache rebuild completed."
 
-log "[deploy] Maintenance OFF"
-"$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer
-"$CURRENT_LINK/vendor/bin/drush" cr
-MAINTENANCE_ENABLED=0
+if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
+  log "[deploy] Maintenance OFF"
+  "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer
+  "$CURRENT_LINK/vendor/bin/drush" cr
+  MAINTENANCE_ENABLED=0
+fi
 
 mapfile -t all_releases < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
 if (( ${#all_releases[@]} > 3 )); then
@@ -215,4 +268,4 @@ if (( ${#all_backups[@]} > 10 )); then
 fi
 
 log "[deploy] SUCCESS"
-log_file "SUCCESS" "Deployment completed successfully"
+log_file "SUCCESS" "Deployment completed successfully at exact SHA ${GIT_COMMIT}"

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/DeployProductionConfigSplitTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/DeployProductionConfigSplitTest.php
@@ -66,7 +66,7 @@ final class DeployProductionConfigSplitTest extends TestCase {
     $script = $this->loadDeployProductionScript();
 
     $prepare_command = 'prepare_public_files';
-    $drush_status_command = '"$NEW_RELEASE/vendor/bin/drush" status >/dev/null';
+    $drush_status_command = 'vendor/bin/drush status --fields=bootstrap >/dev/null';
 
     self::assertStringContainsString('SHARED_FILES_DIR="$SHARED_DIR/files"', $script);
     self::assertStringContainsString('RELEASE_FILES_LINK="$NEW_RELEASE/web/sites/default/files"', $script);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Yaml\Yaml;
 final class ProductionDeploymentSafetyTest extends TestCase {
 
   /**
-   * The workflow must deploy its exact checked-out SHA without mutating current.
+   * Deploys the exact checked-out SHA without mutating current.
    */
   public function testWorkflowDeploysExactShaAndSerializesProduction(): void {
     $root = dirname(DRUPAL_ROOT);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects production deployment atomicity and maintenance recovery.
+ *
+ * @group agency_project_tests
+ * @group production_deploy
+ */
+final class ProductionDeploymentSafetyTest extends TestCase {
+
+  /**
+   * The workflow must deploy its exact checked-out SHA without mutating current.
+   */
+  public function testWorkflowDeploysExactShaAndSerializesProduction(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/deploy-production.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+
+    self::assertStringContainsString(
+      'group: agency-production-deploy',
+      $workflow,
+    );
+    self::assertStringContainsString('cancel-in-progress: false', $workflow);
+    self::assertStringContainsString('uses: actions/checkout@v6', $workflow);
+    self::assertStringContainsString('ref: ${{ github.sha }}', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString(
+      'EXPECTED_SHA: ${{ github.sha }}',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'bash -s -- main "$EXPECTED_SHA" < scripts/deploy-production.sh',
+      $workflow,
+    );
+    self::assertStringNotContainsString('git pull', $workflow);
+    self::assertStringNotContainsString(
+      'cd /var/www/agency/current',
+      $workflow,
+    );
+  }
+
+  /**
+   * The server script must materialize and verify the exact requested commit.
+   */
+  public function testScriptPinsExactCommitAndKeepsCurrentImmutable(): void {
+    $script = $this->deploymentScript();
+
+    self::assertStringContainsString('EXPECTED_SHA="${2:-}"', $script);
+    self::assertStringContainsString(
+      '[[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]',
+      $script,
+    );
+    self::assertStringContainsString(
+      'git -C "$NEW_RELEASE" checkout --detach "$EXPECTED_SHA"',
+      $script,
+    );
+    self::assertStringContainsString(
+      'if [[ "$GIT_COMMIT" != "$EXPECTED_SHA" ]]',
+      $script,
+    );
+    self::assertStringNotContainsString('git pull', $script);
+    self::assertStringNotContainsString(
+      'git -C "$CURRENT_LINK" checkout',
+      $script,
+    );
+    self::assertStringNotContainsString(
+      'git -C "$CURRENT_LINK" reset',
+      $script,
+    );
+  }
+
+  /**
+   * Maintenance recovery must be armed immediately and use the old release.
+   */
+  public function testMaintenanceIsFailSafeAcrossReleaseSwitch(): void {
+    $script = $this->deploymentScript();
+
+    self::assertStringContainsString(
+      'vendor/bin/drush sql:query \'SELECT 1\' >/dev/null',
+      $script,
+    );
+    self::assertStringContainsString('SWITCH_COMPLETED=0', $script);
+    self::assertStringContainsString('SWITCH_COMPLETED=1', $script);
+
+    $maintenanceStart = strpos($script, 'log "[deploy] Maintenance ON"');
+    self::assertIsInt($maintenanceStart);
+    $maintenanceBlock = substr($script, $maintenanceStart, 500);
+
+    $stateOn = strpos(
+      $maintenanceBlock,
+      'vendor/bin/drush state:set system.maintenance_mode 1',
+    );
+    $armed = strpos($maintenanceBlock, 'MAINTENANCE_ENABLED=1');
+    $cacheRebuild = strpos($maintenanceBlock, 'vendor/bin/drush cr');
+
+    self::assertIsInt($stateOn);
+    self::assertIsInt($armed);
+    self::assertIsInt($cacheRebuild);
+    self::assertLessThan($armed, $stateOn);
+    self::assertLessThan($cacheRebuild, $armed);
+
+    $trapStart = strpos($script, 'fail_trap() {');
+    $trapEnd = strpos($script, "\n}\n\ntrap ", $trapStart);
+    self::assertIsInt($trapStart);
+    self::assertIsInt($trapEnd);
+    $trap = substr($script, $trapStart, $trapEnd - $trapStart);
+
+    self::assertStringContainsString(
+      '$ACTIVE_RELEASE/vendor/bin/drush',
+      $trap,
+    );
+    self::assertStringNotContainsString(
+      '$CURRENT_LINK/vendor/bin/drush',
+      $trap,
+    );
+    self::assertStringContainsString(
+      'Deployment failed before release switch.',
+      $trap,
+    );
+    self::assertStringContainsString(
+      'Deployment failed after release switch.',
+      $trap,
+    );
+    self::assertStringContainsString(
+      'automatic database rollback is not attempted.',
+      $trap,
+    );
+  }
+
+  /**
+   * Returns the production deployment script.
+   */
+  private function deploymentScript(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/deploy-production.sh';
+
+    self::assertFileExists($path);
+
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## Objet

Corriger les deux causes structurelles démontrées par l’incident production : mutation de la release active avant switch et maintenance mode pouvant rester armé si `drush cr` échoue après `state:set ... 1`.

## Changements

- checkout GitHub-hosted du SHA exact du run ;
- suppression du `git pull` dans `/var/www/agency/current` ;
- transmission du script repository-owned exact par stdin SSH avec `GITHUB_SHA` explicite ;
- sérialisation des déploiements production (`cancel-in-progress: false`) ;
- matérialisation et vérification du commit exact dans une nouvelle release avant maintenance ;
- preflight Drupal + DB immédiatement avant Maintenance ON ;
- `MAINTENANCE_ENABLED=1` armé immédiatement après le `state:set` réussi, avant `drush cr` ;
- recovery via le chemin absolu de l’ancienne release, même après switch ;
- messages d’échec distincts avant/après switch, sans prétendre à un rollback DB automatique ;
- nouveau test repository-owned protégeant ces invariants ;
- adaptation du test Config Split existant à la nouvelle forme sûre du preflight, tout en conservant la preuve que les fichiers publics partagés sont préparés avant les commandes Drupal.

## Preuve exact-head

- HEAD : `b90745095c877a700ec3ec8707ce19aad5e56635` ;
- CI #1201 / run `32565701646` : SUCCESS ;
- shell/workflow validation : GREEN ;
- Composer validate/install : GREEN ;
- PHPCS / PHPStan / drupal-check : GREEN ;
- 113 tests custom : GREEN.

## Limites

Aucun déploiement réel n’a été lancé depuis cette PR avant la CI verte. Aucun retry aveugle, restauration DB automatique, élargissement SSH/sudo ou changement Drupal fonctionnel.

Closes #636
Refs #590 #634 #635 #402.