### PR TITLE
Issue #696: separate Locale footprint from native locked-language saves

### DIFF
--- a/.github/workflows/trusted-existing-config-locked-languages.yml
+++ b/.github/workflows/trusted-existing-config-locked-languages.yml
@@ -178,13 +178,43 @@ jobs:
           ' artifacts/existing-config-locked-languages/before.json >/dev/null
           test -z "$(git status --short config/sync)"
 
-      - name: Enforce EN ephemerally and resave locked languages natively
+      - name: Enforce EN ephemerally and isolate native locked-language saves
         shell: bash
         run: |
           set -euo pipefail
           ddev drush pm:enable config_language_lock -y
           ddev drush php:eval "\Drupal::configFactory()->getEditable('config_language_lock.settings')->set('locked_langcode', 'en')->set('follow_site_default', FALSE)->save();"
           ddev drush cr
+
+          # Module enable can legitimately localize active labels through Locale.
+          # Capture that footprint before testing ConfigurableLanguage::save().
+          ddev drush php:script \
+            /var/www/html/scripts/runner/locked-language-state.php \
+            > artifacts/existing-config-locked-languages/enabled.json
+
+          jq -e '
+            .site_default_language == "fr" and
+            .config_language_lock_enabled == true and
+            .lock_settings.locked_langcode == "en" and
+            .lock_settings.follow_site_default == false and
+            .languages.und.present == true and
+            .languages.und.id == "und" and
+            .languages.und.langcode == "en" and
+            .languages.und.locked == true and
+            .languages.und.weight == 2 and
+            .languages.zxx.present == true and
+            .languages.zxx.id == "zxx" and
+            .languages.zxx.langcode == "en" and
+            .languages.zxx.locked == true and
+            .languages.zxx.weight == 3
+          ' artifacts/existing-config-locked-languages/enabled.json >/dev/null
+
+          # Labels are localized presentation data here. Structural locked-language
+          # invariants must stay identical to the canonical pre-enable baseline.
+          diff \
+            <(jq -S '.languages | map_values(del(.label))' artifacts/existing-config-locked-languages/before.json) \
+            <(jq -S '.languages | map_values(del(.label))' artifacts/existing-config-locked-languages/enabled.json)
+
           ddev drush php:eval "foreach (['und', 'zxx'] as \$id) { \$language = \Drupal\language\Entity\ConfigurableLanguage::load(\$id); if (!\$language) { throw new \RuntimeException('Missing locked language ' . \$id); } \$language->save(); }"
 
           ddev drush php:script \
@@ -208,8 +238,9 @@ jobs:
             .languages.zxx.weight == 3
           ' artifacts/existing-config-locked-languages/enforced.json >/dev/null
 
+          # The native saves themselves must not mutate the locked languages.
           diff \
-            <(jq -S '.languages' artifacts/existing-config-locked-languages/before.json) \
+            <(jq -S '.languages' artifacts/existing-config-locked-languages/enabled.json) \
             <(jq -S '.languages' artifacts/existing-config-locked-languages/enforced.json)
           test -z "$(git status --short config/sync)"
 
@@ -253,6 +284,7 @@ jobs:
               'verdict': 'EXISTING_CONFIG_AND_LOCKED_LANGUAGES_SAFE',
               'trusted_main': (root / 'trusted-main.txt').read_text().strip(),
               'before': json.loads((root / 'before.json').read_text()),
+              'enabled': json.loads((root / 'enabled.json').read_text()),
               'enforced': json.loads((root / 'enforced.json').read_text()),
               'restored': json.loads((root / 'restored.json').read_text()),
           }
