### PR TITLE
Issue #696: prove EN lock recovers Locale langcode drift

### DIFF
--- a/.github/workflows/trusted-existing-config-locked-languages.yml
+++ b/.github/workflows/trusted-existing-config-locked-languages.yml
@@ -178,7 +178,7 @@ jobs:
           ' artifacts/existing-config-locked-languages/before.json >/dev/null
           test -z "$(git status --short config/sync)"
 
-      - name: Enforce EN ephemerally and isolate native locked-language saves
+      - name: Enforce EN ephemerally and recover Locale langcode drift
         shell: bash
         run: |
           set -euo pipefail
@@ -186,8 +186,8 @@ jobs:
           ddev drush php:eval "\Drupal::configFactory()->getEditable('config_language_lock.settings')->set('locked_langcode', 'en')->set('follow_site_default', FALSE)->save();"
           ddev drush cr
 
-          # Module enable can legitimately localize active labels through Locale.
-          # Capture that footprint before testing ConfigurableLanguage::save().
+          # Module enable can invoke Locale on this FR site. Capture its exact
+          # pre-save footprint before Config Language Lock gets a native save.
           ddev drush php:script \
             /var/www/html/scripts/runner/locked-language-state.php \
             > artifacts/existing-config-locked-languages/enabled.json
@@ -199,21 +199,21 @@ jobs:
             .lock_settings.follow_site_default == false and
             .languages.und.present == true and
             .languages.und.id == "und" and
-            .languages.und.langcode == "en" and
+            (.languages.und.langcode == "en" or .languages.und.langcode == "fr") and
             .languages.und.locked == true and
             .languages.und.weight == 2 and
             .languages.zxx.present == true and
             .languages.zxx.id == "zxx" and
-            .languages.zxx.langcode == "en" and
+            (.languages.zxx.langcode == "en" or .languages.zxx.langcode == "fr") and
             .languages.zxx.locked == true and
             .languages.zxx.weight == 3
           ' artifacts/existing-config-locked-languages/enabled.json >/dev/null
 
-          # Labels are localized presentation data here. Structural locked-language
-          # invariants must stay identical to the canonical pre-enable baseline.
+          # Locale is allowed to change only presentation labels and source
+          # langcodes here. IDs, locked flags, presence and weights stay exact.
           diff \
-            <(jq -S '.languages | map_values(del(.label))' artifacts/existing-config-locked-languages/before.json) \
-            <(jq -S '.languages | map_values(del(.label))' artifacts/existing-config-locked-languages/enabled.json)
+            <(jq -S '.languages | map_values(del(.label, .langcode))' artifacts/existing-config-locked-languages/before.json) \
+            <(jq -S '.languages | map_values(del(.label, .langcode))' artifacts/existing-config-locked-languages/enabled.json)
 
           ddev drush php:eval "foreach (['und', 'zxx'] as \$id) { \$language = \Drupal\language\Entity\ConfigurableLanguage::load(\$id); if (!\$language) { throw new \RuntimeException('Missing locked language ' . \$id); } \$language->save(); }"
 
@@ -238,10 +238,11 @@ jobs:
             .languages.zxx.weight == 3
           ' artifacts/existing-config-locked-languages/enforced.json >/dev/null
 
-          # The native saves themselves must not mutate the locked languages.
+          # The native saves may enforce only the source langcode. Labels and
+          # every semantic locked-language invariant must remain unchanged.
           diff \
-            <(jq -S '.languages' artifacts/existing-config-locked-languages/enabled.json) \
-            <(jq -S '.languages' artifacts/existing-config-locked-languages/enforced.json)
+            <(jq -S '.languages | map_values(del(.langcode))' artifacts/existing-config-locked-languages/enabled.json) \
+            <(jq -S '.languages | map_values(del(.langcode))' artifacts/existing-config-locked-languages/enforced.json)
           test -z "$(git status --short config/sync)"
 
       - name: Restore canonical active configuration and prove reversibility
@@ -264,8 +265,10 @@ jobs:
             .site_default_language == "fr" and
             .config_language_lock_enabled == false and
             .languages.und.id == "und" and
+            .languages.und.langcode == "en" and
             .languages.und.locked == true and
             .languages.zxx.id == "zxx" and
