### PR TITLE
Issue #729: add read-only Canvas language drift diagnostic

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-drift-diagnostic.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-drift-diagnostic.yml
@@ -1,0 +1,276 @@
+name: Agency trusted Canvas language drift diagnostic
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate Canvas drift diagnostic request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-canvas-drift diagnose'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '729' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-canvas-drift diagnose' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  diagnose:
+    name: Reproduce and diagnose exact Canvas component drift
+    needs: validate-request
+    timeout-minutes: 40
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      different: ${{ steps.summary.outputs.different }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          command -v docker
+          command -v ddev
+          command -v jq
+          git --version
+          docker --version
+          ddev version
+
+      - name: Checkout exact live main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable diagnostic inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f scripts/runner/apply-configuration-language-translated-canonical.php
+          test -f scripts/runner/diagnose-configuration-language-canvas-drift.php
+          ddev utility configyaml >/dev/null
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-drift-diagnostic.yaml <<EOF_CONFIG
+          name: agency-config-canvas-drift-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml | grep -F "agency-config-canvas-drift-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Prove baseline fresh install is clean
+        shell: bash
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php
+          ddev exec php -l /var/www/html/scripts/runner/diagnose-configuration-language-canvas-drift.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status"
+          grep -Fq 'No differences' <<<"$config_status"
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Config Language Lock must remain disabled.' >&2
+            exit 1
+          fi
+
+      - name: Prepare local exact #720 canonical patch without push
+        shell: bash
+        env:
+          RESULT_PATH: ${{ runner.temp }}/agency-config-translated-canonical-720-result.json
+        run: |
+          set -euo pipefail
+          ddev drush php:script /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php > "$RESULT_PATH"
+          jq -e '.status == "PASS"' "$RESULT_PATH" >/dev/null
+          jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PATCH_PREPARED"' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.prepared == 173' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.material_translatable_leaf_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.explicit_en_coverage_count == 930' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.config_paths_changed == 353' "$RESULT_PATH" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$RESULT_PATH" >/dev/null
+
+          mapfile -t expected_paths < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[], .paths.manifest' "$RESULT_PATH" | sort)
+          mapfile -t changed_paths < <(
+            git status --porcelain --untracked-files=all -- \
+              config/sync \
+              docs/evidence/configuration-language-translated-canonical-cohort-720.yml \
+              | awk '{print $2}' \
+              | sort
+          )
+          [[ "${#expected_paths[@]}" -eq 354 ]]
+          [[ "${#changed_paths[@]}" -eq 354 ]]
+          diff -u <(printf '%s\n' "${expected_paths[@]}") <(printf '%s\n' "${changed_paths[@]}")
+          git diff --check
+
+      - name: Rebuild second fresh Drupal and capture Canvas drift
+        id: diagnose
+        shell: bash
+        env:
+          DIAGNOSTIC_PATH: ${{ runner.temp }}/agency-config-canvas-drift-729.json
+          STATUS_PATH: ${{ runner.temp }}/agency-config-canvas-drift-729-status.txt
+        run: |
+          set -euo pipefail
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" | tee "$STATUS_PATH"
+
+          ddev drush php:script /var/www/html/scripts/runner/diagnose-configuration-language-canvas-drift.php > "$DIAGNOSTIC_PATH"
+          cat "$DIAGNOSTIC_PATH"
+          jq -e '.status == "PASS"' "$DIAGNOSTIC_PATH" >/dev/null
+          jq -e '.verdict == "EIGHT_CANVAS_COMPONENT_LANGUAGE_DRIFTS_DIAGNOSED"' "$DIAGNOSTIC_PATH" >/dev/null
+          jq -e '.counts.expected == 8 and .counts.different == 8 and .counts.problem_count == 0' "$DIAGNOSTIC_PATH" >/dev/null
+          jq -e '.constraints.read_only == true and .constraints.config_write_allowed == false' "$DIAGNOSTIC_PATH" >/dev/null
+          jq -e '.constraints.config_language_lock_activation_allowed == false' "$DIAGNOSTIC_PATH" >/dev/null
+          ! grep -Fq 'No differences' <<<"$config_status"
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Config Language Lock unexpectedly enabled.' >&2
+            exit 1
+          fi
+          git diff --check
+
+      - name: Upload Canvas drift evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-canvas-drift-729-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/agency-config-canvas-drift-729.json
+            ${{ runner.temp }}/agency-config-canvas-drift-729-status.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Summarize diagnostic
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DIAGNOSTIC_PATH: ${{ runner.temp }}/agency-config-canvas-drift-729.json
+        run: |
+          set -euo pipefail
+          status='MISSING'
+          verdict='MISSING'
+          different='0'
+          if [[ -s "$DIAGNOSTIC_PATH" ]] && jq -e . "$DIAGNOSTIC_PATH" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$DIAGNOSTIC_PATH")"
+            verdict="$(jq -r '.verdict // "UNKNOWN"' "$DIAGNOSTIC_PATH")"
+            different="$(jq -r '.counts.different // 0' "$DIAGNOSTIC_PATH")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "different=$different" >> "$GITHUB_OUTPUT"
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-canvas-drift-diagnostic.yaml
+          git reset --hard HEAD >/dev/null 2>&1 || true
+          git clean -fd -- .ddev config/sync docs/evidence/configuration-language-translated-canonical-cohort-720.yml >/dev/null 2>&1 || true
+
+  report:
+    name: Publish Canvas drift diagnostic result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - diagnose
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment result on #729
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.diagnose.result }}
+          STATUS: ${{ needs.diagnose.outputs.status }}
+          VERDICT: ${{ needs.diagnose.outputs.verdict }}
+          DIFFERENT: ${{ needs.diagnose.outputs.different }}
+        run: |
+          set -euo pipefail
+          heading='### Canvas language drift diagnostic FAIL'
+          if [[ "$OUTCOME" == 'success' && "$STATUS" == 'PASS' && "$DIFFERENT" == '8' ]]; then
+            heading='### Canvas language drift diagnostic PASS'
+          fi
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          status: \`${STATUS:-MISSING}\`
+          verdict: \`${VERDICT:-MISSING}\`
+          different_canvas_components: \`${DIFFERENT:-0}\`
+
+          This route is repository-read-only. It reproduces #720 only in a disposable checkout, captures exact sync/active Canvas component drift and never pushes a branch or enables Config Language Lock.
+          EOF_BODY
+          )"
+          gh issue comment 729 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/diagnose-configuration-language-canvas-drift.php
+++ b/scripts/runner/diagnose-configuration-language-canvas-drift.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Language\LanguageInterface;
+
+$expectedNames = [
+  'canvas.component.block.help_block',
+  'canvas.component.block.language_block.language_content',
+  'canvas.component.block.local_actions_block',
+  'canvas.component.block.page_title_block',
+  'canvas.component.block.system_branding_block',
+  'canvas.component.block.system_breadcrumb_block',
+  'canvas.component.block.system_powered_by_block',
+  'canvas.component.block.views_block.content_recent-block_1',
+];
+
+$syncStorage = \Drupal::service('config.storage.sync');
+$activeStorage = \Drupal::service('config.storage');
+$languageManager = \Drupal::languageManager();
+if (!$syncStorage instanceof StorageInterface || !$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Configuration storages are unavailable.');
+}
+
+$syncEnglish = $syncStorage->createCollection('language.en');
+
+$diffValues = NULL;
+$diffValues = static function (
+  mixed $sync,
+  mixed $active,
+  array $segments = [],
+) use (&$diffValues): array {
+  if (is_array($sync) && is_array($active)) {
+    $differences = [];
+    $keys = array_values(array_unique([...array_keys($sync), ...array_keys($active)]));
+    sort($keys);
+    foreach ($keys as $key) {
+      $syncExists = array_key_exists($key, $sync);
+      $activeExists = array_key_exists($key, $active);
+      $path = [...$segments, $key];
+      if (!$syncExists || !$activeExists) {
+        $differences[] = [
+          'path' => implode('.', array_map('strval', $path)),
+          'sync_exists' => $syncExists,
+          'active_exists' => $activeExists,
+          'sync' => $syncExists ? $sync[$key] : NULL,
+          'active' => $activeExists ? $active[$key] : NULL,
+        ];
+        continue;
+      }
+      foreach ($diffValues($sync[$key], $active[$key], $path) as $difference) {
+        $differences[] = $difference;
+      }
+    }
+    return $differences;
+  }
+
+  if ($sync === $active) {
+    return [];
+  }
+
+  return [[
+    'path' => implode('.', array_map('strval', $segments)),
+    'sync_exists' => TRUE,
+    'active_exists' => TRUE,
+    'sync' => $sync,
+    'active' => $active,
+  ]];
+};
+
+$items = [];
+$differentNames = [];
+foreach ($expectedNames as $name) {
+  $sync = $syncStorage->read($name);
+  $active = $activeStorage->read($name);
+  if (!is_array($sync) || !is_array($active)) {
+    throw new RuntimeException("Missing sync or active Canvas component: $name");
+  }
+
+  $differences = $diffValues($sync, $active);
+  if ($differences !== []) {
+    $differentNames[] = $name;
+  }
+
+  $items[] = [
+    'name' => $name,
+    'has_sync_en_override' => $syncEnglish->exists($name),
+    'sync_langcode' => $sync['langcode'] ?? NULL,
+    'active_langcode' => $active['langcode'] ?? NULL,
+    'sync_active_version' => $sync['active_version'] ?? NULL,
+    'active_active_version' => $active['active_version'] ?? NULL,
+    'sync_label' => $sync['label'] ?? NULL,
+    'active_label' => $active['label'] ?? NULL,
+    'sync_default_label' => $sync['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL,
+    'active_default_label' => $active['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL,
+    'difference_count' => count($differences),
+    'differences' => $differences,
+  ];
+}
+
+sort($differentNames, SORT_STRING);
+$expectedSorted = $expectedNames;
+sort($expectedSorted, SORT_STRING);
+
+$configOverrideLanguage = NULL;
+if (method_exists($languageManager, 'getConfigOverrideLanguage')) {
+  $configOverrideLanguage = $languageManager->getConfigOverrideLanguage()->getId();
+}
+
+$result = [
+  'status' => $differentNames === $expectedSorted ? 'PASS' : 'FAIL',
+  'verdict' => $differentNames === $expectedSorted
+    ? 'EIGHT_CANVAS_COMPONENT_LANGUAGE_DRIFTS_DIAGNOSED'
+    : 'CANVAS_COMPONENT_DRIFT_SET_UNEXPECTED',
+  'expected_names' => $expectedSorted,
+  'different_names' => $differentNames,
+  'counts' => [
+    'expected' => count($expectedSorted),
+    'different' => count($differentNames),
+    'problem_count' => $differentNames === $expectedSorted ? 0 : 1,
+  ],
+  'languages' => [
+    'system_site_default_langcode' => \Drupal::config('system.site')->get('default_langcode'),
+    'manager_default' => $languageManager->getDefaultLanguage()->getId(),
+    'current_interface' => $languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId(),
+    'current_content' => $languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId(),
+    'current_url' => $languageManager->getCurrentLanguage(LanguageInterface::TYPE_URL)->getId(),
+    'config_override' => $configOverrideLanguage,
+  ],
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'repository_mutation_allowed' => FALSE,
+    'config_write_allowed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+  ],
+];
+
+print json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded Canvas drift diagnostic route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageCanvasDriftDiagnosticWorkflowTest extends TestCase {
+
+  /**
+   * The diagnostic script is exact and read-only.
+   */
+  public function testCanvasDriftDiagnosticIsExactAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $script = (string) file_get_contents(
+      $root . '/scripts/runner/diagnose-configuration-language-canvas-drift.php',
+    );
+
+    self::assertIsArray(token_get_all($script, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.storage.sync')", $script);
+    self::assertStringContainsString("\\Drupal::service('config.storage')", $script);
+    self::assertStringContainsString('EIGHT_CANVAS_COMPONENT_LANGUAGE_DRIFTS_DIAGNOSED', $script);
+
+    foreach ([
+      'canvas.component.block.help_block',
+      'canvas.component.block.language_block.language_content',
+      'canvas.component.block.local_actions_block',
+      'canvas.component.block.page_title_block',
+      'canvas.component.block.system_branding_block',
+      'canvas.component.block.system_breadcrumb_block',
+      'canvas.component.block.system_powered_by_block',
+      'canvas.component.block.views_block.content_recent-block_1',
+    ] as $name) {
+      self::assertStringContainsString($name, $script);
+    }
+
+    foreach ([
+      'write(',
+      'delete(',
+      'file_put_contents',
+      'config:set',
+      'pm:enable',
+      'config_language_lock.settings',
+      'drush cex',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted workflow reproduces locally and never pushes.
+   */
+  public function testTrustedCanvasDriftRouteIsRepositoryReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-drift-diagnostic.yml';
+    $workflow = (string) file_get_contents($path);
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-canvas-drift diagnose'",
+      $workflow,
+    );
+    self::assertStringContainsString('[[ "$ISSUE_NUMBER" == \'729\' ]]', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString(
+      'apply-configuration-language-translated-canonical.php',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'diagnose-configuration-language-canvas-drift.php',
+      $workflow,
+    );
+    self::assertGreaterThanOrEqual(
+      2,
+      substr_count($workflow, 'site:install --existing-config'),
+    );
+    self::assertStringContainsString(
+      'EIGHT_CANVAS_COMPONENT_LANGUAGE_DRIFTS_DIAGNOSED',
+      $workflow,
+    );
+    self::assertStringContainsString('different == 8', $workflow);
+    self::assertStringContainsString('actions/upload-artifact@v4', $workflow);
+    self::assertStringContainsString('gh issue comment 729', $workflow);
+
+    foreach ([
+      'git push ',
+      'contents: write',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
Superseded by the already-merged diagnostic implementation for #728 on `main@8419c8b6cd03f42c4f8a440bb2df6c435595f72b`.

This PR is intentionally closed without merge to avoid duplicating the live #728 route. Its CI #1332 was green, but no code from this branch is needed.

Refs #728 #729 #720.