### PR TITLE
Issue #701: prove EN config and FR content through Drupal admin UI

### DIFF
--- a/web/modules/custom/agency_project_tests/tests/src/Functional/ConfigurationLanguageLockAdminUiTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/ConfigurationLanguageLockAdminUiTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Proves EN configuration and FR content through native Drupal forms.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+#[Group('configuration_language_governance')]
+#[RunTestsInSeparateProcesses]
+final class ConfigurationLanguageLockAdminUiTest extends BrowserTestBase {
+
+  /**
+   * Content type used by the proof.
+   */
+  private const CONTENT_TYPE = 'config_lock_ui_probe';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'config_language_lock',
+    'language',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'standard';
+
+  /**
+   * Existing French content created before the configuration lock.
+   */
+  private int $existingNodeId;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    foreach (['fr', 'en'] as $langcode) {
+      if (ConfigurableLanguage::load($langcode) === NULL) {
+        ConfigurableLanguage::createFromLangcode($langcode)->save();
+      }
+    }
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    NodeType::create([
+      'type' => self::CONTENT_TYPE,
+      'name' => 'Config lock UI probe',
+      'description' => 'Before native Drupal admin UI save.',
+      'langcode' => 'fr',
+    ])->save();
+
+    self::assertSame(
+      'fr',
+      $this->config('node.type.' . self::CONTENT_TYPE)->get('langcode'),
+    );
+
+    $existing = $this->drupalCreateNode([
+      'type' => self::CONTENT_TYPE,
+      'title' => 'Existing French editorial content',
+      'langcode' => 'fr',
+      'status' => 1,
+    ]);
+    $this->existingNodeId = (int) $existing->id();
+    self::assertSame('fr', $existing->language()->getId());
+
+    $account = $this->drupalCreateUser([
+      'access content',
+      'administer content types',
+      'create ' . self::CONTENT_TYPE . ' content',
+    ]);
+    self::assertNotFalse($account);
+    $this->drupalLogin($account);
+  }
+
+  /**
+   * Admin config saves are EN while editorial content remains FR.
+   */
+  public function testAdminConfigSaveDoesNotChangeEditorialLanguage(): void {
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+
+    $this->enableEnglishConfigurationLock();
+
+    // Merely enabling the lock must not retroactively rewrite existing config.
+    $this->resetConfig('node.type.' . self::CONTENT_TYPE);
+    self::assertSame(
+      'fr',
+      $this->config('node.type.' . self::CONTENT_TYPE)->get('langcode'),
+    );
+
+    $this->drupalGet('/admin/structure/types/manage/' . self::CONTENT_TYPE);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldValueEquals(
+      'description',
+      'Before native Drupal admin UI save.',
+    );
+
+    $page = $this->getSession()->getPage();
+    $page->fillField(
+      'description',
+      'Updated through the native Drupal admin UI.',
+    );
+    $page->pressButton('edit-submit');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->resetConfig('node.type.' . self::CONTENT_TYPE);
+    $stored_type = $this->config('node.type.' . self::CONTENT_TYPE);
+    self::assertSame('en', $stored_type->get('langcode'));
+    self::assertSame(
+      'Updated through the native Drupal admin UI.',
+      $stored_type->get('description'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+
+    $node_storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $node_storage->resetCache([$this->existingNodeId]);
+    $existing = $node_storage->load($this->existingNodeId);
+    self::assertInstanceOf(NodeInterface::class, $existing);
+    self::assertSame('fr', $existing->language()->getId());
+    self::assertSame('Existing French editorial content', $existing->label());
+
+    $this->drupalGet('/node/add/' . self::CONTENT_TYPE);
+    $this->assertSession()->statusCodeEquals(200);
+    $page = $this->getSession()->getPage();
+    $page->fillField('title[0][value]', 'New French editorial content');
+    $page->pressButton('edit-submit');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $created = $node_storage->loadByProperties([
+      'type' => self::CONTENT_TYPE,
+      'title' => 'New French editorial content',
+    ]);
+    self::assertCount(1, $created);
+    $new_node = reset($created);
+    self::assertInstanceOf(NodeInterface::class, $new_node);
+    self::assertSame('fr', $new_node->language()->getId());
+
+    $this->resetConfig('node.type.' . self::CONTENT_TYPE);
+    self::assertSame(
+      'en',
+      $this->config('node.type.' . self::CONTENT_TYPE)->get('langcode'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * Enables the contributed EN lock only inside this test site.
+   */
+  private function enableEnglishConfigurationLock(): void {
+    $this->config('config_language_lock.settings')
+      ->set('locked_langcode', 'en')
+      ->set('follow_site_default', FALSE)
+      ->save();
+
+    self::assertSame(
+      'en',
+      $this->config('config_language_lock.settings')->get('locked_langcode'),
+    );
+    self::assertFalse(
+      $this->config('config_language_lock.settings')->get('follow_site_default'),
+    );
+    self::assertSame('fr', $this->config('system.site')->get('default_langcode'));
+  }
+
+  /**
+   * Clears one config object from the test process config factory cache.
+   */
+  private function resetConfig(string $name): void {
+    $this->container->get('config.factory')->reset($name);
+  }
+
+}


### PR DESCRIPTION
## Scope

Phase 4F of #609. Adds one native Drupal `BrowserTestBase` proving configuration language and editorial language remain distinct under Config Language Lock.

## Proof

The test:

- starts from site default `fr`;
- creates a pre-existing `node.type.config_lock_ui_probe` with `langcode=fr` and existing FR content;
- enables only test-local lock settings (`locked_langcode=en`, `follow_site_default=false`);
- proves enabling the lock alone does not retroactively rewrite the type;
- edits the type through `/admin/structure/types/manage/config_lock_ui_probe` using the real Drupal form;
- requires the saved type config to become `langcode=en` while preserving the edited description;
- reloads the pre-existing node and requires it to remain `fr`;
- creates a second node through `/node/add/config_lock_ui_probe` and requires it to be `fr`;
- finally reasserts type config `en` and site default `fr`.

No Agency normalization helper, no config/sync write, no persistent lock adoption, no provider/secret/network/production.

## Validation

CI #1301 / run `32650071828`: **SUCCESS** on exact PR head `18e49f36fdf01d9140fc50723609255b511a57e5`.

- PHP 8.4.24 / PHPUnit 11.5.56;
- PHPCS / PHPStan / drupal-check: PASS;
- PHPUnit: **186 tests / 2691 assertions — PASS**;
- BrowserTest HTML output explicitly includes `ConfigurationLanguageLockAdminUiTest` (10 snapshots), proving the new functional scenario executed;
- 151 deprecations / 35 PHPUnit deprecations remain known contrib/historical signals, with no new #701-specific blocker.

Closes #701. Refs #609 #696 #688 #628.