### PR TITLE
Issue #696: prove existing-config locked languages under EN lock

### DIFF
--- a/.github/workflows/trusted-existing-config-locked-languages.yml
+++ b/.github/workflows/trusted-existing-config-locked-languages.yml
@@ -1,0 +1,318 @@
+name: Agency trusted existing-config locked-language proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate existing-config locked-language request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 696 &&
+        github.event.comment.body == '/agency-config-language-lock prove-existing-config'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '696' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-lock prove-existing-config' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Proof must execute the workflow revision on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prove:
+    name: Rebuild existing config and preserve und/zxx under EN lock
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f AGENTS.md
+          test -f config/sync/language.entity.und.yml
+          test -f config/sync/language.entity.zxx.yml
+          test -f scripts/runner/locked-language-state.php
+          grep -Fq 'id: und' config/sync/language.entity.und.yml
+          grep -Fq 'locked: true' config/sync/language.entity.und.yml
+          grep -Fq 'langcode: en' config/sync/language.entity.und.yml
+          grep -Fq 'id: zxx' config/sync/language.entity.zxx.yml
+          grep -Fq 'locked: true' config/sync/language.entity.zxx.yml
+          grep -Fq 'langcode: en' config/sync/language.entity.zxx.yml
+          if grep -Fq '  config_language_lock:' config/sync/core.extension.yml; then
+            echo 'Config Language Lock must remain disabled in canonical config.' >&2
+            exit 1
+          fi
+          test ! -e config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-existing-config-languages.yaml <<EOF
+          name: agency-existing-config-languages-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-existing-config-languages-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild fresh Drupal from existing configuration
+        shell: bash
+        env:
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/existing-config-locked-languages
+          printf '%s\n' "$TRUSTED_MAIN" \
+            > artifacts/existing-config-locked-languages/trusted-main.txt
+
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev composer show drupal/config_language_lock --locked >/dev/null
+          ddev exec php -l /var/www/html/scripts/runner/locked-language-state.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cr
+          ddev drush status \
+            > artifacts/existing-config-locked-languages/drush-status.txt
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/existing-config-locked-languages/config-status-before.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/locked-language-state.php \
+            > artifacts/existing-config-locked-languages/before.json
+
+          jq -e '
+            .schema_version == 1 and
+            .site_default_language == "fr" and
+            .config_language_lock_enabled == false and
+            .languages.und.present == true and
+            .languages.und.id == "und" and
+            .languages.und.langcode == "en" and
+            .languages.und.locked == true and
+            .languages.und.weight == 2 and
+            .languages.zxx.present == true and
+            .languages.zxx.id == "zxx" and
+            .languages.zxx.langcode == "en" and
+            .languages.zxx.locked == true and
+            .languages.zxx.weight == 3
+          ' artifacts/existing-config-locked-languages/before.json >/dev/null
+          test -z "$(git status --short config/sync)"
+
+      - name: Enforce EN ephemerally and resave locked languages natively
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev drush pm:enable config_language_lock -y
+          ddev drush php:eval "\Drupal::configFactory()->getEditable('config_language_lock.settings')->set('locked_langcode', 'en')->set('follow_site_default', FALSE)->save();"
+          ddev drush cr
+          ddev drush php:eval "foreach (['und', 'zxx'] as \$id) { \$language = \Drupal\language\Entity\ConfigurableLanguage::load(\$id); if (!\$language) { throw new \RuntimeException('Missing locked language ' . \$id); } \$language->save(); }"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/locked-language-state.php \
+            > artifacts/existing-config-locked-languages/enforced.json
+
+          jq -e '
+            .site_default_language == "fr" and
+            .config_language_lock_enabled == true and
+            .lock_settings.locked_langcode == "en" and
+            .lock_settings.follow_site_default == false and
+            .languages.und.present == true and
+            .languages.und.id == "und" and
+            .languages.und.langcode == "en" and
+            .languages.und.locked == true and
+            .languages.und.weight == 2 and
+            .languages.zxx.present == true and
+            .languages.zxx.id == "zxx" and
+            .languages.zxx.langcode == "en" and
+            .languages.zxx.locked == true and
+            .languages.zxx.weight == 3
+          ' artifacts/existing-config-locked-languages/enforced.json >/dev/null
+
+          diff \
+            <(jq -S '.languages' artifacts/existing-config-locked-languages/before.json) \
+            <(jq -S '.languages' artifacts/existing-config-locked-languages/enforced.json)
+          test -z "$(git status --short config/sync)"
+
+      - name: Restore canonical active configuration and prove reversibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev drush pm:uninstall config_language_lock -y
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/existing-config-locked-languages/config-status-restored.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/locked-language-state.php \
+            > artifacts/existing-config-locked-languages/restored.json
+          jq -e '
+            .site_default_language == "fr" and
+            .config_language_lock_enabled == false and
+            .languages.und.id == "und" and
+            .languages.und.locked == true and
+            .languages.zxx.id == "zxx" and
+            .languages.zxx.locked == true
+          ' artifacts/existing-config-locked-languages/restored.json >/dev/null
+          diff \
+            <(jq -S '.languages' artifacts/existing-config-locked-languages/before.json) \
+            <(jq -S '.languages' artifacts/existing-config-locked-languages/restored.json)
+          test -z "$(git status --short config/sync)"
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('artifacts/existing-config-locked-languages')
+          result = {
+              'schema_version': 1,
+              'status': 'PASS',
+              'verdict': 'EXISTING_CONFIG_AND_LOCKED_LANGUAGES_SAFE',
+              'trusted_main': (root / 'trusted-main.txt').read_text().strip(),
+              'before': json.loads((root / 'before.json').read_text()),
+              'enforced': json.loads((root / 'enforced.json').read_text()),
+              'restored': json.loads((root / 'restored.json').read_text()),
+          }
+          (root / 'result.json').write_text(
+              json.dumps(result, indent=2, ensure_ascii=False) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+      - name: Upload existing-config locked-language evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-existing-config-locked-languages-696-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/existing-config-locked-languages
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-existing-config-languages.yaml
+          rm -rf artifacts/existing-config-locked-languages
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish existing-config locked-language result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prove
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment bounded result on #696
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          PROOF_OUTCOME: ${{ needs.prove.result }}
+        run: |
+          set -euo pipefail
+          heading='### #696 existing-config locked-language proof FAIL'
+          if [[ "$PROOF_OUTCOME" == 'success' ]]; then
+            heading='### #696 existing-config locked-language proof PASS'
+          fi
+          artifact="agency-existing-config-locked-languages-696-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          proof_outcome: \`${PROOF_OUTCOME:-unknown}\`
+          artifact: \`${artifact}\`
+
+          The proof rebuilds from `site:install --existing-config`, verifies `und`/`zxx`, enables EN lock only inside disposable DDEV, resaves both locked language entities through native Drupal APIs, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
+          EOF_BODY
+          )"
+          gh issue comment 696 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/locked-language-state.php
+++ b/scripts/runner/locked-language-state.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Emits the active state of Drupal's two locked semantic languages.
+ *
+ * This helper is intentionally read-only. It is executed through Drush only
+ * inside the isolated DDEV proof for configuration-language governance.
+ */
+
+$storage = \Drupal::service('config.storage');
+
+$languages = [];
+foreach (['und', 'zxx'] as $expectedId) {
+  $name = 'language.entity.' . $expectedId;
+  $data = $storage->read($name);
+  $present = is_array($data);
+  if (!$present) {
+    $data = [];
+  }
+
+  $languages[$expectedId] = [
+    'present' => $present,
+    'id' => $data['id'] ?? NULL,
+    'langcode' => $data['langcode'] ?? NULL,
+    'locked' => $data['locked'] ?? NULL,
+    'weight' => $data['weight'] ?? NULL,
+    'label' => $data['label'] ?? NULL,
+  ];
+}
+
+$coreExtension = $storage->read('core.extension');
+if (!is_array($coreExtension)) {
+  $coreExtension = [];
+}
+
+$settings = $storage->read('config_language_lock.settings');
+if (!is_array($settings)) {
+  $settings = [];
+}
+
+$output = [
+  'schema_version' => 1,
+  'site_default_language' => \Drupal::languageManager()
+    ->getDefaultLanguage()
+    ->getId(),
+  'config_language_lock_enabled' => array_key_exists(
+    'config_language_lock',
+    $coreExtension['module'] ?? [],
+  ),
+  'lock_settings' => [
+    'locked_langcode' => $settings['locked_langcode'] ?? NULL,
+    'follow_site_default' => $settings['follow_site_default'] ?? NULL,
+  ],
+  'languages' => $languages,
+];
+
+echo json_encode(
+  $output,
+  JSON_PRETTY_PRINT
+    | JSON_UNESCAPED_SLASHES
+    | JSON_UNESCAPED_UNICODE
+    | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the trusted existing-config locked-language proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
+
+  /**
+   * The route stays owner-only and fixed to issue #696.
+   */
+  public function testRouteIsFixedAndOwnerOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-existing-config-locked-languages.yml';
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'github.event.issue.number == 696',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-lock "
+        . "prove-existing-config'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "[[ \"\$GITHUB_ACTOR\" == 'E-merging-digital' ]]",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "[[ \"\$ISSUE_NUMBER\" == '696' ]]",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "[[ \"\$EVENT_DEFAULT_SHA\" == \"\$main_sha\" ]]",
+      $workflow,
+    );
+  }
+
+  /**
+   * The DDEV proof covers reconstruction, enforcement and restoration.
+   */
+  public function testProofCoversExistingConfigAndLockedLanguages(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/trusted-existing-config-locked-languages.yml';
+    $workflow = (string) file_get_contents($path);
+
+    self::assertStringContainsString('self-hosted', $workflow);
+    self::assertStringContainsString('agency', $workflow);
+    self::assertStringContainsString('ddev', $workflow);
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush pm:enable config_language_lock -y',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "set('locked_langcode', 'en')",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "set('follow_site_default', FALSE)",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ConfigurableLanguage::load',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush pm:uninstall config_language_lock -y',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString('No differences', $workflow);
+    self::assertStringContainsString(
+      '.languages.und.locked == true',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.languages.zxx.locked == true',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.languages.und.weight == 2',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.languages.zxx.weight == 3',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'EXISTING_CONFIG_AND_LOCKED_LANGUAGES_SAFE',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev delete --omit-snapshot --yes',
+      $workflow,
+    );
+
+    self::assertStringNotContainsString('drush cex', $workflow);
+    self::assertStringNotContainsString('OPENAI_API_KEY', $workflow);
+    self::assertStringNotContainsString('deploy-production', $workflow);
+    self::assertStringNotContainsString('ssh ', $workflow);
+  }
+
+  /**
+   * The machine-readable helper stays strictly read-only.
+   */
+  public function testLockedLanguageStateHelperIsReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/runner/locked-language-state.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("['und', 'zxx']", $script);
+    self::assertStringContainsString("'locked'", $script);
+    self::assertStringContainsString("'weight'", $script);
+    self::assertStringContainsString("'langcode'", $script);
+    self::assertStringContainsString("'site_default_language'", $script);
+    self::assertStringContainsString(
+      "'config_language_lock_enabled'",
+      $script,
+    );
+    self::assertStringContainsString("'lock_settings'", $script);
+    self::assertStringContainsString('$storage->read(', $script);
+    self::assertStringNotContainsString('->save(', $script);
+    self::assertStringNotContainsString('->write(', $script);
+    self::assertStringNotContainsString('->delete(', $script);
+  }
+
+}


### PR DESCRIPTION
## Résumé

Phase 4E bornée de #609 : ajoute une preuve trusted DDEV de non-régression `site:install --existing-config` et de préservation des langues verrouillées `und` / `zxx` sous Config Language Lock.

## Contenu

- helper read-only `scripts/runner/locked-language-state.php` ;
- workflow owner-only `/agency-config-language-lock prove-existing-config` sur #696 ;
- reconstruction fraîche depuis le `main` exact ;
- vérification `und` / `zxx` actives (`id`, `langcode: en`, `locked: true`, poids core) ;
- activation éphémère de Config Language Lock en `en` / `follow_site_default=false` ;
- sauvegarde native des deux `ConfigurableLanguage` verrouillées ;
- comparaison avant/après ;
- uninstall + `cim` + preuve `No differences` ;
- cleanup DDEV/workspace ;
- test unitaire repository-owned protégeant route et interdits.

## Validation PR

CI exact-head #1293 / run `32644508951` : **SUCCESS** sur `f521dfa2415d2505efc46c8f42386014d9a21f44`.

- PHPCS / PHPStan / drupal-check : PASS ;
- PHPUnit : **185 tests / 2650 assertions — PASS**.

## Invariants

- aucune activation persistée du lock dans `config/sync` ;
- aucun `drush cex` ;
- aucun secret/provider ;
- aucune production/SSH ;
- aucune réécriture bulk.

## Post-merge obligatoire

#696 reste volontairement ouverte après merge : le workflow `issue_comment` exige une issue ouverte. Après fusion, exécuter la commande trusted sur #696, inspecter le résultat et l'artifact, reporter la preuve dans #609, puis seulement fermer #696 si la preuve est PASS.

Refs #696 #609 #412 #694 #692 #690 #688 #684 #608.