### PR TITLE
Issue #715: apply canonical EN migration to 39 mechanical configs

### DIFF
--- a/config/sync/core.entity_form_display.media.audio.default.yml
+++ b/config/sync/core.entity_form_display.media.audio.default.yml
@@ -1,5 +1,5 @@
 uuid: 9acbb65e-0dad-46d2-9461-c035ac1a98c3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.audio.media_library.yml
+++ b/config/sync/core.entity_form_display.media.audio.media_library.yml
@@ -1,5 +1,5 @@
 uuid: d209c418-a001-4983-ae9a-60dbe5714b12
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -1,5 +1,5 @@
 uuid: fbc9f81f-0286-480d-aea1-043b579cafcc
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -1,5 +1,5 @@
 uuid: f468e740-3fdc-4665-ad5a-010020064038
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -1,5 +1,5 @@
 uuid: 1593153b-5966-47d9-87a9-b88fbff7edae
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 21d77b2c-ca06-4411-bbea-3b5cc91281f5
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_form_display.media.remote_video.default.yml
@@ -1,5 +1,5 @@
 uuid: 5f146978-bd75-4e75-b382-85fd21a5be0d
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.remote_video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.remote_video.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 5a1095c8-4478-4f15-b737-eac38bf52f83
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -1,5 +1,5 @@
 uuid: 1bec3c13-dbb2-4536-9964-f8ae13267230
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 84b5dd3a-4914-4d32-ae0d-5d4a8f9ff1e7
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.audio.default.yml
+++ b/config/sync/core.entity_view_display.media.audio.default.yml
@@ -1,5 +1,5 @@
 uuid: eff4e68a-3113-4e1d-8e9d-42e4d2952a65
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.audio.media_library.yml
+++ b/config/sync/core.entity_view_display.media.audio.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 7e0a81e6-25c1-47aa-964a-db5bb806da5c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.document.default.yml
+++ b/config/sync/core.entity_view_display.media.document.default.yml
@@ -1,5 +1,5 @@
 uuid: f3a5d608-9404-46e0-834f-cddcee9f4112
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.document.media_library.yml
+++ b/config/sync/core.entity_view_display.media.document.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 16bb786f-65aa-45e1-b673-bf34911e7c31
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -1,5 +1,5 @@
 uuid: 6f306f1e-0d27-45a7-a655-4b24bb58b982
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.image.media_library.yml
+++ b/config/sync/core.entity_view_display.media.image.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 00bab46c-d682-4a0f-a496-1bc98496265c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_view_display.media.remote_video.default.yml
@@ -1,5 +1,5 @@
 uuid: fcf351df-7a1e-4801-9ede-ed9333cfec55
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.remote_video.media_library.yml
+++ b/config/sync/core.entity_view_display.media.remote_video.media_library.yml
@@ -1,5 +1,5 @@
 uuid: c42116da-609c-455a-b694-6dbc5142ec84
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -1,5 +1,5 @@
 uuid: efda9708-c119-44e8-9d3b-91996e73e747
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.entity_view_display.media.video.media_library.yml
+++ b/config/sync/core.entity_view_display.media.video.media_library.yml
@@ -1,5 +1,5 @@
 uuid: ed3000bd-a423-4a1f-90c3-e53731b8fb7c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/field.storage.media.field_media_audio_file.yml
+++ b/config/sync/field.storage.media.field_media_audio_file.yml
@@ -1,5 +1,5 @@
 uuid: 9e50f90f-7f5a-4cc2-8902-c1b3aef3d5e5
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/field.storage.media.field_media_document.yml
+++ b/config/sync/field.storage.media.field_media_document.yml
@@ -1,5 +1,5 @@
 uuid: ca3ab6bc-d0e7-4ec9-9529-200b220ed7e3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/field.storage.media.field_media_image.yml
+++ b/config/sync/field.storage.media.field_media_image.yml
@@ -1,5 +1,5 @@
 uuid: f80c8839-ee73-4f70-9c4a-426892346c31
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/field.storage.media.field_media_oembed_video.yml
+++ b/config/sync/field.storage.media.field_media_oembed_video.yml
@@ -1,5 +1,5 @@
 uuid: 74a58280-dc7b-4a86-a50b-fc4d01da1c4c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/field.storage.media.field_media_video_file.yml
