### PR TITLE
Issue #709: classify the 41 technical FR bases with typed config

### DIFF
--- a/.github/workflows/trusted-configuration-language-technical-no-override.yml
+++ b/.github/workflows/trusted-configuration-language-technical-no-override.yml
@@ -1,0 +1,250 @@
+name: Agency trusted configuration technical cohort classification
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate technical cohort classification request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-technical classify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '709' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-technical classify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Technical cohort classification must execute live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  classify:
+    name: Rebuild Drupal and classify technical FR bases
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      candidate: ${{ steps.summary.outputs.candidate }}
+      review: ${{ steps.summary.outputs.review }}
+      unresolved: ${{ steps.summary.outputs.unresolved }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f .ddev/config.yaml
+          test -f docs/evidence/configuration-language-baseline-609.yml
+          test -f scripts/runner/configuration-language-technical-no-override.php
+          test -f scripts/runner/run-configuration-language-technical-no-override.sh
+          bash -n scripts/runner/run-configuration-language-technical-no-override.sh
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-technical-ci.yaml <<EOF
+          name: agency-config-technical-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-technical-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-technical-no-override.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Classify bounded read-only technical cohort
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-technical-no-override
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-technical-no-override.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-technical-no-override/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          candidate='0'
+          review='0'
+          unresolved='0'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            candidate="$(jq -r '.counts.no_material_translatable_source_candidate // 0' "$result")"
+            review="$(jq -r '.counts.material_translatable_source_review_required // 0' "$result")"
+            unresolved="$(jq -r '.counts.schema_unresolved_review_required // 0' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "candidate=$candidate" >> "$GITHUB_OUTPUT"
+          echo "review=$review" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$unresolved" >> "$GITHUB_OUTPUT"
+
+      - name: Upload technical cohort evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-technical-709-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-technical-no-override
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-technical-ci.yaml
+          rm -rf artifacts/configuration-language-technical-no-override
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish technical cohort result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - classify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment result on #709
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.classify.result }}
+          STATUS: ${{ needs.classify.outputs.status }}
+          VERDICT: ${{ needs.classify.outputs.verdict }}
+          CANDIDATE: ${{ needs.classify.outputs.candidate }}
+          REVIEW: ${{ needs.classify.outputs.review }}
+          UNRESOLVED: ${{ needs.classify.outputs.unresolved }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration technical cohort FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration technical cohort PASS'
+          fi
+
+          artifact="agency-config-technical-709-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          no_material_translatable_source_candidate: \`${CANDIDATE:-0}\`
+          material_translatable_source_review_required: \`${REVIEW:-0}\`
+          schema_unresolved_review_required: \`${UNRESOLVED:-0}\`
+          artifact: \`${artifact}\`
+
+          Read-only typed-config classification of the bounded 41-object technical cohort. This proof does not migrate/export configuration, enable Configuration Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 709 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/configuration-language-technical-no-override.php
+++ b/scripts/runner/configuration-language-technical-no-override.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$baselinePath = $projectRoot . '/docs/evidence/configuration-language-baseline-609.yml';
+
+if (!is_dir($configDirectory) || !is_file($baselinePath)) {
+  throw new RuntimeException('Configuration sync or #609 baseline is missing.');
+}
+
+$baseline = Yaml::parseFile($baselinePath);
+if (!is_array($baseline)) {
+  throw new RuntimeException('Configuration language baseline must be a mapping.');
+}
+
+$expectedByType = [
+  'entity_form_display' => 11,
+  'entity_view_display' => 10,
+  'field_storage_config' => 6,
+  'language_content_settings' => 14,
+];
+$expectedCandidateCount = array_sum($expectedByType);
+
+$baselineByType = $baseline['migration_analysis']['fr_without_en_override_by_entity_type'] ?? [];
+foreach ($expectedByType as $type => $expected) {
+  if ((int) ($baselineByType[$type] ?? -1) !== $expected) {
+    throw new RuntimeException("Unexpected #609 technical baseline count for $type.");
+  }
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+
+/**
+ * Maps a configuration name to the bounded technical cohort.
+ */
+$configType = static function (string $name): ?string {
+  return match (TRUE) {
+    str_starts_with($name, 'core.entity_form_display.') => 'entity_form_display',
+    str_starts_with($name, 'core.entity_view_display.') => 'entity_view_display',
+    str_starts_with($name, 'field.storage.') => 'field_storage_config',
+    str_starts_with($name, 'language.content_settings.') => 'language_content_settings',
+    default => NULL,
+  };
+};
+
+/**
+ * Returns whether a translatable source value is materially present.
+ */
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+/**
+ * Renders a path for machine-readable evidence.
+ */
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+/**
+ * Collects schema-backed translatable leaves from one config object.
+ */
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate base configuration.');
+}
+sort($baseFiles, SORT_STRING);
+
+$candidates = [];
+foreach ($baseFiles as $basePath) {
+  $name = basename($basePath, '.yml');
+  $type = $configType($name);
+  if ($type === NULL) {
+    continue;
+  }
+
+  $baseData = Yaml::parseFile($basePath);
+  if (!is_array($baseData) || ($baseData['langcode'] ?? NULL) !== 'fr') {
+    continue;
+  }
+
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    continue;
+  }
+
+  $candidates[$name] = $type;
+}
+ksort($candidates, SORT_STRING);
+
+$candidateCountsByType = array_fill_keys(array_keys($expectedByType), 0);
+foreach ($candidates as $type) {
+  $candidateCountsByType[$type]++;
+}
+
+$items = [];
+$baselineProblems = [];
+foreach ($candidates as $name => $type) {
+  $sourceConfig = $configFactory->getEditable($name);
+  $sourceData = $sourceConfig->get();
+  if ($sourceConfig->isNew() || ($sourceData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $name,
+      'type' => $type,
+      'reason' => $sourceConfig->isNew()
+        ? 'active_config_missing'
+        : 'active_source_langcode_not_fr',
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $items[] = [
+      'name' => $name,
+      'type' => $type,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'config_schema_missing',
+      'material_translatable_leaf_count' => 0,
+      'material_translatable_paths' => [],
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData($name, $sourceData);
+    $allTranslatableLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $items[] = [
+      'name' => $name,
+      'type' => $type,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaf_count' => 0,
+      'material_translatable_paths' => [],
+    ];
+    continue;
+  }
+
+  $materialPaths = [];
+  foreach ($allTranslatableLeaves as $leaf) {
+    if ($isMaterial($leaf['value'])) {
+      $materialPaths[] = $leaf['path'];
+    }
+  }
+  sort($materialPaths, SORT_STRING);
+
+  $classification = $materialPaths === []
+    ? 'no_material_translatable_source_candidate'
+    : 'material_translatable_source_review_required';
+  $reason = $materialPaths === []
+    ? 'typed_schema_has_no_material_translatable_source_leaves'
+    : 'typed_schema_has_material_translatable_source_leaves';
+
+  $items[] = [
+    'name' => $name,
+    'type' => $type,
+    'classification' => $classification,
+    'reason' => $reason,
+    'material_translatable_leaf_count' => count($materialPaths),
+    'material_translatable_paths' => $materialPaths,
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int => $left['name'] <=> $right['name'],
+);
+
+$counts = [
+  'candidate_technical_fr_base_without_en_override' => count($candidates),
+  'classified' => count($items),
+  'baseline_problem' => count($baselineProblems),
+  'no_material_translatable_source_candidate' => 0,
+  'material_translatable_source_review_required' => 0,
+  'schema_unresolved_review_required' => 0,
+];
+$classifiedByType = [];
+foreach ($expectedByType as $type => $expected) {
+  $classifiedByType[$type] = [
+    'expected' => $expected,
+    'candidate' => $candidateCountsByType[$type],
+    'classified' => 0,
+    'no_material_translatable_source_candidate' => 0,
+    'material_translatable_source_review_required' => 0,
+    'schema_unresolved_review_required' => 0,
+  ];
+}
+foreach ($items as $item) {
+  $classification = (string) $item['classification'];
+  $type = (string) $item['type'];
+  $counts[$classification]++;
+  $classifiedByType[$type]['classified']++;
+  $classifiedByType[$type][$classification]++;
+}
+
+$status = 'PASS';
+$verdict = 'TECHNICAL_COHORT_CLASSIFIED';
+if (
+  count($candidates) !== $expectedCandidateCount
+  || count($items) !== $expectedCandidateCount
+  || $baselineProblems !== []
+  || $candidateCountsByType !== $expectedByType
+) {
+  $status = 'FAIL';
+  $verdict = 'BASELINE_DRIFT';
+}
+elseif (
+  $counts['material_translatable_source_review_required'] > 0
+  || $counts['schema_unresolved_review_required'] > 0
+) {
+  $verdict = 'REVIEW_REQUIRED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'baseline' => [
+    'baseline_id' => $baseline['baseline_id'] ?? NULL,
+    'expected_candidate_count' => $expectedCandidateCount,
+    'expected_by_type' => $expectedByType,
+  ],
+  'counts' => $counts,
+  'by_type' => $classifiedByType,
+  'baseline_problems' => $baselineProblems,
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'configuration_migration_allowed_by_this_proof' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+    'editorial_semantic_cohort_in_scope' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-technical-no-override.sh
+++ b/scripts/runner/run-configuration-language-technical-no-override.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-technical-no-override'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test -f docs/evidence/configuration-language-baseline-609.yml
+test -f scripts/runner/configuration-language-technical-no-override.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l \
+  /var/www/html/scripts/runner/configuration-language-technical-no-override.php \
+  >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for technical classification.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-technical-no-override.php \
+  > "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.counts.candidate_technical_fr_base_without_en_override == 41' "$result" >/dev/null
+jq -e '.counts.classified == 41' "$result" >/dev/null
+jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+jq -e '.baseline.expected_by_type.entity_form_display == 11' "$result" >/dev/null
+jq -e '.baseline.expected_by_type.entity_view_display == 10' "$result" >/dev/null
+jq -e '.baseline.expected_by_type.field_storage_config == 6' "$result" >/dev/null
+jq -e '.baseline.expected_by_type.language_content_settings == 14' "$result" >/dev/null
+jq -e '.by_type.entity_form_display.candidate == 11' "$result" >/dev/null
+jq -e '.by_type.entity_view_display.candidate == 10' "$result" >/dev/null
+jq -e '.by_type.field_storage_config.candidate == 6' "$result" >/dev/null
+jq -e '.by_type.language_content_settings.candidate == 14' "$result" >/dev/null
+jq -e '.constraints.read_only == true' "$result" >/dev/null
+jq -e '.constraints.configuration_migration_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.editorial_semantic_cohort_in_scope == false' "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u \
+  "$ARTIFACT_DIR/config-status-before.txt" \
+  "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Technical classification unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTechnicalCohortWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTechnicalCohortWorkflowTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the typed-config technical-cohort classification proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageTechnicalCohortWorkflowTest extends TestCase {
+
+  /**
+   * The route remains owner-bound, issue-bound and live-main-only.
+   */
+  public function testTrustedTechnicalGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/'
+      . 'trusted-configuration-language-technical-no-override.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-technical classify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'709\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString('site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString('agency-config-technical-709-', $workflow);
+    self::assertStringContainsString('gh issue comment 709', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'composer require',
+      'drush cex',
+      'config:set',
+      'pm:enable config_language_lock',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The runner enforces the exact 41-object baseline without mutation.
+   */
+  public function testTechnicalRunnerIsReadOnlyAndBaselineBound(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-technical-no-override.sh';
+    $runner = (string) file_get_contents($runnerPath);
+
+    self::assertStringContainsString(
+      '.counts.candidate_technical_fr_base_without_en_override == 41',
+      $runner,
+    );
+    self::assertStringContainsString('.counts.classified == 41', $runner);
+    self::assertStringContainsString('.counts.baseline_problem == 0', $runner);
+    self::assertStringContainsString(
+      '.baseline.expected_by_type.entity_form_display == 11',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.baseline.expected_by_type.entity_view_display == 10',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.baseline.expected_by_type.field_storage_config == 6',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.baseline.expected_by_type.language_content_settings == 14',
+      $runner,
+    );
+    self::assertStringContainsString('config-status-before.txt', $runner);
+    self::assertStringContainsString('config-status-after.txt', $runner);
+    self::assertStringContainsString('git diff --exit-code -- config/sync', $runner);
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush cim',
+      'drush en',
+      'pm:enable',
+      'config:set',
+      'state:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+  /**
+   * The classifier decides from typed-config, never from linguistic heuristics.
+   */
+  public function testTechnicalClassifierUsesTypedConfigAndFailsClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $classifier = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-technical-no-override.php',
+    );
+
+    self::assertIsArray(token_get_all($classifier, TOKEN_PARSE));
+    self::assertStringContainsString(
+      "\\Drupal::service('config.typed')",
+      $classifier,
+    );
+    self::assertStringContainsString('createFromNameAndData', $classifier);
+    self::assertStringContainsString("['translatable']", $classifier);
+    self::assertStringContainsString('entity_form_display', $classifier);
+    self::assertStringContainsString('entity_view_display', $classifier);
+    self::assertStringContainsString('field_storage_config', $classifier);
+    self::assertStringContainsString('language_content_settings', $classifier);
+    self::assertStringContainsString(
+      'no_material_translatable_source_candidate',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'material_translatable_source_review_required',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'schema_unresolved_review_required',
+      $classifier,
+    );
+    self::assertStringContainsString('REVIEW_REQUIRED', $classifier);
+    self::assertStringContainsString('BASELINE_DRIFT', $classifier);
+    self::assertStringContainsString(
+      "'editorial_semantic_cohort_in_scope' => FALSE",
+      $classifier,
+    );
+
+    foreach ([
+      '->save(',
+      '->delete(',
+      'config:set',
+      'drush cex',
+      'drush cim',
+      'config_language_lock.settings',
+      'preg_match',
+    ] as $forbiddenOperation) {
+      self::assertStringNotContainsString($forbiddenOperation, $classifier);
+    }
+  }
+
+  /**
+   * The four cohort counts remain anchored to the approved baseline.
+   */
+  public function testTechnicalCountsRemainAnchoredToBaseline(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $baseline = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-baseline-609.yml',
+    );
+    $byType = $baseline['migration_analysis']['fr_without_en_override_by_entity_type'] ?? [];
+
+    self::assertSame(11, $byType['entity_form_display'] ?? NULL);
+    self::assertSame(10, $byType['entity_view_display'] ?? NULL);
+    self::assertSame(6, $byType['field_storage_config'] ?? NULL);
+    self::assertSame(14, $byType['language_content_settings'] ?? NULL);
+    self::assertSame('migration_required', $baseline['policy_status'] ?? NULL);
+    self::assertFalse(
+      $baseline['classification']['bulk_langcode_replacement_allowed'] ?? TRUE,
+    );
+  }
+
+}


### PR DESCRIPTION
## Scope

Phase 4J of #609 after #707. The historical #684 dry-run called 41 FR-base configs without EN overrides “technical” solely from a conservative entity-type allowlist. This PR replaces that assumption with a read-only Drupal typed-config proof before any migration is allowed.

## Bounded cohort

Exactly the four baseline groups from #609:

- `entity_form_display`: 11;
- `entity_view_display`: 10;
- `field_storage_config`: 6;
- `language_content_settings`: 14;
- total: **41**.

## Classification

For each base `langcode=fr` object with no EN override, the classifier uses `config.typed->createFromNameAndData()` and typed-data `translatable` definitions to classify:

- `no_material_translatable_source_candidate`;
- `material_translatable_source_review_required`;
- `schema_unresolved_review_required`.

It records paths/counts only and never infers language from strings or the historical “technical” label.

## Trusted proof

Owner-only/live-main-only command on open #709:

`/agency-config-language-technical classify`

The disposable DDEV route rebuilds from `site:install --existing-config`, canonicalizes with `cim`, requires exact 41 and type counts, checks clean config before/after, uploads an artifact and cleans the workspace.

A `REVIEW_REQUIRED` verdict is valid evidence if typed-config finds material translatable values. The proof does not try to force a migration-safe result.

## Invariants

- no configuration content changes in this PR;
- no `fr -> en` migration;
- no EN override creation;
- no `cex`, bulk rewrite or Config Language Lock activation;
- no provider/secret/production access;
- the 140 editorial/semantic objects remain outside scope and REVIEW_REQUIRED;
- #709 remains open after merge until the trusted artifact is executed and inspected.

Refs #709 #609 #707 #705 #684.