### PR TITLE
Issue #707: complete the four partial EN overrides

### DIFF
--- a/.github/workflows/trusted-configuration-language-translation-coverage.yml
+++ b/.github/workflows/trusted-configuration-language-translation-coverage.yml
@@ -37,7 +37,7 @@ jobs:
 
           [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
           [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
-          [[ "$ISSUE_NUMBER" == '705' ]]
+          [[ "$ISSUE_NUMBER" == '707' ]]
           [[ "$TRIGGER_COMMENT" == '/agency-config-language-translation-coverage classify' ]]
 
           issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
@@ -187,7 +187,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: agency-config-translation-coverage-705-${{ github.run_id }}-${{ github.run_attempt }}
+          name: agency-config-translation-coverage-707-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/configuration-language-translation-coverage
           if-no-files-found: warn
           retention-days: 30
@@ -222,7 +222,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Comment coverage result on #705
+      - name: Comment coverage result on #707
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -243,7 +243,7 @@ jobs:
             heading='### Agency configuration translation coverage PASS'
           fi
 
-          artifact="agency-config-translation-coverage-705-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact="agency-config-translation-coverage-707-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           body="$(cat <<EOF_BODY
           ${heading}
 
@@ -261,4 +261,4 @@ jobs:
           Read-only typed-config coverage classification only. This proof does not enable Configuration Language Lock, migrate/export configuration, rewrite langcodes or access production.
           EOF_BODY
           )"
-          gh issue comment 705 --repo "$GITHUB_REPOSITORY" --body "$body"
+          gh issue comment 707 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/config/sync/language/en/block.block.emerging_digital_footer_branding.yml
+++ b/config/sync/language/en/block.block.emerging_digital_footer_branding.yml
@@ -1,4 +1,10 @@
 settings:
+  label: 'E-merging Digital'
   tagline: 'Commercial, readable, and scalable Drupal websites for SMEs and non-profits.'
+  legal_name: 'E-merging Digital SRL'
+  company_number: 'BE 0746.356.206'
+  company_address: 'Rue des Peupliers 1, 4254 Ligney (Geer), Belgium'
   company_email_label: Email
+  company_email: contact@emergingdigital.be
   company_phone_label: Phone
+  company_phone: '+32 19 86 06 98'

--- a/config/sync/language/en/metatag.metatag_defaults.front.yml
+++ b/config/sync/language/en/metatag.metatag_defaults.front.yml
@@ -1,4 +1,18 @@
 label: 'Front page'
 tags:
   canonical_url: '[site:url]'
+  description: 'Drupal 11 agency for SMEs, non-profits and institutions: structured, accessible and scalable websites, with useful AI in the CMS.'
+  og_description: 'Drupal 11 agency for SMEs, non-profits and institutions: structured, accessible and scalable websites, with useful AI in the CMS.'
+  og_site_name: '[site:name]'
+  og_title: 'Accessible Drupal & useful AI | [site:name]'
+  og_type: website
+  og_url: '[site:url]'
+  schema_organization_name: '[site:name]'
+  schema_organization_url: '[site:url]'
+  schema_web_site_name: '[site:name]'
+  schema_web_site_url: '[site:url]'
   shortlink: '[site:url]'
+  title: 'Accessible Drupal & useful AI | [site:name]'
+  twitter_cards_description: 'Drupal 11 agency for SMEs, non-profits and institutions: structured, accessible and scalable websites, with useful AI in the CMS.'
+  twitter_cards_title: 'Accessible Drupal & useful AI | [site:name]'
+  twitter_cards_type: summary

--- a/config/sync/language/en/metatag.metatag_defaults.node.yml
+++ b/config/sync/language/en/metatag.metatag_defaults.node.yml
@@ -1,5 +1,15 @@
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
-  description: '[node:summary]'
   canonical_url: '[node:url]'
+  description: '[node:summary]'
+  og_description: '[node:summary]'
+  og_title: '[node:title] | [site:name]'
+  og_type: website
+  og_url: '[node:url]'
+  schema_web_page_description: '[node:summary]'
+  schema_web_page_id: '[node:url]'
+  schema_web_page_publisher: 'a:3:{s:5:"@type";s:12:"Organization";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";}'
+  twitter_cards_type: summary
+  twitter_cards_description: '[node:summary]'
+  twitter_cards_title: '[node:title] | [site:name]'
+  title: '[node:title] | [site:name]'

--- a/config/sync/language/en/webform.webform.contact.yml
+++ b/config/sync/language/en/webform.webform.contact.yml
@@ -101,11 +101,14 @@ handlers:
     label: 'Email confirmation'
     settings:
       from_name: _default
+      reply_to: contact@emergingdigital.be
+      return_path: jonathan@emergingdigital.be
       subject: '[webform_submission:values:subject:raw]'
       body: "Thank you for your message. We will get back to you soon.\r\n\r\n[webform_submission:values]"
   email_notification:
     label: 'Email notification'
     settings:
       from_name: '[webform_submission:values:name:raw]'
+      return_path: jonathan@emergingdigital.be
       subject: '[webform_submission:values:subject:raw]'
       body: '[webform_submission:values]'

--- a/scripts/runner/run-configuration-language-translation-coverage.sh
+++ b/scripts/runner/run-configuration-language-translation-coverage.sh
@@ -49,18 +49,17 @@ cp "$ARTIFACT_DIR/coverage.json" "$ARTIFACT_DIR/result.json"
 result="$ARTIFACT_DIR/result.json"
 jq -e '.schema_version == 1' "$result" >/dev/null
 jq -e '.status == "PASS"' "$result" >/dev/null
-jq -e '.verdict == "COVERAGE_CLASSIFIED" or .verdict == "REVIEW_REQUIRED"' \
-  "$result" >/dev/null
+jq -e '.verdict == "COVERAGE_CLASSIFIED"' "$result" >/dev/null
 jq -e '.baseline.expected_fr_base_with_en_override == 171' "$result" >/dev/null
 jq -e '.counts.candidate_fr_base_with_en_override == 171' "$result" >/dev/null
 jq -e '.counts.classified == 171' "$result" >/dev/null
 jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
-jq -e '(
-  .counts.en_override_complete_for_material_translatable_source
-  + .counts.en_override_partial_review_required
-  + .counts.schema_unresolved_review_required
-) == 171' "$result" >/dev/null
-jq -e '.focus["webform.webform.contact"] != null' "$result" >/dev/null
+jq -e '.counts.en_override_complete_for_material_translatable_source == 171' \
+  "$result" >/dev/null
+jq -e '.counts.en_override_partial_review_required == 0' "$result" >/dev/null
+jq -e '.counts.schema_unresolved_review_required == 0' "$result" >/dev/null
+jq -e '.focus["webform.webform.contact"].classification == "en_override_complete_for_material_translatable_source"' \
+  "$result" >/dev/null
 jq -e '.constraints.read_only == true' "$result" >/dev/null
 jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$result" >/dev/null
 jq -e '.constraints.configuration_migration_allowed_by_this_proof == false' \

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslationCoverageWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslationCoverageWorkflowTest.php
@@ -36,7 +36,7 @@ final class ConfigurationLanguageTranslationCoverageWorkflowTest extends TestCas
       $workflow,
     );
     self::assertStringContainsString(
-      '[[ "$ISSUE_NUMBER" == \'705\' ]]',
+      '[[ "$ISSUE_NUMBER" == \'707\' ]]',
       $workflow,
     );
     self::assertStringContainsString(
@@ -53,6 +53,11 @@ final class ConfigurationLanguageTranslationCoverageWorkflowTest extends TestCas
     );
     self::assertStringContainsString('site:install --existing-config', $workflow);
     self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      'agency-config-translation-coverage-707-',
