### PR TITLE
Issue #680: harden deploy runtime permissions

### DIFF
--- a/docs/operations/production-runtime-permissions.md
+++ b/docs/operations/production-runtime-permissions.md
@@ -1,0 +1,50 @@
+# Production runtime permissions
+
+## Invariant
+
+Nginx and PHP-FPM run as an unprivileged web runtime (`www-data` on the current production host). A release under `/var/www/agency/releases/<timestamp>` must therefore remain readable and traversable by that runtime before `/var/www/agency/current` is switched to it.
+
+The deployment script enforces this independently of the caller's inherited shell configuration:
+
+- `umask 022` is set at script startup;
+- the release root is made readable/traversable;
+- directories under `vendor/` and `web/` are made readable/traversable;
+- files under `vendor/` and `web/` are made readable;
+- `web/index.php` and `web/robots.txt` are checked before the atomic `current` switch;
+- the deploy fails closed before the switch if these runtime invariants are not met.
+
+The normalization uses `find` without `-L`. It must not follow the persistent symlinks under `web/sites/default`.
+
+## Shared paths are separate
+
+Runtime-code permissions and shared-data permissions are intentionally different concerns.
+
+The deploy must not apply the release normalization recursively to the targets of:
+
+- `/var/www/agency/current/web/sites/default/settings.php` -> `/var/www/agency/shared/settings/settings.php`;
+- `/var/www/agency/current/web/sites/default/files` -> `/var/www/agency/shared/files`.
+
+`shared/files` keeps its dedicated `deploy:www-data`, group-write and setgid policy in `scripts/deploy-production.sh`. Production settings remain managed separately and must never be made public merely to satisfy release-code readability.
+
+## Incident reference — 23 August 2026
+
+The release `/var/www/agency/releases/20260822135335` was observed with directories `700 deploy:deploy` and files `600 deploy:deploy` while Nginx/PHP-FPM ran as `www-data`. Nginx consequently returned `403` for `robots.txt` and Drupal HTTP routes returned `404`, although Drupal CLI, the route provider and the published content were healthy.
+
+Issue #678 restored only the required runtime read/traverse permissions, producing:
+
+- release root: `700 -> 755`;
+- `web/`: `700 -> 755`;
+- `web/index.php`: `600 -> 644`;
+- `web/robots.txt`: `600 -> 644`;
+- local `robots.txt`: `403 -> 200`;
+- public FR/EN article URLs: `200`.
+
+The pre-change permission manifest is stored outside Git at:
+
+`/var/www/agency/shared/backups/issue678-permissions-20260823100645.tsv`
+
+Follow-up health, Browser Validation and database diagnostics all passed. See #676, #678, #590, #401, #658 and #680.
+
+## Operator check
+
+If a future release unexpectedly returns HTTP 403/404 while Drupal CLI still boots, compare the Nginx docroot and release traversal permissions before restarting services or modifying Drupal. A release mode of `700` or runtime files at `600` owned only by `deploy` is incompatible with an unprivileged `www-data` web runtime unless an equivalent ACL/group policy is deliberately configured.

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+umask 022
 
 BRANCH="${1:-main}"
 EXPECTED_SHA="${2:-}"
@@ -7,7 +8,7 @@ TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 
 PROJECT_ROOT="/var/www/agency"
 RELEASES_DIR="/var/www/agency/releases"
-SHARED_DIR="/var/www/agency/shared"
+SHARED_DIR="$PROJECT_ROOT/shared"
 BACKUPS_DIR="$SHARED_DIR/backups"
 LOG_FILE="$SHARED_DIR/deployments.log"
 REPO_URL="${REPO_URL:-git@github.com:E-merging-digital/agency-website-drupal.git}"
@@ -79,6 +80,68 @@ fail_trap() {
 }
 
 trap 'fail_trap $LINENO' ERR
