### PR TITLE
Issue #696: canonicalize post-install config before locked-language baseline

### DIFF
--- a/.github/workflows/trusted-existing-config-locked-languages.yml
+++ b/.github/workflows/trusted-existing-config-locked-languages.yml
@@ -142,6 +142,16 @@ jobs:
           ddev drush status \
             > artifacts/existing-config-locked-languages/drush-status.txt
 
+          post_install_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$post_install_status" \
+            > artifacts/existing-config-locked-languages/config-status-post-install.txt
+
+          # Drupal's install/Locale finish tasks can mutate active configuration.
+          # Re-import the repository configuration before defining the canonical
+          # baseline, matching the already-proven #628 trusted evaluation route.
+          ddev drush cim -y
+          ddev drush cr
+
           config_status="$(ddev drush config:status 2>&1)"
           printf '%s\n' "$config_status" \
             > artifacts/existing-config-locked-languages/config-status-before.txt
@@ -312,7 +322,7 @@ jobs:
           proof_outcome: \`${PROOF_OUTCOME:-unknown}\`
           artifact: \`${artifact}\`
 
-          The proof rebuilds from `site:install --existing-config`, verifies `und`/`zxx`, enables EN lock only inside disposable DDEV, resaves both locked language entities through native Drupal APIs, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
+          The proof rebuilds from site:install --existing-config, verifies und/zxx, enables EN lock only inside disposable DDEV, resaves both locked language entities through native Drupal APIs, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
           EOF_BODY
           )"
           gh issue comment 696 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
@@ -66,6 +66,11 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
       $workflow,
     );
     self::assertStringContainsString(
+      'config-status-post-install.txt',
+      $workflow,
+    );
+    self::assertSame(2, substr_count($workflow, 'ddev drush cim -y'));
+    self::assertStringContainsString(
       'ddev drush pm:enable config_language_lock -y',
       $workflow,
     );
@@ -85,7 +90,6 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
       'ddev drush pm:uninstall config_language_lock -y',
       $workflow,
     );
-    self::assertStringContainsString('ddev drush cim -y', $workflow);
     self::assertStringContainsString('No differences', $workflow);
     self::assertStringContainsString(
       '.languages.und.locked == true',


### PR DESCRIPTION
## Diagnostic

Trusted run `32644710812` sur `main` `2ed00a00bac59735a4c9dbb3c22ccf853cfb0951` a prouvé que `site:install --existing-config` réussit. Le défaut était notre assertion `No differences` placée avant la canonicalisation de l'empreinte install/Locale.

Artifact du run : `9494575038`, digest `sha256:3d5d446c5b001007b0310a628c4bf0466c135f5094e89a3119f5a6262fb80d68`.

## Correctif borné

- conserver le `config:status` brut immédiatement post-install dans `config-status-post-install.txt` ;
- exécuter `drush cim -y` puis `drush cr`, comme la route trusted déjà prouvée de #628 ;
- seulement alors exiger `No differences` et définir la baseline `und`/`zxx` ;
- garder un second et unique `cim` pour la restauration finale après uninstall ;
- corriger le commentaire de report afin que le shell n'interprète plus les backticks comme des substitutions de commandes ;
- renforcer le test repository-owned pour imposer l'evidence post-install et exactement deux imports canoniques.

## Validation

CI exact-head #1295 / run `32645039658` : **SUCCESS** sur `4dfffe80ffc24d908daf7a7e3b57bdf8b5bb0714`.

- PHP 8.4.24 ;
- PHPCS / PHPStan / drupal-check : PASS ;
- PHPUnit : **185 tests / 2651 assertions — PASS**.

## Invariants inchangés

- aucun `cex` ;
- aucun bulk rewrite ;
- aucune activation persistée du lock ;
- aucun secret/provider ;
- aucune production/SSH.

#696 reste ouverte pour la relance trusted post-merge.

Refs #696 #609 #628 #412.