### PR TITLE
Issue #688: prove EN lock on native core configuration writes

### DIFF
--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
@@ -110,8 +110,8 @@ final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase
         'node.type.lock_action_probe',
         [
           [
-            'key' => 'description',
-            'value' => 'Updated by Drupal core Config Action',
+            'description',
+            'Updated by Drupal core Config Action',
           ],
         ],
       );

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
@@ -71,8 +71,7 @@ final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase
       $this->config('node.type.lock_direct_probe')->get('langcode'),
     );
     self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
-    self::assertSame(
-      FALSE,
+    self::assertFalse(
       $this->config('config_language_lock.settings')->get('follow_site_default'),
     );
   }
@@ -129,8 +128,7 @@ final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase
       'en',
       $this->config('config_language_lock.settings')->get('locked_langcode'),
     );
-    self::assertSame(
-      FALSE,
+    self::assertFalse(
       $this->config('config_language_lock.settings')->get('follow_site_default'),
     );
     self::assertSame('fr', $this->config('system.site')->get('default_langcode'));

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Proves Configuration Language Lock on native Drupal configuration writes.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+#[Group('configuration_language_governance')]
+final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'language',
+    'config_language_lock',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['system', 'config_language_lock']);
+
+    foreach (['fr', 'en'] as $langcode) {
+      if (ConfigurableLanguage::load($langcode) === NULL) {
+        ConfigurableLanguage::createFromLangcode($langcode)->save();
+      }
+    }
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    self::assertTrue(
+      $this->container->get('module_handler')->moduleExists('config_language_lock'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * A config entity explicitly created as FR is persisted as EN when locked.
+   */
+  public function testDirectConfigEntitySaveUsesLockedEnglishLanguage(): void {
+    $this->enableEnglishConfigurationLock();
+
+    NodeType::create([
+      'type' => 'lock_direct_probe',
+      'name' => 'Lock direct probe',
+      'description' => 'Created with an explicit French configuration language.',
+      'langcode' => 'fr',
+    ])->save();
+
+    self::assertSame(
+      'en',
+      $this->config('node.type.lock_direct_probe')->get('langcode'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+    self::assertSame(
+      FALSE,
+      $this->config('config_language_lock.settings')->get('follow_site_default'),
+    );
+  }
+
+  /**
+   * A core Config Action save normalizes a pre-existing FR config entity to EN.
+   */
+  public function testConfigActionSaveUsesLockedEnglishLanguage(): void {
+    NodeType::create([
+      'type' => 'lock_action_probe',
+      'name' => 'Lock action probe',
+      'description' => 'Before Config Action',
+      'langcode' => 'fr',
+    ])->save();
+
+    self::assertSame(
+      'fr',
+      $this->config('node.type.lock_action_probe')->get('langcode'),
+    );
+
+    $this->enableEnglishConfigurationLock();
+
+    // Setting the lock must not silently rewrite existing configuration. The
+    // normalization under test must be caused by the native Config Action save.
+    self::assertSame(
+      'fr',
+      $this->config('node.type.lock_action_probe')->get('langcode'),
+    );
+
+    $this->container
+      ->get('plugin.manager.config_action')
+      ->applyAction(
+        'setDescription',
+        'node.type.lock_action_probe',
+        'Updated by Drupal core Config Action',
+      );
+
+    $stored = $this->config('node.type.lock_action_probe');
+    self::assertSame('Updated by Drupal core Config Action', $stored->get('description'));
+    self::assertSame('en', $stored->get('langcode'));
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * Enables the contributed module's EN lock without any Agency rewrite logic.
+   */
+  private function enableEnglishConfigurationLock(): void {
+    $this->config('config_language_lock.settings')
+      ->set('locked_langcode', 'en')
+      ->set('follow_site_default', FALSE)
+      ->save();
+
+    self::assertSame(
+      'en',
+      $this->config('config_language_lock.settings')->get('locked_langcode'),
+    );
+    self::assertSame(
+      FALSE,
+      $this->config('config_language_lock.settings')->get('follow_site_default'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockCoreWritesKernelTest.php
@@ -8,6 +8,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\NodeType;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Proves Configuration Language Lock on native Drupal configuration writes.
@@ -16,6 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @group configuration_language_governance
  */
 #[Group('configuration_language_governance')]
+#[RunTestsInSeparateProcesses]
 final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase {
 
   /**
@@ -104,9 +106,14 @@ final class ConfigurationLanguageLockCoreWritesKernelTest extends KernelTestBase
     $this->container
       ->get('plugin.manager.config_action')
       ->applyAction(
-        'setDescription',
+        'setMultiple',
         'node.type.lock_action_probe',
-        'Updated by Drupal core Config Action',
+        [
+          [
+            'key' => 'description',
+            'value' => 'Updated by Drupal core Config Action',
+          ],
+        ],
       );
 
     $stored = $this->config('node.type.lock_action_probe');


### PR DESCRIPTION
## Résumé

Cette PR matérialise la phase 4A bornée de #609 avec **un seul Kernel test** contre le vrai module contrib `drupal/config_language_lock` 1.0.0.

## Preuves exercées

1. site default conservé en `fr` ;
2. `locked_langcode=en` + `follow_site_default=false` appliqués uniquement dans le conteneur de test ;
3. création d'un `node_type` explicitement `fr` après activation du lock -> stockage final `en` ;
4. création d'un second `node_type` `fr` en mode non-enforcing, puis activation du lock ;
5. preuve que l'activation du lock seule ne réécrit pas silencieusement cet objet existant ;
6. application de la **Config Action core** `setMultiple` via `plugin.manager.config_action`, avec les arguments positionnels conformes à `ConfigEntityBase::set($property_name, $value)` ;
7. valeur métier mise à jour et `langcode` final normalisé à `en` par le module contrib.

## Invariants

- aucun helper Agency de réécriture de langcode ;
- aucune modification de `config/sync` ;
- aucune activation persistée du module ;
- aucune migration bulk ;
- aucun accès production ;
- aucune Recipe / Canvas / IA dans cette tranche.

## Validation

CI exact-head #1279 : **SUCCESS** sur `7b3dc80e8bed5b3e7672f09a83f45ccfd5898b20`.

- PHPCS / PHPStan / drupal-check : PASS ;
- PHPUnit : 176 tests PASS ;
- sauvegarde directe FR -> EN : PASS ;
- Config Action core `setMultiple` -> valeur modifiée + langcode EN : PASS.

Closes #688
Refs #609 #684 #628 #608 #412.