### PR TITLE
Issue #684: classify configuration language EN migration dry-run

### DIFF
--- a/.github/workflows/trusted-configuration-language-migration-dry-run.yml
+++ b/.github/workflows/trusted-configuration-language-migration-dry-run.yml
@@ -1,0 +1,285 @@
+name: Agency trusted configuration language migration dry-run
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate configuration language migration request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-migration classify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '684' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-migration classify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Migration dry-run must execute the workflow revision on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  classify:
+    name: Rebuild Drupal and classify EN migration dry-run
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      snapshot_sha256: ${{ steps.summary.outputs.snapshot_sha256 }}
+      fr_with_en: ${{ steps.summary.outputs.fr_with_en }}
+      fr_without_en: ${{ steps.summary.outputs.fr_without_en }}
+      technical: ${{ steps.summary.outputs.technical }}
+      review_required: ${{ steps.summary.outputs.review_required }}
+      unknown: ${{ steps.summary.outputs.unknown }}
+      canvas: ${{ steps.summary.outputs.canvas }}
+      language_content_settings: ${{ steps.summary.outputs.language_content_settings }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable dry-run implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f AGENTS.md
+          test -f .ddev/config.yaml
+          test -f docs/configuration-language-policy.yml
+          test -f docs/evidence/configuration-language-baseline-609.yml
+          test -f scripts/runner/run-configuration-language-audit.sh
+          test -f scripts/runner/configuration-language-audit.php
+          test -f scripts/runner/run-configuration-language-migration-dry-run.sh
+          test -f scripts/runner/configuration-language-migration-dry-run.php
+          bash -n scripts/runner/run-configuration-language-migration-dry-run.sh
+          git diff --check
+
+      - name: Isolate DDEV project for this dry-run
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-migration-ci.yaml <<EOF
+          name: agency-config-language-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml | grep -F "agency-config-language-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-migration-dry-run.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Classify bounded read-only EN migration dry-run
+        id: route
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-migration-dry-run
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-migration-dry-run.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-migration-dry-run/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          snapshot_sha256='n/a'
+          fr_with_en='0'
+          fr_without_en='0'
+          technical='0'
+          review_required='0'
+          unknown='0'
+          canvas='0'
+          language_content_settings='0'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            snapshot_sha256="$(jq -r '.baseline.current_snapshot_sha256 // "n/a"' "$result")"
+            fr_with_en="$(jq -r '.counts.fr_base_with_en_override // 0' "$result")"
+            fr_without_en="$(jq -r '.counts.fr_base_without_en_override // 0' "$result")"
+            technical="$(jq -r '.counts.technical_candidate_without_en_override // 0' "$result")"
+            review_required="$(jq -r '.counts.editorial_or_semantic_review_required // 0' "$result")"
+            unknown="$(jq -r '.counts.unknown // 0' "$result")"
+            canvas="$(jq -r '.focus.canvas.count // 0' "$result")"
+            language_content_settings="$(jq -r '.focus.language_content_settings.count // 0' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "snapshot_sha256=$snapshot_sha256" >> "$GITHUB_OUTPUT"
+          echo "fr_with_en=$fr_with_en" >> "$GITHUB_OUTPUT"
+          echo "fr_without_en=$fr_without_en" >> "$GITHUB_OUTPUT"
+          echo "technical=$technical" >> "$GITHUB_OUTPUT"
+          echo "review_required=$review_required" >> "$GITHUB_OUTPUT"
+          echo "unknown=$unknown" >> "$GITHUB_OUTPUT"
+          echo "canvas=$canvas" >> "$GITHUB_OUTPUT"
+          echo "language_content_settings=$language_content_settings" >> "$GITHUB_OUTPUT"
+
+      - name: Upload migration dry-run evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-migration-684-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-migration-dry-run
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-migration-ci.yaml
+          rm -rf artifacts/configuration-language-audit
+          rm -rf artifacts/configuration-language-migration-dry-run
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish bounded configuration language migration result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - classify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment dry-run result on #684
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.classify.result }}
+          STATUS: ${{ needs.classify.outputs.status }}
+          VERDICT: ${{ needs.classify.outputs.verdict }}
+          SNAPSHOT_SHA256: ${{ needs.classify.outputs.snapshot_sha256 }}
+          FR_WITH_EN: ${{ needs.classify.outputs.fr_with_en }}
+          FR_WITHOUT_EN: ${{ needs.classify.outputs.fr_without_en }}
+          TECHNICAL: ${{ needs.classify.outputs.technical }}
+          REVIEW_REQUIRED: ${{ needs.classify.outputs.review_required }}
+          UNKNOWN: ${{ needs.classify.outputs.unknown }}
+          CANVAS: ${{ needs.classify.outputs.canvas }}
+          LANGUAGE_CONTENT_SETTINGS: ${{ needs.classify.outputs.language_content_settings }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration language migration dry-run FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration language migration dry-run PASS'
+          fi
+
+          artifact="agency-config-language-migration-684-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          snapshot_sha256: \`${SNAPSHOT_SHA256:-n/a}\`
+          fr_base_with_en_override: \`${FR_WITH_EN:-0}\`
+          fr_base_without_en_override: \`${FR_WITHOUT_EN:-0}\`
+          technical_candidate_without_en_override: \`${TECHNICAL:-0}\`
+          editorial_or_semantic_review_required: \`${REVIEW_REQUIRED:-0}\`
+          unknown: \`${UNKNOWN:-0}\`
+          canvas_without_en_override: \`${CANVAS:-0}\`
+          language_content_settings_without_en_override: \`${LANGUAGE_CONTENT_SETTINGS:-0}\`
+          artifact: \`${artifact}\`
+
+          Read-only fresh-DDEV classification only. This proof does not enable Configuration Language Lock, export configuration, rewrite langcodes or access production.
+          EOF_BODY
+          )"
+          gh issue comment 684 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/configuration-language-migration-dry-run.php
+++ b/scripts/runner/configuration-language-migration-dry-run.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(__DIR__, 2);
+require $projectRoot . '/vendor/autoload.php';
+
+$snapshotPath = $projectRoot . '/artifacts/configuration-language-audit/snapshot.json';
+$baselinePath = $projectRoot . '/docs/evidence/configuration-language-baseline-609.yml';
+$configDirectory = $projectRoot . '/config/sync';
+
+if (!is_file($snapshotPath) || !is_file($baselinePath) || !is_dir($configDirectory)) {
+  throw new RuntimeException('Required configuration-language evidence is missing.');
+}
+
+$snapshotRaw = file_get_contents($snapshotPath);
+if ($snapshotRaw === FALSE) {
+  throw new RuntimeException('Unable to read configuration-language snapshot.');
+}
+$snapshot = json_decode($snapshotRaw, TRUE, 512, JSON_THROW_ON_ERROR);
+$baseline = Yaml::parseFile($baselinePath);
+if (!is_array($snapshot) || !is_array($baseline)) {
+  throw new RuntimeException('Configuration-language evidence must be structured data.');
+}
+
+if (($snapshot['schema_version'] ?? NULL) !== 1) {
+  throw new RuntimeException('Unexpected snapshot schema.');
+}
+if (($snapshot['policy']['policy_id'] ?? NULL) !== 'agency-configuration-language-v1') {
+  throw new RuntimeException('Unexpected configuration-language policy.');
+}
+if (($snapshot['policy']['status'] ?? NULL) !== 'migration_required') {
+  throw new RuntimeException('Migration dry-run requires migration_required policy state.');
+}
+if (($snapshot['policy']['canonical_configuration_language'] ?? NULL) !== 'en') {
+  throw new RuntimeException('Migration dry-run expects canonical language en.');
+}
+if (($snapshot['policy']['enforce_consistency'] ?? TRUE) !== FALSE) {
+  throw new RuntimeException('Migration dry-run must precede enforcement.');
+}
+if (($baseline['baseline_id'] ?? NULL) !== 'agency-config-language-609-pre-migration-v1') {
+  throw new RuntimeException('Unexpected durable baseline.');
+}
+
+$expectedSnapshotSha = (string) ($baseline['source']['snapshot_sha256'] ?? '');
+$currentSnapshotSha = hash('sha256', $snapshotRaw);
+$expectedFrWithoutEn = (int) ($baseline['migration_analysis']['fr_base_without_en_override'] ?? -1);
+$expectedFrWithEn = (int) ($baseline['migration_analysis']['fr_base_with_en_override'] ?? -1);
+$baselineMatch = $expectedSnapshotSha !== '' && hash_equals($expectedSnapshotSha, $currentSnapshotSha);
+
+$entries = $snapshot['repository']['entries'] ?? NULL;
+$translations = $snapshot['translations'] ?? NULL;
+if (!is_array($entries) || !is_array($translations)) {
+  throw new RuntimeException('Snapshot repository entries or translations are missing.');
+}
+
+$enOverrides = [];
+foreach ($translations as $translation) {
+  if (!is_array($translation) || ($translation['language'] ?? NULL) !== 'en') {
+    continue;
+  }
+  foreach (($translation['config_names'] ?? []) as $configName) {
+    if (is_string($configName) && $configName !== '') {
+      $enOverrides[$configName] = TRUE;
+    }
+  }
+}
+
+$technicalEntityTypes = [
+  'entity_form_display' => TRUE,
+  'entity_view_display' => TRUE,
+  'field_storage_config' => TRUE,
+  'language_content_settings' => TRUE,
+];
+$specialConfigNames = [
+  'language.entity.und' => TRUE,
+  'language.entity.zxx' => TRUE,
+  'system.menu.footer' => TRUE,
+];
+
+$categories = [
+  'translation_override_present' => [],
+  'technical_candidate_without_en_override' => [],
+  'editorial_or_semantic_review_required' => [],
+  'locked_or_special_preserve' => [],
+  'unknown' => [],
+];
+$frWithoutEn = [];
+$byEntityTypeWithoutEn = [];
+
+foreach ($entries as $entry) {
+  if (!is_array($entry)) {
+    $categories['unknown'][] = ['reason' => 'entry_not_mapping'];
+    continue;
+  }
+
+  $name = $entry['name'] ?? NULL;
+  $langcode = $entry['langcode'] ?? NULL;
+  $kind = $entry['kind'] ?? NULL;
+  $entityType = $entry['entity_type'] ?? NULL;
+  if (!is_string($name) || $name === '' || !is_string($langcode) || !is_string($kind)) {
+    $categories['unknown'][] = [
+      'name' => is_string($name) ? $name : NULL,
+      'reason' => 'invalid_entry_shape',
+    ];
+    continue;
+  }
+
+  $summary = [
+    'name' => $name,
+    'langcode' => $langcode,
+    'kind' => $kind,
+    'entity_type' => is_string($entityType) ? $entityType : NULL,
+  ];
+
+  if (isset($specialConfigNames[$name]) || in_array($langcode, ['und', 'zxx'], TRUE)) {
+    $categories['locked_or_special_preserve'][] = $summary;
+    continue;
+  }
+  if ($langcode !== 'fr') {
+    continue;
+  }
+  if (isset($enOverrides[$name])) {
+    $categories['translation_override_present'][] = $summary;
+    continue;
+  }
+
+  $frWithoutEn[] = $summary;
+  $entityTypeKey = is_string($entityType) && $entityType !== '' ? $entityType : 'simple_config';
+  $byEntityTypeWithoutEn[$entityTypeKey] = ($byEntityTypeWithoutEn[$entityTypeKey] ?? 0) + 1;
+
+  if (is_string($entityType) && isset($technicalEntityTypes[$entityType])) {
+    $categories['technical_candidate_without_en_override'][] = $summary;
+    continue;
+  }
+
+  // Conservative default: configurations carrying labels, editorial semantics,
+  // or unknown user-facing values require explicit review rather than being
+  // silently promoted to an English source language.
+  $categories['editorial_or_semantic_review_required'][] = $summary;
+}
+
+foreach ($categories as &$categoryEntries) {
+  usort(
+    $categoryEntries,
+    static fn(array $left, array $right): int => ($left['name'] ?? '') <=> ($right['name'] ?? ''),
+  );
+}
+unset($categoryEntries);
+ksort($byEntityTypeWithoutEn);
+
+$specialChecks = [];
+foreach (['und', 'zxx'] as $lockedId) {
+  $path = $configDirectory . '/language.entity.' . $lockedId . '.yml';
+  $data = is_file($path) ? Yaml::parseFile($path) : NULL;
+  $specialChecks['language.entity.' . $lockedId] = [
+    'exists' => is_file($path),
+    'id_preserved' => is_array($data) && ($data['id'] ?? NULL) === $lockedId,
+  ];
+}
+$footerPath = $configDirectory . '/system.menu.footer.yml';
+$footer = is_file($footerPath) ? Yaml::parseFile($footerPath) : NULL;
+$specialChecks['system.menu.footer'] = [
+  'exists' => is_file($footerPath),
+  'langcode_preserved' => is_array($footer) && ($footer['langcode'] ?? NULL) === 'und',
+];
+$specialChecksPass = TRUE;
+foreach ($specialChecks as $check) {
+  if (($check['exists'] ?? FALSE) !== TRUE) {
+    $specialChecksPass = FALSE;
+  }
+  foreach ($check as $key => $value) {
+    if ($key !== 'exists' && $value !== TRUE) {
+      $specialChecksPass = FALSE;
+    }
+  }
+}
+
+$frWithEnCount = count($categories['translation_override_present']);
+$frWithoutEnCount = count($frWithoutEn);
+$technicalCount = count($categories['technical_candidate_without_en_override']);
+$reviewCount = count($categories['editorial_or_semantic_review_required']);
+$unknownCount = count($categories['unknown']);
+$classifiedWithoutEn = $technicalCount + $reviewCount;
+
+$focus = [
+  'canvas' => array_values(array_filter(
+    $frWithoutEn,
+    static fn(array $entry): bool => str_starts_with((string) $entry['name'], 'canvas.'),
+  )),
+  'language_content_settings' => array_values(array_filter(
+    $frWithoutEn,
+    static fn(array $entry): bool => ($entry['entity_type'] ?? NULL) === 'language_content_settings',
+  )),
+  'fields_and_displays' => array_values(array_filter(
+    $frWithoutEn,
+    static fn(array $entry): bool => preg_match('/^(core\.(?:base_field_override|entity_form_display|entity_view_display)|field\.(?:field|storage))\./', (string) $entry['name']) === 1,
+  )),
+  'simple_config' => array_values(array_filter(
+    $frWithoutEn,
+    static fn(array $entry): bool => ($entry['kind'] ?? NULL) === 'simple_config',
+  )),
+];
+
+$status = 'PASS';
+$verdict = 'DRY_RUN_READY_FOR_TRANSFORMATION_TESTS';
+if (!$baselineMatch || $frWithoutEnCount !== $expectedFrWithoutEn || $frWithEnCount !== $expectedFrWithEn) {
+  $status = 'FAIL';
+  $verdict = 'BASELINE_DRIFT';
+}
+elseif (!$specialChecksPass) {
+  $status = 'FAIL';
+  $verdict = 'SPECIAL_LANGUAGE_INVARIANT_BROKEN';
+}
+elseif ($unknownCount > 0 || $classifiedWithoutEn !== $frWithoutEnCount) {
+  $status = 'FAIL';
+  $verdict = 'UNKNOWN_CLASSIFICATION';
+}
+elseif ($reviewCount > 0) {
+  $verdict = 'REVIEW_REQUIRED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'policy' => [
+    'policy_id' => $snapshot['policy']['policy_id'],
+    'status' => $snapshot['policy']['status'],
+    'canonical_configuration_language' => $snapshot['policy']['canonical_configuration_language'],
+    'enforce_consistency' => $snapshot['policy']['enforce_consistency'],
+  ],
+  'baseline' => [
+    'baseline_id' => $baseline['baseline_id'],
+    'expected_snapshot_sha256' => $expectedSnapshotSha,
+    'current_snapshot_sha256' => $currentSnapshotSha,
+    'match' => $baselineMatch,
+  ],
+  'counts' => [
+    'fr_base_total' => $frWithEnCount + $frWithoutEnCount,
+    'fr_base_with_en_override' => $frWithEnCount,
+    'fr_base_without_en_override' => $frWithoutEnCount,
+    'classified_fr_without_en_override' => $classifiedWithoutEn,
+    'technical_candidate_without_en_override' => $technicalCount,
+    'editorial_or_semantic_review_required' => $reviewCount,
+    'unknown' => $unknownCount,
+  ],
+  'fr_without_en_override_by_entity_type' => $byEntityTypeWithoutEn,
+  'categories' => array_map(
+    static fn(array $items): array => [
+      'count' => count($items),
+      'items' => $items,
+    ],
+    $categories,
+  ),
+  'focus' => array_map(
+    static fn(array $items): array => [
+      'count' => count($items),
+      'items' => $items,
+    ],
+    $focus,
+  ),
+  'special_invariants' => [
+    'pass' => $specialChecksPass,
+    'checks' => $specialChecks,
+  ],
+  'constraints' => [
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-migration-dry-run.sh
+++ b/scripts/runner/run-configuration-language-migration-dry-run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-migration-dry-run'
+AUDIT_REL='artifacts/configuration-language-audit'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+AUDIT_DIR="$TARGET_DIR/$AUDIT_REL"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+command -v sha256sum >/dev/null
+
+test -f docs/configuration-language-policy.yml
+test -f docs/evidence/configuration-language-baseline-609.yml
+test -f scripts/runner/run-configuration-language-audit.sh
+test -f scripts/runner/configuration-language-audit.php
+test -f scripts/runner/configuration-language-migration-dry-run.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l /var/www/html/scripts/runner/configuration-language-audit.php >/dev/null
+ddev exec php -l /var/www/html/scripts/runner/configuration-language-migration-dry-run.php >/dev/null
+git diff --check
+
+mkdir -p "$AUDIT_DIR"
+TARGET_DIR="$TARGET_DIR" \
+ARTIFACT_DIR="$AUDIT_DIR" \
+TRUSTED_MAIN="$TRUSTED_MAIN" \
+  bash scripts/runner/run-configuration-language-audit.sh
+
+jq -e '.status == "PASS" and .verdict == "SNAPSHOT_CAPTURED"' "$AUDIT_DIR/result.json" >/dev/null
+cp "$AUDIT_DIR/snapshot.json" "$ARTIFACT_DIR/baseline-snapshot.json"
+cp "$AUDIT_DIR/result.json" "$ARTIFACT_DIR/audit-result.json"
+
+ddev exec php /var/www/html/scripts/runner/configuration-language-migration-dry-run.php \
+  > "$ARTIFACT_DIR/classification.json"
+cp "$ARTIFACT_DIR/classification.json" "$ARTIFACT_DIR/result.json"
+
+jq -e '.schema_version == 1' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.status == "PASS"' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.baseline.match == true' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.counts.fr_base_with_en_override == 171' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.counts.fr_base_without_en_override == 181' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.counts.classified_fr_without_en_override == 181' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.counts.unknown == 0' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.categories.locked_or_special_preserve.count >= 3' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.special_invariants.pass == true' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.focus.canvas.count == 43' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.focus.language_content_settings.count == 14' "$ARTIFACT_DIR/result.json" >/dev/null
+
+config_status="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status"
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded configuration-language migration dry-run.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
+
+  /**
+   * The issue-comment gateway remains owner-bound and live-main-only.
+   */
+  public function testTrustedMigrationGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-migration-dry-run.yml',
+    );
+
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-migration classify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'684\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString(
+      'run-configuration-language-migration-dry-run.sh',
+      $workflow,
+    );
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('SSH_PRIVATE_KEY', $workflow);
+    self::assertStringNotContainsString('SERVER_HOST', $workflow);
+    self::assertStringNotContainsString('OPENAI_API_KEY', $workflow);
+    self::assertStringNotContainsString('composer require', $workflow);
+    self::assertStringNotContainsString('drush cex', $workflow);
+    self::assertStringNotContainsString('config:set', $workflow);
+  }
+
+  /**
+   * The runner must reuse the proven snapshot and leave configuration intact.
+   */
+  public function testDryRunReusesAuditAndDoesNotMutateConfig(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runner = (string) file_get_contents(
+      $root . '/scripts/runner/run-configuration-language-migration-dry-run.sh',
+    );
+
+    self::assertStringContainsString(
+      'run-configuration-language-audit.sh',
+      $runner,
+    );
+    self::assertStringContainsString(
+      'configuration-language-migration-dry-run.php',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.fr_base_without_en_override == 181',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.classified_fr_without_en_override == 181',
+      $runner,
+    );
+    self::assertStringContainsString('.counts.unknown == 0', $runner);
+    self::assertStringContainsString('.special_invariants.pass == true', $runner);
+    self::assertStringContainsString('git diff --exit-code -- config/sync', $runner);
+    self::assertStringContainsString('drush config:status', $runner);
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush cim',
+      'drush en',
+      'config:set',
+      'state:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+  }
+
+  /**
+   * Classification remains conservative and enforcement stays forbidden.
+   */
+  public function testClassifierFailsClosedAndProtectsSpecialLanguages(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $classifier = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-migration-dry-run.php',
+    );
+
+    foreach ([
+      "'entity_form_display' => TRUE",
+      "'entity_view_display' => TRUE",
+      "'field_storage_config' => TRUE",
+      "'language_content_settings' => TRUE",
+    ] as $technicalType) {
+      self::assertStringContainsString($technicalType, $classifier);
+    }
+
+    self::assertStringContainsString(
+      'editorial_or_semantic_review_required',
+      $classifier,
+    );
+    self::assertStringContainsString('UNKNOWN_CLASSIFICATION', $classifier);
+    self::assertStringContainsString('BASELINE_DRIFT', $classifier);
+    self::assertStringContainsString('REVIEW_REQUIRED', $classifier);
+    self::assertStringContainsString('language.entity.und', $classifier);
+    self::assertStringContainsString('language.entity.zxx', $classifier);
+    self::assertStringContainsString('system.menu.footer', $classifier);
+    self::assertStringContainsString(
+      "'bulk_langcode_replacement_allowed' => FALSE",
+      $classifier,
+    );
+    self::assertStringContainsString(
+      "'config_language_lock_activation_allowed_by_this_proof' => FALSE",
+      $classifier,
+    );
+
+    foreach (['->save(', 'config.factory', 'drush cex', 'drush en'] as $mutation) {
+      self::assertStringNotContainsString($mutation, $classifier);
+    }
+  }
+
+  /**
+   * The dry-run remains anchored to the durable #609 baseline.
+   */
+  public function testDryRunBaselineContractIsStillMigrationRequired(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $baseline = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-baseline-609.yml',
+    );
+
+    self::assertSame(
+      'agency-config-language-609-pre-migration-v1',
+      $baseline['baseline_id'] ?? NULL,
+    );
+    self::assertSame('migration_required', $baseline['policy_status'] ?? NULL);
+    self::assertSame(
+      171,
+      $baseline['migration_analysis']['fr_base_with_en_override'] ?? NULL,
+    );
+    self::assertSame(
+      181,
+      $baseline['migration_analysis']['fr_base_without_en_override'] ?? NULL,
+    );
+    self::assertFalse(
+      $baseline['classification']['bulk_langcode_replacement_allowed'] ?? TRUE,
+    );
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Unit;
 
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
@@ -24,7 +25,7 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
       $root . '/.github/workflows/trusted-configuration-language-migration-dry-run.yml',
     );
 
-    self::assertIsArray(Yaml::parse($workflow));
+    self::assertIsArray(DrupalYaml::decode($workflow));
     self::assertStringContainsString(
       "github.event.comment.body == '/agency-config-language-migration classify'",
       $workflow,

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
@@ -24,6 +24,7 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
       $root . '/.github/workflows/trusted-configuration-language-migration-dry-run.yml',
     );
 
+    self::assertIsArray(Yaml::parse($workflow));
     self::assertStringContainsString(
       "github.event.comment.body == '/agency-config-language-migration classify'",
       $workflow,
@@ -63,9 +64,8 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
    */
   public function testDryRunReusesAuditAndDoesNotMutateConfig(): void {
     $root = dirname(DRUPAL_ROOT);
-    $runner = (string) file_get_contents(
-      $root . '/scripts/runner/run-configuration-language-migration-dry-run.sh',
-    );
+    $runnerPath = $root . '/scripts/runner/run-configuration-language-migration-dry-run.sh';
+    $runner = (string) file_get_contents($runnerPath);
 
     self::assertStringContainsString(
       'run-configuration-language-audit.sh',
@@ -98,6 +98,11 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
     ] as $forbiddenMutation) {
       self::assertStringNotContainsString($forbiddenMutation, $runner);
     }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
   }
 
   /**
@@ -109,6 +114,7 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
       $root . '/scripts/runner/configuration-language-migration-dry-run.php',
     );
 
+    self::assertIsArray(token_get_all($classifier, TOKEN_PARSE));
     foreach ([
       "'entity_form_display' => TRUE",
       "'entity_view_display' => TRUE",


### PR DESCRIPTION
## Résumé

Cette PR ajoute la phase read-only suivante de #609 : classifier le dry-run de migration vers une langue canonique de configuration EN **sans activer Configuration Language Lock et sans modifier la configuration**.

## Implémentation

- nouvelle route trusted `/agency-config-language-migration classify`, bornée à l'issue #684, owner-only et live-main-only ;
- reconstruction DDEV fraîche depuis le HEAD trusted ;
- réutilisation du snapshot #609 via `run-configuration-language-audit.sh` ;
- comparaison stricte au baseline durable `agency-config-language-609-pre-migration-v1` ;
- classification conservative des bases FR : override EN existant, candidat technique, revue éditoriale/sémantique, spécial à préserver, unknown fail-closed ;
- invariants `language.entity.und`, `language.entity.zxx` et `system.menu.footer: und` vérifiés ;
- Canvas, `language.content_settings`, champs/displays et simple config exposés explicitement dans l'artifact ;
- preuve finale `config:status` + `git diff --exit-code -- config/sync` ;
- tests de contrat statiques.

## Limites intentionnelles

Cette PR n'autorise pas :

- `locked_langcode: en` ;
- activation persistée de `config_language_lock` ;
- `drush cex` ;
- normalisation YAML ;
- mutation production ;
- provider/secret IA.

Le verdict attendu du dry-run peut être `REVIEW_REQUIRED` tout en restant un PASS technique : cela signifie que la classification est complète mais que certaines configurations, notamment Canvas et les surfaces porteuses de labels/sémantique, doivent être revues avant toute transformation.

## Validation attendue

1. CI exact-head verte ;
2. merge de cette route non-mutante ;
3. une seule exécution trusted depuis #684 ;
4. inspection de l'artifact et du verdict ;
5. seulement ensuite décision de la phase suivante de #609.

Refs #684 #609 #608 #614 #628 #632 #412 #530.