### PR TITLE
Issue #711: explicitly cover the two remaining technical EN exceptions

### DIFF
--- a/.github/workflows/trusted-configuration-language-exception-coverage.yml
+++ b/.github/workflows/trusted-configuration-language-exception-coverage.yml
@@ -1,0 +1,265 @@
+name: Agency trusted configuration language exception coverage
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate configuration exception coverage request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-exceptions classify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '711' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-exceptions classify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Exception coverage must execute the workflow revision on live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  classify:
+    name: Rebuild Drupal and prove two exception overrides
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      classified: ${{ steps.summary.outputs.classified }}
+      material: ${{ steps.summary.outputs.material }}
+      covered: ${{ steps.summary.outputs.covered }}
+      source_equal: ${{ steps.summary.outputs.source_equal }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact checkout and immutable exception proof
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f AGENTS.md
+          test -f .ddev/config.yaml
+          test -f config/sync/language/en/core.entity_form_display.node.page.default.yml
+          test -f config/sync/language/en/field.storage.node.ai_automator_status.yml
+          test -f scripts/runner/configuration-language-exception-coverage.php
+          test -f scripts/runner/run-configuration-language-exception-coverage.sh
+          bash -n scripts/runner/run-configuration-language-exception-coverage.sh
+          git diff --check
+
+      - name: Isolate DDEV project for exception coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-exception-coverage-ci.yaml <<EOF
+          name: agency-config-exception-coverage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-exception-coverage-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-exception-coverage.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Prove bounded read-only exception coverage
+        id: route
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-exception-coverage
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-exception-coverage.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-exception-coverage/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          classified='0'
+          material='0'
+          covered='0'
+          source_equal='0'
+          problems='0'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            classified="$(jq -r '.counts.classified // 0' "$result")"
+            material="$(jq -r '.counts.material_translatable_leaf_count // 0' "$result")"
+            covered="$(jq -r '.counts.explicit_en_coverage_count // 0' "$result")"
+            source_equal="$(jq -r '.counts.source_equal_count // 0' "$result")"
+            problems="$(jq -r '.counts.problem_count // 0' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "classified=$classified" >> "$GITHUB_OUTPUT"
+          echo "material=$material" >> "$GITHUB_OUTPUT"
+          echo "covered=$covered" >> "$GITHUB_OUTPUT"
+          echo "source_equal=$source_equal" >> "$GITHUB_OUTPUT"
+          echo "problems=$problems" >> "$GITHUB_OUTPUT"
+
+      - name: Upload configuration exception evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-exception-coverage-711-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-exception-coverage
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-exception-coverage-ci.yaml
+          rm -rf artifacts/configuration-language-exception-coverage
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish bounded configuration exception coverage result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - classify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment exception coverage result on #711
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.classify.result }}
+          STATUS: ${{ needs.classify.outputs.status }}
+          VERDICT: ${{ needs.classify.outputs.verdict }}
+          CLASSIFIED: ${{ needs.classify.outputs.classified }}
+          MATERIAL: ${{ needs.classify.outputs.material }}
+          COVERED: ${{ needs.classify.outputs.covered }}
+          SOURCE_EQUAL: ${{ needs.classify.outputs.source_equal }}
+          PROBLEMS: ${{ needs.classify.outputs.problems }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration exception coverage FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration exception coverage PASS'
+          fi
+
+          artifact="agency-config-exception-coverage-711-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          configurations_classified: \`${CLASSIFIED:-0}\`
+          material_translatable_leaves: \`${MATERIAL:-0}\`
+          explicit_en_coverage: \`${COVERED:-0}\`
+          source_equal_en_leaves: \`${SOURCE_EQUAL:-0}\`
+          problems: \`${PROBLEMS:-0}\`
+          artifact: \`${artifact}\`
+
+          Focused read-only typed-config proof for #711 only. This proof does not migrate base config, enable Configuration Language Lock, export configuration or access production.
+          EOF_BODY
+          )"
+          gh issue comment 711 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/config/sync/language/en/core.entity_form_display.node.page.default.yml
+++ b/config/sync/language/en/core.entity_form_display.node.page.default.yml
@@ -1,0 +1,5 @@
+content:
+  field_home_components:
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs

--- a/config/sync/language/en/field.storage.node.ai_automator_status.yml
+++ b/config/sync/language/en/field.storage.node.ai_automator_status.yml
@@ -1,0 +1,10 @@
+settings:
+  allowed_values:
+    -
+      label: Pending
+    -
+      label: Processing
+    -
+      label: Failed
+    -
+      label: Finished

--- a/scripts/runner/configuration-language-exception-coverage.php
+++ b/scripts/runner/configuration-language-exception-coverage.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+
+$expected = [
+  'core.entity_form_display.node.page.default' => [
+    'content.field_home_components.settings.title' => [
+      'segments' => ['content', 'field_home_components', 'settings', 'title'],
+      'source' => 'Paragraphe',
+      'english' => 'Paragraph',
+    ],
+    'content.field_home_components.settings.title_plural' => [
+      'segments' => [
+        'content',
+        'field_home_components',
+        'settings',
+        'title_plural',
+      ],
+      'source' => 'Paragraphes',
+      'english' => 'Paragraphs',
+    ],
+  ],
+  'field.storage.node.ai_automator_status' => [
+    'settings.allowed_values.0.label' => [
+      'segments' => ['settings', 'allowed_values', 0, 'label'],
+      'source' => 'Pending',
+      'english' => 'Pending',
+    ],
+    'settings.allowed_values.1.label' => [
+      'segments' => ['settings', 'allowed_values', 1, 'label'],
+      'source' => 'Processing',
+      'english' => 'Processing',
+    ],
+    'settings.allowed_values.2.label' => [
+      'segments' => ['settings', 'allowed_values', 2, 'label'],
+      'source' => 'Failed',
+      'english' => 'Failed',
+    ],
+    'settings.allowed_values.3.label' => [
+      'segments' => ['settings', 'allowed_values', 3, 'label'],
+      'source' => 'Finished',
+      'english' => 'Finished',
+    ],
+  ],
+];
+
+$configFactory = \Drupal::service('config.factory');
+$typedConfigManager = \Drupal::service('config.typed');
+$overrideFactory = \Drupal::service('language.config_factory_override');
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach (
+        $collectTranslatableLeaves($child, [...$segments, $key]) as $leaf
+      ) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$collectRawLeafPaths = NULL;
+$collectRawLeafPaths = static function (
+  mixed $value,
+  array $segments = [],
+) use (&$collectRawLeafPaths, $displayPath): array {
+  if (is_array($value)) {
+    $paths = [];
+    foreach ($value as $key => $child) {
+      foreach ($collectRawLeafPaths($child, [...$segments, $key]) as $path) {
+        $paths[] = $path;
+      }
+    }
+    return $paths;
+  }
+
+  return [$displayPath($segments)];
+};
+
+$items = [];
+$problems = [];
+$totalMaterial = 0;
+$totalCovered = 0;
+$totalSourceEqual = 0;
+
+foreach ($expected as $name => $expectedPaths) {
+  $basePath = $configDirectory . '/' . $name . '.yml';
+  $englishPath = $configDirectory . '/language/en/' . $name . '.yml';
+  if (!is_file($basePath) || !is_file($englishPath)) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'base_or_en_override_missing',
+    ];
+    continue;
+  }
+
+  $sourceData = Yaml::parseFile($basePath);
+  $englishData = Yaml::parseFile($englishPath);
+  if (!is_array($sourceData) || !is_array($englishData)) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'base_or_en_override_not_mapping',
+    ];
+    continue;
+  }
+
+  if (($sourceData['langcode'] ?? NULL) !== 'fr') {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'repository_source_langcode_not_fr',
+    ];
+    continue;
+  }
+
+  $activeSource = $configFactory->getEditable($name);
+  if (
+    $activeSource->isNew()
+    || ($activeSource->get('langcode') ?? NULL) !== 'fr'
+  ) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'active_source_missing_or_not_fr',
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'config_schema_missing',
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData(
+      $name,
+      $sourceData,
+    );
+    $materialPaths = [];
+    foreach ($collectTranslatableLeaves($typedSource) as $leaf) {
+      if ($isMaterial($leaf['value'])) {
+        $materialPaths[] = $leaf['path'];
+      }
+    }
+  }
+  catch (Throwable $exception) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+    ];
+    continue;
+  }
+
+  sort($materialPaths, SORT_STRING);
+  $expectedMaterialPaths = array_keys($expectedPaths);
+  sort($expectedMaterialPaths, SORT_STRING);
+  $rawOverridePaths = $collectRawLeafPaths($englishData);
+  sort($rawOverridePaths, SORT_STRING);
+
+  if ($materialPaths !== $expectedMaterialPaths) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'material_translatable_paths_changed',
+      'actual_paths' => $materialPaths,
+      'expected_paths' => $expectedMaterialPaths,
+    ];
+    continue;
+  }
+
+  if ($rawOverridePaths !== $expectedMaterialPaths) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'en_override_not_minimal_or_incomplete',
+      'actual_paths' => $rawOverridePaths,
+      'expected_paths' => $expectedMaterialPaths,
+    ];
+    continue;
+  }
+
+  $activeEnglish = $overrideFactory->getOverride('en', $name);
+  if ($activeEnglish->isNew()) {
+    $problems[] = [
+      'name' => $name,
+      'reason' => 'active_en_override_missing',
+    ];
+    continue;
+  }
+  $activeEnglishData = $activeEnglish->get();
+
+  $sourceEqualCount = 0;
+  foreach ($expectedPaths as $path => $expectation) {
+    $sourceExists = FALSE;
+    $sourceValue = NestedArray::getValue(
+      $sourceData,
+      $expectation['segments'],
+      $sourceExists,
+    );
+    $englishExists = FALSE;
+    $englishValue = NestedArray::getValue(
+      $englishData,
+      $expectation['segments'],
+      $englishExists,
+    );
+    $activeEnglishExists = FALSE;
+    $activeEnglishValue = NestedArray::getValue(
+      $activeEnglishData,
+      $expectation['segments'],
+      $activeEnglishExists,
+    );
+
+    if (
+      !$sourceExists
+      || !$englishExists
+      || !$activeEnglishExists
+      || $sourceValue !== $expectation['source']
+      || $englishValue !== $expectation['english']
+      || $activeEnglishValue !== $expectation['english']
+    ) {
+      $problems[] = [
+        'name' => $name,
+        'reason' => 'expected_translation_value_mismatch',
+        'path' => $path,
+      ];
+      continue 2;
+    }
+
+    if ($sourceValue === $englishValue) {
+      $sourceEqualCount++;
+    }
+  }
+
+  $itemMaterialCount = count($expectedMaterialPaths);
+  $totalMaterial += $itemMaterialCount;
+  $totalCovered += $itemMaterialCount;
+  $totalSourceEqual += $sourceEqualCount;
+  $items[] = [
+    'name' => $name,
+    'classification' => 'en_override_complete_and_minimal',
+    'material_translatable_leaf_count' => $itemMaterialCount,
+    'explicit_en_coverage_count' => $itemMaterialCount,
+    'source_equal_count' => $sourceEqualCount,
+    'covered_paths' => $expectedMaterialPaths,
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int => $left['name'] <=> $right['name'],
+);
+
+$status = 'PASS';
+$verdict = 'TWO_EXCEPTIONS_EXPLICITLY_COVERED';
+if (
+  count($items) !== 2
+  || $totalMaterial !== 6
+  || $totalCovered !== 6
+  || $problems !== []
+) {
+  $status = 'FAIL';
+  $verdict = 'EXCEPTION_COVERAGE_FAILED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'counts' => [
+    'expected_configurations' => 2,
+    'classified' => count($items),
+    'material_translatable_leaf_count' => $totalMaterial,
+    'explicit_en_coverage_count' => $totalCovered,
+    'source_equal_count' => $totalSourceEqual,
+    'problem_count' => count($problems),
+  ],
+  'problems' => $problems,
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'base_langcode_migration_allowed_by_this_proof' => FALSE,
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-exception-coverage.sh
+++ b/scripts/runner/run-configuration-language-exception-coverage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-exception-coverage'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test -f config/sync/language/en/core.entity_form_display.node.page.default.yml
+test -f config/sync/language/en/field.storage.node.ai_automator_status.yml
+test -f scripts/runner/configuration-language-exception-coverage.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l \
+  /var/www/html/scripts/runner/configuration-language-exception-coverage.php \
+  >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for exception coverage.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-exception-coverage.php \
+  > "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "TWO_EXCEPTIONS_EXPLICITLY_COVERED"' "$result" >/dev/null
+jq -e '.counts.expected_configurations == 2' "$result" >/dev/null
+jq -e '.counts.classified == 2' "$result" >/dev/null
+jq -e '.counts.material_translatable_leaf_count == 6' "$result" >/dev/null
+jq -e '.counts.explicit_en_coverage_count == 6' "$result" >/dev/null
+jq -e '.counts.source_equal_count == 4' "$result" >/dev/null
+jq -e '.counts.problem_count == 0' "$result" >/dev/null
+jq -e '.problems == []' "$result" >/dev/null
+jq -e '[.items[].name] == ["core.entity_form_display.node.page.default", "field.storage.node.ai_automator_status"]' \
+  "$result" >/dev/null
+jq -e '[.items[].classification] | all(. == "en_override_complete_and_minimal")' \
+  "$result" >/dev/null
+jq -e '.constraints.read_only == true' "$result" >/dev/null
+jq -e '.constraints.base_langcode_migration_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' \
+  "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u \
+  "$ARTIFACT_DIR/config-status-before.txt" \
+  "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Exception coverage unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageExceptionCoverageWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageExceptionCoverageWorkflowTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the two explicit EN exception overrides and their trusted proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase {
+
+  /**
+   * The two EN overrides remain sparse and contain only approved leaves.
+   */
+  public function testExceptionOverridesAreMinimal(): void {
+    $root = dirname(DRUPAL_ROOT);
+
+    $formOverride = Yaml::parseFile(
+      $root
+      . '/config/sync/language/en/'
+      . 'core.entity_form_display.node.page.default.yml',
+    );
+    self::assertSame([
+      'content' => [
+        'field_home_components' => [
+          'settings' => [
+            'title' => 'Paragraph',
+            'title_plural' => 'Paragraphs',
+          ],
+        ],
+      ],
+    ], $formOverride);
+
+    $statusOverride = Yaml::parseFile(
+      $root
+      . '/config/sync/language/en/'
+      . 'field.storage.node.ai_automator_status.yml',
+    );
+    self::assertSame([
+      'settings' => [
+        'allowed_values' => [
+          ['label' => 'Pending'],
+          ['label' => 'Processing'],
+          ['label' => 'Failed'],
+          ['label' => 'Finished'],
+        ],
+      ],
+    ], $statusOverride);
+  }
+
+  /**
+   * The source configs stay FR and retain the approved source values.
+   */
+  public function testExceptionSourceConfigsRemainUnmigrated(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $form = Yaml::parseFile(
+      $root . '/config/sync/core.entity_form_display.node.page.default.yml',
+    );
+    $status = Yaml::parseFile(
+      $root . '/config/sync/field.storage.node.ai_automator_status.yml',
+    );
+
+    self::assertSame('fr', $form['langcode'] ?? NULL);
+    self::assertSame(
+      'Paragraphe',
+      $form['content']['field_home_components']['settings']['title'] ?? NULL,
+    );
+    self::assertSame(
+      'Paragraphes',
+      $form['content']['field_home_components']['settings']['title_plural']
+        ?? NULL,
+    );
+
+    self::assertSame('fr', $status['langcode'] ?? NULL);
+    self::assertSame([
+      ['value' => 'pending', 'label' => 'Pending'],
+      ['value' => 'processing', 'label' => 'Processing'],
+      ['value' => 'failed', 'label' => 'Failed'],
+      ['value' => 'finished', 'label' => 'Finished'],
+    ], $status['settings']['allowed_values'] ?? NULL);
+  }
+
+  /**
+   * The gateway remains owner-only, issue-only and live-main-only.
+   */
+  public function testTrustedGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-exception-coverage.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-exceptions classify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'711\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString('site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      'agency-config-exception-coverage-711-',
+      $workflow,
+    );
+    self::assertStringContainsString('gh issue comment 711', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'composer require',
+      'drush cex',
+      'pm:enable config_language_lock',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The classifier and runner fail closed without mutating configuration.
+   */
+  public function testProofIsTypedConfigReadOnlyAndExact(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $classifierPath = $root
+      . '/scripts/runner/configuration-language-exception-coverage.php';
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-exception-coverage.sh';
+    $classifier = (string) file_get_contents($classifierPath);
+    $runner = (string) file_get_contents($runnerPath);
+
+    self::assertIsArray(token_get_all($classifier, TOKEN_PARSE));
+    self::assertStringContainsString(
+      "\\Drupal::service('config.typed')",
+      $classifier,
+    );
+    self::assertStringContainsString(
+      "\\Drupal::service('language.config_factory_override')",
+      $classifier,
+    );
+    self::assertStringContainsString('createFromNameAndData', $classifier);
+    self::assertStringContainsString('NestedArray::getValue', $classifier);
+    self::assertStringContainsString("['translatable']", $classifier);
+    self::assertStringContainsString(
+      'TWO_EXCEPTIONS_EXPLICITLY_COVERED',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      'en_override_not_minimal_or_incomplete',
+      $classifier,
+    );
+    self::assertStringContainsString(
+      "'base_langcode_migration_allowed_by_this_proof' => FALSE",
+      $classifier,
+    );
+
+    self::assertStringContainsString(
+      '.counts.material_translatable_leaf_count == 6',
+      $runner,
+    );
+    self::assertStringContainsString(
+      '.counts.explicit_en_coverage_count == 6',
+      $runner,
+    );
+    self::assertStringContainsString('.counts.source_equal_count == 4', $runner);
+    self::assertStringContainsString('.counts.problem_count == 0', $runner);
+    self::assertStringContainsString('config-status-before.txt', $runner);
+    self::assertStringContainsString('config-status-after.txt', $runner);
+    self::assertStringContainsString('git diff --exit-code -- config/sync', $runner);
+
+    foreach ([
+      '->save(',
+      '->delete(',
+      'drush cex',
+      'config:set',
+      'state:set',
+      'pm:enable',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $classifier);
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+}


### PR DESCRIPTION
## Scope

Phase 4K of #609 after #709. The typed-config proof found 39 genuinely non-translatable technical candidates and exactly two technical configs with material translatable leaves. This PR covers those two exceptions explicitly in EN without migrating their FR bases.

## Configuration changes

- `core.entity_form_display.node.page.default`: sparse EN override with only `Paragraph` / `Paragraphs` for the two Paragraphs widget labels;
- `field.storage.node.ai_automator_status`: sparse EN override with only the four already-English status labels (`Pending`, `Processing`, `Failed`, `Finished`). Machine values remain in the FR base and are not overridden.

## Proof

Adds a focused Drupal typed-config classifier that requires:

- exactly 2 source configs, still base `langcode=fr`;
- exactly 6 material translatable leaves;
- exactly 6 sparse EN override leaves;
- exact source/EN values for all six leaves;
- 4 source-equal status labels, proving they were already English;
- no unexpected/non-translatable override path;
- no mutation.

Trusted owner/live-main route on open #711:

`/agency-config-language-exceptions classify`

The DDEV proof rebuilds via `site:install --existing-config`, canonicalizes with `cim`, checks zero-diff before/after, uploads evidence and cleans the workspace.

## Invariants

- no base config changed;
- no `fr -> en` migration;
- no bulk rewrite or `cex`;
- Config Language Lock remains disabled;
- no provider/secret/production access;
- the 39 mechanical candidates and 140 editorial/semantic configs remain untouched.

#711 remains open after merge until the post-merge trusted artifact is inspected.

Refs #711 #709 #609 #707 #703.