### PR TITLE
Issue #726: bound #720 Git gates to migration paths

### DIFF
--- a/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
@@ -172,7 +172,13 @@ jobs:
           diff -u <(printf '%s\n' "${expected_config_paths[@]}") <(printf '%s\n' "${changed_config_paths[@]}")
 
           mapfile -t expected_all_paths < <({ printf '%s\n' "${expected_config_paths[@]}"; jq -r '.paths.manifest' "$RESULT_PATH"; } | sort)
-          mapfile -t changed_all_paths < <(git status --porcelain | awk '{print $2}' | grep -v '^.ddev/config.gate-config-language-translated-canonical-writer.yaml$' | sort)
+          mapfile -t changed_all_paths < <(
+            git status --porcelain --untracked-files=all -- \
+              config/sync \
+              docs/evidence/configuration-language-translated-canonical-cohort-720.yml \
+              | awk '{print $2}' \
+              | sort
+          )
           [[ "${#expected_all_paths[@]}" -eq 354 ]]
           [[ "${#changed_all_paths[@]}" -eq 354 ]]
           diff -u <(printf '%s\n' "${expected_all_paths[@]}") <(printf '%s\n' "${changed_all_paths[@]}")
@@ -235,10 +241,14 @@ jobs:
           fi
 
           git switch -c "$branch"
-          mapfile -t paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[], .paths.manifest' "$RESULT_PATH")
+          mapfile -t paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[], .paths.manifest' "$RESULT_PATH" | sort)
           git add -- "${paths[@]}"
-          [[ "$(git diff --cached --name-only | wc -l)" -eq 354 ]]
-          [[ -z "$(git status --porcelain | grep -v '^?? .ddev/config.gate-config-language-translated-canonical-writer.yaml$' | grep -v '^$')" ]]
+          mapfile -t staged_paths < <(git diff --cached --name-only | sort)
+          [[ "${#paths[@]}" -eq 354 ]]
+          [[ "${#staged_paths[@]}" -eq 354 ]]
+          diff -u <(printf '%s\n' "${paths[@]}") <(printf '%s\n' "${staged_paths[@]}")
+          [[ -z "$(git diff --name-only)" ]]
+          [[ -z "$(git ls-files --others --exclude-standard -- config/sync docs/evidence/configuration-language-translated-canonical-cohort-720.yml)" ]]
 
           git config user.name 'E-merging Digital Automation'
           git config user.email 'actions@users.noreply.github.com'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects #726 migration-path scoping in the governed #720 writer route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest extends TestCase {
+
+  /**
+   * Runtime DDEV files must not participate in canonical migration path gates.
+   */
+  public function testAllPathAndCommitGatesAreBoundedToMigrationSurfaces(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/governed-configuration-language-translated-canonical-migration.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    self::assertStringContainsString(
+      'git status --porcelain --untracked-files=all -- config/sync',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'docs/evidence/configuration-language-translated-canonical-cohort-720.yml',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'mapfile -t staged_paths < <(git diff --cached --name-only | sort)',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'diff -u <(printf \'%s\\n\' "${paths[@]}") <(printf \'%s\\n\' "${staged_paths[@]}")',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ -z "$(git diff --name-only)" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git ls-files --others --exclude-standard -- config/sync docs/evidence/configuration-language-translated-canonical-cohort-720.yml',
+      $workflow,
+    );
+
+    self::assertStringNotContainsString(
+      "mapfile -t changed_all_paths < <(git status --porcelain | awk '{print \$2}'",
+      $workflow,
+    );
+    self::assertStringNotContainsString(
+      '[[ -z "$(git status --porcelain | grep -v',
+      $workflow,
+    );
+  }
+
+}


### PR DESCRIPTION
## Summary

Fixes the third bounded harness defect exposed by governed #720 recovery run `32663958203`.

The writer still completed successfully (`prepared=173`, `config_paths_changed=353`, 930/930 material leaves covered, 0 problems), and the exact 353-path `config/sync` comparison produced no diff. The next all-path gate used global `git status --porcelain`, which includes DDEV runtime files generated during the fresh environment and therefore cannot equal the intended 354 migration paths.

This PR:

- scopes the 354-path inventory to `config/sync` plus the #720 evidence manifest;
- fixes the later commit gate with the same root cause by comparing the exact 354 staged paths, requiring no residual tracked diff and no residual untracked file on the migration surfaces;
- adds a focused repository-owned regression test;
- changes exactly two files;
- does not modify the canonical writer/verifier or `config/sync`.

No cex, no Config Language Lock activation, no production access.

Refs #726 #720 #724 #722 #718 #609.