+
+runtime_other_digit() {
+  local mode
+  mode="$(stat -c '%a' "$1")"
+  printf '%s\n' "${mode: -1}"
+}
+
+assert_runtime_directory_accessible() {
+  local path="$1"
+  local other
+  other="$(runtime_other_digit "$path")"
+  if (( (10#$other & 5) != 5 )); then
+    log "ERROR: Runtime directory is not readable/traversable by the web runtime: ${path} (mode $(stat -c '%a' "$path"))."
+    exit 1
+  fi
+}
+
+assert_runtime_file_readable() {
+  local path="$1"
+  local other
+  other="$(runtime_other_digit "$path")"
+  if (( (10#$other & 4) == 0 )); then
+    log "ERROR: Runtime file is not readable by the web runtime: ${path} (mode $(stat -c '%a' "$path"))."
+    exit 1
+  fi
+}
+
+verify_runtime_permissions() {
+  local path
+
+  for path in "$NEW_RELEASE" "$NEW_RELEASE/vendor" "$NEW_RELEASE/web"; do
+    if [[ ! -d "$path" ]]; then
+      log "ERROR: Required runtime directory is missing: ${path}."
+      exit 1
+    fi
+    assert_runtime_directory_accessible "$path"
+  done
+
+  for path in "$NEW_RELEASE/web/index.php" "$NEW_RELEASE/web/robots.txt"; do
+    if [[ ! -f "$path" ]]; then
+      log "ERROR: Required runtime file is missing: ${path}."
+      exit 1
+    fi
+    assert_runtime_file_readable "$path"
+  done
+}
+
+normalize_runtime_permissions() {
+  log "[deploy] Normalize runtime permissions"
+
+  if [[ ! -d "$NEW_RELEASE/vendor" || ! -d "$NEW_RELEASE/web" ]]; then
+    log "ERROR: Runtime directories must exist before permission normalization."
+    exit 1
+  fi
+
+  chmod a+rx "$NEW_RELEASE"
+  find "$NEW_RELEASE/vendor" "$NEW_RELEASE/web" -xdev -type d -exec chmod a+rx {} +
+  find "$NEW_RELEASE/vendor" "$NEW_RELEASE/web" -xdev -type f -exec chmod a+r {} +
+
+  verify_runtime_permissions
+  log "Runtime permissions are compatible with the unprivileged web runtime."
+}
 
 prepare_public_files() {
   log "[deploy] Public files symlink"
@@ -171,6 +234,7 @@ log "Repository prepared at exact commit ${GIT_COMMIT}."
 
 log "[deploy] Composer"
 composer --working-dir="$NEW_RELEASE" install --no-dev --optimize-autoloader
+normalize_runtime_permissions
 
 mkdir -p "$SHARED_DIR/private" "$SHARED_DIR/settings"
 prepare_public_files
@@ -222,6 +286,7 @@ if [[ -x "$NEW_RELEASE/vendor/bin/drush" ]]; then
 fi
 
 test "$(git -C "$NEW_RELEASE" rev-parse HEAD)" = "$EXPECTED_SHA"
+verify_runtime_permissions
 
 log "[deploy] Switch release"
 ln -sfn "$NEW_RELEASE" "$CURRENT_LINK"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployRuntimePermissionsTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeployRuntimePermissionsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects production deploy runtime permission invariants.
+ *
+ * @group agency_project_tests
+ * @group production_deploy_runtime_permissions
+ */
+final class ProductionDeployRuntimePermissionsTest extends TestCase {
+
+  /**
+   * The deploy must neutralize a restrictive inherited umask before writes.
+   */
+  public function testUmaskIsSetBeforeReleaseCreation(): void {
+    $script = $this->script();
+    $strict = strpos($script, 'set -Eeuo pipefail');
+    $umask = strpos($script, 'umask 022');
+    $releaseCreation = strpos($script, 'mkdir -p "$NEW_RELEASE"');
+
+    self::assertIsInt($strict);
+    self::assertIsInt($umask);
+    self::assertIsInt($releaseCreation);
+    self::assertTrue($strict < $umask);
+    self::assertTrue($umask < $releaseCreation);
+  }
+
+  /**
+   * Runtime code is normalized without following shared symlinks.
+   */
+  public function testRuntimeNormalizationIsBounded(): void {
+    $script = $this->script();
+
+    foreach ([
+      'normalize_runtime_permissions()',
+      'chmod a+rx "$NEW_RELEASE"',
+      'find "$NEW_RELEASE/vendor" "$NEW_RELEASE/web" -xdev -type d -exec chmod a+rx {} +',
+      'find "$NEW_RELEASE/vendor" "$NEW_RELEASE/web" -xdev -type f -exec chmod a+r {} +',
+      'assert_runtime_directory_accessible',
+      'assert_runtime_file_readable',
+      '"$NEW_RELEASE/web/index.php" "$NEW_RELEASE/web/robots.txt"',
+    ] as $required) {
+      self::assertStringContainsString($required, $script);
+    }
+
+    self::assertStringNotContainsString('find -L', $script);
+    self::assertStringNotContainsString('chmod -R a+r', $script);
+    self::assertStringNotContainsString('chmod -R a+rx', $script);
+  }
+
+  /**
+   * Normalization and a final verification must happen before current switches.
+   */
+  public function testRuntimePermissionsAreVerifiedBeforeSwitch(): void {
+    $script = $this->script();
+    $composer = strpos(
+      $script,
+      'composer --working-dir="$NEW_RELEASE" install --no-dev --optimize-autoloader',
+    );
+    $normalize = strpos($script, "normalize_runtime_permissions\n", $composer ?: 0);
+    $publicFiles = strpos($script, "prepare_public_files\n", $normalize ?: 0);
+    $finalVerify = strpos($script, "verify_runtime_permissions\n", $publicFiles ?: 0);
+    $switch = strpos($script, 'log "[deploy] Switch release"');
+
+    self::assertIsInt($composer);
+    self::assertIsInt($normalize);
+    self::assertIsInt($publicFiles);
+    self::assertIsInt($finalVerify);
+    self::assertIsInt($switch);
+    self::assertTrue($composer < $normalize);
+    self::assertTrue($normalize < $publicFiles);
+    self::assertTrue($publicFiles < $finalVerify);
+    self::assertTrue($finalVerify < $switch);
+  }
+
+  /**
+   * Existing shared-files ownership and group-write handling stays explicit.
+   */
+  public function testSharedFilesPolicyRemainsSeparate(): void {
+    $script = $this->script();
+
+    foreach ([
+      'SHARED_FILES_DIR="$SHARED_DIR/files"',
+      'RELEASE_FILES_LINK="$NEW_RELEASE/web/sites/default/files"',
+      'chgrp www-data "$SHARED_FILES_DIR"',
+      'chmod ug+rwX "$SHARED_FILES_DIR"',
+      'chmod g+s "$SHARED_FILES_DIR"',
+      'ln -sfn "$SHARED_DIR/settings/settings.php" "$NEW_RELEASE/web/sites/default/settings.php"',
+    ] as $required) {
+      self::assertStringContainsString($required, $script);
+    }
+  }
+
+  /**
+   * Loads the production deploy script.
+   */
+  private function script(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/deploy-production.sh';
+
+    self::assertFileExists($path);
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
## Résumé

Empêche une future release d'être activée avec les permissions 700/600 qui ont rendu la production inaccessible le 23 août 2026.

## Changements

- `umask 022` explicite dès l'entrée de `scripts/deploy-production.sh` ;
- normalisation bornée de la racine de release, `vendor/` et `web/` après Composer ;
- `find` sans suivi des symlinks ;
- vérification fail-closed des droits runtime, notamment `web/index.php` et `web/robots.txt`, avant le switch de `current` ;
- politique `shared/files` conservée séparément ;
- test de contrat dédié ;
- documentation opérationnelle de l'invariant et de l'incident.

Aucun déploiement production n'est exécuté par cette PR.

Closes #680
Refs #678 #676 #660 #590.