+++ b/config/sync/field.storage.media.field_media_video_file.yml
@@ -1,5 +1,5 @@
 uuid: d00ddf94-2930-4be9-93e8-d7f231aa17b6
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language.content_settings.block_content.basic.yml
+++ b/config/sync/language.content_settings.block_content.basic.yml
@@ -1,5 +1,5 @@
 uuid: 8de54e29-c727-43bf-9d52-21bbdcd4e528
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.comment.comment.yml
+++ b/config/sync/language.content_settings.comment.comment.yml
@@ -1,5 +1,5 @@
 uuid: 6e9ebdec-8ba7-4cdb-9905-3025dbc6d286
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.file.file.yml
+++ b/config/sync/language.content_settings.file.file.yml
@@ -1,5 +1,5 @@
 uuid: 35b5e932-84dd-44bb-bab5-eabe5d89303f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language.content_settings.menu_link_content.menu_link_content.yml
+++ b/config/sync/language.content_settings.menu_link_content.menu_link_content.yml
@@ -1,5 +1,5 @@
 uuid: eb8dda9c-23f3-4726-af9f-49a74250042f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language.content_settings.path_alias.path_alias.yml
+++ b/config/sync/language.content_settings.path_alias.path_alias.yml
@@ -1,5 +1,5 @@
 uuid: 3a2f2f72-2940-40ca-a76d-21f3d9d6a2c7
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language.content_settings.redirect.redirect.yml
+++ b/config/sync/language.content_settings.redirect.redirect.yml
@@ -1,5 +1,5 @@
 uuid: 371b845b-e58d-47c1-9a88-015f77ae4060
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language.content_settings.shortcut.default.yml
+++ b/config/sync/language.content_settings.shortcut.default.yml
@@ -1,5 +1,5 @@
 uuid: d2fcfa4c-1ebe-43b1-8861-0d78dc39daf8
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.blog_categories.yml
+++ b/config/sync/language.content_settings.taxonomy_term.blog_categories.yml
@@ -1,5 +1,5 @@
 uuid: 1c17c6cc-7700-4ee4-bece-cc404ccd5f75
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.localisation.yml
+++ b/config/sync/language.content_settings.taxonomy_term.localisation.yml
@@ -1,5 +1,5 @@
 uuid: e12a0b20-99d6-4e33-a609-46abef4eb471
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.secteur.yml
+++ b/config/sync/language.content_settings.taxonomy_term.secteur.yml
@@ -1,5 +1,5 @@
 uuid: e5f8c38e-6bd2-46b0-b5c8-cd3078656f9d
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.tags.yml
+++ b/config/sync/language.content_settings.taxonomy_term.tags.yml
@@ -1,5 +1,5 @@
 uuid: 95a83691-e4dd-4011-bd55-b8f1f8d8ae03
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.type_fonctionnalite_ia.yml
+++ b/config/sync/language.content_settings.taxonomy_term.type_fonctionnalite_ia.yml
@@ -1,5 +1,5 @@
 uuid: 137bdaaa-3406-4145-b3ba-a082f2309e72
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.taxonomy_term.type_service.yml
+++ b/config/sync/language.content_settings.taxonomy_term.type_service.yml
@@ -1,5 +1,5 @@
 uuid: a1172065-687b-4146-95e5-5e6a123c52ba
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/language.content_settings.user.user.yml
+++ b/config/sync/language.content_settings.user.user.yml
@@ -1,5 +1,5 @@
 uuid: aa0daa14-8452-4cf9-a93c-343c83c55a87
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:


### PR DESCRIPTION
## Summary

Applies the separately proven canonical migration for the exact 39-object mechanical cohort frozen by #713.

- exactly 39 `config/sync/*.yml` files are changed;
- every file changes exactly one top-level line: `langcode: fr` -> `langcode: en`;
- no other YAML value changes;
- no `config/sync/language/*` override is touched;
- the two #711 exceptions remain out of the cohort;
- Configuration Language Lock remains disabled;
- no `cex`, bulk replacement, production mutation or provider/secret access is involved.

The branch was generated by the governed #715 writer from trusted main `479da14a2dc9fdce68c2f764aa97fd76c9096170` in run `32660010392`.

Generated commit: `01a9db6a01d225377958734213f8bba8fce51f00`.

GitHub compare confirms 39 modified files, each `+1/-1`, and the commit patches contain only `-langcode: fr` / `+langcode: en` hunks.

After CI exact-head passes, this PR may be merged; a single read-only trusted post-merge verification on #715 remains required before #715 can close.

Refs #715 #609 #713 #711 #714 #716.