### PR TITLE
Issue #722: capture Drush config status from stderr

### DIFF
--- a/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
@@ -129,7 +129,9 @@ jobs:
           unset admin_pass
           ddev drush cim -y
           ddev drush cr
-          ddev drush config:status | grep -F 'No differences'
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status"
+          grep -Fq 'No differences' <<<"$config_status"
           if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
             echo 'Config Language Lock must be disabled before canonical translation migration.' >&2
             exit 1
@@ -192,7 +194,9 @@ jobs:
           unset admin_pass
           ddev drush cim -y
           ddev drush cr
-          ddev drush config:status | grep -F 'No differences'
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status"
+          grep -Fq 'No differences' <<<"$config_status"
 
           ddev drush php:script /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php \
             > "$VERIFY_PATH"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
@@ -84,6 +84,24 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
     self::assertStringContainsString('git push origin "HEAD:refs/heads/$branch"', $workflow);
     self::assertGreaterThanOrEqual(2, substr_count($workflow, 'site:install --existing-config'));
     self::assertStringContainsString('ddev delete --omit-snapshot --yes', $workflow);
+    self::assertSame(
+      2,
+      substr_count(
+        $workflow,
+        'config_status="$(ddev drush config:status 2>&1)"',
+      ),
+    );
+    self::assertSame(
+      2,
+      substr_count(
+        $workflow,
+        'grep -Fq \'No differences\' <<<"$config_status"',
+      ),
+    );
+    self::assertStringNotContainsString(
+      "ddev drush config:status | grep -F 'No differences'",
+      $workflow,
+    );
     self::assertStringContainsString(
       'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED',
       $workflow,


### PR DESCRIPTION
## Summary

Fixes the bounded recovery defect discovered by governed run `32662566190` for #720.

- captures `ddev drush config:status` with `2>&1` in both fresh-DDEV rebuild gates before grepping `No differences`;
- keeps the writer, verifier and canonical configuration untouched;
- strengthens the repository-owned unit contract to require both stderr captures and reject the previous direct pipe form;
- changes exactly two files and no `config/sync` path.

The original #720 run is conclusively unusable: it completed `site:install --existing-config`, `cim`, `cr` and emitted `No differences`, then failed because grep only received stdout. The 173-object writer never executed and no migration branch/commit was created.

Refs #722 #720 #609.