### PR TITLE
Issue #713: prove bounded migration and rollback for 39 mechanical configs

### DIFF
--- a/.github/workflows/trusted-configuration-language-mechanical-migration.yml
+++ b/.github/workflows/trusted-configuration-language-mechanical-migration.yml
@@ -1,0 +1,256 @@
+name: Agency trusted configuration mechanical migration rollback proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate mechanical migration rollback request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-mechanical prove'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '713' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-mechanical prove' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Mechanical migration rollback proof must execute live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prove:
+    name: Rebuild Drupal and prove 39-object migration rollback
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      classified: ${{ steps.summary.outputs.classified }}
+      migrated: ${{ steps.summary.outputs.migrated }}
+      restored: ${{ steps.summary.outputs.restored }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f .ddev/config.yaml
+          test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+          test -f scripts/runner/configuration-language-mechanical-migration.php
+          test -f scripts/runner/run-configuration-language-mechanical-migration.sh
+          bash -n scripts/runner/run-configuration-language-mechanical-migration.sh
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-mechanical-ci.yaml <<EOF_CONFIG
+          name: agency-config-mechanical-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-mechanical-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-mechanical-migration.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Prove bounded active-config migration and rollback
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-mechanical-migration
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-mechanical-migration.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-mechanical-migration/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          classified='0'
+          migrated='0'
+          restored='0'
+          problems='0'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            classified="$(jq -r '.counts.cohort_classified // 0' "$result")"
+            migrated="$(jq -r '.counts.migrated // 0' "$result")"
+            restored="$(jq -r '.counts.rollback_restored // 0' "$result")"
+            problems="$(jq -r '.counts.problem_count // 0' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "classified=$classified" >> "$GITHUB_OUTPUT"
+          echo "migrated=$migrated" >> "$GITHUB_OUTPUT"
+          echo "restored=$restored" >> "$GITHUB_OUTPUT"
+          echo "problems=$problems" >> "$GITHUB_OUTPUT"
+
+      - name: Upload mechanical migration rollback evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-mechanical-713-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-mechanical-migration
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-mechanical-ci.yaml
+          rm -rf artifacts/configuration-language-mechanical-migration
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish mechanical migration rollback result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prove
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment result on #713
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.prove.result }}
+          STATUS: ${{ needs.prove.outputs.status }}
+          VERDICT: ${{ needs.prove.outputs.verdict }}
+          CLASSIFIED: ${{ needs.prove.outputs.classified }}
+          MIGRATED: ${{ needs.prove.outputs.migrated }}
+          RESTORED: ${{ needs.prove.outputs.restored }}
+          PROBLEMS: ${{ needs.prove.outputs.problems }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency configuration mechanical migration rollback FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency configuration mechanical migration rollback PASS'
+          fi
+
+          artifact="agency-config-mechanical-713-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          cohort_classified: \`${CLASSIFIED:-0}\`
+          migrated: \`${MIGRATED:-0}\`
+          rollback_restored: \`${RESTORED:-0}\`
+          problems: \`${PROBLEMS:-0}\`
+          artifact: \`${artifact}\`
+
+          Bounded Drupal config-entity proof on the exact 39-object mechanical cohort. Migration occurs only in disposable active config and is rolled back before completion. This proof does not mutate config/sync, export configuration, enable Configuration Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 713 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/docs/evidence/configuration-language-mechanical-cohort-713.yml
+++ b/docs/evidence/configuration-language-mechanical-cohort-713.yml
@@ -1,0 +1,95 @@
+schema_version: 1
+source:
+  issue: 709
+  trusted_run_id: 32656359172
+  artifact_id: 9497598673
+  artifact_digest: 'sha256:7dfda4d232c9622c4ee4e34c339c0af7dfb9a84036137634bd1672c09386f30a'
+  classification: no_material_translatable_source_candidate
+expected_count: 39
+expected_by_type:
+  entity_form_display: 10
+  entity_view_display: 10
+  field_storage_config: 5
+  language_content_settings: 14
+excluded_review_required:
+  - core.entity_form_display.node.page.default
+  - field.storage.node.ai_automator_status
+items:
+  - name: core.entity_form_display.media.audio.default
+    type: entity_form_display
+  - name: core.entity_form_display.media.audio.media_library
+    type: entity_form_display
+  - name: core.entity_form_display.media.document.default
+    type: entity_form_display
+  - name: core.entity_form_display.media.document.media_library
+    type: entity_form_display
+  - name: core.entity_form_display.media.image.default
+    type: entity_form_display
+  - name: core.entity_form_display.media.image.media_library
+    type: entity_form_display
+  - name: core.entity_form_display.media.remote_video.default
+    type: entity_form_display
+  - name: core.entity_form_display.media.remote_video.media_library
+    type: entity_form_display
+  - name: core.entity_form_display.media.video.default
+    type: entity_form_display
+  - name: core.entity_form_display.media.video.media_library
+    type: entity_form_display
+  - name: core.entity_view_display.media.audio.default
+    type: entity_view_display
+  - name: core.entity_view_display.media.audio.media_library
+    type: entity_view_display
+  - name: core.entity_view_display.media.document.default
+    type: entity_view_display
+  - name: core.entity_view_display.media.document.media_library
+    type: entity_view_display
+  - name: core.entity_view_display.media.image.default
+    type: entity_view_display
+  - name: core.entity_view_display.media.image.media_library
+    type: entity_view_display
+  - name: core.entity_view_display.media.remote_video.default
+    type: entity_view_display
+  - name: core.entity_view_display.media.remote_video.media_library
+    type: entity_view_display
+  - name: core.entity_view_display.media.video.default
+    type: entity_view_display
+  - name: core.entity_view_display.media.video.media_library
+    type: entity_view_display
+  - name: field.storage.media.field_media_audio_file
+    type: field_storage_config
+  - name: field.storage.media.field_media_document
+    type: field_storage_config
+  - name: field.storage.media.field_media_image
+    type: field_storage_config
+  - name: field.storage.media.field_media_oembed_video
+    type: field_storage_config
+  - name: field.storage.media.field_media_video_file
+    type: field_storage_config
+  - name: language.content_settings.block_content.basic
+    type: language_content_settings
+  - name: language.content_settings.comment.comment
+    type: language_content_settings
+  - name: language.content_settings.file.file
+    type: language_content_settings
+  - name: language.content_settings.menu_link_content.menu_link_content
+    type: language_content_settings
+  - name: language.content_settings.path_alias.path_alias
+    type: language_content_settings
+  - name: language.content_settings.redirect.redirect
+    type: language_content_settings
+  - name: language.content_settings.shortcut.default
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.blog_categories
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.localisation
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.secteur
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.tags
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.type_fonctionnalite_ia
+    type: language_content_settings
+  - name: language.content_settings.taxonomy_term.type_service
+    type: language_content_settings
+  - name: language.content_settings.user.user
+    type: language_content_settings

--- a/scripts/runner/configuration-language-mechanical-migration.php
+++ b/scripts/runner/configuration-language-mechanical-migration.php
@@ -1,0 +1,556 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$cohortPath = $projectRoot . '/docs/evidence/configuration-language-mechanical-cohort-713.yml';
+
+if (!is_dir($configDirectory) || !is_file($cohortPath)) {
+  throw new RuntimeException('Configuration sync or #713 cohort evidence is missing.');
+}
+
+$cohort = Yaml::parseFile($cohortPath);
+if (!is_array($cohort)) {
+  throw new RuntimeException('Mechanical cohort evidence must be a mapping.');
+}
+
+$expectedCount = 39;
+$expectedByType = [
+  'entity_form_display' => 10,
+  'entity_view_display' => 10,
+  'field_storage_config' => 5,
+  'language_content_settings' => 14,
+];
+$excluded = [
+  'core.entity_form_display.node.page.default',
+  'field.storage.node.ai_automator_status',
+];
+
+if ((int) ($cohort['expected_count'] ?? -1) !== $expectedCount) {
+  throw new RuntimeException('Unexpected #713 cohort count.');
+}
+if (($cohort['expected_by_type'] ?? NULL) !== $expectedByType) {
+  throw new RuntimeException('Unexpected #713 cohort type counts.');
+}
+if (($cohort['excluded_review_required'] ?? NULL) !== $excluded) {
+  throw new RuntimeException('Unexpected #713 excluded exception set.');
+}
+
+$items = $cohort['items'] ?? NULL;
+if (!is_array($items) || count($items) !== $expectedCount) {
+  throw new RuntimeException('The #713 cohort must contain exactly 39 items.');
+}
+
+$cohortByName = [];
+$typeCounts = array_fill_keys(array_keys($expectedByType), 0);
+foreach ($items as $item) {
+  if (!is_array($item)) {
+    throw new RuntimeException('Each #713 cohort item must be a mapping.');
+  }
+  $name = $item['name'] ?? NULL;
+  $type = $item['type'] ?? NULL;
+  if (!is_string($name) || !is_string($type) || !array_key_exists($type, $expectedByType)) {
+    throw new RuntimeException('Invalid #713 cohort item.');
+  }
+  if (isset($cohortByName[$name]) || in_array($name, $excluded, TRUE)) {
+    throw new RuntimeException('Duplicate or excluded #713 cohort item.');
+  }
+  $cohortByName[$name] = $type;
+  $typeCounts[$type]++;
+}
+ksort($cohortByName, SORT_STRING);
+if ($typeCounts !== $expectedByType) {
+  throw new RuntimeException('The #713 cohort type distribution drifted.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+$configManager = \Drupal::service('config.manager');
+$entityTypeManager = \Drupal::entityTypeManager();
+$activeStorage = \Drupal::service('config.storage');
+
+if (!$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Active configuration storage is unavailable.');
+}
+
+/**
+ * Renders a path for machine-readable evidence.
+ */
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+/**
+ * Collects schema-backed translatable leaves from one config object.
+ */
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+/**
+ * Returns whether a source value is materially present.
+ */
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+/**
+ * Recursively normalizes mappings while preserving list order.
+ */
+$normalize = NULL;
+$normalize = static function (mixed $value) use (&$normalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($normalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $normalize($child);
+  }
+  return $value;
+};
+
+/**
+ * Hashes normalized configuration data.
+ */
+$fingerprint = static function (array $data) use ($normalize): string {
+  return hash('sha256', json_encode(
+    $normalize($data),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ));
+};
+
+/**
+ * Removes only the source-language metadata before semantic comparison.
+ */
+$withoutLangcode = static function (array $data): array {
+  unset($data['langcode']);
+  return $data;
+};
+
+/**
+ * Captures all raw objects from one configuration collection.
+ */
+$captureStorage = static function (StorageInterface $storage): array {
+  $names = $storage->listAll();
+  sort($names, SORT_STRING);
+  $captured = [];
+  if ($names === []) {
+    return $captured;
+  }
+  $multiple = $storage->readMultiple($names);
+  foreach ($names as $name) {
+    $data = $multiple[$name] ?? NULL;
+    if (!is_array($data)) {
+      throw new RuntimeException("Unable to capture configuration $name.");
+    }
+    $captured[$name] = $data;
+  }
+  return $captured;
+};
+
+/**
+ * Captures every non-default collection, including language overrides.
+ */
+$captureCollections = static function (
+  StorageInterface $storage,
+  callable $captureStorage,
+): array {
+  $collectionNames = $storage->getAllCollectionNames();
+  sort($collectionNames, SORT_STRING);
+  $collections = [];
+  foreach ($collectionNames as $collectionName) {
+    $collections[$collectionName] = $captureStorage(
+      $storage->createCollection($collectionName),
+    );
+  }
+  return $collections;
+};
+
+/**
+ * Returns normalized changed configuration names between snapshots.
+ */
+$changedNames = static function (
+  array $before,
+  array $after,
+  callable $fingerprint,
+): array {
+  $names = array_values(array_unique([...array_keys($before), ...array_keys($after)]));
+  sort($names, SORT_STRING);
+  $changed = [];
+  foreach ($names as $name) {
+    $beforeData = $before[$name] ?? NULL;
+    $afterData = $after[$name] ?? NULL;
+    if (!is_array($beforeData) || !is_array($afterData)) {
+      $changed[] = $name;
+      continue;
+    }
+    if ($fingerprint($beforeData) !== $fingerprint($afterData)) {
+      $changed[] = $name;
+    }
+  }
+  return $changed;
+};
+
+/**
+ * Resolves a config name to its real Drupal config entity.
+ */
+$loadConfigEntity = static function (string $name) use (
+  $configManager,
+  $entityTypeManager,
+): ConfigEntityInterface {
+  $entityTypeId = $configManager->getEntityTypeIdByName($name);
+  if (!is_string($entityTypeId) || $entityTypeId === '') {
+    throw new RuntimeException("No config entity type resolves $name.");
+  }
+  $definition = $entityTypeManager->getDefinition($entityTypeId);
+  $prefix = $definition->getConfigPrefix();
+  if (!str_starts_with($name, $prefix . '.')) {
+    throw new RuntimeException("Config prefix mismatch for $name.");
+  }
+  $id = substr($name, strlen($prefix) + 1);
+  $entity = $entityTypeManager->getStorage($entityTypeId)->load($id);
+  if (!$entity instanceof ConfigEntityInterface) {
+    throw new RuntimeException("Unable to load config entity $name.");
+  }
+  return $entity;
+};
+
+$problems = [];
+$classificationItems = [];
+foreach ($cohortByName as $name => $expectedType) {
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => 'unexpected_en_override_file',
+    ];
+    continue;
+  }
+
+  $sourceConfig = $configFactory->getEditable($name);
+  $sourceData = $sourceConfig->get();
+  if ($sourceConfig->isNew() || ($sourceData['langcode'] ?? NULL) !== 'fr') {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => $sourceConfig->isNew()
+        ? 'active_config_missing'
+        : 'active_source_langcode_not_fr',
+    ];
+    continue;
+  }
+
+  $entityTypeId = $configManager->getEntityTypeIdByName($name);
+  if ($entityTypeId !== $expectedType) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => 'entity_type_mismatch',
+      'expected' => $expectedType,
+      'actual' => $entityTypeId,
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => 'config_schema_missing',
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData($name, $sourceData);
+    $allTranslatableLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+    ];
+    continue;
+  }
+
+  $materialPaths = [];
+  foreach ($allTranslatableLeaves as $leaf) {
+    if ($isMaterial($leaf['value'])) {
+      $materialPaths[] = $leaf['path'];
+    }
+  }
+  sort($materialPaths, SORT_STRING);
+  if ($materialPaths !== []) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'preflight',
+      'reason' => 'material_translatable_source_detected',
+      'paths' => $materialPaths,
+    ];
+  }
+
+  $classificationItems[$name] = [
+    'name' => $name,
+    'type' => $expectedType,
+    'material_translatable_leaf_count' => count($materialPaths),
+  ];
+}
+
+$baselineDefault = $captureStorage($activeStorage);
+$baselineCollections = $captureCollections($activeStorage, $captureStorage);
+$migratedDefault = $baselineDefault;
+$migratedCollections = $baselineCollections;
+$finalDefault = $baselineDefault;
+$finalCollections = $baselineCollections;
+$migratedNames = [];
+$migrationItems = [];
+
+if ($problems === [] && count($classificationItems) === $expectedCount) {
+  foreach (array_keys($cohortByName) as $name) {
+    try {
+      $entity = $loadConfigEntity($name);
+      $entity->set('langcode', 'en');
+      $entity->save();
+      $migratedNames[] = $name;
+    }
+    catch (Throwable $exception) {
+      $problems[] = [
+        'name' => $name,
+        'phase' => 'migration',
+        'reason' => 'config_entity_save_failed',
+        'error_class' => $exception::class,
+        'message' => $exception->getMessage(),
+      ];
+      break;
+    }
+  }
+
+  $migratedDefault = $captureStorage($activeStorage);
+  $migratedCollections = $captureCollections($activeStorage, $captureStorage);
+  $changedDuringMigration = $changedNames($baselineDefault, $migratedDefault, $fingerprint);
+  $expectedChanged = array_keys($cohortByName);
+  sort($expectedChanged, SORT_STRING);
+
+  foreach ($expectedChanged as $name) {
+    $before = $baselineDefault[$name] ?? NULL;
+    $after = $migratedDefault[$name] ?? NULL;
+    if (!is_array($before) || !is_array($after)) {
+      $problems[] = [
+        'name' => $name,
+        'phase' => 'migration_validation',
+        'reason' => 'target_missing_from_snapshot',
+      ];
+      continue;
+    }
+
+    $semanticBefore = $withoutLangcode($before);
+    $semanticAfter = $withoutLangcode($after);
+    $semanticPreserved = $fingerprint($semanticBefore) === $fingerprint($semanticAfter);
+    $langcodeMigrated = ($before['langcode'] ?? NULL) === 'fr'
+      && ($after['langcode'] ?? NULL) === 'en';
+
+    if (!$semanticPreserved) {
+      $problems[] = [
+        'name' => $name,
+        'phase' => 'migration_validation',
+        'reason' => 'non_langcode_value_changed',
+      ];
+    }
+    if (!$langcodeMigrated) {
+      $problems[] = [
+        'name' => $name,
+        'phase' => 'migration_validation',
+        'reason' => 'langcode_not_migrated_fr_to_en',
+        'before' => $before['langcode'] ?? NULL,
+        'after' => $after['langcode'] ?? NULL,
+      ];
+    }
+
+    $migrationItems[$name] = [
+      ...$classificationItems[$name],
+      'before_langcode' => $before['langcode'] ?? NULL,
+      'migrated_langcode' => $after['langcode'] ?? NULL,
+      'semantic_fingerprint_before' => $fingerprint($semanticBefore),
+      'semantic_fingerprint_migrated' => $fingerprint($semanticAfter),
+      'semantic_preserved' => $semanticPreserved,
+    ];
+  }
+
+  $unexpectedChanged = array_values(array_diff($changedDuringMigration, $expectedChanged));
+  sort($unexpectedChanged, SORT_STRING);
+  if ($unexpectedChanged !== []) {
+    $problems[] = [
+      'phase' => 'migration_validation',
+      'reason' => 'unexpected_active_config_mutation',
+      'names' => $unexpectedChanged,
+    ];
+  }
+  $missingChanged = array_values(array_diff($expectedChanged, $changedDuringMigration));
+  sort($missingChanged, SORT_STRING);
+  if ($missingChanged !== []) {
+    $problems[] = [
+      'phase' => 'migration_validation',
+      'reason' => 'expected_target_not_changed',
+      'names' => $missingChanged,
+    ];
+  }
+  if ($fingerprint($baselineCollections) !== $fingerprint($migratedCollections)) {
+    $problems[] = [
+      'phase' => 'migration_validation',
+      'reason' => 'language_or_nondefault_collection_changed',
+    ];
+  }
+}
+
+foreach (array_reverse($migratedNames) as $name) {
+  try {
+    $entity = $loadConfigEntity($name);
+    $entity->set('langcode', 'fr');
+    $entity->save();
+  }
+  catch (Throwable $exception) {
+    $problems[] = [
+      'name' => $name,
+      'phase' => 'rollback',
+      'reason' => 'config_entity_rollback_save_failed',
+      'error_class' => $exception::class,
+      'message' => $exception->getMessage(),
+    ];
+  }
+}
+
+$finalDefault = $captureStorage($activeStorage);
+$finalCollections = $captureCollections($activeStorage, $captureStorage);
+$changedAfterRollback = $changedNames($baselineDefault, $finalDefault, $fingerprint);
+if ($changedAfterRollback !== []) {
+  $problems[] = [
+    'phase' => 'rollback_validation',
+    'reason' => 'active_config_not_fully_restored',
+    'names' => $changedAfterRollback,
+  ];
+}
+if ($fingerprint($baselineCollections) !== $fingerprint($finalCollections)) {
+  $problems[] = [
+    'phase' => 'rollback_validation',
+    'reason' => 'collections_not_fully_restored',
+  ];
+}
+
+$rollbackRestored = 0;
+foreach (array_keys($cohortByName) as $name) {
+  $before = $baselineDefault[$name] ?? NULL;
+  $final = $finalDefault[$name] ?? NULL;
+  if (is_array($before) && is_array($final) && $fingerprint($before) === $fingerprint($final)) {
+    $rollbackRestored++;
+  }
+  if (isset($migrationItems[$name]) && is_array($final)) {
+    $migrationItems[$name]['rollback_langcode'] = $final['langcode'] ?? NULL;
+    $migrationItems[$name]['rollback_restored'] = is_array($before)
+      && $fingerprint($before) === $fingerprint($final);
+  }
+}
+ksort($migrationItems, SORT_STRING);
+
+$migratedCount = 0;
+foreach ($migrationItems as $item) {
+  if (
+    ($item['migrated_langcode'] ?? NULL) === 'en'
+    && ($item['semantic_preserved'] ?? FALSE) === TRUE
+  ) {
+    $migratedCount++;
+  }
+}
+
+$changedDuringMigration = isset($changedDuringMigration) ? $changedDuringMigration : [];
+$expectedChanged = array_keys($cohortByName);
+sort($expectedChanged, SORT_STRING);
+$unexpectedMutationCount = count(array_diff($changedDuringMigration, $expectedChanged));
+$languageOverrideDeltaCount = $fingerprint($baselineCollections) === $fingerprint($migratedCollections) ? 0 : 1;
+$materialLeafCount = array_sum(array_column($classificationItems, 'material_translatable_leaf_count'));
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'THIRTY_NINE_MECHANICAL_CANDIDATES_MIGRATION_ROLLBACK_PROVEN'
+  : 'MECHANICAL_COHORT_MIGRATION_ROLLBACK_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'source' => $cohort['source'] ?? [],
+  'counts' => [
+    'cohort_expected' => $expectedCount,
+    'cohort_classified' => count($classificationItems),
+    'material_translatable_leaf_count' => $materialLeafCount,
+    'migrated' => $migratedCount,
+    'unexpected_mutation_count' => $unexpectedMutationCount,
+    'language_override_delta_count' => $languageOverrideDeltaCount,
+    'rollback_restored' => $rollbackRestored,
+    'problem_count' => count($problems),
+  ],
+  'migration_changed_names' => $changedDuringMigration,
+  'rollback_changed_names' => $changedAfterRollback,
+  'problems' => $problems,
+  'items' => array_values($migrationItems),
+  'constraints' => [
+    'active_config_only' => TRUE,
+    'repository_config_mutation_allowed_by_this_proof' => FALSE,
+    'canonical_base_langcode_migration_allowed_by_this_proof' => FALSE,
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+    'editorial_semantic_cohort_in_scope' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-mechanical-migration.sh
+++ b/scripts/runner/run-configuration-language-mechanical-migration.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-mechanical-migration'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+test -f scripts/runner/configuration-language-mechanical-migration.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l \
+  /var/www/html/scripts/runner/configuration-language-mechanical-migration.php \
+  >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for #713.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-mechanical-migration.php \
+  > "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "THIRTY_NINE_MECHANICAL_CANDIDATES_MIGRATION_ROLLBACK_PROVEN"' "$result" >/dev/null
+jq -e '.counts.cohort_expected == 39' "$result" >/dev/null
+jq -e '.counts.cohort_classified == 39' "$result" >/dev/null
+jq -e '.counts.material_translatable_leaf_count == 0' "$result" >/dev/null
+jq -e '.counts.migrated == 39' "$result" >/dev/null
+jq -e '.counts.unexpected_mutation_count == 0' "$result" >/dev/null
+jq -e '.counts.language_override_delta_count == 0' "$result" >/dev/null
+jq -e '.counts.rollback_restored == 39' "$result" >/dev/null
+jq -e '.counts.problem_count == 0' "$result" >/dev/null
+jq -e '.problems == []' "$result" >/dev/null
+jq -e '.constraints.active_config_only == true' "$result" >/dev/null
+jq -e '.constraints.repository_config_mutation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.canonical_base_langcode_migration_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.editorial_semantic_cohort_in_scope == false' "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u \
+  "$ARTIFACT_DIR/config-status-before.txt" \
+  "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo '#713 unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMechanicalMigrationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMechanicalMigrationWorkflowTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded #713 mechanical migration/rollback proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageMechanicalMigrationWorkflowTest extends TestCase {
+
+  /**
+   * The trusted route remains owner-bound, issue-bound and live-main-only.
+   */
+  public function testTrustedMechanicalMigrationGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/'
+      . 'trusted-configuration-language-mechanical-migration.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-mechanical prove'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'713\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString('site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString('agency-config-mechanical-713-', $workflow);
+    self::assertStringContainsString('gh issue comment 713', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'composer require',
+      'drush cex',
+      'pm:enable config_language_lock',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The exact 39-object cohort remains anchored to trusted #709 evidence.
+   */
+  public function testMechanicalCohortIsExactAndExcludesTwoExceptions(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $cohort = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-mechanical-cohort-713.yml',
+    );
+
+    self::assertSame(39, $cohort['expected_count'] ?? NULL);
+    self::assertSame([
+      'entity_form_display' => 10,
+      'entity_view_display' => 10,
+      'field_storage_config' => 5,
+      'language_content_settings' => 14,
+    ], $cohort['expected_by_type'] ?? NULL);
+    self::assertSame(
+      'no_material_translatable_source_candidate',
+      $cohort['source']['classification'] ?? NULL,
+    );
+    self::assertSame(32656359172, $cohort['source']['trusted_run_id'] ?? NULL);
+    self::assertSame(9497598673, $cohort['source']['artifact_id'] ?? NULL);
+
+    $items = $cohort['items'] ?? [];
+    self::assertCount(39, $items);
+    $names = array_column($items, 'name');
+    self::assertCount(39, array_unique($names));
+    self::assertNotContains('core.entity_form_display.node.page.default', $names);
+    self::assertNotContains('field.storage.node.ai_automator_status', $names);
+  }
+
+  /**
+   * The PHP probe uses typed-config and real config entities, then rolls back.
+   */
+  public function testMechanicalMigrationProbeUsesDrupalApisAndFailsClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $probe = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-mechanical-migration.php',
+    );
+
+    self::assertIsArray(token_get_all($probe, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $probe);
+    self::assertStringContainsString("\\Drupal::service('config.manager')", $probe);
+    self::assertStringContainsString('getEntityTypeIdByName', $probe);
+    self::assertStringContainsString('ConfigEntityInterface', $probe);
+    self::assertStringContainsString("->set('langcode', 'en')", $probe);
+    self::assertStringContainsString("->set('langcode', 'fr')", $probe);
+    self::assertStringContainsString('->save()', $probe);
+    self::assertStringContainsString("['translatable']", $probe);
+    self::assertStringContainsString('unexpected_active_config_mutation', $probe);
+    self::assertStringContainsString('language_or_nondefault_collection_changed', $probe);
+    self::assertStringContainsString('active_config_not_fully_restored', $probe);
+    self::assertStringContainsString(
+      'THIRTY_NINE_MECHANICAL_CANDIDATES_MIGRATION_ROLLBACK_PROVEN',
+      $probe,
+    );
+
+    foreach ([
+      'file_put_contents',
+      'Yaml::dump',
+      'config:set',
+      'drush cex',
+      'pm:enable',
+      'config_language_lock.settings',
+      'preg_replace',
+    ] as $forbiddenOperation) {
+      self::assertStringNotContainsString($forbiddenOperation, $probe);
+    }
+  }
+
+  /**
+   * The shell gate requires all proof counts and a clean rollback.
+   */
+  public function testMechanicalRunnerRequiresExactPassAndNoRepositoryMutation(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-mechanical-migration.sh';
+    $runner = (string) file_get_contents($runnerPath);
+
+    foreach ([
+      '.counts.cohort_expected == 39',
+      '.counts.cohort_classified == 39',
+      '.counts.material_translatable_leaf_count == 0',
+      '.counts.migrated == 39',
+      '.counts.unexpected_mutation_count == 0',
+      '.counts.language_override_delta_count == 0',
+      '.counts.rollback_restored == 39',
+      '.counts.problem_count == 0',
+      '.problems == []',
+      'config-status-before.txt',
+      'config-status-after.txt',
+      'git diff --exit-code -- config/sync',
+    ] as $required) {
+      self::assertStringContainsString($required, $runner);
+    }
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush en',
+      'pm:enable',
+      'config:set',
+      'state:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+}


### PR DESCRIPTION
## Summary

Implements the bounded proof requested by #713 without changing canonical configuration.

- freezes the exact 39-object `no_material_translatable_source_candidate` cohort from trusted #709 evidence;
- revalidates every target with Drupal typed-config before mutation;
- migrates only disposable active config through real Drupal config entities (`fr -> en`);
- requires all non-`langcode` values to remain semantically identical;
- fingerprints the complete active configuration so no out-of-cohort mutation is accepted;
- fingerprints all non-default configuration collections so language override drift is rejected;
- rolls every migrated config entity back to `fr` and requires exact baseline restoration;
- adds an owner-only/live-main-only trusted route on #713;
- explicitly keeps Configuration Language Lock disabled and forbids `cex`, repository config mutation, provider/secret access and production mutation.

## Expected trusted verdict

`THIRTY_NINE_MECHANICAL_CANDIDATES_MIGRATION_ROLLBACK_PROVEN`

Expected counts: 39 classified, 0 material translatable leaves, 39 migrated, 0 unexpected mutations, 0 override deltas, 39 restored, 0 problems.

## Local static validation

- PHP syntax: PASS for probe and unit test;
- Bash syntax: PASS;
- YAML parse: PASS;
- cohort names compared against trusted #709 artifact `9497598673`: exact 39/39 match.

## Invariants

This PR does **not** migrate `config/sync`, does not activate Configuration Language Lock, does not run `cex`, and does not authorize canonical FR -> EN migration. The 2 #711 exceptions and 140 editorial/semantic objects remain out of scope.

Refs #713 #609 #709 #711 #684 #703.