### PR TITLE
Issue #718: prove reversible promotion of 173 translated configs

### DIFF
--- a/.github/workflows/trusted-configuration-language-translated-promotion.yml
+++ b/.github/workflows/trusted-configuration-language-translated-promotion.yml
@@ -1,0 +1,262 @@
+name: Agency trusted translated configuration promotion rollback proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate translated promotion rollback request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-translated-promotion prove'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '718' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-translated-promotion prove' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Translated promotion proof must execute live main.' >&2
+            exit 1
+          }
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prove:
+    name: Rebuild Drupal and prove 173 translated promotions with rollback
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      classified: ${{ steps.summary.outputs.classified }}
+      promoted: ${{ steps.summary.outputs.promoted }}
+      fr_overrides: ${{ steps.summary.outputs.fr_overrides }}
+      restored: ${{ steps.summary.outputs.restored }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f .ddev/config.yaml
+          test -f docs/evidence/configuration-language-translated-cohort-718.yml
+          test -f scripts/runner/configuration-language-translated-promotion.php
+          test -f scripts/runner/run-configuration-language-translated-promotion.sh
+          bash -n scripts/runner/run-configuration-language-translated-promotion.sh
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-translated-ci.yaml <<EOF_CONFIG
+          name: agency-config-translated-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-translated-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from repository-owned configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-translated-promotion.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Prove bounded translated promotion and rollback
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-translated-promotion
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-translated-promotion.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-translated-promotion/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          classified='0'
+          promoted='0'
+          fr_overrides='0'
+          restored='0'
+          problems='0'
+
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            classified="$(jq -r '.counts.cohort_classified // 0' "$result")"
+            promoted="$(jq -r '.counts.promoted // 0' "$result")"
+            fr_overrides="$(jq -r '.counts.fr_overrides_created // 0' "$result")"
+            restored="$(jq -r '.counts.rollback_restored // 0' "$result")"
+            problems="$(jq -r '.counts.problem_count // 0' "$result")"
+          fi
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "classified=$classified" >> "$GITHUB_OUTPUT"
+          echo "promoted=$promoted" >> "$GITHUB_OUTPUT"
+          echo "fr_overrides=$fr_overrides" >> "$GITHUB_OUTPUT"
+          echo "restored=$restored" >> "$GITHUB_OUTPUT"
+          echo "problems=$problems" >> "$GITHUB_OUTPUT"
+
+      - name: Upload translated promotion rollback evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-translated-718-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-translated-promotion
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-translated-ci.yaml
+          rm -rf artifacts/configuration-language-translated-promotion
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish translated promotion rollback result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prove
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment result on #718
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.prove.result }}
+          STATUS: ${{ needs.prove.outputs.status }}
+          VERDICT: ${{ needs.prove.outputs.verdict }}
+          CLASSIFIED: ${{ needs.prove.outputs.classified }}
+          PROMOTED: ${{ needs.prove.outputs.promoted }}
+          FR_OVERRIDES: ${{ needs.prove.outputs.fr_overrides }}
+          RESTORED: ${{ needs.prove.outputs.restored }}
+          PROBLEMS: ${{ needs.prove.outputs.problems }}
+        run: |
+          set -euo pipefail
+
+          heading='### Agency translated configuration promotion rollback FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency translated configuration promotion rollback PASS'
+          fi
+
+          artifact="agency-config-translated-718-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          cohort_classified: \`${CLASSIFIED:-0}\`
+          promoted: \`${PROMOTED:-0}\`
+          fr_overrides_created_when_needed: \`${FR_OVERRIDES:-0}\`
+          rollback_restored: \`${RESTORED:-0}\`
+          problems: \`${PROBLEMS:-0}\`
+          artifact: \`${artifact}\`
+
+          Bounded Drupal configuration-API proof on the frozen 173-object translated cohort. Promotion occurs only in disposable active config and is rolled back before completion. This proof does not mutate config/sync, export configuration, enable Configuration Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 718 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/docs/evidence/configuration-language-translated-cohort-718.yml
+++ b/docs/evidence/configuration-language-translated-cohort-718.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+issue: 718
+expected_count: 173
+identity_rule: "sha256(sorted config names joined by newline, with trailing newline)"
+names_sha256: "3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547"
+sources:
+  historical_complete_171:
+    issue: 707
+    trusted_run: 32655167659
+    artifact_id: 9497280060
+    artifact_digest: "sha256:3b975a855d3f19f8e71f0a2f6bff8f12f31d6bd8aa5bc219d3d433f278ed0494"
+    count: 171
+    verdict: COVERAGE_CLASSIFIED
+    complete: 171
+    partial: 0
+    unresolved: 0
+  technical_exceptions_2:
+    issue: 711
+    trusted_run: 32657297513
+    artifact_id: 9497831272
+    artifact_digest: "sha256:6deaed67d04f612a49543b6188b7cd901ef1b90453e05cb5e9b1a50f6a203610"
+    count: 2
+    verdict: TWO_EXCEPTIONS_EXPLICITLY_COVERED
+    material_translatable_leaf_count: 6
+    explicit_en_coverage_count: 6
+required_exception_names:
+  - core.entity_form_display.node.page.default
+  - field.storage.node.ai_automator_status
+expected_preexisting_fr_overrides_outside_cohort:
+  - block.block.emerging_digital_footer_menu
+  - views.view.blog
+constraints:
+  canonical_configuration_language: en
+  site_default_language: fr
+  config_language_lock_enabled_canonically: false
+  editorial_semantic_without_en_override_in_scope: false

--- a/scripts/runner/configuration-language-translated-promotion.php
+++ b/scripts/runner/configuration-language-translated-promotion.php
@@ -1,0 +1,743 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$cohortPath = $projectRoot . '/docs/evidence/configuration-language-translated-cohort-718.yml';
+
+if (!is_dir($configDirectory) || !is_file($cohortPath)) {
+  throw new RuntimeException('Configuration sync or #718 cohort evidence is missing.');
+}
+
+$cohort = Yaml::parseFile($cohortPath);
+if (!is_array($cohort)) {
+  throw new RuntimeException('#718 cohort evidence must be a mapping.');
+}
+
+$expectedCount = 173;
+$expectedHash = '3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547';
+$requiredExceptions = [
+  'core.entity_form_display.node.page.default',
+  'field.storage.node.ai_automator_status',
+];
+$expectedPreexistingFrenchOverrides = [
+  'block.block.emerging_digital_footer_menu',
+  'views.view.blog',
+];
+
+if ((int) ($cohort['expected_count'] ?? -1) !== $expectedCount) {
+  throw new RuntimeException('Unexpected #718 cohort count.');
+}
+if (($cohort['names_sha256'] ?? NULL) !== $expectedHash) {
+  throw new RuntimeException('Unexpected #718 cohort identity hash.');
+}
+if (($cohort['required_exception_names'] ?? NULL) !== $requiredExceptions) {
+  throw new RuntimeException('Unexpected #718 required exception set.');
+}
+if (($cohort['expected_preexisting_fr_overrides_outside_cohort'] ?? NULL) !== $expectedPreexistingFrenchOverrides) {
+  throw new RuntimeException('Unexpected #718 pre-existing FR override set.');
+}
+
+$configFactory = \Drupal::service('config.factory');
+$typedConfigManager = \Drupal::service('config.typed');
+$overrideFactory = \Drupal::service('language.config_factory_override');
+$activeStorage = \Drupal::service('config.storage');
+if (!$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Active configuration storage is unavailable.');
+}
+
+/**
+ * Normalizes mappings recursively while preserving list order.
+ */
+$normalize = NULL;
+$normalize = static function (mixed $value) use (&$normalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($normalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $normalize($child);
+  }
+  return $value;
+};
+
+/**
+ * Hashes normalized data.
+ */
+$fingerprint = static function (mixed $value) use ($normalize): string {
+  return hash('sha256', json_encode(
+    $normalize($value),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ));
+};
+
+/**
+ * Returns whether a source value is materially present.
+ */
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+/**
+ * Stable path key preserving numeric indexes.
+ */
+$pathKey = static function (array $segments): string {
+  return json_encode($segments, JSON_THROW_ON_ERROR);
+};
+
+/**
+ * Human-readable typed-config path.
+ */
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+/**
+ * Collects all schema-backed translatable leaves.
+ */
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath, $pathKey): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+/**
+ * Collects raw scalar leaves from an override.
+ */
+$collectRawLeaves = NULL;
+$collectRawLeaves = static function (
+  mixed $value,
+  array $segments = [],
+) use (&$collectRawLeaves, $displayPath, $pathKey): array {
+  if (is_array($value) && $value !== []) {
+    $leaves = [];
+    foreach ($value as $key => $child) {
+      foreach ($collectRawLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+    'value' => $value,
+  ]];
+};
+
+/**
+ * Captures all raw objects from one storage collection.
+ */
+$captureStorage = static function (StorageInterface $storage): array {
+  $names = $storage->listAll();
+  sort($names, SORT_STRING);
+  if ($names === []) {
+    return [];
+  }
+  $multiple = $storage->readMultiple($names);
+  $captured = [];
+  foreach ($names as $name) {
+    $data = $multiple[$name] ?? NULL;
+    if (!is_array($data)) {
+      throw new RuntimeException("Unable to capture configuration $name.");
+    }
+    $captured[$name] = $data;
+  }
+  return $captured;
+};
+
+/**
+ * Captures all non-default collections.
+ */
+$captureCollections = static function (
+  StorageInterface $storage,
+  callable $captureStorage,
+): array {
+  $names = $storage->getAllCollectionNames();
+  sort($names, SORT_STRING);
+  $collections = [];
+  foreach ($names as $name) {
+    $collections[$name] = $captureStorage($storage->createCollection($name));
+  }
+  return $collections;
+};
+
+/**
+ * Returns names whose normalized raw data changed.
+ */
+$changedNames = static function (
+  array $before,
+  array $after,
+  callable $fingerprint,
+): array {
+  $names = array_values(array_unique([...array_keys($before), ...array_keys($after)]));
+  sort($names, SORT_STRING);
+  $changed = [];
+  foreach ($names as $name) {
+    if (!array_key_exists($name, $before) || !array_key_exists($name, $after)) {
+      $changed[] = $name;
+      continue;
+    }
+    if ($fingerprint($before[$name]) !== $fingerprint($after[$name])) {
+      $changed[] = $name;
+    }
+  }
+  return $changed;
+};
+
+/**
+ * Enumerates repository base-FR configs that carry an EN override file.
+ */
+$discoverCandidates = static function (string $configDirectory): array {
+  $baseFiles = glob($configDirectory . '/*.yml');
+  if ($baseFiles === FALSE) {
+    throw new RuntimeException('Unable to enumerate repository configuration.');
+  }
+  $names = [];
+  foreach ($baseFiles as $path) {
+    $data = Yaml::parseFile($path);
+    if (!is_array($data) || ($data['langcode'] ?? NULL) !== 'fr') {
+      continue;
+    }
+    $name = basename($path, '.yml');
+    if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+      $names[] = $name;
+    }
+  }
+  sort($names, SORT_STRING);
+  return $names;
+};
+
+/**
+ * Enumerates repository FR override names.
+ */
+$discoverFrenchOverrides = static function (string $configDirectory): array {
+  $files = glob($configDirectory . '/language/fr/*.yml');
+  if ($files === FALSE) {
+    throw new RuntimeException('Unable to enumerate repository FR overrides.');
+  }
+  $names = array_map(
+    static fn(string $path): string => basename($path, '.yml'),
+    $files,
+  );
+  sort($names, SORT_STRING);
+  return $names;
+};
+
+$candidateNames = $discoverCandidates($configDirectory);
+$candidateHash = hash('sha256', implode("\n", $candidateNames) . "\n");
+$repositoryFrenchOverrides = $discoverFrenchOverrides($configDirectory);
+
+$problems = [];
+if (count($candidateNames) !== $expectedCount) {
+  $problems[] = [
+    'phase' => 'identity',
+    'reason' => 'candidate_count_mismatch',
+    'expected' => $expectedCount,
+    'actual' => count($candidateNames),
+  ];
+}
+if ($candidateHash !== $expectedHash) {
+  $problems[] = [
+    'phase' => 'identity',
+    'reason' => 'candidate_identity_hash_mismatch',
+    'expected' => $expectedHash,
+    'actual' => $candidateHash,
+  ];
+}
+foreach ($requiredExceptions as $name) {
+  if (!in_array($name, $candidateNames, TRUE)) {
+    $problems[] = [
+      'phase' => 'identity',
+      'name' => $name,
+      'reason' => 'required_exception_missing',
+    ];
+  }
+}
+if ($repositoryFrenchOverrides !== $expectedPreexistingFrenchOverrides) {
+  $problems[] = [
+    'phase' => 'identity',
+    'reason' => 'preexisting_fr_override_set_drifted',
+    'expected' => $expectedPreexistingFrenchOverrides,
+    'actual' => $repositoryFrenchOverrides,
+  ];
+}
+if (array_intersect($candidateNames, $repositoryFrenchOverrides) !== []) {
+  $problems[] = [
+    'phase' => 'identity',
+    'reason' => 'candidate_already_has_fr_override',
+    'names' => array_values(array_intersect($candidateNames, $repositoryFrenchOverrides)),
+  ];
+}
+
+$classificationItems = [];
+$totalMaterialLeaves = 0;
+$totalExplicitCoverage = 0;
+
+if ($problems === []) {
+  foreach ($candidateNames as $name) {
+    $baseConfig = $configFactory->getEditable($name);
+    $baseData = $baseConfig->get();
+    $englishOverride = $overrideFactory->getOverride('en', $name);
+    $frenchOverride = $overrideFactory->getOverride('fr', $name);
+
+    if ($baseConfig->isNew() || ($baseData['langcode'] ?? NULL) !== 'fr') {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => $baseConfig->isNew() ? 'active_base_missing' : 'active_base_not_fr',
+      ];
+      continue;
+    }
+    if ($englishOverride->isNew()) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'active_en_override_missing',
+      ];
+      continue;
+    }
+    if (!$frenchOverride->isNew()) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'active_fr_override_already_exists',
+      ];
+      continue;
+    }
+    if (!$typedConfigManager->hasConfigSchema($name)) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'config_schema_missing',
+      ];
+      continue;
+    }
+
+    try {
+      $typedSource = $typedConfigManager->createFromNameAndData($name, $baseData);
+      $translatableLeaves = $collectTranslatableLeaves($typedSource);
+    }
+    catch (Throwable $exception) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'typed_config_traversal_failed',
+        'error_class' => $exception::class,
+        'message' => $exception->getMessage(),
+      ];
+      continue;
+    }
+
+    $translatableByKey = [];
+    foreach ($translatableLeaves as $leaf) {
+      $translatableByKey[$leaf['key']] = $leaf;
+    }
+
+    $englishData = $englishOverride->get();
+    $englishLeaves = $collectRawLeaves($englishData);
+    $englishByKey = [];
+    $unexpectedPaths = [];
+    foreach ($englishLeaves as $leaf) {
+      $englishByKey[$leaf['key']] = $leaf;
+      if (!isset($translatableByKey[$leaf['key']])) {
+        $unexpectedPaths[] = $leaf['path'];
+      }
+    }
+
+    $materialPaths = [];
+    $missingPaths = [];
+    foreach ($translatableLeaves as $leaf) {
+      if (!$isMaterial($leaf['value'])) {
+        continue;
+      }
+      $materialPaths[] = $leaf['path'];
+      if (!isset($englishByKey[$leaf['key']])) {
+        $missingPaths[] = $leaf['path'];
+      }
+    }
+    sort($materialPaths, SORT_STRING);
+    sort($missingPaths, SORT_STRING);
+    sort($unexpectedPaths, SORT_STRING);
+
+    if ($missingPaths !== []) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'material_translatable_source_not_covered',
+        'paths' => $missingPaths,
+      ];
+    }
+    if ($unexpectedPaths !== []) {
+      $problems[] = [
+        'phase' => 'preflight',
+        'name' => $name,
+        'reason' => 'en_override_contains_non_translatable_or_unresolved_path',
+        'paths' => $unexpectedPaths,
+      ];
+    }
+
+    $totalMaterialLeaves += count($materialPaths);
+    $totalExplicitCoverage += count($materialPaths) - count($missingPaths);
+    $classificationItems[$name] = [
+      'name' => $name,
+      'classification' => $missingPaths === [] && $unexpectedPaths === []
+        ? 'complete_for_promotion'
+        : 'review_required',
+      'material_translatable_leaf_count' => count($materialPaths),
+      'explicit_en_coverage_count' => count($materialPaths) - count($missingPaths),
+      'explicit_en_leaf_count' => count($englishLeaves),
+      'translatable_leaves' => $translatableLeaves,
+      'english_leaves' => $englishLeaves,
+    ];
+  }
+}
+
+$baselineDefault = $captureStorage($activeStorage);
+$baselineCollections = $captureCollections($activeStorage, $captureStorage);
+$baselineFingerprint = $fingerprint([
+  'default' => $baselineDefault,
+  'collections' => $baselineCollections,
+]);
+
+$migratedDefault = $baselineDefault;
+$migratedCollections = $baselineCollections;
+$finalDefault = $baselineDefault;
+$finalCollections = $baselineCollections;
+$expectedMigratedDefault = $baselineDefault;
+$expectedMigratedCollections = $baselineCollections;
+$promotionItems = [];
+$touchedNames = [];
+
+try {
+  if ($problems === [] && count($classificationItems) === $expectedCount) {
+    if (!isset($expectedMigratedCollections['language.en'])) {
+      throw new RuntimeException('Active language.en collection is missing.');
+    }
+    if (!isset($expectedMigratedCollections['language.fr'])) {
+      $expectedMigratedCollections['language.fr'] = [];
+    }
+
+    foreach ($candidateNames as $name) {
+      $item = $classificationItems[$name];
+      $baseData = $baselineDefault[$name] ?? NULL;
+      $englishData = $baselineCollections['language.en'][$name] ?? NULL;
+      if (!is_array($baseData) || !is_array($englishData)) {
+        throw new RuntimeException("Baseline data is missing for $name.");
+      }
+
+      $newBase = $baseData;
+      $newBase['langcode'] = 'en';
+      foreach ($item['english_leaves'] as $leaf) {
+        NestedArray::setValue($newBase, $leaf['segments'], $leaf['value'], TRUE);
+      }
+
+      $frenchData = [];
+      $effectiveFrChecks = [];
+      $effectiveEnChecks = [];
+      foreach ($item['translatable_leaves'] as $leaf) {
+        $sourceExists = FALSE;
+        $sourceValue = NestedArray::getValue($baseData, $leaf['segments'], $sourceExists);
+        $englishExists = FALSE;
+        $englishValue = NestedArray::getValue($englishData, $leaf['segments'], $englishExists);
+        $newBaseExists = FALSE;
+        $newBaseValue = NestedArray::getValue($newBase, $leaf['segments'], $newBaseExists);
+
+        $beforeFr = $sourceExists ? $sourceValue : NULL;
+        $beforeEn = $englishExists ? $englishValue : $beforeFr;
+        $afterEn = $newBaseExists ? $newBaseValue : NULL;
+
+        if ($beforeFr !== $afterEn) {
+          NestedArray::setValue($frenchData, $leaf['segments'], $beforeFr, TRUE);
+        }
+
+        $effectiveFrChecks[$leaf['key']] = [
+          'path' => $leaf['path'],
+          'expected' => $beforeFr,
+        ];
+        $effectiveEnChecks[$leaf['key']] = [
+          'path' => $leaf['path'],
+          'expected' => $beforeEn,
+        ];
+      }
+
+      $configFactory->getEditable($name)->setData($newBase)->save();
+      $overrideFactory->getOverride('en', $name)->delete();
+      if ($frenchData !== []) {
+        $overrideFactory->getOverride('fr', $name)->setData($frenchData)->save();
+      }
+      $touchedNames[] = $name;
+
+      $expectedMigratedDefault[$name] = $newBase;
+      unset($expectedMigratedCollections['language.en'][$name]);
+      if ($frenchData !== []) {
+        $expectedMigratedCollections['language.fr'][$name] = $frenchData;
+      }
+      else {
+        unset($expectedMigratedCollections['language.fr'][$name]);
+      }
+
+      $promotionItems[$name] = [
+        'name' => $name,
+        'origin' => in_array($name, $requiredExceptions, TRUE)
+          ? 'issue_711_exception'
+          : 'issue_707_complete',
+        'material_translatable_leaf_count' => $item['material_translatable_leaf_count'],
+        'explicit_en_leaf_count' => $item['explicit_en_leaf_count'],
+        'fr_override_required' => $frenchData !== [],
+        'fr_override_leaf_count' => count($collectRawLeaves($frenchData)),
+        'effective_fr_checks' => $effectiveFrChecks,
+        'effective_en_checks' => $effectiveEnChecks,
+      ];
+    }
+
+    $migratedDefault = $captureStorage($activeStorage);
+    $migratedCollections = $captureCollections($activeStorage, $captureStorage);
+
+    if ($fingerprint($migratedDefault) !== $fingerprint($expectedMigratedDefault)) {
+      $problems[] = [
+        'phase' => 'promotion_validation',
+        'reason' => 'default_collection_does_not_match_expected_promotion',
+        'changed_names' => $changedNames($baselineDefault, $migratedDefault, $fingerprint),
+      ];
+    }
+    if ($fingerprint($migratedCollections) !== $fingerprint($expectedMigratedCollections)) {
+      $problems[] = [
+        'phase' => 'promotion_validation',
+        'reason' => 'language_collections_do_not_match_expected_promotion',
+      ];
+    }
+
+    foreach ($candidateNames as $name) {
+      $promotedBase = $migratedDefault[$name] ?? NULL;
+      $promotedFrench = $migratedCollections['language.fr'][$name] ?? [];
+      $promotedEnglish = $migratedCollections['language.en'][$name] ?? NULL;
+      if (!is_array($promotedBase) || ($promotedBase['langcode'] ?? NULL) !== 'en') {
+        $problems[] = [
+          'phase' => 'promotion_validation',
+          'name' => $name,
+          'reason' => 'base_not_promoted_to_en',
+        ];
+        continue;
+      }
+      if ($promotedEnglish !== NULL) {
+        $problems[] = [
+          'phase' => 'promotion_validation',
+          'name' => $name,
+          'reason' => 'en_override_not_removed',
+        ];
+      }
+
+      foreach ($promotionItems[$name]['effective_fr_checks'] as $check) {
+        $segments = json_decode(array_search($check, $promotionItems[$name]['effective_fr_checks'], TRUE) ?: '[]', TRUE);
+        if (!is_array($segments)) {
+          continue;
+        }
+        $baseExists = FALSE;
+        $baseValue = NestedArray::getValue($promotedBase, $segments, $baseExists);
+        $frExists = FALSE;
+        $frValue = NestedArray::getValue($promotedFrench, $segments, $frExists);
+        $actual = $frExists ? $frValue : ($baseExists ? $baseValue : NULL);
+        if ($actual !== $check['expected']) {
+          $problems[] = [
+            'phase' => 'promotion_validation',
+            'name' => $name,
+            'reason' => 'effective_fr_value_changed',
+            'path' => $check['path'],
+          ];
+        }
+      }
+      foreach ($promotionItems[$name]['effective_en_checks'] as $check) {
+        $segments = json_decode(array_search($check, $promotionItems[$name]['effective_en_checks'], TRUE) ?: '[]', TRUE);
+        if (!is_array($segments)) {
+          continue;
+        }
+        $exists = FALSE;
+        $actual = NestedArray::getValue($promotedBase, $segments, $exists);
+        $actual = $exists ? $actual : NULL;
+        if ($actual !== $check['expected']) {
+          $problems[] = [
+            'phase' => 'promotion_validation',
+            'name' => $name,
+            'reason' => 'effective_en_value_changed',
+            'path' => $check['path'],
+          ];
+        }
+      }
+    }
+  }
+}
+catch (Throwable $exception) {
+  $problems[] = [
+    'phase' => 'promotion',
+    'reason' => 'promotion_execution_failed',
+    'error_class' => $exception::class,
+    'message' => $exception->getMessage(),
+  ];
+}
+finally {
+  foreach (array_reverse($touchedNames) as $name) {
+    try {
+      $base = $baselineDefault[$name] ?? NULL;
+      $english = $baselineCollections['language.en'][$name] ?? NULL;
+      if (!is_array($base) || !is_array($english)) {
+        throw new RuntimeException("Rollback baseline missing for $name.");
+      }
+      $configFactory->getEditable($name)->setData($base)->save();
+      $overrideFactory->getOverride('en', $name)->setData($english)->save();
+      $fr = $overrideFactory->getOverride('fr', $name);
+      if (!$fr->isNew()) {
+        $fr->delete();
+      }
+    }
+    catch (Throwable $exception) {
+      $problems[] = [
+        'phase' => 'rollback',
+        'name' => $name,
+        'reason' => 'rollback_failed',
+        'error_class' => $exception::class,
+        'message' => $exception->getMessage(),
+      ];
+    }
+  }
+}
+
+$finalDefault = $captureStorage($activeStorage);
+$finalCollections = $captureCollections($activeStorage, $captureStorage);
+$finalFingerprint = $fingerprint([
+  'default' => $finalDefault,
+  'collections' => $finalCollections,
+]);
+if ($finalFingerprint !== $baselineFingerprint) {
+  $problems[] = [
+    'phase' => 'rollback_validation',
+    'reason' => 'final_configuration_fingerprint_mismatch',
+    'baseline' => $baselineFingerprint,
+    'final' => $finalFingerprint,
+  ];
+}
+
+$changedDuringPromotion = $changedNames($baselineDefault, $migratedDefault, $fingerprint);
+$unexpectedDefaultChanges = array_values(array_diff($changedDuringPromotion, $candidateNames));
+sort($unexpectedDefaultChanges, SORT_STRING);
+$frOverrideCreated = 0;
+foreach ($promotionItems as $item) {
+  if ($item['fr_override_required']) {
+    $frOverrideCreated++;
+  }
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANDIDATES_PROMOTION_ROLLBACK_PROVEN'
+  : 'TRANSLATED_PROMOTION_ROLLBACK_NOT_PROVEN';
+
+$resultItems = [];
+foreach ($candidateNames as $name) {
+  if (!isset($classificationItems[$name])) {
+    continue;
+  }
+  $resultItems[] = [
+    'name' => $name,
+    'origin' => in_array($name, $requiredExceptions, TRUE)
+      ? 'issue_711_exception'
+      : 'issue_707_complete',
+    'classification' => $classificationItems[$name]['classification'],
+    'material_translatable_leaf_count' => $classificationItems[$name]['material_translatable_leaf_count'],
+    'explicit_en_coverage_count' => $classificationItems[$name]['explicit_en_coverage_count'],
+    'explicit_en_leaf_count' => $classificationItems[$name]['explicit_en_leaf_count'],
+    'promoted' => isset($promotionItems[$name]),
+    'fr_override_required' => $promotionItems[$name]['fr_override_required'] ?? NULL,
+  ];
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'cohort' => [
+    'expected_count' => $expectedCount,
+    'actual_count' => count($candidateNames),
+    'expected_names_sha256' => $expectedHash,
+    'actual_names_sha256' => $candidateHash,
+    'required_exception_names' => $requiredExceptions,
+    'preexisting_fr_overrides_outside_cohort' => $repositoryFrenchOverrides,
+  ],
+  'counts' => [
+    'cohort_classified' => count($classificationItems),
+    'material_translatable_leaf_count' => $totalMaterialLeaves,
+    'explicit_en_coverage_count' => $totalExplicitCoverage,
+    'promoted' => count($promotionItems),
+    'en_overrides_removed' => count($promotionItems),
+    'fr_overrides_created' => $frOverrideCreated,
+    'unexpected_default_mutation_count' => count($unexpectedDefaultChanges),
+    'rollback_restored' => $finalFingerprint === $baselineFingerprint ? count($touchedNames) : 0,
+    'problem_count' => count($problems),
+  ],
+  'baseline_fingerprint' => $baselineFingerprint,
+  'final_fingerprint' => $finalFingerprint,
+  'unexpected_default_mutations' => $unexpectedDefaultChanges,
+  'problems' => $problems,
+  'items' => $resultItems,
+  'constraints' => [
+    'active_config_only' => TRUE,
+    'repository_config_mutation_allowed_by_this_proof' => FALSE,
+    'canonical_translated_migration_allowed_by_this_proof' => FALSE,
+    'bulk_langcode_replacement_allowed' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+    'editorial_semantic_without_en_override_in_scope' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-translated-promotion.sh
+++ b/scripts/runner/run-configuration-language-translated-promotion.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-translated-promotion'
+
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test -f docs/evidence/configuration-language-translated-cohort-718.yml
+test -f scripts/runner/configuration-language-translated-promotion.php
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+
+ddev exec php -l \
+  /var/www/html/scripts/runner/configuration-language-translated-promotion.php \
+  >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for #718.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script \
+  /var/www/html/scripts/runner/configuration-language-translated-promotion.php \
+  > "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANDIDATES_PROMOTION_ROLLBACK_PROVEN"' "$result" >/dev/null
+jq -e '.cohort.expected_count == 173' "$result" >/dev/null
+jq -e '.cohort.actual_count == 173' "$result" >/dev/null
+jq -e '.cohort.expected_names_sha256 == "3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547"' "$result" >/dev/null
+jq -e '.cohort.actual_names_sha256 == .cohort.expected_names_sha256' "$result" >/dev/null
+jq -e '.counts.cohort_classified == 173' "$result" >/dev/null
+jq -e '.counts.material_translatable_leaf_count == .counts.explicit_en_coverage_count' "$result" >/dev/null
+jq -e '.counts.promoted == 173' "$result" >/dev/null
+jq -e '.counts.en_overrides_removed == 173' "$result" >/dev/null
+jq -e '.counts.unexpected_default_mutation_count == 0' "$result" >/dev/null
+jq -e '.counts.rollback_restored == 173' "$result" >/dev/null
+jq -e '.counts.problem_count == 0' "$result" >/dev/null
+jq -e '.problems == []' "$result" >/dev/null
+jq -e '.baseline_fingerprint == .final_fingerprint' "$result" >/dev/null
+jq -e '[.items[] | select(.classification != "complete_for_promotion")] | length == 0' "$result" >/dev/null
+jq -e '[.items[] | select(.promoted != true)] | length == 0' "$result" >/dev/null
+jq -e '[.items[] | select(.origin == "issue_711_exception")] | length == 2' "$result" >/dev/null
+jq -e '.constraints.active_config_only == true' "$result" >/dev/null
+jq -e '.constraints.repository_config_mutation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.canonical_translated_migration_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.bulk_langcode_replacement_allowed == false' "$result" >/dev/null
+jq -e '.constraints.config_language_lock_activation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.config_export_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.production_mutation_allowed_by_this_proof == false' "$result" >/dev/null
+jq -e '.constraints.editorial_semantic_without_en_override_in_scope == false' "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u \
+  "$ARTIFACT_DIR/config-status-before.txt" \
+  "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name \
+  | grep -Fxq 'config_language_lock'; then
+  echo '#718 unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedPromotionWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedPromotionWorkflowTest.php
@@ -60,10 +60,10 @@ final class ConfigurationLanguageTranslatedPromotionWorkflowTest extends TestCas
     self::assertStringContainsString("\\Drupal::service('config.typed')", $probe);
     self::assertStringContainsString("\\Drupal::service('config.factory')", $probe);
     self::assertStringContainsString("\\Drupal::service('language.config_factory_override')", $probe);
-    self::assertStringContainsString("$newBase['langcode'] = 'en'", $probe);
-    self::assertStringContainsString("getOverride('fr', $name)->setData", $probe);
-    self::assertStringContainsString("getOverride('en', $name)->delete()", $probe);
-    self::assertStringContainsString("getEditable($name)->setData($base)->save()", $probe);
+    self::assertStringContainsString("\$newBase['langcode'] = 'en'", $probe);
+    self::assertStringContainsString("getOverride('fr', \$name)->setData", $probe);
+    self::assertStringContainsString("getOverride('en', \$name)->delete()", $probe);
+    self::assertStringContainsString("getEditable(\$name)->setData(\$base)->save()", $probe);
     self::assertStringContainsString('candidate_identity_hash_mismatch', $probe);
     self::assertStringContainsString('material_translatable_source_not_covered', $probe);
     self::assertStringContainsString('en_override_contains_non_translatable_or_unresolved_path', $probe);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedPromotionWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedPromotionWorkflowTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the bounded #718 translated promotion/rollback proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageTranslatedPromotionWorkflowTest extends TestCase {
+
+  /**
+   * The 173-object cohort identity remains anchored to final trusted evidence.
+   */
+  public function testTranslatedCohortIdentityIsFrozen(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $cohort = Yaml::parseFile(
+      $root . '/docs/evidence/configuration-language-translated-cohort-718.yml',
+    );
+
+    self::assertSame(173, $cohort['expected_count'] ?? NULL);
+    self::assertSame(
+      '3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547',
+      $cohort['names_sha256'] ?? NULL,
+    );
+    self::assertSame(32655167659, $cohort['sources']['historical_complete_171']['trusted_run'] ?? NULL);
+    self::assertSame(9497280060, $cohort['sources']['historical_complete_171']['artifact_id'] ?? NULL);
+    self::assertSame(171, $cohort['sources']['historical_complete_171']['complete'] ?? NULL);
+    self::assertSame(0, $cohort['sources']['historical_complete_171']['partial'] ?? NULL);
+    self::assertSame(0, $cohort['sources']['historical_complete_171']['unresolved'] ?? NULL);
+    self::assertSame(32657297513, $cohort['sources']['technical_exceptions_2']['trusted_run'] ?? NULL);
+    self::assertSame(9497831272, $cohort['sources']['technical_exceptions_2']['artifact_id'] ?? NULL);
+    self::assertSame([
+      'core.entity_form_display.node.page.default',
+      'field.storage.node.ai_automator_status',
+    ], $cohort['required_exception_names'] ?? NULL);
+    self::assertSame([
+      'block.block.emerging_digital_footer_menu',
+      'views.view.blog',
+    ], $cohort['expected_preexisting_fr_overrides_outside_cohort'] ?? NULL);
+  }
+
+  /**
+   * The PHP probe uses typed-config and Drupal configuration APIs fail-closed.
+   */
+  public function testTranslatedPromotionProbeUsesDrupalApisAndRollsBack(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $probe = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-translated-promotion.php',
+    );
+
+    self::assertIsArray(token_get_all($probe, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $probe);
+    self::assertStringContainsString("\\Drupal::service('config.factory')", $probe);
+    self::assertStringContainsString("\\Drupal::service('language.config_factory_override')", $probe);
+    self::assertStringContainsString("$newBase['langcode'] = 'en'", $probe);
+    self::assertStringContainsString("getOverride('fr', $name)->setData", $probe);
+    self::assertStringContainsString("getOverride('en', $name)->delete()", $probe);
+    self::assertStringContainsString("getEditable($name)->setData($base)->save()", $probe);
+    self::assertStringContainsString('candidate_identity_hash_mismatch', $probe);
+    self::assertStringContainsString('material_translatable_source_not_covered', $probe);
+    self::assertStringContainsString('en_override_contains_non_translatable_or_unresolved_path', $probe);
+    self::assertStringContainsString('default_collection_does_not_match_expected_promotion', $probe);
+    self::assertStringContainsString('language_collections_do_not_match_expected_promotion', $probe);
+    self::assertStringContainsString('final_configuration_fingerprint_mismatch', $probe);
+    self::assertStringContainsString(
+      'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANDIDATES_PROMOTION_ROLLBACK_PROVEN',
+      $probe,
+    );
+
+    foreach ([
+      'file_put_contents',
+      'Yaml::dump',
+      'drush cex',
+      'pm:enable',
+      'config_language_lock.settings',
+      'preg_replace',
+      'OPENAI_API_KEY',
+    ] as $forbiddenOperation) {
+      self::assertStringNotContainsString($forbiddenOperation, $probe);
+    }
+  }
+
+  /**
+   * The shell runner requires a full pass and exact rollback.
+   */
+  public function testTranslatedPromotionRunnerRequiresExactProof(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $runnerPath = $root
+      . '/scripts/runner/run-configuration-language-translated-promotion.sh';
+    $runner = (string) file_get_contents($runnerPath);
+
+    foreach ([
+      '.cohort.expected_count == 173',
+      '.cohort.actual_count == 173',
+      '.counts.cohort_classified == 173',
+      '.counts.material_translatable_leaf_count == .counts.explicit_en_coverage_count',
+      '.counts.promoted == 173',
+      '.counts.en_overrides_removed == 173',
+      '.counts.unexpected_default_mutation_count == 0',
+      '.counts.rollback_restored == 173',
+      '.counts.problem_count == 0',
+      '.baseline_fingerprint == .final_fingerprint',
+      'config-status-before.txt',
+      'config-status-after.txt',
+      'git diff --exit-code -- config/sync',
+    ] as $required) {
+      self::assertStringContainsString($required, $runner);
+    }
+
+    foreach ([
+      'composer require',
+      'drush cex',
+      'drush en',
+      'pm:enable',
+      'config:set',
+      'state:set',
+    ] as $forbiddenMutation) {
+      self::assertStringNotContainsString($forbiddenMutation, $runner);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+  /**
+   * The trusted route stays owner, issue and live-main bound.
+   */
+  public function testTrustedTranslatedPromotionGatewayIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/'
+      . 'trusted-configuration-language-translated-promotion.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-translated-promotion prove'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$ISSUE_NUMBER" == \'718\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString('site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString('agency-config-translated-718-', $workflow);
+    self::assertStringContainsString('gh issue comment 718', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'composer require',
+      'drush cex',
+      'pm:enable config_language_lock',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

Implements the pre-canonical proof requested by #718 without changing Drupal canonical configuration.

- freezes the exact 173-object translated cohort by SHA-256 identity, anchored to final trusted #707 (171/171 complete) + #711 (2/2 exceptions) evidence;
- rejects candidate count/name drift, missing typed-config schema, incomplete EN coverage, unresolved/non-translatable override paths and any pre-existing FR override on a target;
- promotes only disposable active configuration through Drupal configuration APIs:
  - base FR -> EN with explicit EN values promoted into the base;
  - EN override removed because EN becomes source;
  - FR override created only where required to preserve former FR effective values;
- fingerprints the full default collection and every non-default collection;
- requires the exact expected promoted snapshots, preserves the two pre-existing FR overrides outside the cohort, and detects any out-of-cohort mutation;
- rolls all touched objects back to the exact baseline and requires an identical final fingerprint plus clean `config:status`;
- adds an owner-only/live-main-only trusted DDEV route and repository-owned contract tests.

Expected verdict:

`ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANDIDATES_PROMOTION_ROLLBACK_PROVEN`

This PR does **not** mutate `config/sync`, run `cex`, enable Configuration Language Lock, touch production, or authorize the later canonical migration of the 173 objects. The 140 FR bases without EN overrides remain `REVIEW_REQUIRED` and out of scope.

Refs #718 #609 #703 #707 #711 #715.