+            .languages.zxx.langcode == "en" and
             .languages.zxx.locked == true
           ' artifacts/existing-config-locked-languages/restored.json >/dev/null
           diff \
@@ -354,7 +357,7 @@ jobs:
           proof_outcome: \`${PROOF_OUTCOME:-unknown}\`
           artifact: \`${artifact}\`
 
-          The proof rebuilds from site:install --existing-config, verifies und/zxx, isolates Locale's module-enable label footprint from native locked-language saves, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
+          The proof rebuilds from site:install --existing-config, records Locale's module-enable footprint, proves native locked-language saves enforce canonical EN without changing semantic und/zxx invariants, restores canonical active config, and cleans the workspace. It never exports config or accesses production.
           EOF_BODY
           )"
           gh issue comment 696 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ExistingConfigLockedLanguagesWorkflowTest.php
@@ -85,7 +85,21 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
     self::assertStringContainsString('enabled.json', $workflow);
     self::assertSame(
       2,
-      substr_count($workflow, 'map_values(del(.label))'),
+      substr_count($workflow, 'map_values(del(.label, .langcode))'),
+    );
+    self::assertSame(
+      2,
+      substr_count($workflow, 'map_values(del(.langcode))'),
+    );
+    self::assertStringContainsString(
+      '.languages.und.langcode == "en" or '
+        . '.languages.und.langcode == "fr"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.languages.zxx.langcode == "en" or '
+        . '.languages.zxx.langcode == "fr"',
+      $workflow,
     );
     self::assertStringContainsString(
       'ConfigurableLanguage::load',
@@ -136,6 +150,16 @@ final class ExistingConfigLockedLanguagesWorkflowTest extends TestCase {
     self::assertTrue(
       $enabledPosition < $savePosition && $savePosition < $enforcedPosition,
       'Locale footprint must be captured before native saves are measured.',
+    );
+
+    $enforcedBlock = substr($workflow, $enforcedPosition);
+    self::assertStringContainsString(
+      '.languages.und.langcode == "en"',
+      $enforcedBlock,
+    );
+    self::assertStringContainsString(
+      '.languages.zxx.langcode == "en"',
+      $enforcedBlock,
     );
 
     self::assertStringNotContainsString('drush cex', $workflow);


### PR DESCRIPTION
## Diagnostic

Trusted run `32647759974` on exact `main` `8bda13992fe6a96bcccf25201e9603c4b0fd22ff` isolated the remaining behavior with artifact `9495371577`, digest `sha256:c8c9b99aa7013f05ed01cd95bcc71f7913fdc7fd17816569b202cad5ec08340f`.

Before module enable, canonical `und` / `zxx` are `langcode=en`, locked, weights 2/3. Immediately after `pm:enable config_language_lock` on the FR site and before any native save, Locale changes:

- `und`: `langcode en -> fr`, label `Not specified -> Non spécifié`;
- `zxx`: `langcode en -> fr`, label `Not applicable -> Non applicable`.

IDs, locked flags and weights remain intact. This matches the Locale installation footprint already proven in #628.

## Bounded correction

The trusted proof now:

1. accepts only `label` + pre-save `langcode` as module-enable/Locale footprint relative to the canonical baseline;
2. preserves exact IDs, presence, `locked=true` and weights;
3. executes native `ConfigurableLanguage::save()` under `locked_langcode=en`;
4. requires both locked languages to finish at `langcode=en`;
5. permits only `langcode` to change between `enabled.json` and `enforced.json`, which means labels and all semantic invariants must remain exact;
6. still restores canonical active config and requires final `No differences`.

The repository-owned Unit test locks these two distinct allowlists and the execution order.

## Validation

CI exact-head #1299 / run `32648189688`: **SUCCESS** on `50967fcff533a395842550aceead6308e1a1ab26`.

- PHP 8.4.24;
- PHPCS / PHPStan / drupal-check: PASS;
- PHPUnit: **185 tests / 2662 assertions — PASS**;
- 151 deprecations / 35 PHPUnit deprecations remain known contrib/historical signals and do not introduce a #696 failure.

## Invariants unchanged

- no `drush cex`;
- no bulk rewrite;
- no persistent Config Language Lock activation;
- no provider/secret;
- no production/SSH;
- #696 remains open until the corrected trusted post-merge proof passes.

Refs #696 #609 #412 #628.