### PR TITLE
Issue #720: bootstrap governed canonical promotion of 173 translated configs

### DIFF
--- a/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
@@ -1,0 +1,316 @@
+name: Agency governed canonical translated configuration promotion
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate translated canonical migration request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-translated-canonical migrate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '720' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-translated-canonical migrate' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Translated canonical migration must start from live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prepare-and-push:
+    name: Prepare and fresh-verify exact 173-object canonical promotion
+    needs: validate-request
+    timeout-minutes: 40
+    permissions:
+      contents: write
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      branch: ${{ steps.commit.outputs.branch }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      status: ${{ steps.summary.outputs.status }}
+      prepared: ${{ steps.summary.outputs.prepared }}
+      config_paths: ${{ steps.summary.outputs.config_paths }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact live main with bounded write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Verify immutable migration inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f docs/evidence/configuration-language-translated-cohort-718.yml
+          test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+          test -f scripts/runner/apply-configuration-language-translated-canonical.php
+          test -f scripts/runner/configuration-language-translated-canonical-verify.php
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-translated-canonical-writer.yaml <<EOF_CONFIG
+          name: agency-config-translated-canonical-writer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml | grep -F "agency-config-translated-canonical-writer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild baseline Drupal from live canonical configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush config:status | grep -F 'No differences'
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Config Language Lock must be disabled before canonical translation migration.' >&2
+            exit 1
+          fi
+
+      - name: Prepare exact canonical translated patch through Drupal sync storage
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-translated-canonical-720-result.json
+        run: |
+          set -euo pipefail
+          ddev drush php:script /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php \
+            > "$RESULT_PATH"
+
+          jq -e '.status == "PASS"' "$RESULT_PATH" >/dev/null
+          jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PATCH_PREPARED"' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.expected == 173 and .counts.prepared == 173' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.material_translatable_leaf_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.explicit_en_coverage_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.base_paths_modified == 173' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.en_override_paths_deleted == 173' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.fr_override_paths_created == 7' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.config_paths_changed == 353' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$RESULT_PATH" >/dev/null
+          jq -e '.cohort.names_sha256 == "3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547"' "$RESULT_PATH" >/dev/null
+          jq -e '.constraints.drupal_sync_storage_used == true' "$RESULT_PATH" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$RESULT_PATH" >/dev/null
+          jq -e '.constraints.config_language_lock_activation_allowed == false' "$RESULT_PATH" >/dev/null
+
+          mapfile -t expected_config_paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[]' "$RESULT_PATH" | sort)
+          mapfile -t changed_config_paths < <(git diff --name-only -- config/sync | sort)
+          [[ "${#expected_config_paths[@]}" -eq 353 ]]
+          [[ "${#changed_config_paths[@]}" -eq 353 ]]
+          diff -u <(printf '%s\n' "${expected_config_paths[@]}") <(printf '%s\n' "${changed_config_paths[@]}")
+
+          mapfile -t expected_all_paths < <({ printf '%s\n' "${expected_config_paths[@]}"; jq -r '.paths.manifest' "$RESULT_PATH"; } | sort)
+          mapfile -t changed_all_paths < <(git status --porcelain | awk '{print $2}' | grep -v '^.ddev/config.gate-config-language-translated-canonical-writer.yaml$' | sort)
+          [[ "${#expected_all_paths[@]}" -eq 354 ]]
+          [[ "${#changed_all_paths[@]}" -eq 354 ]]
+          diff -u <(printf '%s\n' "${expected_all_paths[@]}") <(printf '%s\n' "${changed_all_paths[@]}")
+
+          [[ "$(git diff --diff-filter=M --name-only -- config/sync | wc -l)" -eq 173 ]]
+          [[ "$(git diff --diff-filter=D --name-only -- config/sync/language/en | wc -l)" -eq 173 ]]
+          [[ "$(git status --porcelain -- config/sync/language/fr | awk '$1 == "??" {count++} END {print count+0}')" -eq 7 ]]
+          [[ -z "$(git diff --name-only -- config/sync/core.extension.yml)" ]]
+          git diff --check
+
+      - name: Rebuild a second fresh Drupal from the generated canonical patch
+        shell: bash
+        env:
+          VERIFY_PATH: ${{ runner.temp }}/agency-config-translated-canonical-720-verify.json
+        run: |
+          set -euo pipefail
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush config:status | grep -F 'No differences'
+
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php \
+            > "$VERIFY_PATH"
+          jq -e '.status == "PASS"' "$VERIFY_PATH" >/dev/null
+          jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED"' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.verified == 173' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.fr_overrides_required == 7' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.mechanical_715_verified_en == 39' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.remaining_fr_review_required == 140' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.preserved_fr_overrides_outside_cohort == 2' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.preserved_en_overrides_outside_cohort == 1' "$VERIFY_PATH" >/dev/null
+          jq -e '.distribution_by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}' "$VERIFY_PATH" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$VERIFY_PATH" >/dev/null
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Generated canonical patch unexpectedly enables Config Language Lock.' >&2
+            exit 1
+          fi
+          git diff --check
+
+      - name: Commit and push bounded canonical translated migration branch
+        id: commit
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-translated-canonical-720-result.json
+        run: |
+          set -euo pipefail
+          branch='feature/720-apply-canonical-translated-promotion'
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing branch $branch" >&2
+            exit 1
+          fi
+
+          git switch -c "$branch"
+          mapfile -t paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[], .paths.manifest' "$RESULT_PATH")
+          git add -- "${paths[@]}"
+          [[ "$(git diff --cached --name-only | wc -l)" -eq 354 ]]
+          [[ -z "$(git status --porcelain | grep -v '^?? .ddev/config.gate-config-language-translated-canonical-writer.yaml$' | grep -v '^$')" ]]
+
+          git config user.name 'E-merging Digital Automation'
+          git config user.email 'actions@users.noreply.github.com'
+          git commit -m 'Issue #720: promote 173 translated configs to canonical EN'
+          git push origin "HEAD:refs/heads/$branch"
+
+          commit_sha="$(git rev-parse HEAD)"
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize canonical translated preparation
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-translated-canonical-720-result.json
+        run: |
+          set -euo pipefail
+          status='MISSING'
+          prepared='0'
+          config_paths='0'
+          if [[ -s "$RESULT_PATH" ]] && jq -e . "$RESULT_PATH" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$RESULT_PATH")"
+            prepared="$(jq -r '.counts.prepared // 0' "$RESULT_PATH")"
+            config_paths="$(jq -r '.counts.config_paths_changed // 0' "$RESULT_PATH")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "prepared=$prepared" >> "$GITHUB_OUTPUT"
+          echo "config_paths=$config_paths" >> "$GITHUB_OUTPUT"
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-translated-canonical-writer.yaml
+          git reset --hard HEAD >/dev/null 2>&1 || true
+          git clean -fd -- .ddev >/dev/null 2>&1 || true
+
+  report:
+    name: Publish translated canonical migration preparation result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prepare-and-push
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment branch result on #720
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.prepare-and-push.result }}
+          STATUS: ${{ needs.prepare-and-push.outputs.status }}
+          PREPARED: ${{ needs.prepare-and-push.outputs.prepared }}
+          CONFIG_PATHS: ${{ needs.prepare-and-push.outputs.config_paths }}
+          BRANCH: ${{ needs.prepare-and-push.outputs.branch }}
+          COMMIT_SHA: ${{ needs.prepare-and-push.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          heading='### Canonical translated promotion branch FAIL'
+          if [[ "$OUTCOME" == 'success' && "$STATUS" == 'PASS' && "$PREPARED" == '173' && "$CONFIG_PATHS" == '353' ]]; then
+            heading='### Canonical translated promotion branch PREPARED'
+          fi
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          prepared: \`${PREPARED:-0}\`
+          config_paths_changed: \`${CONFIG_PATHS:-0}\`
+          branch: \`${BRANCH:-n/a}\`
+          commit_sha: \`${COMMIT_SHA:-n/a}\`
+
+          The governed writer is restricted to the frozen #718 cohort and uses Drupal sync storage directly: 173 canonical bases, 173 obsolete EN overrides removed and 7 FR overrides created, plus one evidence manifest. It performs a second fresh existing-config rebuild before push. It does not run cex, enable Config Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 720 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/trusted-configuration-language-translated-canonical-verify.yml
+++ b/.github/workflows/trusted-configuration-language-translated-canonical-verify.yml
@@ -1,0 +1,245 @@
+name: Agency trusted canonical translated configuration verification
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate canonical translated verification request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-translated-canonical verify'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '720' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-translated-canonical verify' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Canonical translated verification must execute live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Rebuild Drupal and verify 173-object canonical translated promotion
+    needs: validate-request
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      verified: ${{ steps.summary.outputs.verified }}
+      fr_overrides: ${{ steps.summary.outputs.fr_overrides }}
+      remaining_review: ${{ steps.summary.outputs.remaining_review }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable verification inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f docs/evidence/configuration-language-translated-canonical-cohort-720.yml
+          test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+          test -f scripts/runner/configuration-language-translated-canonical-verify.php
+          test -f scripts/runner/run-configuration-language-translated-canonical-verify.sh
+          bash -n scripts/runner/run-configuration-language-translated-canonical-verify.sh
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-translated-canonical-verify.yaml <<EOF_CONFIG
+          name: agency-config-translated-canonical-verify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml | grep -F "agency-config-translated-canonical-verify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild Drupal from canonical repository configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush status
+
+      - name: Verify canonical translated promotion
+        shell: bash
+        env:
+          TARGET_DIR: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ github.workspace }}/artifacts/configuration-language-translated-canonical
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-configuration-language-translated-canonical-verify.sh
+
+      - name: Summarize machine-readable result
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/configuration-language-translated-canonical/result.json'
+          status='MISSING'
+          verdict='UNKNOWN'
+          verified='0'
+          fr_overrides='0'
+          remaining_review='0'
+          problems='0'
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$result")"
+            verified="$(jq -r '.counts.verified // 0' "$result")"
+            fr_overrides="$(jq -r '.counts.fr_overrides_required // 0' "$result")"
+            remaining_review="$(jq -r '.counts.remaining_fr_review_required // 0' "$result")"
+            problems="$(jq -r '.counts.problem_count // 0' "$result")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
+          echo "fr_overrides=$fr_overrides" >> "$GITHUB_OUTPUT"
+          echo "remaining_review=$remaining_review" >> "$GITHUB_OUTPUT"
+          echo "problems=$problems" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canonical translated verification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-translated-canonical-720-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/configuration-language-translated-canonical
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-translated-canonical-verify.yaml
+          rm -rf artifacts/configuration-language-translated-canonical
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- config/sync web/robots.txt 2>/dev/null || true
+          git clean -fd -- config/sync
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish canonical translated verification result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - verify
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment result on #720
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_OUTCOME: ${{ needs.verify.result }}
+          STATUS: ${{ needs.verify.outputs.status }}
+          VERDICT: ${{ needs.verify.outputs.verdict }}
+          VERIFIED: ${{ needs.verify.outputs.verified }}
+          FR_OVERRIDES: ${{ needs.verify.outputs.fr_overrides }}
+          REMAINING_REVIEW: ${{ needs.verify.outputs.remaining_review }}
+          PROBLEMS: ${{ needs.verify.outputs.problems }}
+        run: |
+          set -euo pipefail
+          heading='### Agency canonical translated configuration verification FAIL'
+          if [[ "$ROUTE_OUTCOME" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Agency canonical translated configuration verification PASS'
+          fi
+          artifact="agency-config-translated-canonical-720-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${ROUTE_OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-UNKNOWN}\`
+          verified: \`${VERIFIED:-0}\`
+          fr_overrides_required: \`${FR_OVERRIDES:-0}\`
+          remaining_fr_review_required: \`${REMAINING_REVIEW:-0}\`
+          problems: \`${PROBLEMS:-0}\`
+          artifact: \`${artifact}\`
+
+          Read-only fresh-DDEV verification of the exact #720 canonical translated promotion. This route does not export configuration, enable Configuration Language Lock or access production.
+          EOF_BODY
+          )"
+          gh issue comment 720 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/apply-configuration-language-translated-canonical.php
+++ b/scripts/runner/apply-configuration-language-translated-canonical.php
@@ -1,0 +1,472 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$sourceEvidence = $projectRoot . '/docs/evidence/configuration-language-translated-cohort-718.yml';
+$manifestPath = $projectRoot . '/docs/evidence/configuration-language-translated-canonical-cohort-720.yml';
+
+if (!is_file($sourceEvidence)) {
+  throw new RuntimeException('#718 translated cohort evidence is missing.');
+}
+
+$evidence = Yaml::parseFile($sourceEvidence);
+if (!is_array($evidence)) {
+  throw new RuntimeException('#718 translated cohort evidence must be a mapping.');
+}
+
+$expectedCount = 173;
+$expectedHash = '3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547';
+$expectedMaterialLeaves = 930;
+$expectedFrenchRequired = [
+  'block.block.emerging_digital_footer_branding',
+  'block.block.emerging_digital_online_presence',
+  'core.entity_form_display.node.page.default',
+  'llms_txt.settings',
+  'metatag.metatag_defaults.front',
+  'system.menu.online-presence',
+  'webform.webform.contact',
+];
+$expectedPreexistingFrench = [
+  'block.block.emerging_digital_footer_menu',
+  'views.view.blog',
+];
+$requiredExceptions = [
+  'core.entity_form_display.node.page.default',
+  'field.storage.node.ai_automator_status',
+];
+
+if ((int) ($evidence['expected_count'] ?? -1) !== $expectedCount
+  || ($evidence['names_sha256'] ?? NULL) !== $expectedHash
+  || ($evidence['required_exception_names'] ?? NULL) !== $requiredExceptions
+  || ($evidence['expected_preexisting_fr_overrides_outside_cohort'] ?? NULL) !== $expectedPreexistingFrench) {
+  throw new RuntimeException('#718 cohort contract drifted.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$syncStorage = \Drupal::service('config.storage.sync');
+$activeStorage = \Drupal::service('config.storage');
+if (!$syncStorage instanceof StorageInterface || !$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Configuration storages are unavailable.');
+}
+$syncEnglish = $syncStorage->createCollection('language.en');
+$syncFrench = $syncStorage->createCollection('language.fr');
+$activeEnglish = $activeStorage->createCollection('language.en');
+$activeFrench = $activeStorage->createCollection('language.fr');
+
+$normalize = NULL;
+$normalize = static function (mixed $value) use (&$normalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($normalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $normalize($child);
+  }
+  return $value;
+};
+
+$fingerprint = static function (mixed $value) use ($normalize): string {
+  return hash('sha256', json_encode(
+    $normalize($value),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ));
+};
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$pathKey = static function (array $segments): string {
+  return json_encode($segments, JSON_THROW_ON_ERROR);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath, $pathKey): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$collectRawLeaves = NULL;
+$collectRawLeaves = static function (
+  mixed $value,
+  array $segments = [],
+) use (&$collectRawLeaves, $displayPath, $pathKey): array {
+  if (is_array($value) && $value !== []) {
+    $leaves = [];
+    foreach ($value as $key => $child) {
+      foreach ($collectRawLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  return [[
+    'segments' => $segments,
+    'key' => $pathKey($segments),
+    'path' => $displayPath($segments),
+    'value' => $value,
+  ]];
+};
+
+$names = $syncStorage->listAll();
+sort($names, SORT_STRING);
+$candidateNames = [];
+foreach ($names as $name) {
+  $data = $syncStorage->read($name);
+  if (is_array($data)
+    && ($data['langcode'] ?? NULL) === 'fr'
+    && $syncEnglish->exists($name)) {
+    $candidateNames[] = $name;
+  }
+}
+sort($candidateNames, SORT_STRING);
+$candidateHash = hash('sha256', implode("\n", $candidateNames) . "\n");
+if (count($candidateNames) !== $expectedCount || $candidateHash !== $expectedHash) {
+  throw new RuntimeException('Current translated candidate identity does not match #718.');
+}
+
+$currentFrench = $syncFrench->listAll();
+sort($currentFrench, SORT_STRING);
+if ($currentFrench !== $expectedPreexistingFrench) {
+  throw new RuntimeException('Pre-existing FR override set drifted before #720.');
+}
+
+$currentEnglish = $syncEnglish->listAll();
+sort($currentEnglish, SORT_STRING);
+$preservedEnglish = array_values(array_diff($currentEnglish, $candidateNames));
+sort($preservedEnglish, SORT_STRING);
+$preservedEnglishFingerprints = [];
+foreach ($preservedEnglish as $name) {
+  $data = $syncEnglish->read($name);
+  if (!is_array($data)) {
+    throw new RuntimeException("Unable to read preserved EN override $name.");
+  }
+  $preservedEnglishFingerprints[$name] = $fingerprint($data);
+}
+$preservedFrenchFingerprints = [];
+foreach ($expectedPreexistingFrench as $name) {
+  $data = $syncFrench->read($name);
+  if (!is_array($data)) {
+    throw new RuntimeException("Unable to read preserved FR override $name.");
+  }
+  $preservedFrenchFingerprints[$name] = $fingerprint($data);
+}
+
+$prepared = [];
+$totalMaterial = 0;
+$totalCovered = 0;
+$frenchRequired = [];
+
+foreach ($candidateNames as $name) {
+  $baseData = $syncStorage->read($name);
+  $englishData = $syncEnglish->read($name);
+  $activeBase = $activeStorage->read($name);
+  $activeEn = $activeEnglish->read($name);
+  if (!is_array($baseData) || !is_array($englishData)
+    || !is_array($activeBase) || !is_array($activeEn)) {
+    throw new RuntimeException("Missing sync/active source data for $name.");
+  }
+  if (($baseData['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Target base is no longer FR: $name");
+  }
+  if ($fingerprint($baseData) !== $fingerprint($activeBase)
+    || $fingerprint($englishData) !== $fingerprint($activeEn)) {
+    throw new RuntimeException("Active/sync baseline mismatch for $name.");
+  }
+  if ($syncFrench->exists($name) || $activeFrench->exists($name)) {
+    throw new RuntimeException("Target unexpectedly already has FR override: $name");
+  }
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    throw new RuntimeException("Typed config schema missing for $name.");
+  }
+
+  $typed = $typedConfigManager->createFromNameAndData($name, $baseData);
+  $translatableLeaves = $collectTranslatableLeaves($typed);
+  $translatableByKey = [];
+  foreach ($translatableLeaves as $leaf) {
+    $translatableByKey[$leaf['key']] = $leaf;
+  }
+
+  $englishLeaves = $collectRawLeaves($englishData);
+  $englishByKey = [];
+  foreach ($englishLeaves as $leaf) {
+    if (!isset($translatableByKey[$leaf['key']])) {
+      throw new RuntimeException("EN override contains non-translatable path {$leaf['path']} in $name.");
+    }
+    $englishByKey[$leaf['key']] = $leaf;
+  }
+
+  $materialCount = 0;
+  $coveredCount = 0;
+  foreach ($translatableLeaves as $leaf) {
+    if (!$isMaterial($leaf['value'])) {
+      continue;
+    }
+    $materialCount++;
+    if (!isset($englishByKey[$leaf['key']])) {
+      throw new RuntimeException("Material translatable path is not covered in $name: {$leaf['path']}");
+    }
+    $coveredCount++;
+  }
+  $totalMaterial += $materialCount;
+  $totalCovered += $coveredCount;
+
+  $newBase = $baseData;
+  $newBase['langcode'] = 'en';
+  foreach ($englishLeaves as $leaf) {
+    NestedArray::setValue($newBase, $leaf['segments'], $leaf['value'], TRUE);
+  }
+
+  $frenchData = [];
+  foreach ($translatableLeaves as $leaf) {
+    $sourceExists = FALSE;
+    $sourceValue = NestedArray::getValue($baseData, $leaf['segments'], $sourceExists);
+    $newExists = FALSE;
+    $newValue = NestedArray::getValue($newBase, $leaf['segments'], $newExists);
+    $beforeFr = $sourceExists ? $sourceValue : NULL;
+    $afterEn = $newExists ? $newValue : NULL;
+    if ($beforeFr !== $afterEn) {
+      NestedArray::setValue($frenchData, $leaf['segments'], $beforeFr, TRUE);
+    }
+  }
+
+  $requiresFrench = $frenchData !== [];
+  if ($requiresFrench) {
+    $frenchRequired[] = $name;
+  }
+
+  $prepared[$name] = [
+    'name' => $name,
+    'origin' => in_array($name, $requiredExceptions, TRUE)
+      ? 'issue_711_exception'
+      : 'issue_707_complete',
+    'material_translatable_leaf_count' => $materialCount,
+    'explicit_en_coverage_count' => $coveredCount,
+    'fr_override_required' => $requiresFrench,
+    'base_before_fingerprint' => $fingerprint($baseData),
+    'en_override_before_fingerprint' => $fingerprint($englishData),
+    'base_after_data' => $newBase,
+    'base_after_fingerprint' => $fingerprint($newBase),
+    'fr_override_after_data' => $frenchData,
+    'fr_override_after_fingerprint' => $requiresFrench ? $fingerprint($frenchData) : NULL,
+  ];
+}
+
+sort($frenchRequired, SORT_STRING);
+if ($totalMaterial !== $expectedMaterialLeaves || $totalCovered !== $expectedMaterialLeaves) {
+  throw new RuntimeException('Typed-config aggregate coverage no longer matches trusted #718.');
+}
+if ($frenchRequired !== $expectedFrenchRequired) {
+  throw new RuntimeException('FR override requirement set no longer matches trusted #718.');
+}
+if (count($prepared) !== $expectedCount) {
+  throw new RuntimeException('Prepared translated canonical target count is not 173.');
+}
+
+foreach ($prepared as $name => $item) {
+  if (!$syncStorage->write($name, $item['base_after_data'])) {
+    throw new RuntimeException("Unable to write canonical base $name.");
+  }
+  if (!$syncEnglish->delete($name)) {
+    throw new RuntimeException("Unable to remove obsolete EN override $name.");
+  }
+  if ($item['fr_override_required']
+    && !$syncFrench->write($name, $item['fr_override_after_data'])) {
+    throw new RuntimeException("Unable to write FR override $name.");
+  }
+}
+
+$postEnglish = $syncEnglish->listAll();
+sort($postEnglish, SORT_STRING);
+if ($postEnglish !== $preservedEnglish) {
+  throw new RuntimeException('Unexpected EN override set after canonical promotion.');
+}
+$postFrench = $syncFrench->listAll();
+sort($postFrench, SORT_STRING);
+$expectedPostFrench = array_values(array_unique([
+  ...$expectedPreexistingFrench,
+  ...$expectedFrenchRequired,
+]));
+sort($expectedPostFrench, SORT_STRING);
+if ($postFrench !== $expectedPostFrench) {
+  throw new RuntimeException('Unexpected FR override set after canonical promotion.');
+}
+foreach ($preservedEnglishFingerprints as $name => $expectedFingerprint) {
+  if ($fingerprint($syncEnglish->read($name)) !== $expectedFingerprint) {
+    throw new RuntimeException("Preserved EN override changed: $name");
+  }
+}
+foreach ($preservedFrenchFingerprints as $name => $expectedFingerprint) {
+  if ($fingerprint($syncFrench->read($name)) !== $expectedFingerprint) {
+    throw new RuntimeException("Preserved FR override changed: $name");
+  }
+}
+
+$manifestItems = [];
+$basePaths = [];
+$englishPaths = [];
+$frenchPaths = [];
+foreach ($prepared as $name => $item) {
+  $base = $syncStorage->read($name);
+  if (!is_array($base)
+    || ($base['langcode'] ?? NULL) !== 'en'
+    || $fingerprint($base) !== $item['base_after_fingerprint']
+    || $syncEnglish->exists($name)) {
+    throw new RuntimeException("Post-write canonical state mismatch for $name.");
+  }
+  $fr = $syncFrench->read($name);
+  if ($item['fr_override_required']) {
+    if (!is_array($fr) || $fingerprint($fr) !== $item['fr_override_after_fingerprint']) {
+      throw new RuntimeException("Post-write FR override mismatch for $name.");
+    }
+  }
+  elseif ($fr !== FALSE && $fr !== NULL) {
+    throw new RuntimeException("Unexpected post-write FR override for $name.");
+  }
+
+  $basePath = 'config/sync/' . $name . '.yml';
+  $englishPath = 'config/sync/language/en/' . $name . '.yml';
+  $basePaths[] = $basePath;
+  $englishPaths[] = $englishPath;
+  if ($item['fr_override_required']) {
+    $frenchPaths[] = 'config/sync/language/fr/' . $name . '.yml';
+  }
+
+  $manifestItems[] = [
+    'name' => $name,
+    'origin' => $item['origin'],
+    'fr_override_required' => $item['fr_override_required'],
+    'material_translatable_leaf_count' => $item['material_translatable_leaf_count'],
+    'explicit_en_coverage_count' => $item['explicit_en_coverage_count'],
+    'base_before_fingerprint' => $item['base_before_fingerprint'],
+    'en_override_before_fingerprint' => $item['en_override_before_fingerprint'],
+    'base_after_fingerprint' => $item['base_after_fingerprint'],
+    'fr_override_after_fingerprint' => $item['fr_override_after_fingerprint'],
+  ];
+}
+
+$manifest = [
+  'schema_version' => 1,
+  'issue' => 720,
+  'source_issue' => 718,
+  'source_trusted_run' => 32661601566,
+  'source_artifact_id' => 9498925772,
+  'source_artifact_digest' => 'sha256:7159ac6d670e4d0d8c9d1981d7882c7dbc72604db0be56a9f4a966d8aecef990',
+  'expected_count' => $expectedCount,
+  'names_sha256' => $expectedHash,
+  'material_translatable_leaf_count' => $totalMaterial,
+  'explicit_en_coverage_count' => $totalCovered,
+  'expected_fr_override_names' => $expectedFrenchRequired,
+  'preserved_fr_overrides_outside_cohort' => $preservedFrenchFingerprints,
+  'preserved_en_overrides_outside_cohort' => $preservedEnglishFingerprints,
+  'items' => $manifestItems,
+];
+
+$manifestText = Yaml::dump($manifest, 8, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+if (file_put_contents($manifestPath, $manifestText) === FALSE) {
+  throw new RuntimeException('Unable to write #720 canonical cohort manifest.');
+}
+
+sort($basePaths, SORT_STRING);
+sort($englishPaths, SORT_STRING);
+sort($frenchPaths, SORT_STRING);
+$resultItems = array_map(
+  static fn(array $item): array => [
+    'name' => $item['name'],
+    'fr_override_required' => $item['fr_override_required'],
+    'base_after_fingerprint' => $item['base_after_fingerprint'],
+    'fr_override_after_fingerprint' => $item['fr_override_after_fingerprint'],
+  ],
+  $manifestItems,
+);
+
+$result = [
+  'schema_version' => 1,
+  'status' => 'PASS',
+  'verdict' => 'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PATCH_PREPARED',
+  'counts' => [
+    'expected' => $expectedCount,
+    'prepared' => count($resultItems),
+    'material_translatable_leaf_count' => $totalMaterial,
+    'explicit_en_coverage_count' => $totalCovered,
+    'base_paths_modified' => count($basePaths),
+    'en_override_paths_deleted' => count($englishPaths),
+    'fr_override_paths_created' => count($frenchPaths),
+    'config_paths_changed' => count($basePaths) + count($englishPaths) + count($frenchPaths),
+    'problem_count' => 0,
+  ],
+  'cohort' => [
+    'names_sha256' => $candidateHash,
+    'fr_override_required_names' => $frenchRequired,
+  ],
+  'paths' => [
+    'base' => $basePaths,
+    'en_deleted' => $englishPaths,
+    'fr_created' => $frenchPaths,
+    'manifest' => 'docs/evidence/configuration-language-translated-canonical-cohort-720.yml',
+  ],
+  'items' => $resultItems,
+  'problems' => [],
+  'constraints' => [
+    'drupal_sync_storage_used' => TRUE,
+    'config_export_used' => FALSE,
+    'global_yaml_rewrite_allowed' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_mutation_allowed' => FALSE,
+    'editorial_semantic_without_en_override_in_scope' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/configuration-language-translated-canonical-verify.php
+++ b/scripts/runner/configuration-language-translated-canonical-verify.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Config\StorageInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$manifestPath = $projectRoot . '/docs/evidence/configuration-language-translated-canonical-cohort-720.yml';
+$mechanicalPath = $projectRoot . '/docs/evidence/configuration-language-mechanical-cohort-713.yml';
+if (!is_file($manifestPath) || !is_file($mechanicalPath)) {
+  throw new RuntimeException('#720 or #713 canonical evidence is missing.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+$mechanical = Yaml::parseFile($mechanicalPath);
+if (!is_array($manifest) || !is_array($mechanical)) {
+  throw new RuntimeException('Canonical evidence must be YAML mappings.');
+}
+
+$expectedCount = 173;
+$expectedHash = '3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547';
+$expectedFrenchRequired = [
+  'block.block.emerging_digital_footer_branding',
+  'block.block.emerging_digital_online_presence',
+  'core.entity_form_display.node.page.default',
+  'llms_txt.settings',
+  'metatag.metatag_defaults.front',
+  'system.menu.online-presence',
+  'webform.webform.contact',
+];
+
+if ((int) ($manifest['expected_count'] ?? -1) !== $expectedCount
+  || ($manifest['names_sha256'] ?? NULL) !== $expectedHash
+  || ($manifest['expected_fr_override_names'] ?? NULL) !== $expectedFrenchRequired
+  || (int) ($manifest['material_translatable_leaf_count'] ?? -1) !== 930
+  || (int) ($manifest['explicit_en_coverage_count'] ?? -1) !== 930) {
+  throw new RuntimeException('#720 manifest contract drifted.');
+}
+
+$items = $manifest['items'] ?? NULL;
+if (!is_array($items) || count($items) !== $expectedCount) {
+  throw new RuntimeException('#720 manifest must contain exactly 173 items.');
+}
+
+$normalize = NULL;
+$normalize = static function (mixed $value) use (&$normalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($normalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $normalize($child);
+  }
+  return $value;
+};
+$fingerprint = static function (mixed $value) use ($normalize): string {
+  return hash('sha256', json_encode(
+    $normalize($value),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ));
+};
+
+$syncStorage = \Drupal::service('config.storage.sync');
+$activeStorage = \Drupal::service('config.storage');
+if (!$syncStorage instanceof StorageInterface || !$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Configuration storages are unavailable.');
+}
+$syncEnglish = $syncStorage->createCollection('language.en');
+$syncFrench = $syncStorage->createCollection('language.fr');
+$activeEnglish = $activeStorage->createCollection('language.en');
+$activeFrench = $activeStorage->createCollection('language.fr');
+
+$problems = [];
+$verified = [];
+$names = [];
+$frenchRequiredSeen = [];
+foreach ($items as $item) {
+  if (!is_array($item) || !is_string($item['name'] ?? NULL)) {
+    $problems[] = ['reason' => 'invalid_manifest_item'];
+    continue;
+  }
+  $name = $item['name'];
+  if (isset($names[$name])) {
+    $problems[] = ['name' => $name, 'reason' => 'duplicate_manifest_name'];
+    continue;
+  }
+  $names[$name] = TRUE;
+
+  $syncBase = $syncStorage->read($name);
+  $activeBase = $activeStorage->read($name);
+  if (!is_array($syncBase) || !is_array($activeBase)) {
+    $problems[] = ['name' => $name, 'reason' => 'canonical_base_missing'];
+    continue;
+  }
+  if (($syncBase['langcode'] ?? NULL) !== 'en' || ($activeBase['langcode'] ?? NULL) !== 'en') {
+    $problems[] = ['name' => $name, 'reason' => 'canonical_base_not_en'];
+  }
+  $expectedBaseFingerprint = $item['base_after_fingerprint'] ?? NULL;
+  if (!is_string($expectedBaseFingerprint)
+    || $fingerprint($syncBase) !== $expectedBaseFingerprint
+    || $fingerprint($activeBase) !== $expectedBaseFingerprint) {
+    $problems[] = ['name' => $name, 'reason' => 'canonical_base_fingerprint_mismatch'];
+  }
+  if ($syncEnglish->exists($name) || $activeEnglish->exists($name)) {
+    $problems[] = ['name' => $name, 'reason' => 'obsolete_en_override_still_present'];
+  }
+
+  $requiresFrench = ($item['fr_override_required'] ?? FALSE) === TRUE;
+  $syncFr = $syncFrench->read($name);
+  $activeFr = $activeFrench->read($name);
+  if ($requiresFrench) {
+    $frenchRequiredSeen[] = $name;
+    $expectedFrFingerprint = $item['fr_override_after_fingerprint'] ?? NULL;
+    if (!is_string($expectedFrFingerprint)
+      || !is_array($syncFr) || !is_array($activeFr)
+      || $fingerprint($syncFr) !== $expectedFrFingerprint
+      || $fingerprint($activeFr) !== $expectedFrFingerprint) {
+      $problems[] = ['name' => $name, 'reason' => 'required_fr_override_mismatch'];
+    }
+  }
+  elseif (($syncFr !== FALSE && $syncFr !== NULL) || ($activeFr !== FALSE && $activeFr !== NULL)) {
+    $problems[] = ['name' => $name, 'reason' => 'unexpected_fr_override_present'];
+  }
+
+  $verified[] = [
+    'name' => $name,
+    'base_langcode' => $syncBase['langcode'] ?? NULL,
+    'fr_override_required' => $requiresFrench,
+    'base_fingerprint' => $fingerprint($syncBase),
+  ];
+}
+
+$nameList = array_keys($names);
+sort($nameList, SORT_STRING);
+$actualHash = hash('sha256', implode("\n", $nameList) . "\n");
+if (count($nameList) !== $expectedCount || $actualHash !== $expectedHash) {
+  $problems[] = ['reason' => 'manifest_identity_mismatch'];
+}
+sort($frenchRequiredSeen, SORT_STRING);
+if ($frenchRequiredSeen !== $expectedFrenchRequired) {
+  $problems[] = ['reason' => 'fr_override_requirement_set_mismatch'];
+}
+
+foreach (($manifest['preserved_fr_overrides_outside_cohort'] ?? []) as $name => $expectedFingerprint) {
+  $syncData = $syncFrench->read((string) $name);
+  $activeData = $activeFrench->read((string) $name);
+  if (!is_array($syncData) || !is_array($activeData)
+    || $fingerprint($syncData) !== $expectedFingerprint
+    || $fingerprint($activeData) !== $expectedFingerprint) {
+    $problems[] = ['name' => $name, 'reason' => 'preserved_fr_override_changed'];
+  }
+}
+foreach (($manifest['preserved_en_overrides_outside_cohort'] ?? []) as $name => $expectedFingerprint) {
+  $syncData = $syncEnglish->read((string) $name);
+  $activeData = $activeEnglish->read((string) $name);
+  if (!is_array($syncData) || !is_array($activeData)
+    || $fingerprint($syncData) !== $expectedFingerprint
+    || $fingerprint($activeData) !== $expectedFingerprint) {
+    $problems[] = ['name' => $name, 'reason' => 'preserved_en_override_changed'];
+  }
+}
+
+$mechanicalItems = $mechanical['items'] ?? NULL;
+$mechanicalVerified = 0;
+if (!is_array($mechanicalItems) || count($mechanicalItems) !== 39) {
+  $problems[] = ['reason' => 'mechanical_cohort_713_invalid'];
+}
+else {
+  foreach ($mechanicalItems as $item) {
+    $name = is_array($item) ? ($item['name'] ?? NULL) : NULL;
+    if (!is_string($name)) {
+      $problems[] = ['reason' => 'mechanical_item_invalid'];
+      continue;
+    }
+    $syncData = $syncStorage->read($name);
+    $activeData = $activeStorage->read($name);
+    if (!is_array($syncData) || !is_array($activeData)
+      || ($syncData['langcode'] ?? NULL) !== 'en'
+      || ($activeData['langcode'] ?? NULL) !== 'en') {
+      $problems[] = ['name' => $name, 'reason' => 'mechanical_715_regressed'];
+      continue;
+    }
+    $mechanicalVerified++;
+  }
+}
+
+$distribution = ['__none__' => 0];
+$remainingReviewRequired = [];
+foreach ($syncStorage->listAll() as $name) {
+  $data = $syncStorage->read($name);
+  if (!is_array($data)) {
+    continue;
+  }
+  $langcode = $data['langcode'] ?? '__none__';
+  $distribution[(string) $langcode] = ($distribution[(string) $langcode] ?? 0) + 1;
+  if ($langcode === 'fr' && !$syncEnglish->exists($name)) {
+    $remainingReviewRequired[] = $name;
+  }
+}
+ksort($distribution, SORT_STRING);
+sort($remainingReviewRequired, SORT_STRING);
+if (count($remainingReviewRequired) !== 140) {
+  $problems[] = [
+    'reason' => 'remaining_fr_review_required_count_mismatch',
+    'actual' => count($remainingReviewRequired),
+  ];
+}
+
+$site = $syncStorage->read('system.site');
+if (!is_array($site) || ($site['default_langcode'] ?? NULL) !== 'fr') {
+  $problems[] = ['reason' => 'site_default_language_not_fr'];
+}
+foreach (['und', 'zxx'] as $langcode) {
+  $language = $syncStorage->read('language.entity.' . $langcode);
+  if (!is_array($language)
+    || ($language['id'] ?? NULL) !== $langcode
+    || ($language['locked'] ?? NULL) !== TRUE) {
+    $problems[] = ['name' => 'language.entity.' . $langcode, 'reason' => 'locked_language_semantics_regressed'];
+  }
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $status === 'PASS'
+    ? 'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED'
+    : 'CANONICAL_TRANSLATED_PROMOTION_INVALID',
+  'counts' => [
+    'expected' => $expectedCount,
+    'verified' => count($verified),
+    'fr_overrides_required' => count($frenchRequiredSeen),
+    'mechanical_715_verified_en' => $mechanicalVerified,
+    'remaining_fr_review_required' => count($remainingReviewRequired),
+    'preserved_fr_overrides_outside_cohort' => count($manifest['preserved_fr_overrides_outside_cohort'] ?? []),
+    'preserved_en_overrides_outside_cohort' => count($manifest['preserved_en_overrides_outside_cohort'] ?? []),
+    'problem_count' => count($problems),
+  ],
+  'cohort' => [
+    'expected_names_sha256' => $expectedHash,
+    'actual_names_sha256' => $actualHash,
+  ],
+  'distribution_by_langcode' => $distribution,
+  'remaining_fr_review_required_names' => $remainingReviewRequired,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'config_language_lock_must_remain_disabled' => TRUE,
+    'production_mutation_allowed' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/run-configuration-language-translated-canonical-verify.sh
+++ b/scripts/runner/run-configuration-language-translated-canonical-verify.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_DIR:?TARGET_DIR is required}"
+: "${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+: "${TRUSTED_MAIN:?TRUSTED_MAIN is required}"
+
+ARTIFACT_REL='artifacts/configuration-language-translated-canonical'
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+if [[ "$ARTIFACT_DIR" != "$TARGET_DIR/$ARTIFACT_REL" ]]; then
+  echo "ARTIFACT_DIR must be $TARGET_DIR/$ARTIFACT_REL" >&2
+  exit 1
+fi
+
+cd "$TARGET_DIR"
+command -v ddev >/dev/null
+command -v git >/dev/null
+command -v jq >/dev/null
+
+test "$(git rev-parse HEAD)" = "$TRUSTED_MAIN"
+test -f docs/evidence/configuration-language-translated-canonical-cohort-720.yml
+test -f docs/evidence/configuration-language-mechanical-cohort-713.yml
+test -f scripts/runner/configuration-language-translated-canonical-verify.php
+
+ddev exec php -l /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php >/dev/null
+git diff --check
+
+if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+  echo 'Config Language Lock must remain disabled for #720.' >&2
+  exit 1
+fi
+
+config_status_before="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_before" > "$ARTIFACT_DIR/config-status-before.txt"
+grep -Fq 'No differences' <<<"$config_status_before"
+
+ddev drush php:script /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php \
+  > "$ARTIFACT_DIR/result.json"
+
+result="$ARTIFACT_DIR/result.json"
+jq -e '.schema_version == 1' "$result" >/dev/null
+jq -e '.status == "PASS"' "$result" >/dev/null
+jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED"' "$result" >/dev/null
+jq -e '.counts.expected == 173' "$result" >/dev/null
+jq -e '.counts.verified == 173' "$result" >/dev/null
+jq -e '.counts.fr_overrides_required == 7' "$result" >/dev/null
+jq -e '.counts.mechanical_715_verified_en == 39' "$result" >/dev/null
+jq -e '.counts.remaining_fr_review_required == 140' "$result" >/dev/null
+jq -e '.counts.preserved_fr_overrides_outside_cohort == 2' "$result" >/dev/null
+jq -e '.counts.preserved_en_overrides_outside_cohort == 1' "$result" >/dev/null
+jq -e '.counts.problem_count == 0' "$result" >/dev/null
+jq -e '.cohort.expected_names_sha256 == "3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547"' "$result" >/dev/null
+jq -e '.cohort.actual_names_sha256 == .cohort.expected_names_sha256' "$result" >/dev/null
+jq -e '.distribution_by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}' "$result" >/dev/null
+jq -e '.problems == []' "$result" >/dev/null
+jq -e '.constraints.read_only == true' "$result" >/dev/null
+
+config_status_after="$(ddev drush config:status 2>&1)"
+printf '%s\n' "$config_status_after" > "$ARTIFACT_DIR/config-status-after.txt"
+grep -Fq 'No differences' <<<"$config_status_after"
+diff -u "$ARTIFACT_DIR/config-status-before.txt" "$ARTIFACT_DIR/config-status-after.txt"
+
+if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+  echo '#720 unexpectedly enabled Config Language Lock.' >&2
+  exit 1
+fi
+
+git diff --exit-code -- config/sync
+git diff --check

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
@@ -59,7 +59,8 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
   }
 
   /**
-   * The governed writer route is owner/live-main bound and fresh-verifies output.
+   * The governed writer route is owner/live-main bound and fresh-verifies
+   * output.
    */
   public function testGovernedCanonicalWriterRouteIsBounded(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -103,7 +104,8 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
   }
 
   /**
-   * The verifier enforces the post-migration distribution and remaining review set.
+   * The verifier enforces the post-migration distribution and remaining
+   * review set.
    */
   public function testCanonicalVerifierKeepsReviewRequiredAndMechanicalBoundaries(): void {
     $root = dirname(DRUPAL_ROOT);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
@@ -59,8 +59,7 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
   }
 
   /**
-   * The governed writer route is owner/live-main bound and fresh-verifies
-   * output.
+   * The governed writer route is bounded and fresh-verifies output.
    */
   public function testGovernedCanonicalWriterRouteIsBounded(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -104,8 +103,7 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
   }
 
   /**
-   * The verifier enforces the post-migration distribution and remaining
-   * review set.
+   * The verifier preserves migration boundaries and review-required state.
    */
   public function testCanonicalVerifierKeepsReviewRequiredAndMechanicalBoundaries(): void {
     $root = dirname(DRUPAL_ROOT);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #720 translated canonical migration routes.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCase {
+
+  /**
+   * The writer uses Drupal sync storage and freezes the trusted #718 contract.
+   */
+  public function testCanonicalWriterUsesDrupalStorageAndExactCohort(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $writer = (string) file_get_contents(
+      $root . '/scripts/runner/apply-configuration-language-translated-canonical.php',
+    );
+
+    self::assertIsArray(token_get_all($writer, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.storage.sync')", $writer);
+    self::assertStringContainsString("createCollection('language.en')", $writer);
+    self::assertStringContainsString("createCollection('language.fr')", $writer);
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $writer);
+    self::assertStringContainsString('NestedArray::setValue', $writer);
+    self::assertStringContainsString('$expectedCount = 173', $writer);
+    self::assertStringContainsString('$expectedMaterialLeaves = 930', $writer);
+    self::assertStringContainsString(
+      '3908bb3b785091d996e969f67af5d0060b3548d2ec732fb055c748085c0d6547',
+      $writer,
+    );
+    self::assertStringContainsString('config_paths_changed', $writer);
+    self::assertStringContainsString(
+      'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PATCH_PREPARED',
+      $writer,
+    );
+    self::assertStringContainsString(
+      'configuration-language-translated-canonical-cohort-720.yml',
+      $writer,
+    );
+
+    foreach ([
+      'drush cex',
+      'config:set',
+      'pm:enable',
+      'config_language_lock.settings',
+      'preg_replace',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $writer);
+    }
+  }
+
+  /**
+   * The governed writer route is owner/live-main bound and fresh-verifies output.
+   */
+  public function testGovernedCanonicalWriterRouteIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/governed-configuration-language-translated-canonical-migration.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-translated-canonical migrate'",
+      $workflow,
+    );
+    self::assertStringContainsString('[[ "$ISSUE_NUMBER" == \'720\' ]]', $workflow);
+    self::assertStringContainsString('[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]', $workflow);
+    self::assertStringContainsString('[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]', $workflow);
+    self::assertStringContainsString('contents: write', $workflow);
+    self::assertStringContainsString('persist-credentials: true', $workflow);
+    self::assertStringContainsString('counts.config_paths_changed == 353', $workflow);
+    self::assertStringContainsString('expected_all_paths[@]}" -eq 354', $workflow);
+    self::assertStringContainsString('feature/720-apply-canonical-translated-promotion', $workflow);
+    self::assertStringContainsString('Refusing to overwrite existing branch', $workflow);
+    self::assertStringContainsString('git push origin "HEAD:refs/heads/$branch"', $workflow);
+    self::assertGreaterThanOrEqual(2, substr_count($workflow, 'site:install --existing-config'));
+    self::assertStringContainsString('ddev delete --omit-snapshot --yes', $workflow);
+    self::assertStringContainsString(
+      'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED',
+      $workflow,
+    );
+
+    foreach ([
+      'workflow_dispatch:',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'git push --force',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The verifier enforces the post-migration distribution and remaining review set.
+   */
+  public function testCanonicalVerifierKeepsReviewRequiredAndMechanicalBoundaries(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $verifier = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-translated-canonical-verify.php',
+    );
+    self::assertIsArray(token_get_all($verifier, TOKEN_PARSE));
+    self::assertStringContainsString('$expectedCount = 173', $verifier);
+    self::assertStringContainsString('count($remainingReviewRequired) !== 140', $verifier);
+    self::assertStringContainsString('mechanical_715_verified_en', $verifier);
+    self::assertStringContainsString('language.entity.', $verifier);
+    self::assertStringContainsString('site_default_language_not_fr', $verifier);
+    self::assertStringContainsString(
+      'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED',
+      $verifier,
+    );
+    foreach (['write(', 'delete(', 'file_put_contents', 'config:set', 'pm:enable'] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $verifier);
+    }
+  }
+
+  /**
+   * The trusted verifier is read-only and asserts exact counts/distribution.
+   */
+  public function testTrustedCanonicalVerificationRouteIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-translated-canonical-verify.yml',
+    );
+    $runnerPath = $root . '/scripts/runner/run-configuration-language-translated-canonical-verify.sh';
+    $runner = (string) file_get_contents($runnerPath);
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-translated-canonical verify'",
+      $workflow,
+    );
+    self::assertStringContainsString('[[ "$ISSUE_NUMBER" == \'720\' ]]', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('- self-hosted', $workflow);
+    self::assertStringContainsString('- agency', $workflow);
+    self::assertStringContainsString('- ddev', $workflow);
+    self::assertStringContainsString('gh issue comment 720', $workflow);
+
+    foreach ([
+      '.counts.verified == 173',
+      '.counts.fr_overrides_required == 7',
+      '.counts.mechanical_715_verified_en == 39',
+      '.counts.remaining_fr_review_required == 140',
+      '.counts.preserved_fr_overrides_outside_cohort == 2',
+      '.counts.preserved_en_overrides_outside_cohort == 1',
+      '.distribution_by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}',
+      'git diff --exit-code -- config/sync',
+    ] as $required) {
+      self::assertStringContainsString($required, $runner);
+    }
+
+    foreach ([
+      'drush cex',
+      'drush en',
+      'pm:enable',
+      'config:set',
+      'state:set',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $runner);
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+  }
+
+}


### PR DESCRIPTION
## Summary

Bootstraps the governed canonical migration requested by #720 without changing `config/sync` yet.

- adds a Drupal `config.storage.sync` writer that revalidates the frozen #718 identity (173 objects / SHA-256), typed-config coverage (930/930) and exact 7-object FR preservation set before any write;
- writes only through the Drupal sync storage and `language.en` / `language.fr` collections; no `cex`, regex/global YAML replacement or Config Language Lock activation;
- generates one durable #720 manifest containing the exact post-promotion fingerprints needed for independent post-merge verification;
- adds a governed owner/live-main-only route that performs a fresh baseline rebuild, prepares exactly 353 config paths, then destroys DDEV and performs a second fresh `site:install --existing-config` from the generated configuration before it may push the fixed migration branch;
- adds a read-only verifier enforcing 173 canonical EN bases, 7 required FR overrides, 39 #715 mechanical objects still EN, 140 remaining FR review-required objects, preserved outside overrides and expected post-migration langcode distribution;
- adds the trusted post-merge verification route and repository-owned contract tests.

This bootstrap PR changes only proof/writer infrastructure. It does not mutate canonical config, enable Configuration Language Lock or access production.

Refs #720 #609 #718 #719 #715.