### PR TITLE
Issue #724: include untracked FR overrides in #720 path gate

### DIFF
--- a/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
@@ -162,7 +162,11 @@ jobs:
           jq -e '.constraints.config_language_lock_activation_allowed == false' "$RESULT_PATH" >/dev/null
 
           mapfile -t expected_config_paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[]' "$RESULT_PATH" | sort)
-          mapfile -t changed_config_paths < <(git diff --name-only -- config/sync | sort)
+          mapfile -t changed_config_paths < <(
+            git status --porcelain --untracked-files=all -- config/sync \
+              | awk '{print $2}' \
+              | sort
+          )
           [[ "${#expected_config_paths[@]}" -eq 353 ]]
           [[ "${#changed_config_paths[@]}" -eq 353 ]]
           diff -u <(printf '%s\n' "${expected_config_paths[@]}") <(printf '%s\n' "${changed_config_paths[@]}")

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalWorkflowTest.php
@@ -103,6 +103,26 @@ final class ConfigurationLanguageTranslatedCanonicalWorkflowTest extends TestCas
       $workflow,
     );
     self::assertStringContainsString(
+      'git status --porcelain --untracked-files=all -- config/sync',
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      'mapfile -t changed_config_paths < <(git diff --name-only -- config/sync | sort)',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git diff --diff-filter=M --name-only -- config/sync',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git diff --diff-filter=D --name-only -- config/sync/language/en',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git status --porcelain -- config/sync/language/fr',
+      $workflow,
+    );
+    self::assertStringContainsString(
       'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED',
       $workflow,
     );


### PR DESCRIPTION
## Summary

Fixes the second bounded harness defect exposed by governed #720 recovery run `32663265961`.

The writer itself completed successfully (`prepared=173`, `config_paths_changed=353`, 0 problems), but the workflow used `git diff --name-only -- config/sync` as the full path set. That excludes the 7 newly-created, untracked FR override files and makes the 353-path gate impossible to satisfy.

This PR:

- changes the complete config path inventory to `git status --porcelain --untracked-files=all -- config/sync`, which includes tracked modifications/deletions and untracked additions;
- retains the independent exact gates for 173 modified bases, 173 deleted EN overrides and 7 untracked FR overrides;
- adds repository-owned anti-regression assertions requiring the untracked-aware inventory and rejecting the previous full-set `git diff` form;
- changes exactly two files, with no writer/verifier business-logic change and no `config/sync` mutation.

No cex, no Config Language Lock activation, no production access.

Refs #724 #720 #609 #718.