### PR TITLE
Issue #676: diagnose production Nginx docroot

### DIFF
--- a/.github/workflows/trusted-production-nginx-docroot-diagnostic.yml
+++ b/.github/workflows/trusted-production-nginx-docroot-diagnostic.yml
@@ -1,0 +1,289 @@
+name: Agency trusted production Nginx docroot diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  nginx-docroot-diagnostic:
+    name: Diagnose production Nginx docroot
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 676 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-production-nginx diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate owner issue and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-production-nginx diagnose' ]]
+          [[ "$ISSUE_NUMBER" == '676' ]]
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Nginx diagnostic must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Inspect fixed Nginx and release facts read-only
+        id: diagnostic
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/nginx-docroot
+          raw='artifacts/nginx-docroot/facts.env'
+          details='artifacts/nginx-docroot/details.txt'
+
+          ssh "$SERVER_USER@$SERVER_HOST" 'bash -s' > "$raw" 2> artifacts/nginx-docroot/ssh.stderr <<'REMOTE'
+          set -u
+          CURRENT='/var/www/agency/current'
+          EXPECTED_ROOT='/var/www/agency/current/web'
+          RELEASES='/var/www/agency/releases'
+
+          scalar() { printf '%s=%s\n' "$1" "$2"; }
+          fact() {
+            key="$1"
+            path="$2"
+            if [[ -e "$path" || -L "$path" ]]; then
+              scalar "$key" "$(stat -Lc '%a|%U|%G|%F' "$path" 2>/dev/null || echo stat_failed)"
+            else
+              scalar "$key" 'missing'
+            fi
+          }
+
+          release="$(readlink -f "$CURRENT" 2>/dev/null || true)"
+          previous="$(ls -1dt "$RELEASES"/* 2>/dev/null | grep -Fvx "$release" | head -n 1 || true)"
+          scalar current_release "${release:-missing}"
+          scalar previous_release "${previous:-missing}"
+          scalar current_sha "$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+          scalar nginx_user "$(awk '$1 == "user" {gsub(";", "", $2); print $2; exit}' /etc/nginx/nginx.conf 2>/dev/null || true)"
+
+          fact path_var_www /var/www
+          fact path_agency /var/www/agency
+          fact path_releases /var/www/agency/releases
+          fact path_current "$CURRENT"
+          fact path_current_release "$release"
+          fact path_current_web "$CURRENT/web"
+          fact path_current_index "$CURRENT/web/index.php"
+          fact path_current_robots "$CURRENT/web/robots.txt"
+          if [[ -n "$previous" ]]; then
+            fact path_previous_release "$previous"
+            fact path_previous_web "$previous/web"
+            fact path_previous_index "$previous/web/index.php"
+            fact path_previous_robots "$previous/web/robots.txt"
+          else
+            scalar path_previous_release missing
+            scalar path_previous_web missing
+            scalar path_previous_index missing
+            scalar path_previous_robots missing
+          fi
+
+          scalar current_index_exists "$([[ -f "$CURRENT/web/index.php" ]] && echo 1 || echo 0)"
+          scalar current_robots_exists "$([[ -f "$CURRENT/web/robots.txt" ]] && echo 1 || echo 0)"
+          scalar current_index_readable "$([[ -r "$CURRENT/web/index.php" ]] && echo 1 || echo 0)"
+          scalar current_robots_readable "$([[ -r "$CURRENT/web/robots.txt" ]] && echo 1 || echo 0)"
+
+          roots="$(grep -RhsE '^[[:space:]]*root[[:space:]]+[^;]+;' /etc/nginx/sites-enabled 2>/dev/null | sed -E 's/^[[:space:]]*root[[:space:]]+([^;]+);.*/\1/' | sort -u | paste -sd ',' -)"
+          scalar nginx_roots "${roots:-unreadable_or_absent}"
+          root_match=0
+          grep -RhsE '^[[:space:]]*root[[:space:]]+/var/www/agency/current/web;' /etc/nginx/sites-enabled 2>/dev/null | grep -q . && root_match=1
+          scalar expected_root_present "$root_match"
+
+          directives_readable=0
+          if grep -RhsE '^[[:space:]]*(server_name|root|index|try_files|fastcgi_pass)[[:space:]]' /etc/nginx/sites-enabled >/tmp/agency-676-nginx-directives.txt 2>/dev/null; then
+            directives_readable=1
+          fi
+          scalar nginx_directives_readable "$directives_readable"
+
+          error_log_readable=0
+          error_permission_denied_count=0
+          if [[ -r /var/log/nginx/error.log ]]; then
+            error_log_readable=1
+            error_permission_denied_count="$(grep -E 'permission denied|/var/www/agency' /var/log/nginx/error.log 2>/dev/null | tail -n 40 | wc -l | tr -d ' ')"
+          fi
+          scalar nginx_error_log_readable "$error_log_readable"
+          scalar nginx_relevant_error_count "$error_permission_denied_count"
+
+          local_robots="$(curl -k -sS --connect-timeout 8 --max-time 15 --resolve 'emergingdigital.be:443:127.0.0.1' -o /dev/null -w '%{http_code}' https://emergingdigital.be/robots.txt 2>/dev/null || echo 000)"
+          local_root="$(curl -k -sS --connect-timeout 8 --max-time 15 --resolve 'emergingdigital.be:443:127.0.0.1' -o /dev/null -w '%{http_code}' https://emergingdigital.be/ 2>/dev/null || echo 000)"
+          scalar local_robots_status "$local_robots"
+          scalar local_root_status "$local_root"
+
+          {
+            echo '=== namei current/web/index.php ==='
+            namei -l "$CURRENT/web/index.php" 2>&1 || true
+            echo '=== namei current/web/robots.txt ==='
+            namei -l "$CURRENT/web/robots.txt" 2>&1 || true
+            echo '=== enabled Nginx directives ==='
+            if [[ -s /tmp/agency-676-nginx-directives.txt ]]; then
+              sed -E 's/[[:space:]]+/ /g; s/^ //' /tmp/agency-676-nginx-directives.txt | head -n 100
+            else
+              echo unavailable
+            fi
+            rm -f /tmp/agency-676-nginx-directives.txt
+            echo '=== filtered Nginx errors ==='
+            if [[ "$error_log_readable" == '1' ]]; then
+              grep -E 'permission denied|/var/www/agency' /var/log/nginx/error.log 2>/dev/null | tail -n 40 || true
+            else
+              echo unreadable
+            fi
+          } >&2
+          REMOTE
+
+          cat artifacts/nginx-docroot/ssh.stderr > "$details"
+          : > artifacts/nginx-docroot/ssh.stderr
+
+          value() { grep -m1 "^$1=" "$raw" | cut -d= -f2- || true; }
+          current_release="$(value current_release)"
+          current_sha="$(value current_sha)"
+          nginx_user="$(value nginx_user)"
+          roots="$(value nginx_roots)"
+          root_match="$(value expected_root_present)"
+          current_web="$(value path_current_web)"
+          previous_web="$(value path_previous_web)"
+          index_fact="$(value path_current_index)"
+          robots_fact="$(value path_current_robots)"
+          index_exists="$(value current_index_exists)"
+          robots_exists="$(value current_robots_exists)"
+          error_count="$(value nginx_relevant_error_count)"
+          robots_status="$(value local_robots_status)"
+          root_status="$(value local_root_status)"
+
+          verdict='NGINX_STATIC_ACCESS_DENIED'
+          if [[ "$root_match" != '1' ]]; then
+            verdict='NGINX_ROOT_MISMATCH'
+          elif [[ "${error_count:-0}" =~ ^[0-9]+$ && "${error_count:-0}" -gt 0 ]]; then
+            verdict='NGINX_PATH_OR_PERMISSION_ERROR'
+          elif [[ "$index_exists" != '1' || "$robots_exists" != '1' ]]; then
+            verdict='CURRENT_RELEASE_WEB_MISSING'
+          elif [[ "$robots_status" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='STATIC_ACCESS_HEALTHY'
+          elif [[ "$current_web" != "$previous_web" && "$previous_web" != 'missing' ]]; then
+            verdict='CURRENT_RELEASE_PERMISSION_REGRESSION'
+          fi
+
+          jq -n \
+            --arg verdict "$verdict" \
+            --arg current_release "$current_release" \
+            --arg current_sha "$current_sha" \
+            --arg nginx_user "${nginx_user:-unknown}" \
+            --arg nginx_roots "${roots:-unknown}" \
+            --arg expected_root_present "${root_match:-unknown}" \
+            --arg path_var_www "$(value path_var_www)" \
+            --arg path_agency "$(value path_agency)" \
+            --arg path_releases "$(value path_releases)" \
+            --arg path_current "$(value path_current)" \
+            --arg path_current_release "$(value path_current_release)" \
+            --arg path_current_web "$current_web" \
+            --arg path_current_index "$index_fact" \
+            --arg path_current_robots "$robots_fact" \
+            --arg previous_release "$(value previous_release)" \
+            --arg path_previous_release "$(value path_previous_release)" \
+            --arg path_previous_web "$previous_web" \
+            --arg path_previous_index "$(value path_previous_index)" \
+            --arg path_previous_robots "$(value path_previous_robots)" \
+            --arg current_index_exists "$index_exists" \
+            --arg current_robots_exists "$robots_exists" \
+            --arg current_index_readable "$(value current_index_readable)" \
+            --arg current_robots_readable "$(value current_robots_readable)" \
+            --arg nginx_directives_readable "$(value nginx_directives_readable)" \
+            --arg nginx_error_log_readable "$(value nginx_error_log_readable)" \
+            --arg nginx_relevant_error_count "${error_count:-0}" \
+            --arg local_robots_status "$robots_status" \
+            --arg local_root_status "$root_status" \
+            '{schema_version:1,verdict:$verdict,current_release:$current_release,current_sha:$current_sha,nginx_user:$nginx_user,nginx_roots:$nginx_roots,expected_root_present:$expected_root_present,paths:{var_www:$path_var_www,agency:$path_agency,releases:$path_releases,current:$path_current,current_release:$path_current_release,current_web:$path_current_web,current_index:$path_current_index,current_robots:$path_current_robots,previous_release:$previous_release,previous_release_fact:$path_previous_release,previous_web:$path_previous_web,previous_index:$path_previous_index,previous_robots:$path_previous_robots},files:{index_exists:$current_index_exists,robots_exists:$current_robots_exists,index_readable_by_deploy:$current_index_readable,robots_readable_by_deploy:$current_robots_readable},nginx:{directives_readable:$nginx_directives_readable,error_log_readable:$nginx_error_log_readable,relevant_error_count:$nginx_relevant_error_count},http:{local_robots:$local_robots_status,local_root:$local_root_status}}' \
+            > artifacts/nginx-docroot/result.json
+
+      - name: Upload diagnostic evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-nginx-676-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/nginx-docroot
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/nginx-docroot/result.json'
+          [[ -s "$result" ]] && jq -e . "$result" >/dev/null
+          field() { jq -r "$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-nginx-676-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production Nginx diagnostic $(field '.verdict')
+
+          trusted_main: \`${TRUSTED_MAIN}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${DIAGNOSTIC_OUTCOME:-unknown}\`
+          production_current_sha: \`$(field '.current_sha')\`
+          current_release: \`$(field '.current_release')\`
+          nginx_user: \`$(field '.nginx_user')\`
+          nginx_roots: \`$(field '.nginx_roots')\`
+          expected_root_present: \`$(field '.expected_root_present')\`
+          current_release_mode: \`$(field '.paths.current_release')\`
+          current_web_mode: \`$(field '.paths.current_web')\`
+          current_index_mode: \`$(field '.paths.current_index')\`
+          current_robots_mode: \`$(field '.paths.current_robots')\`
+          previous_release: \`$(field '.paths.previous_release')\`
+          previous_web_mode: \`$(field '.paths.previous_web')\`
+          nginx_error_log_readable: \`$(field '.nginx.error_log_readable')\`
+          nginx_relevant_error_count: \`$(field '.nginx.relevant_error_count')\`
+          local_robots: \`$(field '.http.local_robots')\`
+          local_root: \`$(field '.http.local_root')\`
+          artifact: \`${artifact}\`
+
+          Read-only diagnostic only. No privilege elevation, service mutation, deployment or application/database write is performed.
+          EOF_BODY
+          )"
+          gh issue comment 676 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the read-only production Nginx/docroot diagnostic.
+ *
+ * @group agency_project_tests
+ * @group production_nginx_docroot_diagnostic
+ */
+final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
+
+  public function testControlSurfaceIsPinned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/agency-production-nginx diagnose',
+      'github.event.issue.number == 676',
+      "github.actor == 'E-merging-digital'",
+      "ISSUE_NUMBER\" == '676'",
+      'currently on live main',
+      'runs-on: ubuntu-24.04',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('github.event.inputs', $workflow);
+  }
+
+  public function testFixedReadOnlyFactsAreCollected(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/var/www/agency/current',
+      '/var/www/agency/releases',
+      '$CURRENT/web/index.php',
+      '$CURRENT/web/robots.txt',
+      'namei -l "$CURRENT/web/index.php"',
+      'namei -l "$CURRENT/web/robots.txt"',
+      '/etc/nginx/sites-enabled',
+      'server_name|root|index|try_files|fastcgi_pass',
+      '/var/log/nginx/error.log',
+      'permission denied|/var/www/agency',
+      "--resolve 'emergingdigital.be:443:127.0.0.1'",
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  public function testMutationSurfacesAreAbsent(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'sudo ',
+      'systemctl restart',
+      'systemctl reload',
+      'nginx -s reload',
+      'chmod ',
+      'chown ',
+      'setfacl ',
+      'drush cr',
+      'drush cim',
+      'drush updb',
+      'state:set',
+      'config:set',
+      'git pull',
+      'git reset',
+      'git checkout',
+      'deploy-production.sh main',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  public function testDiagnosticClassificationsAreBounded(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'NGINX_ROOT_MISMATCH',
+      'NGINX_PATH_OR_PERMISSION_ERROR',
+      'CURRENT_RELEASE_WEB_MISSING',
+      'STATIC_ACCESS_HEALTHY',
+      'CURRENT_RELEASE_PERMISSION_REGRESSION',
+      'NGINX_STATIC_ACCESS_DENIED',
+      'artifacts/nginx-docroot/result.json',
+      'expected_root_present',
+      'previous_web_mode',
+      'nginx_relevant_error_count',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-nginx-docroot-diagnostic.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
 
+  /**
+   * Ensures the control surface is owner, issue and live-main bound.
+   */
   public function testControlSurfaceIsPinned(): void {
     $workflow = $this->workflow();
 
@@ -33,6 +36,9 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     self::assertStringNotContainsString('github.event.inputs', $workflow);
   }
 
+  /**
+   * Ensures only the fixed Nginx, path and HTTP facts are collected.
+   */
   public function testFixedReadOnlyFactsAreCollected(): void {
     $workflow = $this->workflow();
 
@@ -53,6 +59,9 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     }
   }
 
+  /**
+   * Ensures the production-side block cannot mutate host or application state.
+   */
   public function testMutationSurfacesAreAbsentFromProductionBlock(): void {
     $workflow = $this->workflow();
     $remoteStart = strpos(
@@ -87,6 +96,9 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     }
   }
 
+  /**
+   * Ensures diagnostic outcomes remain explicit and machine-readable.
+   */
   public function testDiagnosticClassificationsAreBounded(): void {
     $workflow = $this->workflow();
 
@@ -106,6 +118,9 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     }
   }
 
+  /**
+   * Loads and parses the trusted Nginx/docroot diagnostic workflow.
+   */
   private function workflow(): string {
     $root = dirname(DRUPAL_ROOT);
     $path = $root . '/.github/workflows/trusted-production-nginx-docroot-diagnostic.yml';

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
@@ -53,8 +53,17 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     }
   }
 
-  public function testMutationSurfacesAreAbsent(): void {
+  public function testMutationSurfacesAreAbsentFromProductionBlock(): void {
     $workflow = $this->workflow();
+    $remoteStart = strpos(
+      $workflow,
+      "ssh \"$SERVER_USER@$SERVER_HOST\" 'bash -s' > \"$raw\"",
+    );
+    $remoteEnd = strpos($workflow, "          REMOTE\n", $remoteStart ?: 0);
+
+    self::assertIsInt($remoteStart);
+    self::assertIsInt($remoteEnd);
+    $remote = substr($workflow, $remoteStart, $remoteEnd - $remoteStart);
 
     foreach ([
       'sudo ',
@@ -74,7 +83,7 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
       'git checkout',
       'deploy-production.sh main',
     ] as $forbidden) {
-      self::assertStringNotContainsString($forbidden, $workflow);
+      self::assertStringNotContainsString($forbidden, $remote);
     }
   }
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionNginxDocrootDiagnosticWorkflowTest.php
@@ -57,7 +57,7 @@ final class ProductionNginxDocrootDiagnosticWorkflowTest extends TestCase {
     $workflow = $this->workflow();
     $remoteStart = strpos(
       $workflow,
-      "ssh \"$SERVER_USER@$SERVER_HOST\" 'bash -s' > \"$raw\"",
+      'ssh "$SERVER_USER@$SERVER_HOST" \'bash -s\' > "$raw"',
     );
     $remoteEnd = strpos($workflow, "          REMOTE\n", $remoteStart ?: 0);
 


### PR DESCRIPTION
## Résumé

Ajoute un diagnostic strictement read-only pour le défaut Nginx/docroot prouvé par #674 (`robots.txt=403`, routes Drupal=404 alors que le routeur CLI et les contenus sont sains).

La route compare le vhost activé, la cible `current`, les modes/owners/groups de la release courante et précédente, les chemins `web/index.php`/`robots.txt`, `namei`, et les seules erreurs Nginx pertinentes.

## Sécurité

- owner-only ;
- issue #676 uniquement ;
- live-main-only ;
- aucune élévation de privilège ;
- aucun chmod/chown ;
- aucun reload/restart ;
- aucun Drush mutateur ;
- aucun deploy ;
- aucun argument libre.

Refs #676 #674 #660 #590.