### PR TITLE
Issue #668: add deterministic temporary sudo push probe

### DIFF
--- a/.github/workflows/temporary-production-sudo-push-probe-668.yml
+++ b/.github/workflows/temporary-production-sudo-push-probe-668.yml
@@ -1,0 +1,195 @@
+name: Agency temporary production sudo push probe 668
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/temporary-production-sudo-push-probe-668.yml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sudo-probe:
+    name: Probe historical production sudo credential once
+    if: >-
+      ${{
+        github.repository == 'E-merging-digital/agency-website-drupal' &&
+        github.ref == 'refs/heads/main' &&
+        github.actor == 'E-merging-digital'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate exact live main and open incident gates
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$GITHUB_SHA" == "$main_sha" ]]
+
+          for issue in 660 666 668; do
+            state="$(gh api "repos/$GITHUB_REPOSITORY/issues/$issue" --jq '.state')"
+            [[ "$state" == 'open' ]]
+          done
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Run bounded historical sudo credential probe
+        id: probe
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SERVER_SUDO_PASSWORD: ${{ secrets.SERVER_SUDO_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p artifacts/production-sudo-push-probe
+
+          expected_runtime='9188a2ebd6516a738be6df6f854794d41889aa90'
+          secret_present=0
+          sudo_password_valid=0
+          ssh_channel_ok=0
+          current_sha=unavailable
+          active_deploy_processes=unavailable
+
+          if [[ -n "$SERVER_SUDO_PASSWORD" ]]; then
+            secret_present=1
+          fi
+
+          state="$(
+            ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' <<'REMOTE_STATE'
+            set -euo pipefail
+            CURRENT='/var/www/agency/current'
+            current_sha="$(
+              git -C "$CURRENT" rev-parse HEAD 2>/dev/null |
+              tr -cd '0-9a-f' |
+              head -c 40
+            )"
+            deploys="$(pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true)"
+            printf 'current_sha=%s\n' "$current_sha"
+            printf 'active_deploy_processes=%s\n' "$deploys"
+            REMOTE_STATE
+          )" && ssh_channel_ok=1
+
+          if [[ "$ssh_channel_ok" == '1' ]]; then
+            current_sha="$(grep -m1 '^current_sha=' <<<"$state" | cut -d= -f2-)"
+            active_deploy_processes="$(
+              grep -m1 '^active_deploy_processes=' <<<"$state" |
+              cut -d= -f2-
+            )"
+          fi
+
+          if [[ "$ssh_channel_ok" == '1' &&
+                "$current_sha" == "$expected_runtime" &&
+                "$active_deploy_processes" == '0' &&
+                "$secret_present" == '1' ]]; then
+            if printf '%s\n' "$SERVER_SUDO_PASSWORD" |
+              ssh "$SERVER_USER@$SERVER_HOST" \
+                "sudo -S -k -p '' /usr/bin/true >/dev/null 2>&1; rc=\$?; sudo -k >/dev/null 2>&1 || true; exit \$rc"; then
+              sudo_password_valid=1
+            fi
+          fi
+
+          verdict=BLOCKED
+          if [[ "$ssh_channel_ok" == '1' &&
+                "$current_sha" == "$expected_runtime" &&
+                "$active_deploy_processes" == '0' ]]; then
+            if [[ "$secret_present" == '0' ]]; then
+              verdict=ABSENT
+            elif [[ "$sudo_password_valid" == '1' ]]; then
+              verdict=AVAILABLE
+            else
+              verdict=INVALID
+            fi
+          fi
+
+          jq -n \
+            --arg trusted_main "${{ steps.request.outputs.main_sha }}" \
+            --arg verdict "$verdict" \
+            --arg ssh_channel_ok "$ssh_channel_ok" \
+            --arg current_sha "$current_sha" \
+            --arg deploys "$active_deploy_processes" \
+            --arg secret_present "$secret_present" \
+            --arg sudo_password_valid "$sudo_password_valid" \
+            '{schema_version:1, trusted_main:$trusted_main, verdict:$verdict,
+              ssh_channel_ok:$ssh_channel_ok, current_sha:$current_sha,
+              active_deploy_processes:$deploys,
+              secret_present:$secret_present,
+              sudo_password_valid:$sudo_password_valid}' \
+            > artifacts/production-sudo-push-probe/result.json
+
+          case "$verdict" in
+            AVAILABLE|INVALID|ABSENT|BLOCKED) ;;
+            *) exit 1 ;;
+          esac
+
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bounded probe evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-sudo-push-probe-668-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-sudo-push-probe/result.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded verdict
+        if: ${{ always() && steps.request.outcome == 'success' && steps.probe.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-sudo-push-probe/result.json'
+          [[ -s "$result" ]]
+          field() { jq -r "$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-sudo-push-probe-668-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          body="$(cat <<EOF_BODY
+          ### Agency production sudo push probe $(field '.verdict')
+
+          trusted_main: \`$(field '.trusted_main')\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          ssh_channel_ok: \`$(field '.ssh_channel_ok')\`
+          current_sha: \`$(field '.current_sha')\`
+          active_deploy_processes: \`$(field '.active_deploy_processes')\`
+          secret_present: \`$(field '.secret_present')\`
+          sudo_password_valid: \`$(field '.sudo_password_valid')\`
+          artifact: \`$artifact\`
+
+          Read-only authentication probe. No production mutation was attempted; the sole privileged command is /usr/bin/true followed by sudo timestamp invalidation.
+          EOF_BODY
+          )"
+
+          for issue in 666 668; do
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$issue/comments" \
+              -f body="$body"
+          done

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/TemporaryProductionSudoPushProbeWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/TemporaryProductionSudoPushProbeWorkflowTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the temporary deterministic production sudo credential probe.
+ *
+ * @group agency_project_tests
+ * @group production_sudo_push_probe
+ */
+final class TemporaryProductionSudoPushProbeWorkflowTest extends TestCase {
+
+  /**
+   * Ensures the temporary route runs only when its own file reaches main.
+   */
+  public function testPushSurfaceIsStrictlyBounded(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'push:',
+      'branches:',
+      '- main',
+      '.github/workflows/temporary-production-sudo-push-probe-668.yml',
+      "github.repository == 'E-merging-digital/agency-website-drupal'",
+      "github.ref == 'refs/heads/main'",
+      "github.actor == 'E-merging-digital'",
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('issue_comment:', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+  }
+
+  /**
+   * Ensures the live incident and owner gates remain fixed.
+   */
+  public function testIncidentGatesAreFixed(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'for issue in 660 666 668',
+      '9188a2ebd6516a738be6df6f854794d41889aa90',
+      "pgrep -fc '[d]eploy-production.sh'",
+      'AVAILABLE|INVALID|ABSENT|BLOCKED',
+      'ssh_channel_ok',
+      'active_deploy_processes',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Ensures the credential is ephemeral and never exposed.
+   */
+  public function testCredentialHandlingIsEphemeral(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'SERVER_SUDO_PASSWORD: ${{ secrets.SERVER_SUDO_PASSWORD }}',
+      'printf \'%s\\n\' "$SERVER_SUDO_PASSWORD" |',
+      "sudo -S -k -p '' /usr/bin/true",
+      'sudo -k >/dev/null 2>&1 || true',
+      'secret_present=0',
+      'sudo_password_valid=0',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'echo "$SERVER_SUDO_PASSWORD"',
+      'SERVER_SUDO_PASSWORD" >',
+      'SERVER_SUDO_PASSWORD" >>',
+      '/tmp/sudo',
+      'password.txt',
+      'credential.txt',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Ensures no useful root or application mutation can be performed.
+   */
+  public function testProbeCannotMutateProduction(): void {
+    $workflow = $this->workflow();
+
+    self::assertSame(
+      1,
+      substr_count($workflow, "sudo -S -k -p '' /usr/bin/true"),
+    );
+
+    foreach ([
+      'systemctl restart',
+      'systemctl reload',
+      '/usr/bin/install',
+      '/usr/bin/rm',
+      '/usr/bin/tar',
+      'apt-get',
+      'mariadb ',
+      'vendor/bin/drush cr',
+      'state:set',
+      'config:import',
+      'chmod 777',
+      '/etc/sudoers',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Ensures only bounded scalar evidence is retained and published.
+   */
+  public function testEvidenceIsBounded(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'artifacts/production-sudo-push-probe/result.json',
+      'secret_present:$secret_present',
+      'sudo_password_valid:$sudo_password_valid',
+      'for issue in 666 668',
+      'Read-only authentication probe.',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString(
+      "path: artifacts/production-sudo-push-probe\n",
+      $workflow,
+    );
+  }
+
+  /**
+   * Loads and parses the temporary production probe workflow.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/temporary-production-sudo-push-probe-668.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## Résumé

Ajoute une sonde temporaire déclenchée uniquement lorsque son propre fichier atteint `main`, afin d'obtenir un verdict déterministe sur le canal historique `SERVER_SUDO_PASSWORD` après l'absence de résultat de #666.

## Sécurité

- 2 fichiers seulement : workflow + test de contrat ;
- aucune mutation Drupal/MariaDB/système ;
- runtime production et zéro deploy actif revalidés ;
- secret jamais publié, écrit sur disque ou passé en argv ;
- unique commande privilégiée : `/usr/bin/true`, suivie de `sudo -k` ;
- verdict borné `AVAILABLE|INVALID|ABSENT|BLOCKED` publié dans #666 et #668 ;
- artifact limité à un JSON de scalaires.

Après verdict, le workflow temporaire sera retiré via une issue/PR de cleanup séparée.

Closes #668
Refs #666 #660 #658 #590 #367.