### PR TITLE
Issue #654: harden maintenance transitions and error recovery

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -42,6 +42,15 @@ log_file() {
 fail_trap() {
   local exit_code="$?"
   local line_no="${1:-unknown}"
+
+  # ERR traps are inherited by subshells because the script uses errtrace (-E).
+  # Let the parent shell own failure logging and recovery so one failing
+  # subshell cannot produce duplicate FAILURE entries or run recovery twice.
+  if (( BASH_SUBSHELL > 0 )); then
+    trap - ERR
+    return "$exit_code"
+  fi
+
   trap - ERR
   set +e
 
@@ -54,7 +63,6 @@ fail_trap() {
       (
         cd "$ACTIVE_RELEASE"
         vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer
-        vendor/bin/drush cr
       ) || true
     else
       log "[deploy] WARNING: maintenance may remain enabled; previous absolute release is unavailable"
@@ -200,10 +208,6 @@ if [[ -L "$CURRENT_LINK" ]]; then
       vendor/bin/drush state:set system.maintenance_mode 1 --input-format=integer
     )
     MAINTENANCE_ENABLED=1
-    (
-      cd "$ACTIVE_RELEASE"
-      vendor/bin/drush cr
-    )
   fi
 else
   log "No current release detected."
@@ -244,7 +248,6 @@ log "Drupal update, config import, production config split import, Governed Cont
 if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
   log "[deploy] Maintenance OFF"
   "$CURRENT_LINK/vendor/bin/drush" state:set system.maintenance_mode 0 --input-format=integer
-  "$CURRENT_LINK/vendor/bin/drush" cr
   MAINTENANCE_ENABLED=0
 fi
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
@@ -182,13 +182,14 @@ final class ProductionDeploymentSafetyTest extends TestCase {
       'vendor/bin/drush state:set system.maintenance_mode 1',
     );
     $armed = strpos($maintenanceBlock, 'MAINTENANCE_ENABLED=1');
-    $cacheRebuild = strpos($maintenanceBlock, 'vendor/bin/drush cr');
 
     self::assertIsInt($stateOn);
     self::assertIsInt($armed);
-    self::assertIsInt($cacheRebuild);
     self::assertLessThan($armed, $stateOn);
-    self::assertLessThan($cacheRebuild, $armed);
+    self::assertStringNotContainsString(
+      'vendor/bin/drush cr',
+      $maintenanceBlock,
+    );
 
     $trapStart = strpos($script, 'fail_trap() {');
     $trapEnd = strpos($script, "\n}\n\ntrap ", $trapStart);
@@ -204,6 +205,7 @@ final class ProductionDeploymentSafetyTest extends TestCase {
       '$CURRENT_LINK/vendor/bin/drush',
       $trap,
     );
+    self::assertStringNotContainsString('vendor/bin/drush cr', $trap);
     self::assertStringContainsString(
       'Deployment failed before release switch.',
       $trap,
@@ -216,6 +218,48 @@ final class ProductionDeploymentSafetyTest extends TestCase {
       'automatic database rollback is not attempted.',
       $trap,
     );
+
+    $maintenanceOffStart = strpos(
+      $script,
+      'log "[deploy] Maintenance OFF"',
+    );
+    self::assertIsInt($maintenanceOffStart);
+    $maintenanceOffBlock = substr($script, $maintenanceOffStart, 300);
+    self::assertStringContainsString(
+      'state:set system.maintenance_mode 0',
+      $maintenanceOffBlock,
+    );
+    self::assertStringNotContainsString(
+      'vendor/bin/drush" cr',
+      $maintenanceOffBlock,
+    );
+  }
+
+  /**
+   * A subshell error must defer failure logging and recovery to its parent.
+   */
+  public function testSubshellErrTrapDefersRecoveryToParent(): void {
+    $script = $this->script('scripts/deploy-production.sh');
+
+    $trapStart = strpos($script, 'fail_trap() {');
+    $trapEnd = strpos($script, "\n}\n\ntrap ", $trapStart);
+    self::assertIsInt($trapStart);
+    self::assertIsInt($trapEnd);
+    $trap = substr($script, $trapStart, $trapEnd - $trapStart);
+
+    $guard = strpos($trap, 'if (( BASH_SUBSHELL > 0 )); then');
+    $return = strpos($trap, 'return "$exit_code"');
+    $failure = strpos($trap, 'log_file "FAILURE"');
+    $recovery = strpos($trap, 'Attempting Maintenance OFF');
+
+    self::assertIsInt($guard);
+    self::assertIsInt($return);
+    self::assertIsInt($failure);
+    self::assertIsInt($recovery);
+    self::assertTrue($guard < $return);
+    self::assertTrue($return < $failure);
+    self::assertTrue($return < $recovery);
+    self::assertSame(1, substr_count($trap, 'log_file "FAILURE"'));
   }
 
   /**


### PR DESCRIPTION
## Résumé

Corrige le défaut de déploiement production démontré par #641/#652 sans masquer les erreurs Drupal/DB :

- supprime le `drush cr` immédiatement après `Maintenance ON` ;
- supprime le `drush cr` de la recovery `Maintenance OFF` ;
- supprime le second `drush cr` après le `state:set ... 0` final ;
- conserve le rebuild fonctionnel déjà exécuté après Governed Content ;
- rend le trap `ERR` non réentrant pour les sous-shells héritant de `errtrace (-E)` : le sous-shell remonte le statut, le parent est l'unique propriétaire du log `FAILURE` et de la recovery ;
- ajoute des assertions unitaires protégeant ces invariants.

## HEAD

`0db534f040af72bda65f7d7ec8a2bec4a96d7a97`

Base exacte : `main@fbf9d81ca41a7e0fe51bab9610c0f432c181f389`.

## Diff

Exactement deux fichiers :

- `scripts/deploy-production.sh` ;
- `web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php`.

## Validations effectuées avant push

- `bash -n scripts/deploy-production.sh` : PASS ;
- `php -l ProductionDeploymentSafetyTest.php` : PASS ;
- simulation shell isolée `set -Eeuo pipefail` : une erreur dans un sous-shell remonte au parent et produit une seule entrée de recovery ;
- comparaison GitHub : branche 1 commit ahead, 0 behind, uniquement les deux fichiers attendus.

## Sécurité / production

- aucun retry aveugle `updb`/`cim`/cache rebuild ;
- aucun rollback DB implicite ;
- exact SHA, atomic switch, server lock, worker détaché et `result.env` inchangés ;
- aucune exécution production dans cette PR avant CI exact-head verte et merge conformément à #654.

Closes #654
Refs #636 #639 #641 #650 #652 #590