+      $workflow,
+    );
+    self::assertStringContainsString('gh issue comment 707', $workflow);
 
     self::assertStringNotContainsString('workflow_dispatch:', $workflow);
     self::assertStringNotContainsString('SSH_PRIVATE_KEY', $workflow);
@@ -65,7 +70,7 @@ final class ConfigurationLanguageTranslationCoverageWorkflowTest extends TestCas
   }
 
   /**
-   * The runner proves read-only execution around the typed-config classifier.
+   * The runner proves read-only execution and full typed-config coverage.
    */
   public function testCoverageRunnerIsReadOnlyAndFailsClosed(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -84,7 +89,19 @@ final class ConfigurationLanguageTranslationCoverageWorkflowTest extends TestCas
     self::assertStringContainsString('.counts.classified == 171', $runner);
     self::assertStringContainsString('.counts.baseline_problem == 0', $runner);
     self::assertStringContainsString(
-      '.focus["webform.webform.contact"] != null',
+      '.counts.en_override_complete_for_material_translatable_source == 171',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.en_override_partial_review_required == 0',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.schema_unresolved_review_required == 0',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.focus["webform.webform.contact"].classification == "en_override_complete_for_material_translatable_source"',
       $runner,
     );
     self::assertStringContainsString('config-status-before.txt', $runner);


### PR DESCRIPTION
## Scope

Phase 4I of #609 after the typed-config audit #705. That proof classified 171/171 FR-source configs with EN overrides: 167 complete, 4 partial, 0 schema unresolved.

This PR completes only those four EN overrides. It does **not** migrate any base config from FR to EN and does not enable Config Language Lock.

## Changes

- footer branding: explicitly covers legal/business identity fields and localizes only the country name to `Belgium`;
- front-page Metatag defaults: provides explicit EN title/description/OpenGraph/Twitter values plus language-neutral tokens/protocol values;
- node Metatag defaults: explicitly covers the existing token/protocol fallback values;
- contact Webform: explicitly covers `reply_to` / `return_path` with the same addresses already inherited from the FR base;
- trusted typed-config coverage route rebound from completed #705 to open #707;
- trusted runner now fails unless coverage is exactly **171 complete / 0 partial / 0 unresolved** and `webform.webform.contact` is complete;
- repository-owned Unit test protects the new route and strict gate.

## Validation

CI #1307 / run `32654951829`: **SUCCESS** on exact HEAD `007cbe380ecd5b64cfc841603ed2e6e2486ade2a`.

- PHP 8.4.24 / Drupal 11.4.5 / PHPUnit 11.5.56;
- PHPCS / PHPStan / drupal-check: PASS;
- PHPUnit: **192 tests / 2812 assertions — PASS**;
- 151 deprecations / 36 PHPUnit deprecations remain known contrib/historical signals and do not introduce a #707 failure.

## Invariants

- only four files under `config/sync/language/en` are changed for configuration content;
- no base FR YAML or `langcode` is changed;
- no config export, bulk rewrite, provider, secret, production access or persistent Config Language Lock activation;
- #707 remains open after merge until the post-merge trusted classifier is executed and its artifact inspected.

Refs #707 #705 #609 #703 #684.