### PR TITLE
Issue #674: diagnose production Drupal 404

### DIFF
--- a/.github/workflows/trusted-production-404-diagnostic.yml
+++ b/.github/workflows/trusted-production-404-diagnostic.yml
@@ -1,0 +1,296 @@
+name: Agency trusted production 404 diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-404-diagnostic:
+    name: Diagnose production Drupal 404
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 674 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-404 diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate actor incident and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-404 diagnose' ]]
+          [[ "$ISSUE_NUMBER" == '674' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Production 404 diagnostic must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Run fixed read-only production 404 diagnostic
+        id: diagnostic
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p artifacts/production-404
+          raw='artifacts/production-404/diagnostic.env'
+
+          set +e
+          ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' > "$raw" 2>&1 <<'REMOTE_DIAGNOSTIC'
+          set -u
+          CURRENT='/var/www/agency/current'
+          ORIGIN='https://emergingdigital.be'
+          FR_ALIAS='/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier'
+          EN_ALIAS='/blog/website-redesign-checklist-12-things-verify-you-start'
+
+          scalar() { printf '%s=%s\n' "$1" "$2"; }
+
+          probe_local() {
+            label="$1"
+            path="$2"
+            status="$(curl -k -sS --connect-timeout 8 --max-time 15 \
+              -A 'agency-production-404-diagnostic/1' \
+              --resolve 'emergingdigital.be:443:127.0.0.1' \
+              -o /dev/null -w '%{http_code}' "${ORIGIN}${path}" 2>/dev/null)"
+            exit_code="$?"
+            [[ "$exit_code" -eq 0 ]] || status='000'
+            scalar "local_${label}_status" "$status"
+          }
+
+          probe_public() {
+            label="$1"
+            path="$2"
+            status="$(curl -k -sS --connect-timeout 8 --max-time 15 \
+              -A 'agency-production-404-diagnostic/1' \
+              -o /dev/null -w '%{http_code}' "${ORIGIN}${path}" 2>/dev/null)"
+            exit_code="$?"
+            [[ "$exit_code" -eq 0 ]] || status='000'
+            scalar "public_${label}_status" "$status"
+          }
+
+          scalar current_release "$(readlink -f "$CURRENT" 2>/dev/null || echo unavailable)"
+          scalar current_sha "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+          scalar drupal_bootstrap "$(cd "$CURRENT" && vendor/bin/drush status --field=bootstrap --format=string 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          scalar maintenance_mode "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \\Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+
+          probe_local robots '/robots.txt'
+          probe_local root '/'
+          probe_local fr_root '/fr'
+          probe_local en_root '/en'
+          probe_local user_login '/user/login'
+          probe_local node37 '/node/37'
+          probe_local fr_node37 '/fr/node/37'
+          probe_local en_node37 '/en/node/37'
+          probe_local fr_alias "$FR_ALIAS"
+          probe_local fr_prefixed_alias "/fr${FR_ALIAS}"
+          probe_local en_prefixed_alias "/en${EN_ALIAS}"
+
+          probe_public root '/'
+          probe_public fr_root '/fr'
+          probe_public en_root '/en'
+          probe_public fr_prefixed_alias "/fr${FR_ALIAS}"
+          probe_public en_prefixed_alias "/en${EN_ALIAS}"
+
+          cd "$CURRENT" || exit 1
+          vendor/bin/drush php:eval '
+            $scalar = static function (string $key, string|int $value): void { print $key . "=" . $value . PHP_EOL; };
+            $front = (string) (\\Drupal::config("system.site")->get("page.front") ?? "");
+            $scalar("front_page", $front === "" ? "empty" : $front);
+            $node = \\Drupal\\node\\Entity\\Node::load(37);
+            $scalar("node37_exists", $node ? 1 : 0);
+            $scalar("node37_published", $node && $node->isPublished() ? 1 : 0);
+            $scalar("node37_has_fr", $node && ($node->language()->getId() === "fr" || $node->hasTranslation("fr")) ? 1 : 0);
+            $scalar("node37_has_en", $node && ($node->language()->getId() === "en" || $node->hasTranslation("en")) ? 1 : 0);
+            try {
+              \\Drupal::service("router.route_provider")->getRouteByName("entity.node.canonical");
+              $scalar("node_route_present", 1);
+            }
+            catch (\\Throwable) {
+              $scalar("node_route_present", 0);
+            }
+            try {
+              $match = \\Drupal::service("router.no_access_checks")->match("/node/37");
+              $scalar("node37_route_match", (string) ($match["_route"] ?? "none"));
+            }
+            catch (\\Throwable) {
+              $scalar("node37_route_match", "error");
+            }
+            $aliases = \\Drupal::service("path_alias.manager");
+            $scalar("fr_alias_target", $aliases->getPathByAlias("/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier", "fr"));
+            $scalar("en_alias_target", $aliases->getPathByAlias("/blog/website-redesign-checklist-12-things-verify-you-start", "en"));
+          ' 2>/dev/null
+          REMOTE_DIAGNOSTIC
+          ssh_status="$?"
+          set -e
+
+          value() { grep -m1 "^$1=" "$raw" | cut -d= -f2- || true; }
+          current_sha="$(value current_sha)"
+          bootstrap="$(value drupal_bootstrap)"
+          maintenance="$(value maintenance_mode)"
+          robots="$(value local_robots_status)"
+          root="$(value local_root_status)"
+          login="$(value local_user_login_status)"
+          node37="$(value local_node37_status)"
+          fr_alias="$(value local_fr_prefixed_alias_status)"
+          en_alias="$(value local_en_prefixed_alias_status)"
+          node_exists="$(value node37_exists)"
+          node_published="$(value node37_published)"
+          node_route="$(value node_route_present)"
+          node_match="$(value node37_route_match)"
+          fr_target="$(value fr_alias_target)"
+          en_target="$(value en_alias_target)"
+
+          verdict='MIXED'
+          if [[ "$ssh_status" -ne 0 ]]; then
+            verdict='SSH_DIAGNOSTIC_FAILED'
+          elif [[ ! "$robots" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='DOCROOT_OR_NGINX'
+          elif [[ "$node_exists" == '1' && "$node_published" == '1' && "$node_route" == '1' && "$node37" == '404' && "$login" == '404' ]]; then
+            verdict='DRUPAL_REQUEST_ROUTING'
+          elif [[ "$node37" =~ ^[23][0-9][0-9]$ && ( "$fr_alias" == '404' || "$en_alias" == '404' ) ]]; then
+            verdict='ALIAS_OR_LANGUAGE_ROUTING'
+          elif [[ "$node37" =~ ^[23][0-9][0-9]$ && "$login" =~ ^[23][0-9][0-9]$ && "$root" == '404' ]]; then
+            verdict='FRONT_PAGE_ONLY'
+          elif [[ "$root" =~ ^[23][0-9][0-9]$ && "$fr_alias" =~ ^[23][0-9][0-9]$ && "$en_alias" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='HTTP_HEALTHY'
+          fi
+
+          jq -n \
+            --arg verdict "$verdict" \
+            --arg current_sha "${current_sha:-unknown}" \
+            --arg drupal_bootstrap "${bootstrap:-unknown}" \
+            --arg maintenance_mode "${maintenance:-unknown}" \
+            --arg local_robots_status "${robots:-unknown}" \
+            --arg local_root_status "${root:-unknown}" \
+            --arg local_fr_root_status "$(value local_fr_root_status)" \
+            --arg local_en_root_status "$(value local_en_root_status)" \
+            --arg local_user_login_status "${login:-unknown}" \
+            --arg local_node37_status "${node37:-unknown}" \
+            --arg local_fr_node37_status "$(value local_fr_node37_status)" \
+            --arg local_en_node37_status "$(value local_en_node37_status)" \
+            --arg local_fr_alias_status "$(value local_fr_alias_status)" \
+            --arg local_fr_prefixed_alias_status "${fr_alias:-unknown}" \
+            --arg local_en_prefixed_alias_status "${en_alias:-unknown}" \
+            --arg public_root_status "$(value public_root_status)" \
+            --arg public_fr_root_status "$(value public_fr_root_status)" \
+            --arg public_en_root_status "$(value public_en_root_status)" \
+            --arg public_fr_prefixed_alias_status "$(value public_fr_prefixed_alias_status)" \
+            --arg public_en_prefixed_alias_status "$(value public_en_prefixed_alias_status)" \
+            --arg front_page "$(value front_page)" \
+            --arg node37_exists "${node_exists:-unknown}" \
+            --arg node37_published "${node_published:-unknown}" \
+            --arg node37_has_fr "$(value node37_has_fr)" \
+            --arg node37_has_en "$(value node37_has_en)" \
+            --arg node_route_present "${node_route:-unknown}" \
+            --arg node37_route_match "${node_match:-unknown}" \
+            --arg fr_alias_target "${fr_target:-unknown}" \
+            --arg en_alias_target "${en_target:-unknown}" \
+            --argjson ssh_exit "$ssh_status" \
+            '{schema_version:1, verdict:$verdict, ssh_exit:$ssh_exit, current_sha:$current_sha, drupal_bootstrap:$drupal_bootstrap, maintenance_mode:$maintenance_mode, local:{robots:$local_robots_status, root:$local_root_status, fr_root:$local_fr_root_status, en_root:$local_en_root_status, user_login:$local_user_login_status, node37:$local_node37_status, fr_node37:$local_fr_node37_status, en_node37:$local_en_node37_status, fr_alias:$local_fr_alias_status, fr_prefixed_alias:$local_fr_prefixed_alias_status, en_prefixed_alias:$local_en_prefixed_alias_status}, public:{root:$public_root_status, fr_root:$public_fr_root_status, en_root:$public_en_root_status, fr_prefixed_alias:$public_fr_prefixed_alias_status, en_prefixed_alias:$public_en_prefixed_alias_status}, drupal:{front_page:$front_page, node37_exists:$node37_exists, node37_published:$node37_published, node37_has_fr:$node37_has_fr, node37_has_en:$node37_has_en, node_route_present:$node_route_present, node37_route_match:$node37_route_match, fr_alias_target:$fr_alias_target, en_alias_target:$en_alias_target}}' \
+            > artifacts/production-404/result.json
+
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          test "$ssh_status" -eq 0
+
+      - name: Upload diagnostic evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-404-674-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/production-404
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded diagnostic result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/production-404/result.json'
+          [[ -s "$result" ]] && jq -e . "$result" >/dev/null
+          field() { jq -r "$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-404-674-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production 404 diagnostic $(field '.verdict')
+
+          trusted_main: \`${TRUSTED_MAIN}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${DIAGNOSTIC_OUTCOME:-unknown}\`
+          production_current_sha: \`$(field '.current_sha')\`
+          drupal_bootstrap: \`$(field '.drupal_bootstrap')\`
+          maintenance_mode: \`$(field '.maintenance_mode')\`
+          local_robots: \`$(field '.local.robots')\`
+          local_root: \`$(field '.local.root')\`
+          local_user_login: \`$(field '.local.user_login')\`
+          local_node37: \`$(field '.local.node37')\`
+          local_fr_alias: \`$(field '.local.fr_prefixed_alias')\`
+          local_en_alias: \`$(field '.local.en_prefixed_alias')\`
+          public_root: \`$(field '.public.root')\`
+          public_fr_root: \`$(field '.public.fr_root')\`
+          public_en_root: \`$(field '.public.en_root')\`
+          public_fr_alias: \`$(field '.public.fr_prefixed_alias')\`
+          public_en_alias: \`$(field '.public.en_prefixed_alias')\`
+          front_page: \`$(field '.drupal.front_page')\`
+          node37_exists: \`$(field '.drupal.node37_exists')\`
+          node37_published: \`$(field '.drupal.node37_published')\`
+          node_route_present: \`$(field '.drupal.node_route_present')\`
+          node37_route_match: \`$(field '.drupal.node37_route_match')\`
+          fr_alias_target: \`$(field '.drupal.fr_alias_target')\`
+          en_alias_target: \`$(field '.drupal.en_alias_target')\`
+          artifact: \`${artifact}\`
+
+          Read-only fixed-path diagnostic. No sudo, service restart, deployment, Drupal/DB mutation, arbitrary URL, path, command or shell input is accepted.
+          EOF_BODY
+          )"
+          gh issue comment 674 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/trusted-production-404-diagnostic.yml
+++ b/.github/workflows/trusted-production-404-diagnostic.yml
@@ -118,7 +118,7 @@ jobs:
           scalar current_release "$(readlink -f "$CURRENT" 2>/dev/null || echo unavailable)"
           scalar current_sha "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
           scalar drupal_bootstrap "$(cd "$CURRENT" && vendor/bin/drush status --field=bootstrap --format=string 2>/dev/null | tr -d '\r\n' || echo unavailable)"
-          scalar maintenance_mode "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) \\Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          scalar maintenance_mode "$(cd "$CURRENT" && vendor/bin/drush php:eval 'echo (int) Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
 
           probe_local robots '/robots.txt'
           probe_local root '/'
@@ -141,28 +141,28 @@ jobs:
           cd "$CURRENT" || exit 1
           vendor/bin/drush php:eval '
             $scalar = static function (string $key, string|int $value): void { print $key . "=" . $value . PHP_EOL; };
-            $front = (string) (\\Drupal::config("system.site")->get("page.front") ?? "");
+            $front = (string) (Drupal::config("system.site")->get("page.front") ?? "");
             $scalar("front_page", $front === "" ? "empty" : $front);
-            $node = \\Drupal\\node\\Entity\\Node::load(37);
+            $node = Drupal\node\Entity\Node::load(37);
             $scalar("node37_exists", $node ? 1 : 0);
             $scalar("node37_published", $node && $node->isPublished() ? 1 : 0);
             $scalar("node37_has_fr", $node && ($node->language()->getId() === "fr" || $node->hasTranslation("fr")) ? 1 : 0);
             $scalar("node37_has_en", $node && ($node->language()->getId() === "en" || $node->hasTranslation("en")) ? 1 : 0);
             try {
-              \\Drupal::service("router.route_provider")->getRouteByName("entity.node.canonical");
+              Drupal::service("router.route_provider")->getRouteByName("entity.node.canonical");
               $scalar("node_route_present", 1);
             }
-            catch (\\Throwable) {
+            catch (Throwable) {
               $scalar("node_route_present", 0);
             }
             try {
-              $match = \\Drupal::service("router.no_access_checks")->match("/node/37");
+              $match = Drupal::service("router.no_access_checks")->match("/node/37");
               $scalar("node37_route_match", (string) ($match["_route"] ?? "none"));
             }
-            catch (\\Throwable) {
+            catch (Throwable) {
               $scalar("node37_route_match", "error");
             }
-            $aliases = \\Drupal::service("path_alias.manager");
+            $aliases = Drupal::service("path_alias.manager");
             $scalar("fr_alias_target", $aliases->getPathByAlias("/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier", "fr"));
             $scalar("en_alias_target", $aliases->getPathByAlias("/blog/website-redesign-checklist-12-things-verify-you-start", "en"));
           ' 2>/dev/null

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/Production404DiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/Production404DiagnosticWorkflowTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded read-only production 404 diagnostic.
+ *
+ * @group agency_project_tests
+ * @group production_404_diagnostic
+ */
+final class Production404DiagnosticWorkflowTest extends TestCase {
+
+  /**
+   * The route stays owner-only, issue-bound and live-main-only.
+   */
+  public function testControlSurfaceIsPinned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/agency-production-404 diagnose',
+      'github.event.issue.number == 674',
+      "github.actor == 'E-merging-digital'",
+      "github.event.comment.user.login == 'E-merging-digital'",
+      "ISSUE_NUMBER\" == '674'",
+      'currently on live main',
+      'runs-on: ubuntu-24.04',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('github.event.inputs', $workflow);
+  }
+
+  /**
+   * Fixed HTTP probes distinguish docroot from Drupal routing.
+   */
+  public function testHttpProbeSetIsFixed(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      "probe_local robots '/robots.txt'",
+      "probe_local root '/'",
+      "probe_local fr_root '/fr'",
+      "probe_local en_root '/en'",
+      "probe_local user_login '/user/login'",
+      "probe_local node37 '/node/37'",
+      "probe_local fr_node37 '/fr/node/37'",
+      "probe_local en_node37 '/en/node/37'",
+      'checklist-avant-une-refonte-de-site-internet-12-points-verifier',
+      'website-redesign-checklist-12-things-verify-you-start',
+      "--resolve 'emergingdigital.be:443:127.0.0.1'",
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Drupal inspection is limited to fixed, read-only facts.
+   */
+  public function testDrupalInspectionIsReadOnly(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'system.site',
+      'page.front',
+      'Node::load(37)',
+      'entity.node.canonical',
+      'router.no_access_checks',
+      'path_alias.manager',
+      'fr_alias_target',
+      'en_alias_target',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'state:set',
+      'config:set',
+      'entity:delete',
+      'node:delete',
+      'drush cr',
+      'drush cim',
+      'drush updb',
+      'systemctl restart',
+      'systemctl reload',
+      'sudo ',
+      'git pull',
+      'git reset',
+      'git checkout',
+      'deploy-production.sh main',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Results remain machine-readable and diagnostically classified.
+   */
+  public function testResultIsBoundedAndClassified(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'artifacts/production-404/result.json',
+      'DOCROOT_OR_NGINX',
+      'DRUPAL_REQUEST_ROUTING',
+      'ALIAS_OR_LANGUAGE_ROUTING',
+      'FRONT_PAGE_ONLY',
+      'HTTP_HEALTHY',
+      'MIXED',
+      'node37_route_match',
+      'node37_published',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Loads and parses the workflow.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-404-diagnostic.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## Résumé

Ajoute un diagnostic P1 strictement read-only pour isoler le 404 production restant après la convergence de #660 à 64 MiB.

Le diagnostic compare des chemins fixes en public et via `127.0.0.1`, puis inspecte uniquement des faits Drupal bornés : front page, nœud 37, route canonique et résolution des deux alias #401.

## Sécurité

- owner-only ;
- issue #674 uniquement ;
- live-main-only ;
- aucune URL/commande/path libre ;
- aucun sudo ;
- aucun restart ;
- aucune mutation Drupal/DB ;
- aucun deploy ;
- artefact machine-readable.

Refs #674 #660 #590 #401.