### PR TITLE
Issue #678: recover production runtime permissions

### DIFF
--- a/.github/workflows/trusted-production-runtime-permissions-recovery.yml
+++ b/.github/workflows/trusted-production-runtime-permissions-recovery.yml
@@ -1,0 +1,308 @@
+name: Agency trusted production runtime permissions recovery
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  runtime-permissions-recovery:
+    name: Recover production runtime permissions
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 678 &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        (
+          github.event.comment.body == '/agency-production-permissions preflight' ||
+          github.event.comment.body == '/agency-production-permissions apply'
+        )
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate owner issue and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '678' ]]
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          case "$TRIGGER_COMMENT" in
+            '/agency-production-permissions preflight') mode='preflight' ;;
+            '/agency-production-permissions apply') mode='apply' ;;
+            *) echo 'Unsupported recovery command.' >&2; exit 1 ;;
+          esac
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Permission recovery must execute the workflow revision currently on live main.' >&2
+            exit 1
+          }
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Preflight or apply exact runtime permission recovery
+        id: recovery
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          MODE: ${{ steps.request.outputs.mode }}
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          [[ "$MODE" == 'preflight' || "$MODE" == 'apply' ]]
+          mkdir -p artifacts/runtime-permissions
+          raw='artifacts/runtime-permissions/facts.env'
+
+          ssh "$SERVER_USER@$SERVER_HOST" "MODE='$MODE' bash -s" > "$raw" <<'REMOTE'
+          set -u
+
+          EXPECTED_RELEASE='/var/www/agency/releases/20260822135335'
+          EXPECTED_SHA='9188a2ebd6516a738be6df6f854794d41889aa90'
+          CURRENT='/var/www/agency/current'
+          BACKUPS='/var/www/agency/shared/backups'
+          FR_PATH='/fr/blog/checklist-avant-une-refonte-de-site-internet-12-points-verifier'
+          EN_PATH='/en/blog/website-redesign-checklist-12-things-verify-you-start'
+          EXPECTED_SETTINGS='/var/www/agency/shared/settings/settings.php'
+          EXPECTED_FILES='/var/www/agency/shared/files'
+
+          scalar() { printf '%s=%s\n' "$1" "$2"; }
+          mode_of() { stat -Lc '%a' "$1" 2>/dev/null || echo missing; }
+          owner_group_of() { stat -Lc '%U|%G' "$1" 2>/dev/null || echo missing; }
+          http_local() {
+            curl -k -sS --connect-timeout 8 --max-time 15 \
+              --resolve 'emergingdigital.be:443:127.0.0.1' \
+              -o /dev/null -w '%{http_code}' "https://emergingdigital.be$1" 2>/dev/null || echo 000
+          }
+          http_public() {
+            curl -k -sS --connect-timeout 8 --max-time 15 \
+              -o /dev/null -w '%{http_code}' "https://emergingdigital.be$1" 2>/dev/null || echo 000
+          }
+
+          release="$(readlink -f "$CURRENT" 2>/dev/null || true)"
+          sha="$(git -C "$CURRENT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+          bootstrap="$(cd "$CURRENT" 2>/dev/null && vendor/bin/drush status --field=bootstrap --format=string 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          maintenance="$(cd "$CURRENT" 2>/dev/null && vendor/bin/drush php:eval 'echo (int) \Drupal::state()->get("system.maintenance_mode", 0);' 2>/dev/null | tr -d '\r\n' || echo unavailable)"
+          deploy_count="$(pgrep -fc '[d]eploy-production.sh' 2>/dev/null || true)"
+          release_mode="$(mode_of "$release")"
+          web_mode="$(mode_of "$release/web")"
+          index_mode="$(mode_of "$release/web/index.php")"
+          robots_mode="$(mode_of "$release/web/robots.txt")"
+          settings_target="$(readlink -f "$release/web/sites/default/settings.php" 2>/dev/null || true)"
+          files_target="$(readlink -f "$release/web/sites/default/files" 2>/dev/null || true)"
+          settings_before="$(mode_of "$EXPECTED_SETTINGS")|$(owner_group_of "$EXPECTED_SETTINGS")"
+          files_before="$(mode_of "$EXPECTED_FILES")|$(owner_group_of "$EXPECTED_FILES")"
+          local_robots_before="$(http_local '/robots.txt')"
+          local_root_before="$(http_local '/')"
+
+          exact_context=0
+          if [[ "$release" == "$EXPECTED_RELEASE" && "$sha" == "$EXPECTED_SHA" && "$bootstrap" == 'Successful' && "$maintenance" == '0' && "$deploy_count" == '0' && "$settings_target" == "$EXPECTED_SETTINGS" && "$files_target" == "$EXPECTED_FILES" ]]; then
+            exact_context=1
+          fi
+
+          verdict='BLOCKED'
+          backup_manifest=''
+          apply_error=0
+
+          if [[ "$exact_context" == '1' && "$local_robots_before" =~ ^[23][0-9][0-9]$ && "$local_root_before" =~ ^[23][0-9][0-9]$ ]]; then
+            verdict='CONVERGED'
+          elif [[ "$exact_context" == '1' && "$release_mode" == '700' && "$web_mode" == '700' && "$index_mode" == '600' && "$robots_mode" == '600' && "$local_robots_before" == '403' ]]; then
+            verdict='READY'
+          fi
+
+          if [[ "$MODE" == 'apply' ]]; then
+            if [[ "$verdict" != 'READY' ]]; then
+              scalar verdict 'APPLY_PRECONDITION_FAILED'
+              scalar exact_context "$exact_context"
+              scalar current_release "$release"
+              scalar current_sha "$sha"
+              scalar drupal_bootstrap "$bootstrap"
+              scalar maintenance_mode "$maintenance"
+              scalar active_deploy_processes "$deploy_count"
+              scalar release_mode "$release_mode"
+              scalar web_mode "$web_mode"
+              scalar index_mode "$index_mode"
+              scalar robots_mode "$robots_mode"
+              scalar local_robots_before "$local_robots_before"
+              scalar local_root_before "$local_root_before"
+              exit 0
+            fi
+
+            timestamp="$(date -u +%Y%m%d%H%M%S)"
+            backup_manifest="$BACKUPS/issue678-permissions-$timestamp.tsv"
+            mkdir -p "$BACKUPS" || apply_error=1
+            {
+              printf '%s\t%s\n' "$(mode_of "$release")" "$release"
+              find "$release/vendor" "$release/web" -xdev \( -type d -o -type f \) -printf '%m\t%p\n'
+            } > "$backup_manifest" || apply_error=1
+            [[ -s "$backup_manifest" ]] || apply_error=1
+
+            if [[ "$apply_error" == '0' ]]; then
+              chmod a+rx "$release" || apply_error=1
+              find "$release/vendor" "$release/web" -xdev -type d -exec chmod a+rx {} + || apply_error=1
+              find "$release/vendor" "$release/web" -xdev -type f -exec chmod a+r {} + || apply_error=1
+            fi
+          fi
+
+          release_mode_after="$(mode_of "$release")"
+          web_mode_after="$(mode_of "$release/web")"
+          index_mode_after="$(mode_of "$release/web/index.php")"
+          robots_mode_after="$(mode_of "$release/web/robots.txt")"
+          settings_after="$(mode_of "$EXPECTED_SETTINGS")|$(owner_group_of "$EXPECTED_SETTINGS")"
+          files_after="$(mode_of "$EXPECTED_FILES")|$(owner_group_of "$EXPECTED_FILES")"
+          local_robots_after="$(http_local '/robots.txt')"
+          local_root_after="$(http_local '/')"
+          public_fr_after="$(http_public "$FR_PATH")"
+          public_en_after="$(http_public "$EN_PATH")"
+
+          if [[ "$MODE" == 'apply' ]]; then
+            verdict='APPLY_FAILED'
+            if [[ "$apply_error" == '0' && "$settings_before" == "$settings_after" && "$files_before" == "$files_after" && "$local_robots_after" =~ ^[23][0-9][0-9]$ && "$local_root_after" =~ ^[23][0-9][0-9]$ && "$public_fr_after" =~ ^[23][0-9][0-9]$ && "$public_en_after" =~ ^[23][0-9][0-9]$ ]]; then
+              verdict='PASS'
+            fi
+          fi
+
+          scalar verdict "$verdict"
+          scalar exact_context "$exact_context"
+          scalar current_release "$release"
+          scalar current_sha "$sha"
+          scalar drupal_bootstrap "$bootstrap"
+          scalar maintenance_mode "$maintenance"
+          scalar active_deploy_processes "$deploy_count"
+          scalar release_mode_before "$release_mode"
+          scalar web_mode_before "$web_mode"
+          scalar index_mode_before "$index_mode"
+          scalar robots_mode_before "$robots_mode"
+          scalar release_mode_after "$release_mode_after"
+          scalar web_mode_after "$web_mode_after"
+          scalar index_mode_after "$index_mode_after"
+          scalar robots_mode_after "$robots_mode_after"
+          scalar settings_target_unchanged "$([[ "$settings_before" == "$settings_after" ]] && echo 1 || echo 0)"
+          scalar files_target_unchanged "$([[ "$files_before" == "$files_after" ]] && echo 1 || echo 0)"
+          scalar local_robots_before "$local_robots_before"
+          scalar local_root_before "$local_root_before"
+          scalar local_robots_after "$local_robots_after"
+          scalar local_root_after "$local_root_after"
+          scalar public_fr_after "$public_fr_after"
+          scalar public_en_after "$public_en_after"
+          scalar backup_manifest "${backup_manifest:-none}"
+          REMOTE
+
+          value() { grep -m1 "^$1=" "$raw" | cut -d= -f2- || true; }
+          jq -n \
+            --arg mode "$MODE" \
+            --arg verdict "$(value verdict)" \
+            --arg exact_context "$(value exact_context)" \
+            --arg current_release "$(value current_release)" \
+            --arg current_sha "$(value current_sha)" \
+            --arg drupal_bootstrap "$(value drupal_bootstrap)" \
+            --arg maintenance_mode "$(value maintenance_mode)" \
+            --arg active_deploy_processes "$(value active_deploy_processes)" \
+            --arg release_mode_before "$(value release_mode_before)" \
+            --arg web_mode_before "$(value web_mode_before)" \
+            --arg index_mode_before "$(value index_mode_before)" \
+            --arg robots_mode_before "$(value robots_mode_before)" \
+            --arg release_mode_after "$(value release_mode_after)" \
+            --arg web_mode_after "$(value web_mode_after)" \
+            --arg index_mode_after "$(value index_mode_after)" \
+            --arg robots_mode_after "$(value robots_mode_after)" \
+            --arg settings_target_unchanged "$(value settings_target_unchanged)" \
+            --arg files_target_unchanged "$(value files_target_unchanged)" \
+            --arg local_robots_before "$(value local_robots_before)" \
+            --arg local_root_before "$(value local_root_before)" \
+            --arg local_robots_after "$(value local_robots_after)" \
+            --arg local_root_after "$(value local_root_after)" \
+            --arg public_fr_after "$(value public_fr_after)" \
+            --arg public_en_after "$(value public_en_after)" \
+            --arg backup_manifest "$(value backup_manifest)" \
+            '{schema_version:1,mode:$mode,verdict:$verdict,exact_context:$exact_context,current_release:$current_release,current_sha:$current_sha,drupal_bootstrap:$drupal_bootstrap,maintenance_mode:$maintenance_mode,active_deploy_processes:$active_deploy_processes,permissions:{release_before:$release_mode_before,web_before:$web_mode_before,index_before:$index_mode_before,robots_before:$robots_mode_before,release_after:$release_mode_after,web_after:$web_mode_after,index_after:$index_mode_after,robots_after:$robots_mode_after},shared_targets:{settings_unchanged:$settings_target_unchanged,files_unchanged:$files_target_unchanged},http:{local_robots_before:$local_robots_before,local_root_before:$local_root_before,local_robots_after:$local_robots_after,local_root_after:$local_root_after,public_fr_after:$public_fr_after,public_en_after:$public_en_after},backup_manifest:$backup_manifest}' \
+            > artifacts/runtime-permissions/result.json
+
+      - name: Upload recovery evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-permissions-678-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/runtime-permissions
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          RECOVERY_OUTCOME: ${{ steps.recovery.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/runtime-permissions/result.json'
+          [[ -s "$result" ]] && jq -e . "$result" >/dev/null
+          field() { jq -r "$1 // \"unknown\"" "$result"; }
+          artifact="agency-production-permissions-678-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency production permissions $(field '.mode') $(field '.verdict')
+
+          trusted_main: \`${TRUSTED_MAIN}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${RECOVERY_OUTCOME:-unknown}\`
+          production_current_sha: \`$(field '.current_sha')\`
+          current_release: \`$(field '.current_release')\`
+          drupal_bootstrap: \`$(field '.drupal_bootstrap')\`
+          maintenance_mode: \`$(field '.maintenance_mode')\`
+          active_deploy_processes: \`$(field '.active_deploy_processes')\`
+          release_mode: \`$(field '.permissions.release_before') -> $(field '.permissions.release_after')\`
+          web_mode: \`$(field '.permissions.web_before') -> $(field '.permissions.web_after')\`
+          index_mode: \`$(field '.permissions.index_before') -> $(field '.permissions.index_after')\`
+          robots_mode: \`$(field '.permissions.robots_before') -> $(field '.permissions.robots_after')\`
+          shared_settings_unchanged: \`$(field '.shared_targets.settings_unchanged')\`
+          shared_files_unchanged: \`$(field '.shared_targets.files_unchanged')\`
+          local_robots: \`$(field '.http.local_robots_before') -> $(field '.http.local_robots_after')\`
+          local_root: \`$(field '.http.local_root_before') -> $(field '.http.local_root_after')\`
+          public_fr_after: \`$(field '.http.public_fr_after')\`
+          public_en_after: \`$(field '.http.public_en_after')\`
+          backup_manifest: \`$(field '.backup_manifest')\`
+          artifact: \`${artifact}\`
+
+          Recovery is restricted to the exact production release and only adds runtime read/traverse permissions to the release root, vendor and web. Shared settings/files targets are not modified; no sudo, restart, deploy or Drupal/database mutation is performed.
+          EOF_BODY
+          )"
+          gh issue comment 678 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionRuntimePermissionsRecoveryWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionRuntimePermissionsRecoveryWorkflowTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded production runtime permission recovery.
+ *
+ * @group agency_project_tests
+ * @group production_runtime_permissions_recovery
+ */
+final class ProductionRuntimePermissionsRecoveryWorkflowTest extends TestCase {
+
+  /**
+   * The recovery surface is restricted to the owner and issue #678.
+   */
+  public function testControlSurfaceIsPinned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      '/agency-production-permissions preflight',
+      '/agency-production-permissions apply',
+      'github.event.issue.number == 678',
+      "github.actor == 'E-merging-digital'",
+      "ISSUE_NUMBER\" == '678'",
+      'currently on live main',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('github.event.inputs', $workflow);
+  }
+
+  /**
+   * Recovery is pinned to the already-proven release and production SHA.
+   */
+  public function testProductionIdentityIsExact(): void {
+    $workflow = $this->workflow();
+
+    self::assertStringContainsString(
+      "EXPECTED_RELEASE='/var/www/agency/releases/20260822135335'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "EXPECTED_SHA='9188a2ebd6516a738be6df6f854794d41889aa90'",
+      $workflow,
+    );
+    self::assertStringContainsString("$maintenance\" == '0'", $workflow);
+    self::assertStringContainsString("$deploy_count\" == '0'", $workflow);
+  }
+
+  /**
+   * Only runtime code permissions may be broadened during apply.
+   */
+  public function testApplyIsPermissionOnlyAndDoesNotFollowSharedSymlinks(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'chmod a+rx "$release"',
+      'find "$release/vendor" "$release/web" -xdev -type d -exec chmod a+rx {} +',
+      'find "$release/vendor" "$release/web" -xdev -type f -exec chmod a+r {} +',
+      "EXPECTED_SETTINGS='/var/www/agency/shared/settings/settings.php'",
+      "EXPECTED_FILES='/var/www/agency/shared/files'",
+      'settings_target_unchanged',
+      'files_target_unchanged',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'sudo ',
+      'systemctl restart',
+      'systemctl reload',
+      'nginx -s reload',
+      'chown ',
+      'chgrp ',
+      'setfacl ',
+      'drush cr',
+      'drush cim',
+      'drush updb',
+      'state:set',
+      'config:set',
+      'deploy-production.sh main',
+      'chmod -R',
+      'find -L',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+
+    self::assertStringNotContainsString(
+      'chmod a+r "$EXPECTED_SETTINGS"',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      'chmod a+r "$EXPECTED_FILES"',
+      $workflow,
+    );
+  }
+
+  /**
+   * Apply must save permission evidence before the first production chmod.
+   */
+  public function testPermissionManifestPrecedesMutation(): void {
+    $workflow = $this->workflow();
+    $manifest = strpos($workflow, 'backup_manifest="$BACKUPS/issue678-permissions-$timestamp.tsv"');
+    $manifestWrite = strpos($workflow, '} > "$backup_manifest"');
+    $firstMutation = strpos($workflow, 'chmod a+rx "$release"');
+
+    self::assertIsInt($manifest);
+    self::assertIsInt($manifestWrite);
+    self::assertIsInt($firstMutation);
+    self::assertLessThan($manifestWrite, $firstMutation);
+    self::assertLessThan($firstMutation, strpos($workflow, 'local_robots_after="$(http_local'));
+  }
+
+  /**
+   * Success requires local and public HTTP recovery evidence.
+   */
+  public function testSuccessRequiresHttpAndSharedTargetEvidence(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'local_robots_after',
+      'local_root_after',
+      'public_fr_after',
+      'public_en_after',
+      '$settings_before" == "$settings_after',
+      '$files_before" == "$files_after',
+      "verdict='PASS'",
+      'agency-production-permissions-678-',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+  }
+
+  /**
+   * Loads and parses the workflow under test.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-production-runtime-permissions-recovery.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionRuntimePermissionsRecoveryWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionRuntimePermissionsRecoveryWorkflowTest.php
@@ -50,8 +50,8 @@ final class ProductionRuntimePermissionsRecoveryWorkflowTest extends TestCase {
       "EXPECTED_SHA='9188a2ebd6516a738be6df6f854794d41889aa90'",
       $workflow,
     );
-    self::assertStringContainsString("$maintenance\" == '0'", $workflow);
-    self::assertStringContainsString("$deploy_count\" == '0'", $workflow);
+    self::assertStringContainsString('$maintenance" == \'0\'', $workflow);
+    self::assertStringContainsString('$deploy_count" == \'0\'', $workflow);
   }
 
   /**
@@ -110,12 +110,15 @@ final class ProductionRuntimePermissionsRecoveryWorkflowTest extends TestCase {
     $manifest = strpos($workflow, 'backup_manifest="$BACKUPS/issue678-permissions-$timestamp.tsv"');
     $manifestWrite = strpos($workflow, '} > "$backup_manifest"');
     $firstMutation = strpos($workflow, 'chmod a+rx "$release"');
+    $postProbe = strpos($workflow, 'local_robots_after="$(http_local');
 
     self::assertIsInt($manifest);
     self::assertIsInt($manifestWrite);
     self::assertIsInt($firstMutation);
-    self::assertLessThan($manifestWrite, $firstMutation);
-    self::assertLessThan($firstMutation, strpos($workflow, 'local_robots_after="$(http_local'));
+    self::assertIsInt($postProbe);
+    self::assertLessThan($manifestWrite, $manifest);
+    self::assertLessThan($firstMutation, $manifestWrite);
+    self::assertLessThan($postProbe, $firstMutation);
   }
 
   /**


### PR DESCRIPTION
## Résumé

Ajoute une recovery production strictement bornée pour restaurer les droits de lecture/traversée de la release courante prouvée en 700/600 par #676.

## Sécurité

- owner-only ;
- issue #678 uniquement ;
- live-main-only ;
- release exacte `/var/www/agency/releases/20260822135335` ;
- SHA prod exact `9188a2ebd6516a738be6df6f854794d41889aa90` ;
- aucun sudo ;
- aucun restart/reload ;
- aucun deploy complet ;
- aucune mutation Drupal/DB ;
- aucun `drush cr` ;
- les symlinks partagés ne sont pas suivis ;
- manifeste de modes avant mutation.

L'apply ne fait qu'ajouter les droits runtime nécessaires sur la racine de release, `vendor/` et `web/`, puis exige des preuves HTTP locales et publiques <400.

Refs #678 #676 #674 #660 #590.