### PR TITLE
Issue #686: correct Canvas dry-run focus invariant

### DIFF
--- a/scripts/runner/run-configuration-language-migration-dry-run.sh
+++ b/scripts/runner/run-configuration-language-migration-dry-run.sh
@@ -63,7 +63,7 @@ jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$ARTIFACT_DIR/r
 jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
 jq -e '.constraints.config_export_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
 jq -e '.constraints.production_mutation_allowed_by_this_proof == false' "$ARTIFACT_DIR/result.json" >/dev/null
-jq -e '.focus.canvas.count == 43' "$ARTIFACT_DIR/result.json" >/dev/null
+jq -e '.focus.canvas.count == 45' "$ARTIFACT_DIR/result.json" >/dev/null
 jq -e '.focus.language_content_settings.count == 14' "$ARTIFACT_DIR/result.json" >/dev/null
 
 config_status="$(ddev drush config:status 2>&1)"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMigrationDryRunWorkflowTest.php
@@ -86,6 +86,7 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
     );
     self::assertStringContainsString('.counts.unknown == 0', $runner);
     self::assertStringContainsString('.special_invariants.pass == true', $runner);
+    self::assertStringContainsString('.focus.canvas.count == 45', $runner);
     self::assertStringContainsString('git diff --exit-code -- config/sync', $runner);
     self::assertStringContainsString('drush config:status', $runner);
 
@@ -135,6 +136,7 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
     self::assertStringContainsString('language.entity.und', $classifier);
     self::assertStringContainsString('language.entity.zxx', $classifier);
     self::assertStringContainsString('system.menu.footer', $classifier);
+    self::assertStringContainsString("str_starts_with((string) \$entry['name'], 'canvas.')", $classifier);
     self::assertStringContainsString(
       "'bulk_langcode_replacement_allowed' => FALSE",
       $classifier,
@@ -174,6 +176,14 @@ final class ConfigurationLanguageMigrationDryRunWorkflowTest extends TestCase {
     self::assertFalse(
       $baseline['classification']['bulk_langcode_replacement_allowed'] ?? TRUE,
     );
+
+    $canvasComponents = (int) ($baseline['migration_analysis']['canvas']['fr_components_without_en_override'] ?? 0);
+    $canvasFolders = (int) ($baseline['migration_analysis']['canvas']['fr_folders_without_en_override'] ?? 0);
+    $canvasAssets = (int) ($baseline['migration_analysis']['fr_without_en_override_by_entity_type']['asset_library'] ?? 0);
+    $canvasBrandKits = (int) ($baseline['migration_analysis']['fr_without_en_override_by_entity_type']['brand_kit'] ?? 0);
+
+    self::assertSame(43, $canvasComponents + $canvasFolders);
+    self::assertSame(45, $canvasComponents + $canvasFolders + $canvasAssets + $canvasBrandKits);
   }
 
 }


### PR DESCRIPTION
## Résumé

Correction strictement bornée du harness introduit par #684 après la preuve trusted `32637652986`.

La classification est restée valide : snapshot #609 exact, 181/181 bases FR sans override EN classées, `unknown=0`, 41 candidats techniques, 140 cas de revue. Le run a échoué uniquement parce que le runner attendait `focus.canvas.count == 43`.

`43` est le sous-total historique 30 `canvas.component` + 13 `canvas.folder`. Le focus du classificateur couvre volontairement tout `canvas.*`, soit **45** avec `canvas.asset_library.global` et `canvas.brand_kit.global`.

## Changement

- assertion trusted corrigée de 43 à 45 ;
- test de contrat ajouté pour verrouiller explicitement :
  - components + folders = 43 ;
  - namespace complet `canvas.*` = 45.

## Non-changements

- aucune modification du classificateur ;
- aucune modification de `config/sync` ;
- aucune activation de Configuration Language Lock ;
- aucune mutation production ;
- aucune modification des comptes 171/181 ou du comportement fail-closed.

Après CI exact-head verte et merge, la preuve #684 sera relancée une seule fois comme recovery documentée du harness défectueux.

Refs #686 #684 #609 #608 #628 #412.