### PR TITLE
Issue #728: diagnose eight-component Canvas drift after #720

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-drift-diagnostic.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-drift-diagnostic.yml
@@ -1,0 +1,310 @@
+name: Agency trusted Canvas configuration drift diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate Canvas drift diagnostic request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-canvas-drift diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '728' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-canvas-drift diagnose' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Canvas drift diagnostic must start from live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  diagnose:
+    name: Reproduce and classify exact eight-component Canvas drift
+    needs: validate-request
+    timeout-minutes: 45
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      verdict: ${{ steps.classify.outputs.verdict }}
+      reimport_exit: ${{ steps.classify.outputs.reimport_exit }}
+      before_different: ${{ steps.classify.outputs.before_different }}
+      after_different: ${{ steps.classify.outputs.after_different }}
+    steps:
+      - name: Checkout exact live main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable diagnostic inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f scripts/runner/apply-configuration-language-translated-canonical.php
+          test -f scripts/runner/configuration-language-canvas-drift-diagnostic.php
+          test -f docs/evidence/configuration-language-translated-cohort-718.yml
+          ddev utility configyaml >/dev/null
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-drift.yaml <<EOF_CONFIG
+          name: agency-config-canvas-drift-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml | grep -F "agency-config-canvas-drift-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild baseline and prepare exact #720 patch
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/canvas-drift-writer-result.json
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          baseline_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$baseline_status"
+          grep -Fq 'No differences' <<<"$baseline_status"
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Config Language Lock must remain disabled during the diagnostic.' >&2
+            exit 1
+          fi
+
+          ddev drush php:script /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php > "$RESULT_PATH"
+          jq -e '.status == "PASS"' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.prepared == 173' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.material_translatable_leaf_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.explicit_en_coverage_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.config_paths_changed == 353' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$RESULT_PATH" >/dev/null
+
+      - name: Rebuild second fresh Drupal and capture initial Canvas drift
+        shell: bash
+        env:
+          BEFORE_JSON: ${{ runner.temp }}/canvas-drift-before.json
+          BEFORE_STATUS: ${{ runner.temp }}/canvas-drift-status-before.txt
+        run: |
+          set -euo pipefail
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          ddev drush config:status > "$BEFORE_STATUS" 2>&1
+          cat "$BEFORE_STATUS"
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php > "$BEFORE_JSON"
+          jq -e '.status == "PASS" and .counts.expected == 8 and .counts.problems == 0' "$BEFORE_JSON" >/dev/null
+          jq -e '.counts.different == 8' "$BEFORE_JSON" >/dev/null
+
+          jq -e '.different_names == [
+            "canvas.component.block.help_block",
+            "canvas.component.block.language_block.language_content",
+            "canvas.component.block.local_actions_block",
+            "canvas.component.block.page_title_block",
+            "canvas.component.block.system_branding_block",
+            "canvas.component.block.system_breadcrumb_block",
+            "canvas.component.block.system_powered_by_block",
+            "canvas.component.block.views_block.content_recent-block_1"
+          ]' "$BEFORE_JSON" >/dev/null
+
+      - name: Attempt one bounded reimport and classify convergence
+        id: classify
+        shell: bash
+        env:
+          BEFORE_JSON: ${{ runner.temp }}/canvas-drift-before.json
+          AFTER_JSON: ${{ runner.temp }}/canvas-drift-after.json
+          AFTER_STATUS: ${{ runner.temp }}/canvas-drift-status-after.txt
+          REIMPORT_LOG: ${{ runner.temp }}/canvas-drift-reimport.txt
+          SUMMARY_JSON: ${{ runner.temp }}/canvas-drift-summary.json
+        run: |
+          set -euo pipefail
+
+          set +e
+          ddev drush cim -y > "$REIMPORT_LOG" 2>&1
+          reimport_exit=$?
+          set -e
+          cat "$REIMPORT_LOG"
+
+          if [[ "$reimport_exit" -eq 0 ]]; then
+            ddev drush cr
+          fi
+
+          ddev drush config:status > "$AFTER_STATUS" 2>&1 || true
+          cat "$AFTER_STATUS"
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php > "$AFTER_JSON"
+          jq -e '.status == "PASS" and .counts.expected == 8 and .counts.problems == 0' "$AFTER_JSON" >/dev/null
+
+          before_different="$(jq -r '.counts.different' "$BEFORE_JSON")"
+          after_different="$(jq -r '.counts.different' "$AFTER_JSON")"
+
+          if [[ "$reimport_exit" -ne 0 ]]; then
+            verdict='CANVAS_EIGHT_COMPONENT_REIMPORT_REJECTED'
+          elif [[ "$after_different" -eq 0 ]] && grep -Fq 'No differences' "$AFTER_STATUS"; then
+            verdict='CANVAS_EIGHT_COMPONENT_DRIFT_CONVERGES'
+          else
+            verdict='CANVAS_EIGHT_COMPONENT_DRIFT_PERSISTS'
+          fi
+
+          jq -n \
+            --arg status PASS \
+            --arg verdict "$verdict" \
+            --argjson reimport_exit "$reimport_exit" \
+            --argjson before_different "$before_different" \
+            --argjson after_different "$after_different" \
+            '{
+              status: $status,
+              verdict: $verdict,
+              reimport_exit: $reimport_exit,
+              before_different: $before_different,
+              after_different: $after_different,
+              constraints: {
+                diagnostic_only: true,
+                config_export_used: false,
+                repository_write_used: false,
+                config_language_lock_activation_allowed: false,
+                production_access_allowed: false,
+                extra_reimport_attempts: 1
+              }
+            }' > "$SUMMARY_JSON"
+
+          cat "$SUMMARY_JSON"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "reimport_exit=$reimport_exit" >> "$GITHUB_OUTPUT"
+          echo "before_different=$before_different" >> "$GITHUB_OUTPUT"
+          echo "after_different=$after_different" >> "$GITHUB_OUTPUT"
+
+      - name: Stage diagnostic artifact files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/canvas-drift-artifact"
+          mkdir -p "$artifact_dir"
+          for file in \
+            canvas-drift-writer-result.json \
+            canvas-drift-before.json \
+            canvas-drift-after.json \
+            canvas-drift-status-before.txt \
+            canvas-drift-status-after.txt \
+            canvas-drift-reimport.txt \
+            canvas-drift-summary.json; do
+            if [[ -f "${RUNNER_TEMP}/${file}" ]]; then
+              cp "${RUNNER_TEMP}/${file}" "$artifact_dir/$file"
+            fi
+          done
+
+      - name: Upload Canvas drift diagnostic artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-canvas-drift-728-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/canvas-drift-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-canvas-drift.yaml
+          git reset --hard HEAD >/dev/null 2>&1 || true
+          git clean -fd -- .ddev >/dev/null 2>&1 || true
+
+  report:
+    name: Publish Canvas drift diagnostic result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - diagnose
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment diagnostic result on #728
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.diagnose.result }}
+          VERDICT: ${{ needs.diagnose.outputs.verdict }}
+          REIMPORT_EXIT: ${{ needs.diagnose.outputs.reimport_exit }}
+          BEFORE_DIFFERENT: ${{ needs.diagnose.outputs.before_different }}
+          AFTER_DIFFERENT: ${{ needs.diagnose.outputs.after_different }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF_BODY
+          ### Canvas eight-component drift diagnostic
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-n/a}\`
+          reimport_exit: \`${REIMPORT_EXIT:-n/a}\`
+          before_different: \`${BEFORE_DIFFERENT:-n/a}\`
+          after_different: \`${AFTER_DIFFERENT:-n/a}\`
+
+          This route is diagnostic-only. It reproduces the frozen #720 patch in disposable DDEV environments, compares only the eight bounded Canvas component configs, performs at most one additional config import, uploads evidence, never runs cex, never enables Config Language Lock, never pushes a branch and never accesses production.
+          EOF_BODY
+          )"
+          gh issue comment 728 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/configuration-language-canvas-drift-diagnostic.php
+++ b/scripts/runner/configuration-language-canvas-drift-diagnostic.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Compares the eight bounded Canvas component configs in active and sync storage.
+ */
+
+use Drupal\Core\Config\StorageInterface;
+
+$names = [
+  'canvas.component.block.help_block',
+  'canvas.component.block.language_block.language_content',
+  'canvas.component.block.local_actions_block',
+  'canvas.component.block.page_title_block',
+  'canvas.component.block.system_branding_block',
+  'canvas.component.block.system_breadcrumb_block',
+  'canvas.component.block.system_powered_by_block',
+  'canvas.component.block.views_block.content_recent-block_1',
+];
+
+$activeStorage = \Drupal::service('config.storage');
+$syncStorage = \Drupal::service('config.storage.sync');
+
+if (!$activeStorage instanceof StorageInterface || !$syncStorage instanceof StorageInterface) {
+  throw new RuntimeException('Expected Drupal active and sync configuration storage services.');
+}
+
+/**
+ * Flattens a nested configuration value into JSON-path-like keys.
+ *
+ * @param mixed $value
+ *   The value to flatten.
+ * @param string $prefix
+ *   Current path prefix.
+ *
+ * @return array<string, mixed>
+ *   Flattened path/value map.
+ */
+function agency_canvas_drift_flatten(mixed $value, string $prefix = '$'): array {
+  if (!is_array($value)) {
+    return [$prefix => $value];
+  }
+
+  if ($value === []) {
+    return [$prefix => []];
+  }
+
+  $flattened = [];
+  foreach ($value as $key => $child) {
+    $encodedKey = json_encode((string) $key, JSON_THROW_ON_ERROR);
+    $childPrefix = $prefix . '[' . $encodedKey . ']';
+    $flattened += agency_canvas_drift_flatten($child, $childPrefix);
+  }
+  return $flattened;
+}
+
+/**
+ * Returns exact differing paths between active and sync data.
+ *
+ * @param array<string, mixed> $active
+ *   Active configuration data.
+ * @param array<string, mixed> $sync
+ *   Sync configuration data.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Differences keyed by path.
+ */
+function agency_canvas_drift_diff(array $active, array $sync): array {
+  $activeFlat = agency_canvas_drift_flatten($active);
+  $syncFlat = agency_canvas_drift_flatten($sync);
+  $paths = array_values(array_unique(array_merge(array_keys($activeFlat), array_keys($syncFlat))));
+  sort($paths, SORT_STRING);
+
+  $differences = [];
+  foreach ($paths as $path) {
+    $activeExists = array_key_exists($path, $activeFlat);
+    $syncExists = array_key_exists($path, $syncFlat);
+    $activeValue = $activeExists ? $activeFlat[$path] : NULL;
+    $syncValue = $syncExists ? $syncFlat[$path] : NULL;
+    if ($activeExists === $syncExists && $activeValue === $syncValue) {
+      continue;
+    }
+    $differences[] = [
+      'path' => $path,
+      'active_exists' => $activeExists,
+      'sync_exists' => $syncExists,
+      'active' => $activeValue,
+      'sync' => $syncValue,
+    ];
+  }
+  return $differences;
+}
+
+$items = [];
+$differentNames = [];
+$problemNames = [];
+
+foreach ($names as $name) {
+  $active = $activeStorage->read($name);
+  $sync = $syncStorage->read($name);
+  if (!is_array($active) || !is_array($sync)) {
+    $problemNames[] = $name;
+    $items[] = [
+      'name' => $name,
+      'status' => 'MISSING',
+      'active_exists' => is_array($active),
+      'sync_exists' => is_array($sync),
+    ];
+    continue;
+  }
+
+  $differences = agency_canvas_drift_diff($active, $sync);
+  if ($differences !== []) {
+    $differentNames[] = $name;
+  }
+
+  $items[] = [
+    'name' => $name,
+    'status' => $differences === [] ? 'SAME' : 'DIFFERENT',
+    'active' => [
+      'langcode' => $active['langcode'] ?? NULL,
+      'active_version' => $active['active_version'] ?? NULL,
+      'label' => $active['label'] ?? NULL,
+      'default_label' => $active['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL,
+    ],
+    'sync' => [
+      'langcode' => $sync['langcode'] ?? NULL,
+      'active_version' => $sync['active_version'] ?? NULL,
+      'label' => $sync['label'] ?? NULL,
+      'default_label' => $sync['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL,
+    ],
+    'difference_count' => count($differences),
+    'differences' => $differences,
+  ];
+}
+
+sort($differentNames, SORT_STRING);
+sort($problemNames, SORT_STRING);
+
+$result = [
+  'status' => $problemNames === [] ? 'PASS' : 'FAIL',
+  'expected_names' => $names,
+  'different_names' => $differentNames,
+  'problem_names' => $problemNames,
+  'counts' => [
+    'expected' => count($names),
+    'different' => count($differentNames),
+    'problems' => count($problemNames),
+  ],
+  'items' => $items,
+  'constraints' => [
+    'read_only_probe' => TRUE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+  ],
+];
+
+print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #728 Canvas drift diagnostic route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest extends TestCase {
+
+  /**
+   * The diagnostic probe is read-only and frozen to eight Canvas configs.
+   */
+  public function testProbeIsReadOnlyAndBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $probe = (string) file_get_contents(
+      $root . '/scripts/runner/configuration-language-canvas-drift-diagnostic.php',
+    );
+
+    self::assertIsArray(token_get_all($probe, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.storage')", $probe);
+    self::assertStringContainsString("\\Drupal::service('config.storage.sync')", $probe);
+
+    foreach ([
+      'canvas.component.block.help_block',
+      'canvas.component.block.language_block.language_content',
+      'canvas.component.block.local_actions_block',
+      'canvas.component.block.page_title_block',
+      'canvas.component.block.system_branding_block',
+      'canvas.component.block.system_breadcrumb_block',
+      'canvas.component.block.system_powered_by_block',
+      'canvas.component.block.views_block.content_recent-block_1',
+    ] as $name) {
+      self::assertStringContainsString($name, $probe);
+    }
+
+    foreach ([
+      '->write(',
+      '->delete(',
+      'file_put_contents',
+      'config:set',
+      'pm:enable',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $probe);
+    }
+  }
+
+  /**
+   * The trusted route reproduces but never publishes the #720 patch.
+   */
+  public function testWorkflowIsDiagnosticOnlyAndClassifiesConvergence(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-canvas-drift-diagnostic.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-canvas-drift diagnose'",
+      $workflow,
+    );
+    self::assertStringContainsString('[[ "$ISSUE_NUMBER" == \'728\' ]]', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('.counts.prepared == 173', $workflow);
+    self::assertStringContainsString('.counts.material_translatable_leaf_count == 930', $workflow);
+    self::assertStringContainsString('.counts.config_paths_changed == 353', $workflow);
+    self::assertStringContainsString('.counts.different == 8', $workflow);
+    self::assertStringContainsString('CANVAS_EIGHT_COMPONENT_DRIFT_CONVERGES', $workflow);
+    self::assertStringContainsString('CANVAS_EIGHT_COMPONENT_DRIFT_PERSISTS', $workflow);
+    self::assertStringContainsString('CANVAS_EIGHT_COMPONENT_REIMPORT_REJECTED', $workflow);
+    self::assertStringContainsString('actions/upload-artifact@v4', $workflow);
+    self::assertStringContainsString('gh issue comment 728', $workflow);
+    self::assertSame(2, substr_count($workflow, 'site:install --existing-config'));
+    self::assertSame(3, substr_count($workflow, 'ddev drush cim -y'));
+
+    foreach ([
+      'workflow_dispatch:',
+      'drush cex',
+      'git push',
+      'contents: write',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds a governed, diagnostic-only reproduction route for the exact eight Canvas component configs left dirty by #720 run `32665077064` after the second fresh install.

The route:

- reproduces the frozen #720 writer patch in disposable DDEV only;
- requires the same 173 prepared configs / 930 covered leaves / 353 config paths;
- performs the second fresh existing-config install and first import;
- compares active vs sync storage for exactly the eight observed `canvas.component.block.*` configs;
- performs exactly one additional `cim -y` attempt and captures whether it converges, persists or is rejected;
- uploads before/after JSON diffs, config-status outputs, reimport output and summary evidence;
- never runs cex, never enables Config Language Lock, never pushes a branch and has read-only repository permissions.

This is motivated by upstream Canvas issue #3555538, which documents multilingual component config changes involving langcode, active_version and labels, including block components such as local_actions_block.

No `config/sync` mutation and no change to the #720 writer/verifier.

Refs #728 #720 #726 #718 #609.