### PR TITLE
Issue #715: bootstrap governed canonical migration of 39 mechanical configs

### DIFF
--- a/.github/workflows/governed-configuration-language-mechanical-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-mechanical-canonical-migration.yml
@@ -1,0 +1,262 @@
+name: Agency governed canonical mechanical configuration migration
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate canonical migration request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-mechanical-canonical migrate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '715' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-mechanical-canonical migrate' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Canonical migration must start from live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prepare-and-push:
+    name: Prepare exact 39-file canonical migration branch
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      branch: ${{ steps.commit.outputs.branch }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      status: ${{ steps.summary.outputs.status }}
+      prepared: ${{ steps.summary.outputs.prepared }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact live main with bounded write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Verify immutable migration inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+          test -f scripts/runner/apply-configuration-language-mechanical-canonical.php
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canonical-writer.yaml <<EOF_CONFIG
+          name: agency-config-canonical-writer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canonical-writer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Install repository dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/apply-configuration-language-mechanical-canonical.php
+
+      - name: Prepare exact canonical patch
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-canonical-715-result.json
+        run: |
+          set -euo pipefail
+          ddev exec php \
+            /var/www/html/scripts/runner/apply-configuration-language-mechanical-canonical.php \
+            > "$RESULT_PATH"
+
+          jq -e '.status == "PASS"' "$RESULT_PATH" >/dev/null
+          jq -e '.verdict == "THIRTY_NINE_MECHANICAL_CANONICAL_PATCH_PREPARED"' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.expected == 39' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.prepared == 39' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.excluded_exceptions_preserved == 2' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.problem_count == 0' "$RESULT_PATH" >/dev/null
+          jq -e '.problems == []' "$RESULT_PATH" >/dev/null
+          jq -e '[.items[] | select(.before_langcode != "fr" or .after_langcode != "en" or .semantic_preserved != true)] == []' "$RESULT_PATH" >/dev/null
+
+          mapfile -t expected_paths < <(jq -r '.items[].path' "$RESULT_PATH" | sort)
+          mapfile -t changed_paths < <(git diff --name-only -- config/sync | sort)
+          [[ "${#expected_paths[@]}" -eq 39 ]]
+          [[ "${#changed_paths[@]}" -eq 39 ]]
+          diff -u \
+            <(printf '%s\n' "${expected_paths[@]}") \
+            <(printf '%s\n' "${changed_paths[@]}")
+
+          [[ "$(git diff --numstat -- config/sync | wc -l)" -eq 39 ]]
+          if git diff --numstat -- config/sync | awk '$1 != 1 || $2 != 1 {bad=1} END {exit bad ? 1 : 0}'; then
+            :
+          else
+            echo 'Every canonical file must have exactly one added and one removed line.' >&2
+            exit 1
+          fi
+
+          [[ -z "$(git diff --name-only -- config/sync/language)" ]]
+          [[ -z "$(git diff --name-only -- config/sync/core.extension.yml)" ]]
+          git diff --check
+
+      - name: Commit and push bounded migration branch
+        id: commit
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-canonical-715-result.json
+        run: |
+          set -euo pipefail
+          branch='feature/715-apply-canonical-mechanical-migration'
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing branch $branch" >&2
+            exit 1
+          fi
+
+          git switch -c "$branch"
+          mapfile -t paths < <(jq -r '.items[].path' "$RESULT_PATH")
+          git add -- "${paths[@]}"
+
+          [[ "$(git diff --cached --name-only | wc -l)" -eq 39 ]]
+          [[ -z "$(git status --porcelain | awk '$1 != "" && $2 ~ /^config\/sync\/language\// {print}')" ]]
+
+          git config user.name 'E-merging Digital Automation'
+          git config user.email 'actions@users.noreply.github.com'
+          git commit -m 'Issue #715: migrate 39 mechanical configs to canonical EN'
+          git push origin "HEAD:refs/heads/$branch"
+
+          commit_sha="$(git rev-parse HEAD)"
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize migration preparation
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-canonical-715-result.json
+        run: |
+          set -euo pipefail
+          status='MISSING'
+          prepared='0'
+          if [[ -s "$RESULT_PATH" ]] && jq -e . "$RESULT_PATH" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$RESULT_PATH")"
+            prepared="$(jq -r '.counts.prepared // 0' "$RESULT_PATH")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "prepared=$prepared" >> "$GITHUB_OUTPUT"
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-canonical-writer.yaml
+          git restore --worktree -- .ddev/config.gate-config-language-canonical-writer.yaml 2>/dev/null || true
+
+  report:
+    name: Publish canonical migration preparation result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prepare-and-push
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment branch result on #715
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.prepare-and-push.result }}
+          STATUS: ${{ needs.prepare-and-push.outputs.status }}
+          PREPARED: ${{ needs.prepare-and-push.outputs.prepared }}
+          BRANCH: ${{ needs.prepare-and-push.outputs.branch }}
+          COMMIT_SHA: ${{ needs.prepare-and-push.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          heading='### Canonical 39-object migration branch FAIL'
+          if [[ "$OUTCOME" == 'success' && "$STATUS" == 'PASS' && "$PREPARED" == '39' ]]; then
+            heading='### Canonical 39-object migration branch PREPARED'
+          fi
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          prepared: \`${PREPARED:-0}\`
+          branch: \`${BRANCH:-n/a}\`
+          commit_sha: \`${COMMIT_SHA:-n/a}\`
+
+          The governed writer is restricted to the exact #713 cohort and prepares only top-level \`langcode: fr -> en\` changes. It does not export configuration, touch language overrides, enable Config Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 715 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/trusted-configuration-language-mechanical-canonical-verify.yml
+++ b/.github/workflows/trusted-configuration-language-mechanical-canonical-verify.yml
@@ -1,0 +1,249 @@
+name: Agency trusted canonical mechanical configuration verification
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate canonical verification request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-mechanical-canonical verify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '715' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-mechanical-canonical verify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Canonical verification must execute live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Rebuild Drupal and verify canonical 39-object migration
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      verified: ${{ steps.summary.outputs.verified }}
+      material: ${{ steps.summary.outputs.material }}
+      exceptions: ${{ steps.summary.outputs.exceptions }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+          test -f scripts/runner/configuration-language-mechanical-canonical-verify.php
+          test -f scripts/runner/configuration-language-exception-coverage.php
+          test -f scripts/runner/run-configuration-language-mechanical-canonical-verify.sh
+          bash -n scripts/runner/run-configuration-language-mechanical-canonical-verify.sh
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canonical-verify.yaml <<EOF_CONFIG
+          name: agency-config-canonical-verify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canonical-verify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from migrated canonical configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-mechanical-canonical-verify.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Verify canonical 39-object migration and preserved exceptions
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-mechanical-canonical-verify
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-mechanical-canonical-verify.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-mechanical-canonical-verify/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          verified='0'
+          material='0'
+          exceptions='0'
+          problems='0'
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            verified="$(jq -r '.counts.cohort_verified_en // 0' "$result")"
+            material="$(jq -r '.counts.material_translatable_leaf_count // 0' "$result")"
+            exceptions="$(jq -r '.counts.excluded_exceptions_preserved_fr // 0' "$result")"
+            problems="$(jq -r '.counts.problem_count // 0' "$result")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
+          echo "material=$material" >> "$GITHUB_OUTPUT"
+          echo "exceptions=$exceptions" >> "$GITHUB_OUTPUT"
+          echo "problems=$problems" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canonical migration verification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-canonical-715-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-mechanical-canonical-verify
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-canonical-verify.yaml
+          rm -rf artifacts/configuration-language-mechanical-canonical-verify
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish canonical migration verification result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - verify
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment verification result on #715
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.verify.result }}
+          STATUS: ${{ needs.verify.outputs.status }}
+          VERDICT: ${{ needs.verify.outputs.verdict }}
+          VERIFIED: ${{ needs.verify.outputs.verified }}
+          MATERIAL: ${{ needs.verify.outputs.material }}
+          EXCEPTIONS: ${{ needs.verify.outputs.exceptions }}
+          PROBLEMS: ${{ needs.verify.outputs.problems }}
+        run: |
+          set -euo pipefail
+          heading='### Canonical 39-object migration verification FAIL'
+          if [[ "$OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Canonical 39-object migration verification PASS'
+          fi
+          artifact="agency-config-canonical-715-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          canonical_en_verified: \`${VERIFIED:-0}\`
+          material_translatable_leaves: \`${MATERIAL:-0}\`
+          exceptions_preserved_fr: \`${EXCEPTIONS:-0}\`
+          problems: \`${PROBLEMS:-0}\`
+          artifact: \`${artifact}\`
+
+          Read-only fresh-DDEV verification. This route does not export configuration, enable Config Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 715 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/apply-configuration-language-mechanical-canonical.php
+++ b/scripts/runner/apply-configuration-language-mechanical-canonical.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(__DIR__, 2);
+$autoload = $projectRoot . '/vendor/autoload.php';
+$cohortPath = $projectRoot . '/docs/evidence/configuration-language-mechanical-cohort-713.yml';
+$configDirectory = $projectRoot . '/config/sync';
+
+if (!is_file($autoload) || !is_file($cohortPath) || !is_dir($configDirectory)) {
+  throw new RuntimeException('Required repository inputs are unavailable.');
+}
+require_once $autoload;
+
+$cohort = Yaml::parseFile($cohortPath);
+if (!is_array($cohort) || (int) ($cohort['expected_count'] ?? -1) !== 39) {
+  throw new RuntimeException('The #713 cohort must contain exactly 39 targets.');
+}
+
+$excluded = [
+  'core.entity_form_display.node.page.default',
+  'field.storage.node.ai_automator_status',
+];
+if (($cohort['excluded_review_required'] ?? NULL) !== $excluded) {
+  throw new RuntimeException('The #713 excluded exception set drifted.');
+}
+
+$items = $cohort['items'] ?? NULL;
+if (!is_array($items) || count($items) !== 39) {
+  throw new RuntimeException('The #713 cohort inventory is invalid.');
+}
+
+$prepared = [];
+$names = [];
+foreach ($items as $item) {
+  if (!is_array($item) || !is_string($item['name'] ?? NULL)) {
+    throw new RuntimeException('Invalid #713 cohort item.');
+  }
+
+  $name = $item['name'];
+  if (isset($names[$name]) || in_array($name, $excluded, TRUE)) {
+    throw new RuntimeException("Duplicate or excluded cohort item: $name");
+  }
+  $names[$name] = TRUE;
+
+  $relativePath = 'config/sync/' . $name . '.yml';
+  $absolutePath = $projectRoot . '/' . $relativePath;
+  if (!is_file($absolutePath)) {
+    throw new RuntimeException("Missing canonical configuration: $relativePath");
+  }
+
+  $beforeText = file_get_contents($absolutePath);
+  if (!is_string($beforeText)) {
+    throw new RuntimeException("Unable to read $relativePath");
+  }
+  if (str_contains($beforeText, "\r\n")) {
+    throw new RuntimeException("Unexpected CRLF line endings in $relativePath");
+  }
+
+  $beforeData = Yaml::parse($beforeText);
+  if (!is_array($beforeData) || ($beforeData['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Expected top-level langcode fr in $relativePath");
+  }
+
+  $afterText = str_replace(
+    "langcode: fr\n",
+    "langcode: en\n",
+    $beforeText,
+    $replacementCount,
+  );
+  if ($replacementCount !== 1) {
+    throw new RuntimeException(
+      "Expected exactly one literal top-level langcode replacement in $relativePath; got $replacementCount.",
+    );
+  }
+
+  $afterData = Yaml::parse($afterText);
+  if (!is_array($afterData) || ($afterData['langcode'] ?? NULL) !== 'en') {
+    throw new RuntimeException("Failed to prepare langcode en for $relativePath");
+  }
+
+  $beforeWithoutLangcode = $beforeData;
+  $afterWithoutLangcode = $afterData;
+  unset($beforeWithoutLangcode['langcode'], $afterWithoutLangcode['langcode']);
+  if ($beforeWithoutLangcode !== $afterWithoutLangcode) {
+    throw new RuntimeException("Semantic data outside langcode changed in $relativePath");
+  }
+
+  $prepared[$name] = [
+    'name' => $name,
+    'type' => $item['type'] ?? NULL,
+    'path' => $relativePath,
+    'before_sha256' => hash('sha256', $beforeText),
+    'after_sha256' => hash('sha256', $afterText),
+    'before_text' => $beforeText,
+    'after_text' => $afterText,
+  ];
+}
+
+if (count($prepared) !== 39) {
+  throw new RuntimeException('Prepared canonical migration count is not 39.');
+}
+
+foreach ($excluded as $name) {
+  $path = $configDirectory . '/' . $name . '.yml';
+  $data = is_file($path) ? Yaml::parseFile($path) : NULL;
+  if (!is_array($data) || ($data['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Excluded exception base must remain FR: $name");
+  }
+  if (!is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    throw new RuntimeException("Excluded exception EN override is missing: $name");
+  }
+}
+
+foreach ($prepared as $entry) {
+  if (file_put_contents($projectRoot . '/' . $entry['path'], $entry['after_text']) === FALSE) {
+    throw new RuntimeException('Unable to write ' . $entry['path']);
+  }
+}
+
+$resultItems = [];
+foreach ($prepared as $entry) {
+  $written = file_get_contents($projectRoot . '/' . $entry['path']);
+  if (!is_string($written) || hash('sha256', $written) !== $entry['after_sha256']) {
+    throw new RuntimeException('Post-write fingerprint mismatch for ' . $entry['path']);
+  }
+  $resultItems[] = [
+    'name' => $entry['name'],
+    'type' => $entry['type'],
+    'path' => $entry['path'],
+    'before_langcode' => 'fr',
+    'after_langcode' => 'en',
+    'before_sha256' => $entry['before_sha256'],
+    'after_sha256' => $entry['after_sha256'],
+    'semantic_preserved' => TRUE,
+  ];
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => 'PASS',
+  'verdict' => 'THIRTY_NINE_MECHANICAL_CANONICAL_PATCH_PREPARED',
+  'counts' => [
+    'expected' => 39,
+    'prepared' => count($resultItems),
+    'excluded_exceptions_preserved' => 2,
+    'problem_count' => 0,
+  ],
+  'items' => $resultItems,
+  'problems' => [],
+  'constraints' => [
+    'cohort_source' => 'docs/evidence/configuration-language-mechanical-cohort-713.yml',
+    'global_langcode_replacement_allowed' => FALSE,
+    'config_export_used' => FALSE,
+    'language_override_mutation_allowed' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_mutation_allowed' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/configuration-language-mechanical-canonical-verify.php
+++ b/scripts/runner/configuration-language-mechanical-canonical-verify.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$cohortPath = $projectRoot . '/docs/evidence/configuration-language-mechanical-cohort-713.yml';
+
+if (!is_dir($configDirectory) || !is_file($cohortPath)) {
+  throw new RuntimeException('Required canonical verification inputs are missing.');
+}
+
+$cohort = Yaml::parseFile($cohortPath);
+if (!is_array($cohort) || (int) ($cohort['expected_count'] ?? -1) !== 39) {
+  throw new RuntimeException('Expected the exact 39-object #713 cohort.');
+}
+
+$excluded = [
+  'core.entity_form_display.node.page.default',
+  'field.storage.node.ai_automator_status',
+];
+if (($cohort['excluded_review_required'] ?? NULL) !== $excluded) {
+  throw new RuntimeException('The excluded #711 exception set drifted.');
+}
+
+$items = $cohort['items'] ?? NULL;
+if (!is_array($items) || count($items) !== 39) {
+  throw new RuntimeException('The #713 cohort inventory is invalid.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+$configManager = \Drupal::service('config.manager');
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'path' => implode('.', array_map(static fn($part): string => (string) $part, $segments)),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$problems = [];
+$resultItems = [];
+$seen = [];
+$materialLeafCount = 0;
+
+foreach ($items as $item) {
+  if (!is_array($item) || !is_string($item['name'] ?? NULL) || !is_string($item['type'] ?? NULL)) {
+    throw new RuntimeException('Invalid #713 cohort item.');
+  }
+
+  $name = $item['name'];
+  $expectedType = $item['type'];
+  if (isset($seen[$name]) || in_array($name, $excluded, TRUE)) {
+    throw new RuntimeException("Duplicate or excluded cohort item: $name");
+  }
+  $seen[$name] = TRUE;
+
+  $repositoryPath = $configDirectory . '/' . $name . '.yml';
+  $repositoryData = is_file($repositoryPath) ? Yaml::parseFile($repositoryPath) : NULL;
+  $activeConfig = $configFactory->getEditable($name);
+  $activeData = $activeConfig->get();
+
+  $itemProblems = [];
+  if (!is_array($repositoryData)) {
+    $itemProblems[] = 'repository_config_missing';
+  }
+  elseif (($repositoryData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'repository_langcode_not_en';
+  }
+
+  if ($activeConfig->isNew()) {
+    $itemProblems[] = 'active_config_missing';
+  }
+  elseif (($activeData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'active_langcode_not_en';
+  }
+
+  $entityTypeId = $configManager->getEntityTypeIdByName($name);
+  if ($entityTypeId !== $expectedType) {
+    $itemProblems[] = 'entity_type_mismatch';
+  }
+
+  $materialPaths = [];
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $itemProblems[] = 'config_schema_missing';
+  }
+  elseif (!$activeConfig->isNew()) {
+    try {
+      $typed = $typedConfigManager->createFromNameAndData($name, $activeData);
+      foreach ($collectTranslatableLeaves($typed) as $leaf) {
+        if ($isMaterial($leaf['value'])) {
+          $materialPaths[] = $leaf['path'];
+        }
+      }
+      sort($materialPaths, SORT_STRING);
+      $materialLeafCount += count($materialPaths);
+      if ($materialPaths !== []) {
+        $itemProblems[] = 'material_translatable_source_detected';
+      }
+    }
+    catch (Throwable $exception) {
+      $itemProblems[] = 'typed_config_traversal_failed:' . $exception::class;
+    }
+  }
+
+  if ($itemProblems !== []) {
+    $problems[] = [
+      'name' => $name,
+      'reasons' => $itemProblems,
+      'material_paths' => $materialPaths,
+    ];
+  }
+
+  $resultItems[] = [
+    'name' => $name,
+    'type' => $expectedType,
+    'repository_langcode' => is_array($repositoryData) ? ($repositoryData['langcode'] ?? NULL) : NULL,
+    'active_langcode' => $activeConfig->isNew() ? NULL : ($activeData['langcode'] ?? NULL),
+    'material_translatable_leaf_count' => count($materialPaths),
+    'classification' => $itemProblems === []
+      ? 'canonical_en_no_material_translatable_source'
+      : 'problem',
+  ];
+}
+
+$exceptionItems = [];
+foreach ($excluded as $name) {
+  $repositoryPath = $configDirectory . '/' . $name . '.yml';
+  $overridePath = $configDirectory . '/language/en/' . $name . '.yml';
+  $repositoryData = is_file($repositoryPath) ? Yaml::parseFile($repositoryPath) : NULL;
+  $activeConfig = $configFactory->getEditable($name);
+
+  $baseFr = is_array($repositoryData)
+    && ($repositoryData['langcode'] ?? NULL) === 'fr'
+    && !$activeConfig->isNew()
+    && ($activeConfig->get('langcode') ?? NULL) === 'fr';
+  $overridePresent = is_file($overridePath);
+
+  if (!$baseFr || !$overridePresent) {
+    $problems[] = [
+      'name' => $name,
+      'reasons' => array_values(array_filter([
+        $baseFr ? NULL : 'excluded_exception_base_not_fr',
+        $overridePresent ? NULL : 'excluded_exception_en_override_missing',
+      ])),
+    ];
+  }
+
+  $exceptionItems[] = [
+    'name' => $name,
+    'base_langcode' => $activeConfig->isNew() ? NULL : $activeConfig->get('langcode'),
+    'en_override_present' => $overridePresent,
+  ];
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'THIRTY_NINE_MECHANICAL_CANONICAL_MIGRATION_VERIFIED'
+  : 'MECHANICAL_CANONICAL_MIGRATION_VERIFICATION_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'counts' => [
+    'cohort_expected' => 39,
+    'cohort_verified_en' => count(array_filter(
+      $resultItems,
+      static fn(array $item): bool => $item['classification'] === 'canonical_en_no_material_translatable_source',
+    )),
+    'material_translatable_leaf_count' => $materialLeafCount,
+    'excluded_exceptions_expected' => 2,
+    'excluded_exceptions_preserved_fr' => count(array_filter(
+      $exceptionItems,
+      static fn(array $item): bool => $item['base_langcode'] === 'fr' && $item['en_override_present'] === TRUE,
+    )),
+    'problem_count' => count($problems),
+  ],
+  'problems' => $problems,
+  'items' => $resultItems,
+  'excluded_exceptions' => $exceptionItems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+    'editorial_semantic_cohort_in_scope' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-mechanical-canonical-verify.sh
+++ b/scripts/runner/run-configuration-language-mechanical-canonical-verify.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-mechanical-canonical-verify'
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+test -f scripts/runner/configuration-language-mechanical-canonical-verify.php
+test -f scripts/runner/configuration-language-exception-coverage.php
+test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+
+ddev exec php -l /var/www/html/scripts/runner/configuration-language-mechanical-canonical-verify.php >/dev/null
+
+if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for canonical migration verification.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-mechanical-canonical-verify.php \
+  > "$ARTIFACT_DIR/result.json"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-exception-coverage.php \
+  > "$ARTIFACT_DIR/exceptions-result.json"
+
+result="$ARTIFACT_DIR/result.json"
+exceptions="$ARTIFACT_DIR/exceptions-result.json"
+
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "THIRTY_NINE_MECHANICAL_CANONICAL_MIGRATION_VERIFIED"' "$result" >/dev/null
+jq -e '.counts.cohort_expected == 39' "$result" >/dev/null
+jq -e '.counts.cohort_verified_en == 39' "$result" >/dev/null
+jq -e '.counts.material_translatable_leaf_count == 0' "$result" >/dev/null
+jq -e '.counts.excluded_exceptions_expected == 2' "$result" >/dev/null
+jq -e '.counts.excluded_exceptions_preserved_fr == 2' "$result" >/dev/null
+jq -e '.counts.problem_count == 0' "$result" >/dev/null
+jq -e '.problems == []' "$result" >/dev/null
+jq -e '[.items[] | select(.repository_langcode != "en" or .active_langcode != "en" or .material_translatable_leaf_count != 0 or .classification != "canonical_en_no_material_translatable_source")] == []' "$result" >/dev/null
+jq -e '[.excluded_exceptions[] | select(.base_langcode != "fr" or .en_override_present != true)] == []' "$result" >/dev/null
+jq -e '.constraints.read_only == true' "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.editorial_semantic_cohort_in_scope == false' "$result" >/dev/null
+
+jq -e '.status == "PASS"' "$exceptions" >/dev/null
+jq -e '.verdict == "TWO_EXCEPTIONS_EXPLICITLY_COVERED"' "$exceptions" >/dev/null
+jq -e '.counts.expected_configurations == 2' "$exceptions" >/dev/null
+jq -e '.counts.classified == 2' "$exceptions" >/dev/null
+jq -e '.counts.material_translatable_leaf_count == 6' "$exceptions" >/dev/null
+jq -e '.counts.explicit_en_coverage_count == 6' "$exceptions" >/dev/null
+jq -e '.counts.problem_count == 0' "$exceptions" >/dev/null
+jq -e '.problems == []' "$exceptions" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u "$ARTIFACT_DIR/config-status-before.txt" "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+  echo '#715 verification unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMechanicalCanonicalMigrationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageMechanicalCanonicalMigrationWorkflowTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the governed #715 canonical mechanical migration routes.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageMechanicalCanonicalMigrationWorkflowTest extends TestCase {
+
+  /**
+   * The writer route is owner/issue/live-main bounded and branch-only.
+   */
+  public function testGovernedWriterRouteIsStrictlyBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/'
+      . 'governed-configuration-language-mechanical-canonical-migration.yml';
+    $workflow = (string) file_get_contents($path);
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    foreach ([
+      "github.event.comment.body == '/agency-config-language-mechanical-canonical migrate'",
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      '[[ "$ISSUE_NUMBER" == \'715\' ]]',
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      'contents: write',
+      "branch='feature/715-apply-canonical-mechanical-migration'",
+      'Refusing to overwrite existing branch',
+      '.counts.prepared == 39',
+      'git diff --numstat -- config/sync',
+      'git diff --name-only -- config/sync/language',
+      'git diff --name-only -- config/sync/core.extension.yml',
+      'gh issue comment 715',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'git push --force',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The writer changes only exact cohort files and preserves YAML semantics.
+   */
+  public function testCanonicalWriterIsExactAndFailClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/apply-configuration-language-mechanical-canonical.php';
+    $script = (string) file_get_contents($path);
+
+    self::assertIsArray(token_get_all($script, TOKEN_PARSE));
+    foreach ([
+      "(int) (\$cohort['expected_count'] ?? -1) !== 39",
+      "'core.entity_form_display.node.page.default'",
+      "'field.storage.node.ai_automator_status'",
+      "'langcode'] ?? NULL) !== 'fr'",
+      '"langcode: fr\\n"',
+      '"langcode: en\\n"',
+      '$replacementCount !== 1',
+      'unset($beforeWithoutLangcode[\'langcode\'], $afterWithoutLangcode[\'langcode\'])',
+      '$beforeWithoutLangcode !== $afterWithoutLangcode',
+      "'THIRTY_NINE_MECHANICAL_CANONICAL_PATCH_PREPARED'",
+      "'global_langcode_replacement_allowed' => FALSE",
+      "'language_override_mutation_allowed' => FALSE",
+    ] as $required) {
+      self::assertStringContainsString($required, $script);
+    }
+
+    foreach ([
+      'preg_replace',
+      'Yaml::dump',
+      'config:export',
+      'drush cex',
+      'config_language_lock.settings',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted verifier is read-only and requires all canonical gates.
+   */
+  public function testTrustedCanonicalVerifierRequiresExactEvidence(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflowPath = $root . '/.github/workflows/'
+      . 'trusted-configuration-language-mechanical-canonical-verify.yml';
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-mechanical-canonical-verify.sh';
+    $probePath = $root
+      . '/scripts/runner/configuration-language-mechanical-canonical-verify.php';
+
+    $workflow = (string) file_get_contents($workflowPath);
+    $runner = (string) file_get_contents($runnerPath);
+    $probe = (string) file_get_contents($probePath);
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertIsArray(token_get_all($probe, TOKEN_PARSE));
+
+    foreach ([
+      "github.event.comment.body == '/agency-config-language-mechanical-canonical verify'",
+      '[[ "$ISSUE_NUMBER" == \'715\' ]]',
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      'persist-credentials: false',
+      'site:install --existing-config',
+      'ddev drush cim -y',
+      'agency-config-canonical-715-',
+      'gh issue comment 715',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      '.counts.cohort_expected == 39',
+      '.counts.cohort_verified_en == 39',
+      '.counts.material_translatable_leaf_count == 0',
+      '.counts.excluded_exceptions_preserved_fr == 2',
+      '.counts.problem_count == 0',
+      '.verdict == "TWO_EXCEPTIONS_EXPLICITLY_COVERED"',
+      'config-status-before.txt',
+      'config-status-after.txt',
+      'git diff --exit-code -- config/sync',
+    ] as $required) {
+      self::assertStringContainsString($required, $runner);
+    }
+
+    foreach ([
+      "'repository_langcode_not_en'",
+      "'active_langcode_not_en'",
+      "'material_translatable_source_detected'",
+      "'excluded_exception_base_not_fr'",
+      "'THIRTY_NINE_MECHANICAL_CANONICAL_MIGRATION_VERIFIED'",
+      "'read_only' => TRUE",
+    ] as $required) {
+      self::assertStringContainsString($required, $probe);
+    }
+
+    foreach ([$workflow, $runner, $probe] as $surface) {
+      foreach ([
+        'OPENAI_API_KEY',
+        'SSH_PRIVATE_KEY',
+        'drush cex',
+        'pm:enable config_language_lock',
+      ] as $forbidden) {
+        self::assertStringNotContainsString($forbidden, $surface);
+      }
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+}


### PR DESCRIPTION
## Summary

Bootstrap infrastructure for the separately governed canonical migration phase #715.

This PR **does not change any canonical Drupal configuration yet**. It adds:

- a deterministic writer restricted to the exact 39-object cohort frozen by #713;
- an owner-only/live-main migration route that prepares a new branch and refuses to overwrite an existing target branch;
- exact diff gates requiring 39 files and exactly 1 added / 1 removed line per file;
- explicit exclusion of `config/sync/language/*` and `core.extension.yml`;
- a read-only trusted post-migration verifier rebuilding Drupal from `--existing-config`;
- re-execution of the #711 exception coverage proof to guarantee the two exceptions remain FR + sparse EN overrides;
- repository-owned tests protecting both routes.

The actual 39-file canonical migration will only be generated after this bootstrap PR is green and merged, then reviewed through a separate PR before any post-merge trusted verification.

Refs #715 #609 #713 #711.