### PR TITLE
Issue #662: make zero-deploy checks pipefail-safe

### DIFF
--- a/.github/workflows/trusted-production-db-packet-recovery.yml
+++ b/.github/workflows/trusted-production-db-packet-recovery.yml
@@ -141,7 +141,7 @@ jobs:
             tr -cd '0-9' |
             head -c 2
           )"
-          deploys="$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')"
+          deploys="$(pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true)"
           db_version="$(
             cd "$CURRENT" &&
             vendor/bin/drush sql:query --extra=--skip-column-names 'SELECT VERSION();' 2>/dev/null |
@@ -342,7 +342,7 @@ jobs:
 
           current_sha="$(git -C "$CURRENT" rev-parse HEAD)"
           [[ "$current_sha" == "$EXPECTED_RUNTIME" ]]
-          [[ "$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')" == '0' ]]
+          [[ "$(pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true)" == '0' ]]
           [[ "$(cd "$CURRENT" && vendor/bin/drush php:eval \
             'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);')" == '0' ]]
           [[ "$(sql_number 'SELECT @@global.max_allowed_packet;')" == "$SOURCE_PACKET" ]]
@@ -390,7 +390,7 @@ jobs:
           [[ "$bootstrap" == 'Successful' ]]
           [[ "$(vendor/bin/drush php:eval \
             'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);')" == '0' ]]
-          [[ "$(pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l | tr -d ' ')" == '0' ]]
+          [[ "$(pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true)" == '0' ]]
 
           cache_max="$(sql_number \
             'SELECT COALESCE(MAX(OCTET_LENGTH(data)),0) FROM cache_file_parsing;')"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDatabasePacketRecoveryWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDatabasePacketRecoveryWorkflowTest.php
@@ -146,6 +146,18 @@ final class ProductionDatabasePacketRecoveryWorkflowTest extends TestCase {
   }
 
   /**
+   * Ensures zero active deploy processes remain valid under pipefail.
+   */
+  public function testZeroDeployCountIsPipefailSafe(): void {
+    $workflow = $this->workflow();
+    $safeCount = "pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true";
+    $unsafeCount = "pgrep -af '[d]eploy-production.sh' 2>/dev/null | wc -l";
+
+    self::assertSame(3, substr_count($workflow, $safeCount));
+    self::assertStringNotContainsString($unsafeCount, $workflow);
+  }
+
+  /**
    * Ensures recovery is one cache rebuild followed by real HTTP checks.
    */
   public function testRecoveryAndHealthChecksAreFixed(): void {


### PR DESCRIPTION
## Résumé

Corrige le défaut fail-closed découvert lors du premier preflight #660 après merge de #661.

Sous `set -euo pipefail`, `pgrep -af ... | wc -l` échoue quand aucun deploy n'est actif parce que `pgrep` retourne 1. C'est précisément l'état sain attendu.

La correction remplace les trois occurrences (preflight, garde apply, postcheck apply) par :

```bash
pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true
```

`pgrep -c` conserve une sortie numérique `0` lorsqu'aucun process ne correspond, et `|| true` neutralise uniquement son statut 1 normal sous `pipefail`.

Un test protège :

- exactement 3 occurrences du comptage sûr ;
- absence de l'ancien pipeline `pgrep -af ... | wc -l`.

Aucune portée privilégiée, précondition, valeur MariaDB, URL ou opération de recovery n'est modifiée. Diff : 3 lignes workflow remplacées + test.

Closes #662.

Refs #660 #661 #658 #590.