### PR TITLE
Issue #666: add bounded production sudo auth diagnostic

### DIFF
--- a/.github/workflows/trusted-production-sudo-auth-diagnostic.yml
+++ b/.github/workflows/trusted-production-sudo-auth-diagnostic.yml
@@ -1,0 +1,204 @@
+name: Agency trusted production sudo auth diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-sudo-auth:
+    name: Diagnose production sudo credential availability
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 666 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-sudo-auth diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate owner request and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-sudo-auth diagnose' ]]
+          [[ "$ISSUE_NUMBER" == '666' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Sudo auth diagnostic must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Run bounded sudo authentication diagnostic
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SERVER_SUDO_PASSWORD: ${{ secrets.SERVER_SUDO_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p artifacts/production-sudo-auth
+
+          secret_present=0
+          sudo_password_valid=0
+          ssh_channel_ok=0
+          current_sha=unavailable
+          active_deploy_processes=unavailable
+          expected_runtime='9188a2ebd6516a738be6df6f854794d41889aa90'
+
+          if [[ -n "$SERVER_SUDO_PASSWORD" ]]; then
+            secret_present=1
+          fi
+
+          state="$(
+            ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' <<'REMOTE_STATE'
+            set -euo pipefail
+            CURRENT='/var/www/agency/current'
+            deploy_count() {
+              pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true
+            }
+            current_sha="$(
+              git -C "$CURRENT" rev-parse HEAD 2>/dev/null |
+              tr -cd '0-9a-f' |
+              head -c 40
+            )"
+            printf 'current_sha=%s\n' "$current_sha"
+            printf 'active_deploy_processes=%s\n' "$(deploy_count)"
+            REMOTE_STATE
+          )" && ssh_channel_ok=1
+
+          if [[ "$ssh_channel_ok" == '1' ]]; then
+            current_sha="$(grep -m1 '^current_sha=' <<<"$state" | cut -d= -f2-)"
+            active_deploy_processes="$(
+              grep -m1 '^active_deploy_processes=' <<<"$state" |
+              cut -d= -f2-
+            )"
+          fi
+
+          if [[ "$ssh_channel_ok" == '1' &&
+                "$current_sha" == "$expected_runtime" &&
+                "$active_deploy_processes" == '0' &&
+                "$secret_present" == '1' ]]; then
+            if printf '%s\n' "$SERVER_SUDO_PASSWORD" |
+              ssh "$SERVER_USER@$SERVER_HOST" \
+                "sudo -S -k -p '' /usr/bin/true >/dev/null 2>&1; rc=\$?; sudo -k >/dev/null 2>&1 || true; exit \$rc"; then
+              sudo_password_valid=1
+            fi
+          fi
+
+          verdict=BLOCKED
+          if [[ "$ssh_channel_ok" == '1' &&
+                "$current_sha" == "$expected_runtime" &&
+                "$active_deploy_processes" == '0' ]]; then
+            if [[ "$secret_present" == '0' ]]; then
+              verdict=ABSENT
+            elif [[ "$sudo_password_valid" == '1' ]]; then
+              verdict=AVAILABLE
+            else
+              verdict=INVALID
+            fi
+          fi
+
+          jq -n \
+            --arg trusted_main "${{ steps.request.outputs.main_sha }}" \
+            --arg verdict "$verdict" \
+            --arg ssh_channel_ok "$ssh_channel_ok" \
+            --arg current_sha "$current_sha" \
+            --arg deploys "$active_deploy_processes" \
+            --arg secret_present "$secret_present" \
+            --arg sudo_password_valid "$sudo_password_valid" \
+            '{schema_version:1, trusted_main:$trusted_main, verdict:$verdict,
+              ssh_channel_ok:$ssh_channel_ok, current_sha:$current_sha,
+              active_deploy_processes:$deploys,
+              secret_present:$secret_present,
+              sudo_password_valid:$sudo_password_valid}' \
+            > artifacts/production-sudo-auth/result.json
+
+          case "$verdict" in
+            AVAILABLE|INVALID|ABSENT|BLOCKED) ;;
+            *) exit 1 ;;
+          esac
+
+      - name: Upload bounded sudo auth evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-sudo-auth-666-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-sudo-auth/result.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-sudo-auth/result.json'
+          [[ -s "$result" ]]
+          field() { jq -r "$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-sudo-auth-666-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          body="$(cat <<EOF_BODY
+          ### Agency production sudo auth $(field '.verdict')
+
+          trusted_main: \`$(field '.trusted_main')\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          ssh_channel_ok: \`$(field '.ssh_channel_ok')\`
+          current_sha: \`$(field '.current_sha')\`
+          active_deploy_processes: \`$(field '.active_deploy_processes')\`
+          secret_present: \`$(field '.secret_present')\`
+          sudo_password_valid: \`$(field '.sudo_password_valid')\`
+          artifact: \`$artifact\`
+
+          Authentication probe only. The secret is never published or written to disk; the sole privileged command attempted is /usr/bin/true, followed by sudo timestamp invalidation.
+          EOF_BODY
+          )"
+
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/issues/666/comments" \
+            -f body="$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionSudoAuthDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionSudoAuthDiagnosticWorkflowTest.php
@@ -72,7 +72,10 @@ final class ProductionSudoAuthDiagnosticWorkflowTest extends TestCase {
   public function testOnlyPrivilegedCommandIsTrue(): void {
     $workflow = $this->workflow();
 
-    self::assertSame(1, substr_count($workflow, '/usr/bin/true'));
+    self::assertSame(
+      1,
+      substr_count($workflow, "sudo -S -k -p '' /usr/bin/true"),
+    );
 
     foreach ([
       'systemctl restart',

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionSudoAuthDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionSudoAuthDiagnosticWorkflowTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded production sudo authentication diagnostic.
+ *
+ * @group agency_project_tests
+ * @group production_sudo_auth_diagnostic
+ */
+final class ProductionSudoAuthDiagnosticWorkflowTest extends TestCase {
+
+  /**
+   * Ensures the route is owner-only and pinned to issue 666.
+   */
+  public function testControlSurfaceIsPinned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/agency-production-sudo-auth diagnose',
+      'github.event.issue.number == 666',
+      "github.actor == 'E-merging-digital'",
+      '[[ "$ISSUE_NUMBER" == \'666\' ]]',
+      'EVENT_DEFAULT_SHA',
+      'currently on live main',
+      'runs-on: ubuntu-24.04',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('github.event.inputs', $workflow);
+  }
+
+  /**
+   * Ensures the credential never becomes an argument or persisted artifact.
+   */
+  public function testCredentialHandlingIsEphemeral(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'SERVER_SUDO_PASSWORD: ${{ secrets.SERVER_SUDO_PASSWORD }}',
+      'printf \'%s\\n\' "$SERVER_SUDO_PASSWORD" |',
+      "sudo -S -k -p '' /usr/bin/true",
+      'sudo -k >/dev/null 2>&1 || true',
+      'secret_present=0',
+      'sudo_password_valid=0',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'echo "$SERVER_SUDO_PASSWORD"',
+      'SERVER_SUDO_PASSWORD" >',
+      'SERVER_SUDO_PASSWORD" >>',
+      '/tmp/sudo',
+      'password.txt',
+      'credential.txt',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Ensures the remote privilege probe cannot perform useful root work.
+   */
+  public function testOnlyPrivilegedCommandIsTrue(): void {
+    $workflow = $this->workflow();
+
+    self::assertSame(1, substr_count($workflow, '/usr/bin/true'));
+
+    foreach ([
+      'systemctl restart',
+      'systemctl reload',
+      '/usr/bin/install',
+      '/usr/bin/rm',
+      '/usr/bin/tar',
+      'apt-get',
+      'mariadb ',
+      'vendor/bin/drush cr',
+      'state:set',
+      'config:import',
+      'chmod 777',
+      '/etc/sudoers',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Ensures the probe is tied to the current failed production runtime.
+   */
+  public function testRuntimeGuardAndVerdictsAreFixed(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '9188a2ebd6516a738be6df6f854794d41889aa90',
+      "pgrep -fc '[d]eploy-production.sh'",
+      'AVAILABLE|INVALID|ABSENT|BLOCKED',
+      'ssh_channel_ok',
+      'active_deploy_processes',
+      'secret_present',
+      'sudo_password_valid',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Ensures only a bounded JSON result can be retained.
+   */
+  public function testPublishedEvidenceIsBounded(): void {
+    $workflow = $this->workflow();
+
+    self::assertStringContainsString(
+      'path: artifacts/production-sudo-auth/result.json',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      "path: artifacts/production-sudo-auth\n",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'The secret is never published or written to disk',
+      $workflow,
+    );
+  }
+
+  /**
+   * Loads and parses the trusted sudo authentication diagnostic workflow.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-production-sudo-auth-diagnostic.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## Résumé

Épuise le dernier canal machine connu avant de conclure à un gate humain : vérifier si le secret historique `SERVER_SUDO_PASSWORD` de #367 existe encore et s'authentifie sur le compte SSH production.

Commande owner-only :

`/agency-production-sudo-auth diagnose`

## Sécurité

- aucune écriture production ;
- le secret n'est jamais publié, écrit sur disque ou passé en argv ;
- s'il existe, il est envoyé uniquement sur stdin à travers SSH ;
- l'unique commande privilégiée tentée est `/usr/bin/true` ;
- `sudo -k` invalide ensuite immédiatement le timestamp ;
- artifact limité à un JSON de scalaires : `secret_present`, `sudo_password_valid`, état SSH/runtime et verdict.

Verdicts : `AVAILABLE`, `INVALID`, `ABSENT`, `BLOCKED`.

#666 reste OPEN jusqu'à exécution du diagnostic.

Refs #666 #660 #664 #367 #658 #590.