@@ -322,7 +354,7 @@ jobs:
           proof_outcome: \`${PROOF_OUTCOME:-unknown}\`
           artifact: \`${artifact}\`
 
-          The proof rebuilds from site:install --existing-config, verifies und/zxx, enables EN lock only inside disposable DDEV, resaves both locked language entities through native Drupal APIs, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
+          The proof rebuilds from site:install --existing-config, verifies und/zxx, isolates Locale's module-enable label footprint from native locked-language saves, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
           EOF_BODY
           )"
           gh issue comment 696 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
@@ -82,6 +82,11 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
       "set('follow_site_default', FALSE)",
       $workflow,
     );
+    self::assertStringContainsString('enabled.json', $workflow);
+    self::assertSame(
+      2,
+      substr_count($workflow, 'map_values(del(.label))'),
+    );
     self::assertStringContainsString(
       'ConfigurableLanguage::load',
       $workflow,
@@ -114,6 +119,17 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
     self::assertStringContainsString(
       'ddev delete --omit-snapshot --yes',
       $workflow,
+    );
+
+    $enabledPosition = strpos($workflow, '> artifacts/existing-config-locked-languages/enabled.json');
+    $savePosition = strpos($workflow, 'ConfigurableLanguage::load');
+    $enforcedPosition = strpos($workflow, '> artifacts/existing-config-locked-languages/enforced.json');
+    self::assertNotFalse($enabledPosition);
+    self::assertNotFalse($savePosition);
+    self::assertNotFalse($enforcedPosition);
+    self::assertTrue(
+      $enabledPosition < $savePosition && $savePosition < $enforcedPosition,
+      'Locale footprint must be captured before native saves are measured.',
     );
 
     self::assertStringNotContainsString('drush cex', $workflow);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
@@ -121,9 +121,15 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
       $workflow,
     );
 
-    $enabledPosition = strpos($workflow, '> artifacts/existing-config-locked-languages/enabled.json');
+    $enabledPosition = strpos(
+      $workflow,
+      '> artifacts/existing-config-locked-languages/enabled.json',
+    );
     $savePosition = strpos($workflow, 'ConfigurableLanguage::load');
-    $enforcedPosition = strpos($workflow, '> artifacts/existing-config-locked-languages/enforced.json');
+    $enforcedPosition = strpos(
+      $workflow,
+      '> artifacts/existing-config-locked-languages/enforced.json',
+    );
     self::assertNotFalse($enabledPosition);
     self::assertNotFalse($savePosition);
     self::assertNotFalse($enforcedPosition);


### PR DESCRIPTION
## Diagnostic

Trusted run `32645236253` on live `main` `8ef9f5387cae776dce8a1ffaa582a989747aa5f4` proved:

- `site:install --existing-config`: PASS;
- post-install canonicalization with `drush cim -y`: PASS;
- canonical `config:status`: No differences;
- site default remains `fr`;
- `und` and `zxx` remain present with `langcode=en`, `locked=true`, weights `2` / `3`;
- ephemeral Config Language Lock activation with `locked_langcode=en` and `follow_site_default=false`: PASS;
- the only observed difference between pre-module baseline and post-enable state is Locale translating the locked language labels (`Not specified` → `Non spécifié`, `Not applicable` → `Non applicable`).

Artifact: `9494721565`, digest `sha256:61b66769b5c196691cd0c2e748dc666a8e81b78cb52f89766ca2ba5d3b149d86`.

## Bounded fix

The trusted proof now separates three states:

1. `before.json`: canonical baseline before module enable;
2. `enabled.json`: state immediately after module enable + Locale footprint, before native saves;
3. `enforced.json`: state after native `ConfigurableLanguage::save()` calls.

The proof permits only the expected label localization when comparing `before` to `enabled`, while all semantic invariants remain exact. It then requires **full equality** of `.languages` between `enabled` and `enforced`, so any mutation caused by the native save path remains detectable.

The repository-owned workflow test requires this separation explicitly.

## Validation

CI exact-head #1297 / run `32647521833`: **SUCCESS** on `00e1fcd90aaa2a6021f7951f7bbd1bd96ab99d24`.

- PHP 8.4.24;
- PHPCS / PHPStan / drupal-check: PASS;
- PHPUnit: **185 tests / 2657 assertions — PASS**.

## Invariants unchanged

- no `drush cex`;
- no bulk rewrite;
- no persistent Config Language Lock activation;
- no provider/secret;
- no production/SSH;
- #696 remains open until the corrected trusted run passes post-merge.

Refs #696 #609 #412 #628.