### PR TITLE
Issue #690: prove EN lock for Recipe and module install

### DIFF
--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockRecipeInstallKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockRecipeInstallKernelTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Kernel;
+
+use Drupal\Core\Recipe\RecipeRunner;
+use Drupal\FunctionalTests\Core\Recipe\RecipeTestTrait;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Proves Configuration Language Lock for recipes and extension installation.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+#[Group('configuration_language_governance')]
+#[RunTestsInSeparateProcesses]
+final class ConfigurationLanguageLockRecipeInstallKernelTest extends KernelTestBase {
+
+  use RecipeTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'language',
+    'config_language_lock',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['system', 'config_language_lock']);
+
+    foreach (['fr', 'en'] as $langcode) {
+      if (ConfigurableLanguage::load($langcode) === NULL) {
+        ConfigurableLanguage::createFromLangcode($langcode)->save();
+      }
+    }
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    self::assertTrue(
+      $this->container->get('module_handler')->moduleExists('config_language_lock'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * Installing a core module keeps its config entity canonically English.
+   */
+  public function testModuleInstallKeepsCanonicalEnglishConfiguration(): void {
+    $this->enableEnglishConfigurationLock();
+
+    self::assertFalse(
+      $this->container->get('module_handler')->moduleExists('shortcut'),
+    );
+
+    self::assertTrue(
+      $this->container->get('module_installer')->install(['shortcut']),
+    );
+
+    self::assertTrue(\Drupal::moduleHandler()->moduleExists('shortcut'));
+    self::assertSame('en', \Drupal::config('shortcut.set.default')->get('langcode'));
+    self::assertSame('fr', \Drupal::config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * A real Recipe cannot persist a deliberately wrong French base langcode.
+   */
+  public function testRecipeNormalizesExplicitFrenchLangcodeAndInstallsModule(): void {
+    NodeType::create([
+      'type' => 'lock_recipe_probe',
+      'name' => 'Lock recipe probe',
+      'description' => 'Before Recipe',
+      'langcode' => 'fr',
+    ])->save();
+
+    self::assertSame(
+      'fr',
+      $this->config('node.type.lock_recipe_probe')->get('langcode'),
+    );
+
+    $this->enableEnglishConfigurationLock();
+
+    $recipe = $this->createRecipe([
+      'name' => 'Configuration language lock Recipe probe',
+      'install' => [
+        'shortcut',
+      ],
+      'config' => [
+        'actions' => [
+          'node.type.lock_recipe_probe' => [
+            'setMultiple' => [
+              [
+                'langcode',
+                'fr',
+              ],
+              [
+                'description',
+                'Updated by Drupal Recipe',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ]);
+
+    RecipeRunner::processRecipe($recipe);
+
+    self::assertSame(
+      'Updated by Drupal Recipe',
+      \Drupal::config('node.type.lock_recipe_probe')->get('description'),
+    );
+    self::assertSame(
+      'en',
+      \Drupal::config('node.type.lock_recipe_probe')->get('langcode'),
+    );
+    self::assertTrue(\Drupal::moduleHandler()->moduleExists('shortcut'));
+    self::assertSame('en', \Drupal::config('shortcut.set.default')->get('langcode'));
+    self::assertSame('fr', \Drupal::config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * Enables the contributed module's EN lock only inside the Kernel test.
+   */
+  private function enableEnglishConfigurationLock(): void {
+    $this->config('config_language_lock.settings')
+      ->set('locked_langcode', 'en')
+      ->set('follow_site_default', FALSE)
+      ->save();
+
+    self::assertSame(
+      'en',
+      $this->config('config_language_lock.settings')->get('locked_langcode'),
+    );
+    self::assertFalse(
+      $this->config('config_language_lock.settings')->get('follow_site_default'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockRecipeInstallKernelTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Kernel/ConfigurationLanguageLockRecipeInstallKernelTest.php
@@ -41,7 +41,9 @@ final class ConfigurationLanguageLockRecipeInstallKernelTest extends KernelTestB
   protected function setUp(): void {
     parent::setUp();
 
-    $this->installConfig(['system', 'config_language_lock']);
+    // Language's install configuration is required when a module is installed
+    // dynamically because language_modules_installed() updates negotiation.
+    $this->installConfig(['system', 'language', 'config_language_lock']);
 
     foreach (['fr', 'en'] as $langcode) {
       if (ConfigurableLanguage::load($langcode) === NULL) {
@@ -130,7 +132,11 @@ final class ConfigurationLanguageLockRecipeInstallKernelTest extends KernelTestB
       \Drupal::config('node.type.lock_recipe_probe')->get('langcode'),
     );
     self::assertTrue(\Drupal::moduleHandler()->moduleExists('shortcut'));
-    self::assertSame('en', \Drupal::config('shortcut.set.default')->get('langcode'));
+
+    // RecipeRunner intentionally sets ConfigInstaller to syncing while it
+    // installs extensions, so config entities shipped by that extension are
+    // not implicitly created. This is a Drupal Recipe invariant, not drift.
+    self::assertTrue(\Drupal::config('shortcut.set.default')->isNew());
     self::assertSame('fr', \Drupal::config('system.site')->get('default_langcode'));
   }
 


### PR DESCRIPTION
## Résumé

Phase 4B bornée de #609 avec un seul Kernel test contre les primitives Drupal réelles.

## Scénarios validés

### Installation directe

- site default `fr` ;
- Config Language Lock actif uniquement dans le test avec `locked_langcode=en`, `follow_site_default=false` ;
- configuration d'installation de `language` présente afin de supporter une installation dynamique réelle ;
- installation du module core `shortcut` via `module_installer` ;
- `shortcut.set.default:langcode = en` ;
- site default toujours `fr`.

### Recipe

- `node_type` de probe créé en `fr` avant enforcement ;
- lock EN activé ;
- vraie Recipe temporaire créée via `RecipeTestTrait::createRecipe()` ;
- Recipe installe `shortcut` ;
- Config Action `setMultiple` tente volontairement de fixer `langcode` à `fr` tout en modifiant la description ;
- `RecipeRunner::processRecipe()` applique la description demandée mais produit un `langcode` final `en` ;
- `shortcut` est bien activé ;
- `shortcut.set.default` reste volontairement absent : `RecipeRunner::installModules()` place `config.installer` en mode syncing et désactive l'installation implicite des config entities. Le test verrouille cette sémantique core avec `isNew()` au lieu d'inventer une garantie inexistante ;
- site default reste `fr`.

## Invariants

- aucune modification de `config/sync` ;
- aucune activation persistée de `config_language_lock` ;
- aucun helper Agency de réécriture ;
- aucune production ;
- Canvas/IA hors scope de cette tranche.

## Validation

CI exact-head #1282 : **SUCCESS** sur `331b42ce285377292aad4fe980fd783e770501b0`.

- PHPCS / PHPStan / drupal-check : PASS ;
- PHPUnit : PASS ;
- installation classique + config EN : PASS ;
- Recipe + tentative `langcode: fr` -> état final EN : PASS ;
- sémantique core d'absence de config entity implicite pendant `install:` Recipe : PASS.

Closes #690
Refs #609 #688 #689 #684 #628 #608 #412.