### PR TITLE
Issue #652: diagnose exact detached production deploy phase

### DIFF
--- a/.github/workflows/trusted-production-deploy-phase-diagnostic.yml
+++ b/.github/workflows/trusted-production-deploy-phase-diagnostic.yml
@@ -1,0 +1,274 @@
+name: Agency trusted production deploy phase diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-deploy-phase-diagnostic:
+    name: Diagnose exact detached production deploy phase
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 636 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-deploy-phase diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    env:
+      REQUEST_ID: run-32567826577-1-acea55cf0aa02acdee9ee9866977733f0e0cff8e
+      REQUEST_SHA: acea55cf0aa02acdee9ee9866977733f0e0cff8e
+
+    steps:
+      - name: Validate actor incident and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-deploy-phase diagnose' ]]
+          [[ "$ISSUE_NUMBER" == '636' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Phase diagnostic must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Inspect allowlisted phase and process names
+        id: diagnostic
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/production-deploy-phase
+          raw='artifacts/production-deploy-phase/diagnostic.env'
+
+          set +e
+          ssh "$SERVER_USER@$SERVER_HOST" \
+            "REQUEST_ID='$REQUEST_ID' REQUEST_SHA='$REQUEST_SHA' bash -s" \
+            > "$raw" 2>&1 <<'REMOTE_DIAGNOSTIC'
+          set -u
+          request_dir="/var/www/agency/shared/deploy-jobs/$REQUEST_ID"
+          request_file="$request_dir/request.env"
+          pid_file="$request_dir/pid"
+          result_file="$request_dir/result.env"
+          output_file="$request_dir/output.log"
+
+          scalar() { printf '%s=%s\n' "$1" "$2"; }
+          field() { sed -n "s/^$1=//p" "$2" 2>/dev/null | head -n 1; }
+          safe_comm() { ps -p "$1" -o comm= 2>/dev/null | head -n 1 | tr -cd 'A-Za-z0-9_.+-'; }
+          safe_elapsed() { ps -p "$1" -o etimes= 2>/dev/null | tr -cd '0-9' | head -c 12; }
+          first_child() { ps --ppid "$1" -o pid= 2>/dev/null | awk 'NR==1 {print $1}'; }
+
+          scalar schema_version 1
+          scalar request_id "$REQUEST_ID"
+          scalar request_sha "$REQUEST_SHA"
+
+          if [[ ! -d "$request_dir" || -L "$request_dir" || ! -f "$request_file" || -L "$request_file" ]]; then
+            scalar diagnostic_outcome INVALID
+            scalar reason request_surface_missing_or_unsafe
+            exit 0
+          fi
+
+          [[ "$(field request_id "$request_file")" == "$REQUEST_ID" ]] || {
+            scalar diagnostic_outcome INVALID
+            scalar reason request_id_mismatch
+            exit 0
+          }
+          [[ "$(field expected_sha "$request_file")" == "$REQUEST_SHA" ]] || {
+            scalar diagnostic_outcome INVALID
+            scalar reason request_sha_mismatch
+            exit 0
+          }
+
+          worker_pid=unknown
+          worker_state=unknown
+          if [[ -f "$pid_file" && ! -L "$pid_file" ]]; then
+            worker_pid="$(tr -cd '0-9' < "$pid_file")"
+            if [[ "$worker_pid" =~ ^[0-9]+$ ]] && kill -0 "$worker_pid" 2>/dev/null; then
+              worker_state=alive
+            elif [[ "$worker_pid" =~ ^[0-9]+$ ]]; then
+              worker_state=dead
+            else
+              worker_state=invalid
+            fi
+          fi
+          scalar worker_pid "$worker_pid"
+          scalar worker_state "$worker_state"
+
+          output_size=0
+          result_present=0
+          phase=NO_MARKER
+          if [[ -f "$output_file" && ! -L "$output_file" ]]; then
+            output_size="$(stat -c '%s' "$output_file" 2>/dev/null || echo 0)"
+            if grep -Fq '[deploy] ERROR' "$output_file"; then phase=ERROR
+            elif grep -Fq '[deploy] SUCCESS' "$output_file"; then phase=SUCCESS
+            elif grep -Fq '[deploy] Maintenance OFF' "$output_file"; then phase=MAINTENANCE_OFF
+            elif grep -Fq '[deploy] Governed Content' "$output_file"; then phase=GOVERNED_CONTENT
+            elif grep -Fq '[deploy] Production Config Split' "$output_file"; then phase=PRODUCTION_SPLIT
+            elif grep -Fq '[deploy] Switch release' "$output_file"; then phase=SWITCH_RELEASE
+            elif grep -Fq '[deploy] Maintenance ON' "$output_file"; then phase=MAINTENANCE_ON
+            elif grep -Fq '[deploy] Preflight active Drupal and database' "$output_file"; then phase=PREFLIGHT
+            elif grep -Fq '[deploy] Backup DB' "$output_file"; then phase=BACKUP_DB
+            elif grep -Fq '[deploy] Public files symlink' "$output_file"; then phase=PUBLIC_FILES
+            elif grep -Fq '[deploy] Composer' "$output_file"; then phase=COMPOSER
+            elif grep -Fq '[deploy] Clone' "$output_file"; then phase=CLONE
+            elif grep -Fq '[deploy] Prepare release' "$output_file"; then phase=PREPARE_RELEASE
+            elif grep -Fq '[deploy] START' "$output_file"; then phase=START
+            fi
+          fi
+          [[ -f "$result_file" && ! -L "$result_file" ]] && result_present=1
+          scalar last_allowlisted_phase "$phase"
+          scalar output_log_size "$output_size"
+          scalar result_present "$result_present"
+
+          root_comm=unknown
+          root_elapsed=unknown
+          child_pid=none
+          child_comm=none
+          child_elapsed=none
+          grandchild_pid=none
+          grandchild_comm=none
+          grandchild_elapsed=none
+
+          if [[ "$worker_state" == alive ]]; then
+            root_comm="$(safe_comm "$worker_pid")"; [[ -n "$root_comm" ]] || root_comm=unknown
+            root_elapsed="$(safe_elapsed "$worker_pid")"; [[ -n "$root_elapsed" ]] || root_elapsed=unknown
+            child_pid="$(first_child "$worker_pid")"; [[ -n "$child_pid" ]] || child_pid=none
+            if [[ "$child_pid" =~ ^[0-9]+$ ]]; then
+              child_comm="$(safe_comm "$child_pid")"; [[ -n "$child_comm" ]] || child_comm=unknown
+              child_elapsed="$(safe_elapsed "$child_pid")"; [[ -n "$child_elapsed" ]] || child_elapsed=unknown
+              grandchild_pid="$(first_child "$child_pid")"; [[ -n "$grandchild_pid" ]] || grandchild_pid=none
+              if [[ "$grandchild_pid" =~ ^[0-9]+$ ]]; then
+                grandchild_comm="$(safe_comm "$grandchild_pid")"; [[ -n "$grandchild_comm" ]] || grandchild_comm=unknown
+                grandchild_elapsed="$(safe_elapsed "$grandchild_pid")"; [[ -n "$grandchild_elapsed" ]] || grandchild_elapsed=unknown
+              fi
+            fi
+          fi
+
+          scalar worker_comm "$root_comm"
+          scalar worker_elapsed_seconds "$root_elapsed"
+          scalar child_pid "$child_pid"
+          scalar child_comm "$child_comm"
+          scalar child_elapsed_seconds "$child_elapsed"
+          scalar grandchild_pid "$grandchild_pid"
+          scalar grandchild_comm "$grandchild_comm"
+          scalar grandchild_elapsed_seconds "$grandchild_elapsed"
+          scalar diagnostic_outcome PASS
+          scalar reason allowlisted_phase_and_process_names_observed
+          REMOTE_DIAGNOSTIC
+          ssh_status=$?
+          set -e
+
+          value() { grep -m1 "^$1=" "$raw" | cut -d= -f2- || true; }
+          outcome="$(value diagnostic_outcome)"; [[ -n "$outcome" ]] || outcome=SSH_DIAGNOSTIC_FAILED
+          reason="$(value reason)"; [[ -n "$reason" ]] || reason=remote_result_missing
+
+          jq -n \
+            --arg trusted_main "${{ steps.request.outputs.main_sha }}" \
+            --arg outcome "$outcome" \
+            --arg reason "$reason" \
+            --arg phase "$(value last_allowlisted_phase)" \
+            --arg worker_state "$(value worker_state)" \
+            --arg worker_pid "$(value worker_pid)" \
+            --arg worker_comm "$(value worker_comm)" \
+            --arg worker_elapsed "$(value worker_elapsed_seconds)" \
+            --arg child_pid "$(value child_pid)" \
+            --arg child_comm "$(value child_comm)" \
+            --arg child_elapsed "$(value child_elapsed_seconds)" \
+            --arg grandchild_pid "$(value grandchild_pid)" \
+            --arg grandchild_comm "$(value grandchild_comm)" \
+            --arg grandchild_elapsed "$(value grandchild_elapsed_seconds)" \
+            --arg output_size "$(value output_log_size)" \
+            --arg result_present "$(value result_present)" \
+            --argjson ssh_exit "$ssh_status" \
+            '{schema_version:1, diagnostic_outcome:$outcome, reason:$reason, trusted_main:$trusted_main, request_id:"run-32567826577-1-acea55cf0aa02acdee9ee9866977733f0e0cff8e", request_sha:"acea55cf0aa02acdee9ee9866977733f0e0cff8e", last_allowlisted_phase:$phase, worker_state:$worker_state, worker_pid:$worker_pid, worker_comm:$worker_comm, worker_elapsed_seconds:$worker_elapsed, child_pid:$child_pid, child_comm:$child_comm, child_elapsed_seconds:$child_elapsed, grandchild_pid:$grandchild_pid, grandchild_comm:$grandchild_comm, grandchild_elapsed_seconds:$grandchild_elapsed, output_log_size:$output_size, result_present:$result_present, ssh_exit:$ssh_exit}' \
+            > artifacts/production-deploy-phase/result.json
+
+          test "$ssh_status" -eq 0
+
+      - name: Upload phase diagnostic evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-deploy-phase-636-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-deploy-phase
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded phase diagnostic
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-deploy-phase/result.json'
+          [[ -s "$result" ]] && jq -e . "$result" >/dev/null
+          field() { jq -r ".$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-deploy-phase-636-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production deploy phase diagnostic $(field diagnostic_outcome)
+
+          trusted_main: \`$(field trusted_main)\`
+          diagnostic_run_id: \`${GITHUB_RUN_ID}\`
+          request_id: \`$(field request_id)\`
+          last_allowlisted_phase: \`$(field last_allowlisted_phase)\`
+          worker_state: \`$(field worker_state)\`
+          worker_pid: \`$(field worker_pid)\`
+          worker_comm: \`$(field worker_comm)\`
+          worker_elapsed_seconds: \`$(field worker_elapsed_seconds)\`
+          child_pid: \`$(field child_pid)\`
+          child_comm: \`$(field child_comm)\`
+          child_elapsed_seconds: \`$(field child_elapsed_seconds)\`
+          grandchild_pid: \`$(field grandchild_pid)\`
+          grandchild_comm: \`$(field grandchild_comm)\`
+          grandchild_elapsed_seconds: \`$(field grandchild_elapsed_seconds)\`
+          output_log_size: \`$(field output_log_size)\`
+          result_present: \`$(field result_present)\`
+          artifact: \`${artifact}\`
+
+          Read-only allowlisted phase/process-name diagnostic. It never emits free-form output.log content and performs no signal, deployment or server mutation.
+          EOF_BODY
+          )"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/636/comments" -f body="$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
@@ -38,11 +38,11 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
 
     foreach ([
       'last_allowlisted_phase',
-      "phase=MAINTENANCE_ON",
-      "phase=SWITCH_RELEASE",
-      "phase=MAINTENANCE_OFF",
-      "phase=SUCCESS",
-      "phase=ERROR",
+      'phase=MAINTENANCE_ON',
+      'phase=SWITCH_RELEASE',
+      'phase=MAINTENANCE_OFF',
+      'phase=SUCCESS',
+      'phase=ERROR',
       "grep -Fq '[deploy] Maintenance ON'",
       "grep -Fq '[deploy] Switch release'",
       "grep -Fq '[deploy] SUCCESS'",
@@ -67,8 +67,8 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
     $workflow = $this->workflow();
 
     foreach ([
-      "ps -p \"$1\" -o comm=",
-      "ps -p \"$1\" -o etimes=",
+      'ps -p "$1" -o comm=',
+      'ps -p "$1" -o etimes=',
       'ps --ppid "$1" -o pid=',
       'worker_comm',
       'worker_elapsed_seconds',

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
 
+  /**
+   * Ensures the incident control surface and target request stay pinned.
+   */
   public function testControlSurfaceAndTargetArePinned(): void {
     $workflow = $this->workflow();
 
@@ -33,6 +36,9 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
   }
 
+  /**
+   * Ensures only fixed deployment phase markers can be reported.
+   */
   public function testOnlyAllowlistedPhaseMarkersAreReported(): void {
     $workflow = $this->workflow();
 
@@ -63,6 +69,9 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
     }
   }
 
+  /**
+   * Ensures process evidence contains names and elapsed time, not arguments.
+   */
   public function testProcessEvidenceContainsNamesWithoutArguments(): void {
     $workflow = $this->workflow();
 
@@ -92,6 +101,9 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
     }
   }
 
+  /**
+   * Ensures the diagnostic cannot mutate Actions, Drupal, or the server.
+   */
   public function testRouteHasNoMutationCapability(): void {
     $workflow = $this->workflow();
 
@@ -121,6 +133,9 @@ final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
     self::assertStringContainsString('issues: write', $workflow);
   }
 
+  /**
+   * Loads and parses the trusted phase diagnostic workflow.
+   */
   private function workflow(): string {
     $root = dirname(DRUPAL_ROOT);
     $path = $root

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployPhaseDiagnosticWorkflowTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded read-only detached deploy phase diagnostic.
+ *
+ * @group agency_project_tests
+ * @group production_deploy_phase_diagnostic
+ */
+final class ProductionDeployPhaseDiagnosticWorkflowTest extends TestCase {
+
+  public function testControlSurfaceAndTargetArePinned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/agency-production-deploy-phase diagnose',
+      'github.event.issue.number == 636',
+      "github.actor == 'E-merging-digital'",
+      'currently on live main',
+      'run-32567826577-1-acea55cf0aa02acdee9ee9866977733f0e0cff8e',
+      'acea55cf0aa02acdee9ee9866977733f0e0cff8e',
+      'runs-on: ubuntu-24.04',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  public function testOnlyAllowlistedPhaseMarkersAreReported(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'last_allowlisted_phase',
+      "phase=MAINTENANCE_ON",
+      "phase=SWITCH_RELEASE",
+      "phase=MAINTENANCE_OFF",
+      "phase=SUCCESS",
+      "phase=ERROR",
+      "grep -Fq '[deploy] Maintenance ON'",
+      "grep -Fq '[deploy] Switch release'",
+      "grep -Fq '[deploy] SUCCESS'",
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'cat "$output_file"',
+      'tail "$output_file"',
+      'tail -n',
+      'sed -n "$output_file"',
+      'command=',
+      'args=',
+      'cmdline',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  public function testProcessEvidenceContainsNamesWithoutArguments(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      "ps -p \"$1\" -o comm=",
+      "ps -p \"$1\" -o etimes=",
+      'ps --ppid "$1" -o pid=',
+      'worker_comm',
+      'worker_elapsed_seconds',
+      'child_comm',
+      'child_elapsed_seconds',
+      'grandchild_comm',
+      'grandchild_elapsed_seconds',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'ps aux',
+      'ps -ef',
+      '-o args',
+      '-o command',
+      '/proc/',
+      'environ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  public function testRouteHasNoMutationCapability(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'kill -TERM',
+      'kill -KILL',
+      'pkill',
+      'state:set',
+      'drush cr',
+      'drush cim',
+      'drush updb',
+      'composer install',
+      'git pull',
+      '/cancel',
+      '/rerun',
+      '/dispatches',
+      'actions: write',
+      'contents: write',
+      'sudo ',
+      'rm -',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+
+    self::assertStringContainsString('kill -0 "$worker_pid"', $workflow);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+  }
+
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-production-deploy-phase-diagnostic.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## But

Le deploy #641 est réellement actif et détaché, mais reste en maintenance sans résultat terminal. Cette PR ajoute une observation bornée du worker courant sans exposer le contenu libre de `output.log`.

Commande exacte sur #636 :

`/agency-production-deploy-phase diagnose`

La route est pinnée au request :

`run-32567826577-1-acea55cf0aa02acdee9ee9866977733f0e0cff8e`

Elle expose uniquement :

- dernier marqueur `[deploy]` appartenant à une allowlist fixe du script ;
- état/PID du worker ;
- `comm` + temps écoulé du worker, premier enfant et premier petit-enfant ;
- taille d'`output.log` et présence de `result.env`.

Elle ne publie jamais le contenu libre du log, les arguments/process command lines ou l'environnement. Aucun signal, kill, rerun, dispatch, deploy ou mutation serveur/Drupal.

Diff limité `.github/**` + test custom, donc hors trigger Deploy Production.

Closes #652
Refs #636 #640 #641 #650 #590.