### PR TITLE
Issue #705: classify EN translation override coverage

### DIFF
--- a/.github/workflows/trusted-configuration-language-translation-coverage.yml
+++ b/.github/workflows/trusted-configuration-language-translation-coverage.yml
@@ -1,0 +1,264 @@
+name: Agency trusted configuration translation coverage
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate configuration translation coverage request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-translation-coverage classify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '705' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-translation-coverage classify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Translation coverage must execute the workflow revision on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  classify:
+    name: Rebuild Drupal and classify EN override coverage
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      complete: ${{ steps.summary.outputs.complete }}
+      partial: ${{ steps.summary.outputs.partial }}
+      unresolved: ${{ steps.summary.outputs.unresolved }}
+      source_equal: ${{ steps.summary.outputs.source_equal }}
+      webform_contact: ${{ steps.summary.outputs.webform_contact }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable coverage implementation
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f AGENTS.md
+          test -f .ddev/config.yaml
+          test -f docs/evidence/configuration-language-baseline-609.yml
+          test -f scripts/runner/configuration-language-translation-coverage.php
+          test -f scripts/runner/run-configuration-language-translation-coverage.sh
+          bash -n scripts/runner/run-configuration-language-translation-coverage.sh
+          git diff --check
+
+      - name: Isolate DDEV project for translation coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-translation-coverage-ci.yaml <<EOF
+          name: agency-config-translation-coverage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-translation-coverage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-translation-coverage.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Classify bounded read-only EN override coverage
+        id: route
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-translation-coverage
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-translation-coverage.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-translation-coverage/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          complete='0'
+          partial='0'
+          unresolved='0'
+          source_equal='0'
+          webform_contact='missing'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            complete="$(jq -r '.counts.en_override_complete_for_material_translatable_source // 0' "$result")"
+            partial="$(jq -r '.counts.en_override_partial_review_required // 0' "$result")"
+            unresolved="$(jq -r '.counts.schema_unresolved_review_required // 0' "$result")"
+            source_equal="$(jq -r '.counts.en_override_redundant_or_source_equal // 0' "$result")"
+            webform_contact="$(jq -r '.focus["webform.webform.contact"].classification // "missing"' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "complete=$complete" >> "$GITHUB_OUTPUT"
+          echo "partial=$partial" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$unresolved" >> "$GITHUB_OUTPUT"
+          echo "source_equal=$source_equal" >> "$GITHUB_OUTPUT"
+          echo "webform_contact=$webform_contact" >> "$GITHUB_OUTPUT"
+
+      - name: Upload configuration translation coverage evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-translation-coverage-705-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-translation-coverage
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-translation-coverage-ci.yaml
+          rm -rf artifacts/configuration-language-translation-coverage
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish bounded configuration translation coverage result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - classify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment coverage result on #705
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.classify.result }}
+          STATUS: ${{ needs.classify.outputs.status }}
+          VERDICT: ${{ needs.classify.outputs.verdict }}
+          COMPLETE: ${{ needs.classify.outputs.complete }}
+          PARTIAL: ${{ needs.classify.outputs.partial }}
+          UNRESOLVED: ${{ needs.classify.outputs.unresolved }}
+          SOURCE_EQUAL: ${{ needs.classify.outputs.source_equal }}
+          WEBFORM_CONTACT: ${{ needs.classify.outputs.webform_contact }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration translation coverage FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration translation coverage PASS'
+          fi
+
+          artifact="agency-config-translation-coverage-705-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          en_override_complete: \`${COMPLETE:-0}\`
+          en_override_partial_review_required: \`${PARTIAL:-0}\`
+          schema_unresolved_review_required: \`${UNRESOLVED:-0}\`
+          source_equal_signal: \`${SOURCE_EQUAL:-0}\`
+          webform.webform.contact: \`${WEBFORM_CONTACT:-missing}\`
+          artifact: \`${artifact}\`
+
+          Read-only typed-config coverage classification only. This proof does not enable Configuration Language Lock, migrate/export configuration, rewrite langcodes or access production.
+          EOF_BODY
+          )"
+          gh issue comment 705 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/configuration-language-translation-coverage.php
+++ b/scripts/runner/configuration-language-translation-coverage.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$baselinePath = $projectRoot . '/docs/evidence/configuration-language-baseline-609.yml';
+
+if (!is_dir($configDirectory) || !is_file($baselinePath)) {
+  throw new RuntimeException('Configuration sync or #609 baseline is missing.');
+}
+
+$baseline = Yaml::parseFile($baselinePath);
+if (!is_array($baseline)) {
+  throw new RuntimeException('Configuration language baseline must be a mapping.');
+}
+
+$expectedCandidateCount = (int) (
+  $baseline['migration_analysis']['fr_base_with_en_override'] ?? -1
+);
+if ($expectedCandidateCount !== 171) {
+  throw new RuntimeException('Unexpected #609 translated FR-base baseline count.');
+}
+
+$configFactory = \Drupal::service('config.factory');
+$typedConfigManager = \Drupal::service('config.typed');
+$overrideFactory = \Drupal::service('language.config_factory_override');
+
+/**
+ * Returns whether a translatable source value needs explicit coverage.
+ */
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+/**
+ * Encodes a path without losing numeric sequence keys.
+ */
+$pathKey = static function (array $segments): string {
+  return json_encode($segments, JSON_THROW_ON_ERROR);
+};
+
+/**
+ * Renders a path for machine-readable evidence and human inspection.
+ */
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+/**
+ * Collects schema-backed translatable leaves from one source config object.
+ */
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath, $pathKey): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      $childSegments = [...$segments, $key];
+      foreach ($collectTranslatableLeaves($child, $childSegments) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+/**
+ * Collects scalar leaf paths from one raw language override.
+ */
+$collectRawLeafPaths = NULL;
+$collectRawLeafPaths = static function (
+  mixed $value,
+  array $segments = [],
+) use (&$collectRawLeafPaths, $displayPath, $pathKey): array {
+  if (is_array($value)) {
+    $leaves = [];
+    foreach ($value as $key => $child) {
+      foreach ($collectRawLeafPaths($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+  ]];
+};
+
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate base configuration.');
+}
+sort($baseFiles, SORT_STRING);
+
+$candidateNames = [];
+foreach ($baseFiles as $basePath) {
+  $baseData = Yaml::parseFile($basePath);
+  if (!is_array($baseData) || ($baseData['langcode'] ?? NULL) !== 'fr') {
+    continue;
+  }
+
+  $name = basename($basePath, '.yml');
+  $englishPath = $configDirectory . '/language/en/' . $name . '.yml';
+  if (is_file($englishPath)) {
+    $candidateNames[] = $name;
+  }
+}
+sort($candidateNames, SORT_STRING);
+
+$items = [];
+$baselineProblems = [];
+foreach ($candidateNames as $name) {
+  $sourceConfig = $configFactory->getEditable($name);
+  $sourceData = $sourceConfig->get();
+  $sourceLangcode = $sourceData['langcode'] ?? NULL;
+  if ($sourceConfig->isNew() || $sourceLangcode !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => $sourceConfig->isNew()
+        ? 'active_config_missing'
+        : 'active_source_langcode_not_fr',
+    ];
+    continue;
+  }
+
+  $englishOverride = $overrideFactory->getOverride('en', $name);
+  if ($englishOverride->isNew()) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'active_en_override_missing',
+      'material_translatable_leaf_count' => 0,
+      'explicit_en_coverage_count' => 0,
+      'missing_count' => 0,
+      'covered_paths' => [],
+      'missing_paths' => [],
+      'source_equal_paths' => [],
+      'unexpected_override_paths' => [],
+    ];
+    continue;
+  }
+  $englishData = $englishOverride->get();
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'config_schema_missing',
+      'material_translatable_leaf_count' => 0,
+      'explicit_en_coverage_count' => 0,
+      'missing_count' => 0,
+      'covered_paths' => [],
+      'missing_paths' => [],
+      'source_equal_paths' => [],
+      'unexpected_override_paths' => array_column(
+        $collectRawLeafPaths($englishData),
+        'path',
+      ),
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData(
+      $name,
+      $sourceData,
+    );
+    $allTranslatableLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaf_count' => 0,
+      'explicit_en_coverage_count' => 0,
+      'missing_count' => 0,
+      'covered_paths' => [],
+      'missing_paths' => [],
+      'source_equal_paths' => [],
+      'unexpected_override_paths' => array_column(
+        $collectRawLeafPaths($englishData),
+        'path',
+      ),
+    ];
+    continue;
+  }
+
+  $translatableByKey = [];
+  $materialLeaves = [];
+  foreach ($allTranslatableLeaves as $leaf) {
+    $translatableByKey[$leaf['key']] = TRUE;
+    if ($isMaterial($leaf['value'])) {
+      $materialLeaves[] = $leaf;
+    }
+  }
+
+  $coveredPaths = [];
+  $missingPaths = [];
+  $sourceEqualPaths = [];
+  foreach ($materialLeaves as $leaf) {
+    $keyExists = FALSE;
+    $overrideValue = NestedArray::getValue(
+      $englishData,
+      $leaf['segments'],
+      $keyExists,
+    );
+    if (!$keyExists) {
+      $missingPaths[] = $leaf['path'];
+      continue;
+    }
+
+    $coveredPaths[] = $leaf['path'];
+    if ($overrideValue === $leaf['value']) {
+      $sourceEqualPaths[] = $leaf['path'];
+    }
+  }
+
+  $unexpectedOverridePaths = [];
+  foreach ($collectRawLeafPaths($englishData) as $overrideLeaf) {
+    if (!isset($translatableByKey[$overrideLeaf['key']])) {
+      $unexpectedOverridePaths[] = $overrideLeaf['path'];
+    }
+  }
+
+  sort($coveredPaths, SORT_STRING);
+  sort($missingPaths, SORT_STRING);
+  sort($sourceEqualPaths, SORT_STRING);
+  sort($unexpectedOverridePaths, SORT_STRING);
+
+  $classification = 'en_override_complete_for_material_translatable_source';
+  $reason = 'all_material_translatable_source_leaves_explicitly_overridden';
+  if ($unexpectedOverridePaths !== []) {
+    $classification = 'schema_unresolved_review_required';
+    $reason = 'override_contains_non_translatable_or_unresolved_paths';
+  }
+  elseif ($missingPaths !== []) {
+    $classification = 'en_override_partial_review_required';
+    $reason = 'material_translatable_source_leaves_missing_from_en_override';
+  }
+
+  $allExplicitOverridesEqualSource = $coveredPaths !== []
+    && count($sourceEqualPaths) === count($coveredPaths);
+
+  $items[] = [
+    'name' => $name,
+    'classification' => $classification,
+    'reason' => $reason,
+    'material_translatable_leaf_count' => count($materialLeaves),
+    'explicit_en_coverage_count' => count($coveredPaths),
+    'missing_count' => count($missingPaths),
+    'source_equal_explicit_override_count' => count($sourceEqualPaths),
+    'signals' => [
+      'en_override_redundant_or_source_equal' => $allExplicitOverridesEqualSource,
+    ],
+    'covered_paths' => $coveredPaths,
+    'missing_paths' => $missingPaths,
+    'source_equal_paths' => $sourceEqualPaths,
+    'unexpected_override_paths' => $unexpectedOverridePaths,
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int => $left['name'] <=> $right['name'],
+);
+
+$counts = [
+  'candidate_fr_base_with_en_override' => count($candidateNames),
+  'classified' => count($items),
+  'baseline_problem' => count($baselineProblems),
+  'en_override_complete_for_material_translatable_source' => 0,
+  'en_override_partial_review_required' => 0,
+  'schema_unresolved_review_required' => 0,
+  'en_override_redundant_or_source_equal' => 0,
+];
+foreach ($items as $item) {
+  $classification = (string) $item['classification'];
+  if (array_key_exists($classification, $counts)) {
+    $counts[$classification]++;
+  }
+  if (($item['signals']['en_override_redundant_or_source_equal'] ?? FALSE) === TRUE) {
+    $counts['en_override_redundant_or_source_equal']++;
+  }
+}
+
+$webformContact = NULL;
+foreach ($items as $item) {
+  if ($item['name'] === 'webform.webform.contact') {
+    $webformContact = $item;
+    break;
+  }
+}
+
+$status = 'PASS';
+$verdict = 'COVERAGE_CLASSIFIED';
+if (
+  count($candidateNames) !== $expectedCandidateCount
+  || $baselineProblems !== []
+  || count($items) !== $expectedCandidateCount
+) {
+  $status = 'FAIL';
+  $verdict = 'BASELINE_DRIFT';
+}
+elseif ($webformContact === NULL) {
+  $status = 'FAIL';
+  $verdict = 'CONTROL_CASE_MISSING';
+}
+elseif (
+  $counts['en_override_partial_review_required'] > 0
+  || $counts['schema_unresolved_review_required'] > 0
+) {
+  $verdict = 'REVIEW_REQUIRED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'baseline' => [
+    'baseline_id' => $baseline['baseline_id'] ?? NULL,
+    'expected_fr_base_with_en_override' => $expectedCandidateCount,
+  ],
+  'counts' => $counts,
+  'baseline_problems' => $baselineProblems,
+  'focus' => [
+    'webform.webform.contact' => $webformContact,
+  ],
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'configuration_migration_allowed_by_this_proof' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-translation-coverage.sh
+++ b/scripts/runner/run-configuration-language-translation-coverage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-translation-coverage'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test -f docs/evidence/configuration-language-baseline-609.yml
+test -f scripts/runner/configuration-language-translation-coverage.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l \
+  /var/www/html/scripts/runner/configuration-language-translation-coverage.php \
+  >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for coverage classification.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-translation-coverage.php \
+  > "$ARTIFACT_DIR/coverage.json"
+cp "$ARTIFACT_DIR/coverage.json" "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "COVERAGE_CLASSIFIED" or .verdict == "REVIEW_REQUIRED"' \
+  "$result" >/dev/null
+jq -e '.baseline.expected_fr_base_with_en_override == 171' "$result" >/dev/null
+jq -e '.counts.candidate_fr_base_with_en_override == 171' "$result" >/dev/null
+jq -e '.counts.classified == 171' "$result" >/dev/null
+jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+jq -e '(
+  .counts.en_override_complete_for_material_translatable_source
+  + .counts.en_override_partial_review_required
+  + .counts.schema_unresolved_review_required
+) == 171' "$result" >/dev/null
+jq -e '.focus["webform.webform.contact"] != null' "$result" >/dev/null
+jq -e '.constraints.read_only == true' "$result" >/dev/null
+jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$result" >/dev/null
+jq -e '.constraints.configuration_migration_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u \
+  "$ARTIFACT_DIR/config-status-before.txt" \
+  "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Coverage classification unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslationCoverageWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslationCoverageWorkflowTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the read-only EN translation-coverage proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageTranslationCoverageWorkflowTest extends TestCase {
+
+  /**
+   * The trusted route remains owner-bound, issue-bound and live-main-only.
+   */
+  public function testTrustedCoverageGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/'
+      . 'trusted-configuration-language-translation-coverage.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-translation-coverage classify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'705\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString(
+      'run-configuration-language-translation-coverage.sh',
+      $workflow,
+    );
+    self::assertStringContainsString('site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString('SSH_PRIVATE_KEY', $workflow);
+    self::assertStringNotContainsString('SERVER_HOST', $workflow);
+    self::assertStringNotContainsString('OPENAI_API_KEY', $workflow);
+    self::assertStringNotContainsString('composer require', $workflow);
+    self::assertStringNotContainsString('drush cex', $workflow);
+    self::assertStringNotContainsString('config:set', $workflow);
+    self::assertStringNotContainsString('pm:enable config_language_lock', $workflow);
+  }
+
+  /**
+   * The runner proves read-only execution around the typed-config classifier.
+   */
+  public function testCoverageRunnerIsReadOnlyAndFailsClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-translation-coverage.sh';
+    $runner = (string) file_get_contents($runnerPath);
+
+    self::assertStringContainsString(
+      'configuration-language-translation-coverage.php',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.candidate_fr_base_with_en_override == 171',
+      $runner,
+    );
+    self::assertStringContainsString('.counts.classified == 171', $runner);
+    self::assertStringContainsString('.counts.baseline_problem == 0', $runner);
+    self::assertStringContainsString(
+      '.focus["webform.webform.contact"] != null',
+      $runner,
+    );
+    self::assertStringContainsString('config-status-before.txt', $runner);
+    self::assertStringContainsString('config-status-after.txt', $runner);
+    self::assertStringContainsString('git diff --exit-code -- config/sync', $runner);
+    self::assertStringContainsString(
+      "grep -Fxq 'config_language_lock'",
+      $runner,
+    );
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush cim',
+      'drush en',
+      'pm:enable',
+      'config:set',
+      'state:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+  /**
+   * The classifier uses Drupal schema and never infers language from strings.
+   */
+  public function testClassifierUsesTypedConfigAndNeverMutates(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $classifier = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-translation-coverage.php',
+    );
+
+    self::assertIsArray(token_get_all($classifier, TOKEN_PARSE));
+    self::assertStringContainsString(
+      "\\Drupal::service('config.typed')",
+      $classifier,
+    );
+    self::assertStringContainsString(
+      "\\Drupal::service('language.config_factory_override')",
+      $classifier,
+    );
+    self::assertStringContainsString('createFromNameAndData', $classifier);
+    self::assertStringContainsString('NestedArray::getValue', $classifier);
+    self::assertStringContainsString("['translatable']", $classifier);
+    self::assertStringContainsString(
+      'en_override_complete_for_material_translatable_source',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'en_override_partial_review_required',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'schema_unresolved_review_required',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'en_override_redundant_or_source_equal',
+      $classifier,
+    );
+    self::assertStringContainsString('webform.webform.contact', $classifier);
+    self::assertStringContainsString('REVIEW_REQUIRED', $classifier);
+    self::assertStringContainsString('BASELINE_DRIFT', $classifier);
+    self::assertStringContainsString(
+      "'configuration_migration_allowed_by_this_proof' => FALSE",
+      $classifier,
+    );
+
+    foreach ([
+      '->save(',
+      '->delete(',
+      'config:set',
+      'drush cex',
+      'drush cim',
+      'config_language_lock.settings',
+      'preg_match',
+      'str_contains',
+    ] as $forbiddenOperation) {
+      self::assertStringNotContainsString($forbiddenOperation, $classifier);
+    }
+  }
+
+  /**
+   * The coverage proof stays anchored to the approved #609 baseline.
+   */
+  public function testCoverageBaselineRemainsMigrationRequired(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $baseline = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-baseline-609.yml',
+    );
+
+    self::assertSame(
+      'agency-config-language-609-pre-migration-v1',
+      $baseline['baseline_id'] ?? NULL,
+    );
+    self::assertSame('migration_required', $baseline['policy_status'] ?? NULL);
+    self::assertSame(
+      171,
+      $baseline['migration_analysis']['fr_base_with_en_override'] ?? NULL,
+    );
+    self::assertSame(
+      181,
+      $baseline['migration_analysis']['fr_base_without_en_override'] ?? NULL,
+    );
+    self::assertFalse(
+      $baseline['classification']['bulk_langcode_replacement_allowed'] ?? TRUE,
+    );
+  }
+
+}


### PR DESCRIPTION
## Scope

Phase 4H of #609. Adds a strictly read-only typed-config audit for the 171 real FR source configurations that already have an EN language override (#684).

#703 proved the transformation semantics but did not prove that every EN override is complete enough to become the canonical EN source. This PR classifies that coverage before any migration is allowed.

## Implementation

- `configuration-language-translation-coverage.php`: uses Drupal `config.typed->createFromNameAndData()` and typed-data `translatable` definitions to enumerate material source leaves; checks explicit raw EN override coverage through `NestedArray::getValue()`; emits paths/counts only, never content values.
- `run-configuration-language-translation-coverage.sh`: requires converged config before/after, verifies Config Language Lock remains disabled, asserts exactly 171 candidates/classifications, checks the real `webform.webform.contact` control case and proves `config/sync` is untouched.
- trusted issue-comment workflow bound to #705, owner-only and live-main-only, using the existing Agency self-hosted DDEV execution model with `site:install --existing-config`, pre-baseline `cim`, artifact and cleanup.
- repository-owned Unit test protects route, categories, typed-config API usage and mutation prohibitions.

## Conservative classifications

- `en_override_complete_for_material_translatable_source`;
- `en_override_partial_review_required`;
- `schema_unresolved_review_required`;
- secondary signal `en_override_redundant_or_source_equal`.

Missing translatable source coverage always remains review-required even if a source string appears English. No linguistic inference is used.

## Validation

CI #1305 / run `32651214769`: **SUCCESS** on exact HEAD `99d571f52bbed5a62d58ca00d9128a6198af9bfe`.

- PHPCS / PHPStan / drupal-check: PASS;
- PHPUnit: **192 tests / 2807 assertions — PASS**;
- 151 deprecations / 36 PHPUnit deprecations remain known contrib/historical signals and do not introduce a #705 failure.

## Invariants

No config save/delete, no config/sync mutation, no Config Language Lock activation, no config export, no bulk rewrite, no provider/secret/production access. The 140 FR-without-EN editorial/semantic objects remain outside this audit.

#705 must remain open after merge until the post-merge trusted artifact is executed and inspected. Refs #609 #703 #684 #628.