### PR TITLE
Issue #640: detach and observe production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
 
     steps:
       - name: Checkout exact deployment source
@@ -47,7 +48,8 @@ jobs:
           ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Run exact deployment script on production server
+      - name: Stage exact detached deployment request
+        id: request
         env:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
           SERVER_USER: ${{ secrets.SERVER_USER }}
@@ -58,5 +60,193 @@ jobs:
           test -n "$SERVER_USER"
           [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
           test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+          request_id="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${EXPECTED_SHA}"
+          remote_dir="/var/www/agency/shared/deploy-jobs/${request_id}"
+          [[ "$request_id" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
+
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
+
           ssh "$SERVER_USER@$SERVER_HOST" \
-            bash -s -- main "$EXPECTED_SHA" < scripts/deploy-production.sh
+            "umask 077; mkdir -p '$remote_dir'; test ! -L '$remote_dir'; test ! -e '$remote_dir/result.env'; test ! -e '$remote_dir/pid'"
+
+          scp \
+            scripts/deploy-production.sh \
+            scripts/launch-production-deploy.sh \
+            scripts/inspect-production-deploy.sh \
+            "$SERVER_USER@$SERVER_HOST:$remote_dir/"
+
+          ssh "$SERVER_USER@$SERVER_HOST" \
+            "chmod 700 '$remote_dir/deploy-production.sh' '$remote_dir/launch-production-deploy.sh' '$remote_dir/inspect-production-deploy.sh'"
+
+      - name: Launch detached production worker
+        id: launch
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          EXPECTED_SHA: ${{ github.sha }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
+          [[ "$REMOTE_DIR" == "/var/www/agency/shared/deploy-jobs/$REQUEST_ID" ]]
+
+          set +e
+          launch_output="$(
+            ssh \
+              -o ConnectTimeout=10 \
+              -o ServerAliveInterval=5 \
+              -o ServerAliveCountMax=2 \
+              "$SERVER_USER@$SERVER_HOST" \
+              "'$REMOTE_DIR/launch-production-deploy.sh' '$REQUEST_ID' '$EXPECTED_SHA'" \
+              2>&1
+          )"
+          launch_status="$?"
+          set -e
+
+          printf '%s\n' "$launch_output"
+          echo "transport_exit=$launch_status" >> "$GITHUB_OUTPUT"
+          echo "Launch transport exit was $launch_status; detached result polling remains authoritative."
+
+      - name: Poll detached production result
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          EXPECTED_SHA: ${{ github.sha }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
+          [[ "$REMOTE_DIR" == "/var/www/agency/shared/deploy-jobs/$REQUEST_ID" ]]
+
+          artifact_dir='artifacts/production-deploy'
+          mkdir -p "$artifact_dir"
+          terminal_outcome=''
+          poll_output=''
+          starting_count=0
+
+          result_field() {
+            local key="$1"
+            printf '%s\n' "$poll_output" | sed -n "s/^${key}=//p" | head -n 1
+          }
+
+          collect_remote_evidence() {
+            local filename
+            for filename in output.log bootstrap.log request.env pid; do
+              set +e
+              ssh \
+                -o ConnectTimeout=10 \
+                "$SERVER_USER@$SERVER_HOST" \
+                "cat '$REMOTE_DIR/$filename' 2>/dev/null || true" \
+                > "$artifact_dir/$filename" 2>&1
+              set -e
+            done
+          }
+
+          for attempt in $(seq 1 180); do
+            set +e
+            poll_output="$(
+              ssh \
+                -o ConnectTimeout=10 \
+                -o ServerAliveInterval=5 \
+                -o ServerAliveCountMax=2 \
+                "$SERVER_USER@$SERVER_HOST" \
+                "'$REMOTE_DIR/inspect-production-deploy.sh' '$REQUEST_ID' '$EXPECTED_SHA'" \
+                2>&1
+            )"
+            poll_status="$?"
+            set -e
+
+            if [[ "$poll_status" -ne 0 ]]; then
+              echo "Detached deploy poll transport unavailable on attempt $attempt (exit $poll_status)."
+              sleep 5
+              continue
+            fi
+
+            outcome="$(result_field outcome)"
+            case "$outcome" in
+              SUCCESS)
+                result_request="$(result_field request_id)"
+                result_sha="$(result_field expected_sha)"
+                result_exit="$(result_field exit_code)"
+                [[ "$result_request" == "$REQUEST_ID" ]]
+                [[ "$result_sha" == "$EXPECTED_SHA" ]]
+                [[ "$result_exit" == '0' ]]
+                terminal_outcome='SUCCESS'
+                break
+                ;;
+              FAILURE|LOCKED|LOST|INVALID)
+                terminal_outcome="$outcome"
+                break
+                ;;
+              RUNNING)
+                starting_count=0
+                echo "Detached production worker is running for $REQUEST_ID."
+                ;;
+              STARTING|NOT_STARTED)
+                starting_count=$((starting_count + 1))
+                if [[ "$starting_count" -ge 12 ]]; then
+                  terminal_outcome='LOST'
+                  poll_output="$(cat <<EOF_RESULT
+          schema_version=1
+          request_id=$REQUEST_ID
+          expected_sha=$EXPECTED_SHA
+          outcome=LOST
+          reason=worker_never_became_observable
+          EOF_RESULT
+          )"
+                  break
+                fi
+                ;;
+              *)
+                terminal_outcome='INVALID'
+                poll_output="$(cat <<EOF_RESULT
+          schema_version=1
+          request_id=$REQUEST_ID
+          expected_sha=$EXPECTED_SHA
+          outcome=INVALID
+          reason=unexpected_poll_payload
+          EOF_RESULT
+          )"
+                break
+                ;;
+            esac
+
+            sleep 5
+          done
+
+          if [[ -z "$terminal_outcome" ]]; then
+            terminal_outcome='TIMEOUT'
+            poll_output="$(cat <<EOF_RESULT
+          schema_version=1
+          request_id=$REQUEST_ID
+          expected_sha=$EXPECTED_SHA
+          outcome=TIMEOUT
+          reason=no_terminal_result_before_workflow_deadline
+          EOF_RESULT
+          )"
+          fi
+
+          printf '%s\n' "$poll_output" | tee "$artifact_dir/result.env"
+          collect_remote_evidence
+
+          if [[ "$terminal_outcome" != 'SUCCESS' ]]; then
+            echo "Detached production deployment ended with $terminal_outcome." >&2
+            exit 1
+          fi
+
+          echo "Detached production deployment completed successfully for exact SHA $EXPECTED_SHA."
+
+      - name: Upload production deployment evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-deploy-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-deploy
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/inspect-production-deploy.sh
+++ b/scripts/inspect-production-deploy.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REQUEST_ID="${1:-}"
+EXPECTED_SHA="${2:-}"
+JOBS_DIR="/var/www/agency/shared/deploy-jobs"
+REQUEST_DIR="$JOBS_DIR/$REQUEST_ID"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+WORKER_SCRIPT="$REQUEST_DIR/worker.sh"
+
+if [[ ! "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]; then
+  echo "outcome=INVALID"
+  echo "reason=invalid_request_id"
+  exit 0
+fi
+
+if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "outcome=INVALID"
+  echo "reason=invalid_expected_sha"
+  exit 0
+fi
+
+if [[ "$REQUEST_ID" != *"-$EXPECTED_SHA" ]]; then
+  echo "outcome=INVALID"
+  echo "reason=request_sha_mismatch"
+  exit 0
+fi
+
+if [[ ! -d "$REQUEST_DIR" || -L "$REQUEST_DIR" ]]; then
+  echo "schema_version=1"
+  echo "request_id=$REQUEST_ID"
+  echo "expected_sha=$EXPECTED_SHA"
+  echo "outcome=NOT_STARTED"
+  echo "reason=request_directory_missing"
+  exit 0
+fi
+
+field() {
+  local key="$1"
+  local file="$2"
+  sed -n "s/^${key}=//p" "$file" | head -n 1
+}
+
+if [[ -s "$RESULT_FILE" && ! -L "$RESULT_FILE" ]]; then
+  result_request="$(field request_id "$RESULT_FILE")"
+  result_sha="$(field expected_sha "$RESULT_FILE")"
+  result_outcome="$(field outcome "$RESULT_FILE")"
+  result_exit="$(field exit_code "$RESULT_FILE")"
+
+  if [[ "$result_request" != "$REQUEST_ID" ]]; then
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=INVALID"
+    echo "reason=result_request_mismatch"
+    exit 0
+  fi
+
+  if [[ "$result_sha" != "$EXPECTED_SHA" ]]; then
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=INVALID"
+    echo "reason=result_sha_mismatch"
+    exit 0
+  fi
+
+  if [[ ! "$result_outcome" =~ ^(SUCCESS|FAILURE|LOCKED)$ ]]; then
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=INVALID"
+    echo "reason=result_outcome_invalid"
+    exit 0
+  fi
+
+  if [[ ! "$result_exit" =~ ^[0-9]+$ ]]; then
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=INVALID"
+    echo "reason=result_exit_invalid"
+    exit 0
+  fi
+
+  cat "$RESULT_FILE"
+  exit 0
+fi
+
+if [[ -s "$PID_FILE" && ! -L "$PID_FILE" ]]; then
+  worker_pid="$(tr -d '\r\n' < "$PID_FILE")"
+
+  if [[ ! "$worker_pid" =~ ^[0-9]+$ ]]; then
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=INVALID"
+    echo "reason=worker_pid_invalid"
+    exit 0
+  fi
+
+  if kill -0 "$worker_pid" 2>/dev/null; then
+    command_line="$(tr '\0' ' ' < "/proc/$worker_pid/cmdline" 2>/dev/null || true)"
+    if [[ "$command_line" == *"$WORKER_SCRIPT"* ]]; then
+      echo "schema_version=1"
+      echo "request_id=$REQUEST_ID"
+      echo "expected_sha=$EXPECTED_SHA"
+      echo "outcome=RUNNING"
+      echo "worker_pid=$worker_pid"
+      exit 0
+    fi
+
+    echo "schema_version=1"
+    echo "request_id=$REQUEST_ID"
+    echo "expected_sha=$EXPECTED_SHA"
+    echo "outcome=LOST"
+    echo "reason=worker_pid_reused"
+    echo "worker_pid=$worker_pid"
+    exit 0
+  fi
+
+  echo "schema_version=1"
+  echo "request_id=$REQUEST_ID"
+  echo "expected_sha=$EXPECTED_SHA"
+  echo "outcome=LOST"
+  echo "reason=worker_exited_without_result"
+  echo "worker_pid=$worker_pid"
+  exit 0
+fi
+
+echo "schema_version=1"
+echo "request_id=$REQUEST_ID"
+echo "expected_sha=$EXPECTED_SHA"
+echo "outcome=STARTING"
+echo "reason=worker_pid_not_visible_yet"

--- a/scripts/launch-production-deploy.sh
+++ b/scripts/launch-production-deploy.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REQUEST_ID="${1:-}"
+EXPECTED_SHA="${2:-}"
+JOBS_DIR="/var/www/agency/shared/deploy-jobs"
+LOCK_FILE="/var/www/agency/shared/deploy.lock"
+REQUEST_DIR="$JOBS_DIR/$REQUEST_ID"
+DEPLOY_SCRIPT="$REQUEST_DIR/deploy-production.sh"
+WORKER_SCRIPT="$REQUEST_DIR/worker.sh"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+METADATA_FILE="$REQUEST_DIR/request.env"
+OUTPUT_FILE="$REQUEST_DIR/output.log"
+BOOTSTRAP_LOG="$REQUEST_DIR/bootstrap.log"
+
+if [[ ! "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]; then
+  echo "REQUEST_ID must match run-<run_id>-<attempt>-<sha>." >&2
+  exit 2
+fi
+
+if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "EXPECTED_SHA must be an exact 40-character lowercase Git commit SHA." >&2
+  exit 2
+fi
+
+if [[ "$REQUEST_ID" != *"-$EXPECTED_SHA" ]]; then
+  echo "REQUEST_ID does not contain EXPECTED_SHA." >&2
+  exit 2
+fi
+
+for command in flock nohup setsid; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "Required command is unavailable: $command" >&2
+    exit 2
+  }
+done
+
+setsid --help 2>&1 | grep -q -- '--wait' || {
+  echo "setsid --wait is required for detached worker lifecycle tracking." >&2
+  exit 2
+}
+
+[[ -d "$REQUEST_DIR" ]] || {
+  echo "Request directory does not exist: $REQUEST_DIR" >&2
+  exit 2
+}
+[[ ! -L "$REQUEST_DIR" ]] || {
+  echo "Request directory must not be a symlink: $REQUEST_DIR" >&2
+  exit 2
+}
+[[ -f "$DEPLOY_SCRIPT" && ! -L "$DEPLOY_SCRIPT" ]] || {
+  echo "Exact deployment script is missing or unsafe: $DEPLOY_SCRIPT" >&2
+  exit 2
+}
+[[ ! -e "$RESULT_FILE" ]] || {
+  echo "Refusing to relaunch a request with an existing result: $RESULT_FILE" >&2
+  exit 2
+}
+[[ ! -e "$PID_FILE" ]] || {
+  echo "Refusing to relaunch a request with an existing pid file: $PID_FILE" >&2
+  exit 2
+}
+
+umask 077
+chmod 700 "$DEPLOY_SCRIPT"
+: > "$OUTPUT_FILE"
+: > "$BOOTSTRAP_LOG"
+
+metadata_tmp="${METADATA_FILE}.tmp.$$"
+{
+  printf 'schema_version=1\n'
+  printf 'request_id=%s\n' "$REQUEST_ID"
+  printf 'expected_sha=%s\n' "$EXPECTED_SHA"
+  printf 'launched_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+} > "$metadata_tmp"
+mv -f "$metadata_tmp" "$METADATA_FILE"
+
+cat > "$WORKER_SCRIPT" <<'WORKER'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REQUEST_DIR="${1:?request directory required}"
+REQUEST_ID="${2:?request id required}"
+EXPECTED_SHA="${3:?expected sha required}"
+LOCK_FILE="${4:?lock file required}"
+DEPLOY_SCRIPT="$REQUEST_DIR/deploy-production.sh"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+OUTPUT_FILE="$REQUEST_DIR/output.log"
+RESULT_WRITTEN=0
+
+write_result() {
+  local outcome="$1"
+  local exit_code="$2"
+  local result_tmp="${RESULT_FILE}.tmp.$$"
+
+  RESULT_WRITTEN=1
+  {
+    printf 'schema_version=1\n'
+    printf 'request_id=%s\n' "$REQUEST_ID"
+    printf 'expected_sha=%s\n' "$EXPECTED_SHA"
+    printf 'outcome=%s\n' "$outcome"
+    printf 'exit_code=%s\n' "$exit_code"
+    printf 'worker_pid=%s\n' "$$"
+    printf 'finished_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$result_tmp"
+  mv -f "$result_tmp" "$RESULT_FILE"
+}
+
+finalize_unexpected_exit() {
+  local exit_code="$?"
+  if [[ "$RESULT_WRITTEN" -eq 0 ]]; then
+    write_result FAILURE "$exit_code" || true
+  fi
+}
+trap finalize_unexpected_exit EXIT
+
+pid_tmp="${PID_FILE}.tmp.$$"
+printf '%s\n' "$$" > "$pid_tmp"
+mv -f "$pid_tmp" "$PID_FILE"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  printf '[%s] production deploy lock is already held\n' "$(date '+%Y-%m-%d %H:%M:%S')" >> "$OUTPUT_FILE"
+  write_result LOCKED 75
+  exit 75
+fi
+
+printf '[%s] production deploy lock acquired for %s\n' \
+  "$(date '+%Y-%m-%d %H:%M:%S')" \
+  "$REQUEST_ID" >> "$OUTPUT_FILE"
+
+set +e
+"$DEPLOY_SCRIPT" main "$EXPECTED_SHA" >> "$OUTPUT_FILE" 2>&1
+deploy_exit="$?"
+set -e
+
+if [[ "$deploy_exit" -eq 0 ]]; then
+  write_result SUCCESS 0
+else
+  write_result FAILURE "$deploy_exit"
+fi
+
+exit "$deploy_exit"
+WORKER
+
+chmod 700 "$WORKER_SCRIPT"
+
+nohup setsid --wait \
+  "$WORKER_SCRIPT" \
+  "$REQUEST_DIR" \
+  "$REQUEST_ID" \
+  "$EXPECTED_SHA" \
+  "$LOCK_FILE" \
+  </dev/null >> "$BOOTSTRAP_LOG" 2>&1 &
+
+printf 'request_id=%s\n' "$REQUEST_ID"
+printf 'expected_sha=%s\n' "$EXPECTED_SHA"
+printf 'launcher_outcome=DETACHED\n'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
@@ -16,22 +16,17 @@ use Symfony\Component\Yaml\Yaml;
 final class ProductionDeploymentSafetyTest extends TestCase {
 
   /**
-   * Deploys the exact checked-out SHA without mutating current.
+   * Deploys the exact SHA through a detached, observable server request.
    */
-  public function testWorkflowDeploysExactShaAndSerializesProduction(): void {
-    $root = dirname(DRUPAL_ROOT);
-    $path = $root . '/.github/workflows/deploy-production.yml';
-
-    self::assertFileExists($path);
-    self::assertIsArray(Yaml::parseFile($path));
-
-    $workflow = (string) file_get_contents($path);
+  public function testWorkflowStagesDetachedDeployAndPollsItsResult(): void {
+    $workflow = $this->deploymentWorkflow();
 
     self::assertStringContainsString(
       'group: agency-production-deploy',
       $workflow,
     );
     self::assertStringContainsString('cancel-in-progress: false', $workflow);
+    self::assertStringContainsString('timeout-minutes: 35', $workflow);
     self::assertStringContainsString('uses: actions/checkout@v6', $workflow);
     self::assertStringContainsString('ref: ${{ github.sha }}', $workflow);
     self::assertStringContainsString('persist-credentials: false', $workflow);
@@ -39,7 +34,23 @@ final class ProductionDeploymentSafetyTest extends TestCase {
       'EXPECTED_SHA: ${{ github.sha }}',
       $workflow,
     );
-    self::assertStringContainsString(
+
+    foreach ([
+      'Stage exact detached deployment request',
+      'scripts/deploy-production.sh',
+      'scripts/launch-production-deploy.sh',
+      'scripts/inspect-production-deploy.sh',
+      'Launch detached production worker',
+      'Launch transport exit was $launch_status; detached result polling remains authoritative.',
+      'Poll detached production result',
+      'outcome=LOST',
+      'outcome=TIMEOUT',
+      'agency-production-deploy-${{ github.run_id }}-${{ github.run_attempt }}',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString(
       'bash -s -- main "$EXPECTED_SHA" < scripts/deploy-production.sh',
       $workflow,
     );
@@ -51,10 +62,79 @@ final class ProductionDeploymentSafetyTest extends TestCase {
   }
 
   /**
+   * The launcher must detach the worker and own a server-side deploy lock.
+   */
+  public function testLauncherDetachesWorkerAndPublishesAtomicResult(): void {
+    $launcher = $this->script('scripts/launch-production-deploy.sh');
+
+    foreach ([
+      'JOBS_DIR="/var/www/agency/shared/deploy-jobs"',
+      'LOCK_FILE="/var/www/agency/shared/deploy.lock"',
+      'result.env',
+      'worker.sh',
+      'flock -n 9',
+      'write_result LOCKED 75',
+      'write_result SUCCESS 0',
+      'write_result FAILURE "$deploy_exit"',
+      'mv -f "$result_tmp" "$RESULT_FILE"',
+      'nohup setsid --wait',
+      '</dev/null >> "$BOOTSTRAP_LOG" 2>&1 &',
+      '"$DEPLOY_SCRIPT" main "$EXPECTED_SHA"',
+    ] as $required) {
+      self::assertStringContainsString($required, $launcher);
+    }
+
+    $lock = strpos($launcher, 'flock -n 9');
+    $deploy = strpos($launcher, '"$DEPLOY_SCRIPT" main "$EXPECTED_SHA"');
+    self::assertIsInt($lock);
+    self::assertIsInt($deploy);
+    self::assertLessThan($deploy, $lock);
+
+    self::assertStringNotContainsString('drush ', $launcher);
+    self::assertStringNotContainsString('git pull', $launcher);
+  }
+
+  /**
+   * Polling must remain read-only and classify lost workers fail-closed.
+   */
+  public function testInspectorIsReadOnlyAndFailClosed(): void {
+    $inspector = $this->script('scripts/inspect-production-deploy.sh');
+
+    foreach ([
+      'outcome=NOT_STARTED',
+      'outcome=STARTING',
+      'outcome=RUNNING',
+      'outcome=LOST',
+      'outcome=INVALID',
+      'worker_exited_without_result',
+      'worker_pid_reused',
+      'result_request_mismatch',
+      'result_sha_mismatch',
+      'kill -0 "$worker_pid"',
+    ] as $required) {
+      self::assertStringContainsString($required, $inspector);
+    }
+
+    foreach ([
+      'drush ',
+      'git pull',
+      'git checkout',
+      'git reset',
+      'composer ',
+      'systemctl ',
+      'sudo ',
+      'rm -',
+      'mv ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $inspector);
+    }
+  }
+
+  /**
    * The server script must materialize and verify the exact requested commit.
    */
   public function testScriptPinsExactCommitAndKeepsCurrentImmutable(): void {
-    $script = $this->deploymentScript();
+    $script = $this->script('scripts/deploy-production.sh');
 
     self::assertStringContainsString('EXPECTED_SHA="${2:-}"', $script);
     self::assertStringContainsString(
@@ -84,7 +164,7 @@ final class ProductionDeploymentSafetyTest extends TestCase {
    * Maintenance recovery must be armed immediately and use the old release.
    */
   public function testMaintenanceIsFailSafeAcrossReleaseSwitch(): void {
-    $script = $this->deploymentScript();
+    $script = $this->script('scripts/deploy-production.sh');
 
     self::assertStringContainsString(
       'vendor/bin/drush sql:query \'SELECT 1\' >/dev/null',
@@ -139,11 +219,24 @@ final class ProductionDeploymentSafetyTest extends TestCase {
   }
 
   /**
-   * Returns the production deployment script.
+   * Returns and validates the production deployment workflow.
    */
-  private function deploymentScript(): string {
+  private function deploymentWorkflow(): string {
     $root = dirname(DRUPAL_ROOT);
-    $path = $root . '/scripts/deploy-production.sh';
+    $path = $root . '/.github/workflows/deploy-production.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+  /**
+   * Returns a repository-owned deployment script.
+   */
+  private function script(string $relativePath): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/' . $relativePath;
 
     self::assertFileExists($path);
 


### PR DESCRIPTION
## Cause

#638 a correctement rendu le code déployé atomique et pinné au SHA exact, mais le deploy `7816206a…` est resté lié à la session SSH longue. L’artifact read-only #590 `9474068190` ne contient pour cette release qu’un `START`, sans `FAILURE` ni `SUCCESS`, alors que le process serveur avait disparu et Drupal était resté en maintenance.

## Correction

Cette PR conserve `scripts/deploy-production.sh` et ses garde-fous, mais change son transport/exécution :

- staging d’une requête unique `/var/www/agency/shared/deploy-jobs/run-<run>-<attempt>-<sha>` ;
- copie des scripts exacts depuis le checkout GitHub du SHA à déployer ;
- launcher repository-owned utilisant `nohup setsid --wait` ;
- worker détaché de stdin/stdout/stderr SSH ;
- verrou serveur `flock -n` sur `/var/www/agency/shared/deploy.lock` ;
- résultat terminal atomique `result.env` : SUCCESS / FAILURE / LOCKED ;
- inspecteur read-only : STARTING / RUNNING / LOST / INVALID en plus des résultats terminaux ;
- le statut de la connexion SSH de lancement n’est plus l’autorité : le workflow poll le résultat par connexions courtes ;
- disparition du PID sans résultat => LOST fail-closed ;
- artifact Actions avec résultat, output, bootstrap, metadata et pid ;
- conservation de la concurrency GitHub existante.

Aucun `git pull`, aucun élargissement sudo/service, aucune relaxation des traps maintenance.

## Validation attendue

- parsing YAML ;
- shell syntax repository-owned ;
- quality scripts ;
- PHPUnit avec protections transport/lock/result/read-only ;
- CI exact-head green avant ready/merge.

Après merge seulement : un unique deploy réel puis diagnostic #590. Le merge modifiera `scripts/**`, donc il constituera lui-même cet unique deploy de validation.

Closes #640
Refs #636 #638 #590 #634.