### PR TITLE
Issue #733: prove deterministic Canvas baseline stabilization

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-stabilization-proof.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-stabilization-proof.yml
@@ -1,0 +1,340 @@
+name: Agency trusted Canvas deterministic baseline stabilization proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate Canvas stabilization proof request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.comment.body == '/agency-config-language-canvas-stabilization prove'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '733' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-canvas-stabilization prove' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Canvas stabilization proof must start from live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prove:
+    name: Prove exact eight-component deterministic Canvas stabilization
+    needs: validate-request
+    timeout-minutes: 55
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      verdict: ${{ steps.summary.outputs.verdict }}
+      stabilized: ${{ steps.summary.outputs.stabilized }}
+      final_different: ${{ steps.summary.outputs.final_different }}
+    steps:
+      - name: Checkout exact live main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f scripts/runner/apply-configuration-language-translated-canonical.php
+          test -f scripts/runner/configuration-language-translated-canonical-verify.php
+          test -f scripts/runner/configuration-language-canvas-drift-diagnostic.php
+          test -f scripts/runner/stabilize-configuration-language-canvas-components.php
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-stabilization.yaml <<EOF_CONFIG
+          name: agency-config-canvas-stabilization-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml | grep -F "agency-config-canvas-stabilization-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild clean baseline and prepare exact #720 patch
+        shell: bash
+        env:
+          WRITER_RESULT: ${{ runner.temp }}/canvas-stabilization-writer-720.json
+        run: |
+          set -euo pipefail
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php
+          ddev exec php -l /var/www/html/scripts/runner/stabilize-configuration-language-canvas-components.php
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          baseline_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$baseline_status"
+          grep -Fq 'No differences' <<<"$baseline_status"
+
+          ddev drush php:script /var/www/html/scripts/runner/apply-configuration-language-translated-canonical.php > "$WRITER_RESULT"
+          jq -e '.status == "PASS"' "$WRITER_RESULT" >/dev/null
+          jq -e '.counts.prepared == 173' "$WRITER_RESULT" >/dev/null
+          jq -e '.counts.material_translatable_leaf_count == 930' "$WRITER_RESULT" >/dev/null
+          jq -e '.counts.explicit_en_coverage_count == 930' "$WRITER_RESULT" >/dev/null
+          jq -e '.counts.config_paths_changed == 353' "$WRITER_RESULT" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$WRITER_RESULT" >/dev/null
+
+      - name: Rebuild second fresh Drupal and prepare exact Canvas stabilization
+        shell: bash
+        env:
+          BEFORE_JSON: ${{ runner.temp }}/canvas-stabilization-before.json
+          SECOND_STATUS: ${{ runner.temp }}/canvas-stabilization-second-status.txt
+          STABILIZE_RESULT: ${{ runner.temp }}/canvas-stabilization-result.json
+          WRITER_RESULT: ${{ runner.temp }}/canvas-stabilization-writer-720.json
+        run: |
+          set -euo pipefail
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush config:status > "$SECOND_STATUS" 2>&1 || true
+          cat "$SECOND_STATUS"
+
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php > "$BEFORE_JSON"
+          jq -e '.status == "PASS" and .counts.expected == 8 and .counts.different == 8 and .counts.problems == 0' "$BEFORE_JSON" >/dev/null
+
+          ddev drush php:script /var/www/html/scripts/runner/stabilize-configuration-language-canvas-components.php > "$STABILIZE_RESULT"
+          jq -e '.status == "PASS"' "$STABILIZE_RESULT" >/dev/null
+          jq -e '.verdict == "EIGHT_CANVAS_COMPONENT_STABILIZATION_PATCH_PREPARED"' "$STABILIZE_RESULT" >/dev/null
+          jq -e '.counts.expected == 8 and .counts.stabilized == 8 and .counts.paths_changed == 8' "$STABILIZE_RESULT" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$STABILIZE_RESULT" >/dev/null
+          jq -e '.constraints.langcode_preserved_fr == true' "$STABILIZE_RESULT" >/dev/null
+
+          mapfile -t expected_720 < <(jq -r '.paths.base[], .paths.en_deleted[], .paths.fr_created[]' "$WRITER_RESULT")
+          mapfile -t expected_canvas < <(jq -r '.paths[]' "$STABILIZE_RESULT")
+          mapfile -t expected_config_paths < <({ printf '%s\n' "${expected_720[@]}"; printf '%s\n' "${expected_canvas[@]}"; } | sort -u)
+          mapfile -t actual_config_paths < <(
+            git status --porcelain --untracked-files=all -- config/sync \
+              | awk '{print $2}' \
+              | sort
+          )
+          [[ "${#expected_config_paths[@]}" -eq 361 ]]
+          [[ "${#actual_config_paths[@]}" -eq 361 ]]
+          diff -u <(printf '%s\n' "${expected_config_paths[@]}") <(printf '%s\n' "${actual_config_paths[@]}")
+
+          manifest="$(jq -r '.paths.manifest' "$WRITER_RESULT")"
+          mapfile -t expected_all_paths < <({ printf '%s\n' "${expected_config_paths[@]}"; printf '%s\n' "$manifest"; } | sort)
+          mapfile -t actual_all_paths < <(
+            git status --porcelain --untracked-files=all -- \
+              config/sync \
+              docs/evidence/configuration-language-translated-canonical-cohort-720.yml \
+              | awk '{print $2}' \
+              | sort
+          )
+          [[ "${#expected_all_paths[@]}" -eq 362 ]]
+          [[ "${#actual_all_paths[@]}" -eq 362 ]]
+          diff -u <(printf '%s\n' "${expected_all_paths[@]}") <(printf '%s\n' "${actual_all_paths[@]}")
+          [[ -z "$(git diff --name-only -- config/sync/core.extension.yml)" ]]
+          git diff --check
+
+      - name: Rebuild third fresh Drupal and prove convergence
+        id: convergence
+        shell: bash
+        env:
+          FINAL_STATUS: ${{ runner.temp }}/canvas-stabilization-final-status.txt
+          FINAL_CANVAS: ${{ runner.temp }}/canvas-stabilization-final-canvas.json
+          FINAL_VERIFY: ${{ runner.temp }}/canvas-stabilization-final-720-verify.json
+        run: |
+          set -euo pipefail
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          ddev drush config:status > "$FINAL_STATUS" 2>&1
+          cat "$FINAL_STATUS"
+          grep -Fq 'No differences' "$FINAL_STATUS"
+
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-translated-canonical-verify.php > "$FINAL_VERIFY"
+          jq -e '.status == "PASS"' "$FINAL_VERIFY" >/dev/null
+          jq -e '.verdict == "ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED"' "$FINAL_VERIFY" >/dev/null
+          jq -e '.counts.verified == 173' "$FINAL_VERIFY" >/dev/null
+          jq -e '.counts.fr_overrides_required == 7' "$FINAL_VERIFY" >/dev/null
+          jq -e '.counts.mechanical_715_verified_en == 39' "$FINAL_VERIFY" >/dev/null
+          jq -e '.counts.remaining_fr_review_required == 140' "$FINAL_VERIFY" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$FINAL_VERIFY" >/dev/null
+          jq -e '.distribution_by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}' "$FINAL_VERIFY" >/dev/null
+
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-drift-diagnostic.php > "$FINAL_CANVAS"
+          jq -e '.status == "PASS" and .counts.expected == 8 and .counts.different == 0 and .counts.problems == 0' "$FINAL_CANVAS" >/dev/null
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Config Language Lock unexpectedly enabled.' >&2
+            exit 1
+          fi
+          git diff --check
+
+      - name: Build proof summary
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          STABILIZE_RESULT: ${{ runner.temp }}/canvas-stabilization-result.json
+          FINAL_CANVAS: ${{ runner.temp }}/canvas-stabilization-final-canvas.json
+          FINAL_STATUS: ${{ runner.temp }}/canvas-stabilization-final-status.txt
+          SUMMARY_JSON: ${{ runner.temp }}/canvas-stabilization-summary.json
+        run: |
+          set -euo pipefail
+          stabilized='0'
+          final_different='-1'
+          verdict='CANVAS_STABILIZATION_PROOF_INCOMPLETE'
+          if [[ -s "$STABILIZE_RESULT" ]] && jq -e . "$STABILIZE_RESULT" >/dev/null 2>&1; then
+            stabilized="$(jq -r '.counts.stabilized // 0' "$STABILIZE_RESULT")"
+          fi
+          if [[ -s "$FINAL_CANVAS" ]] && jq -e . "$FINAL_CANVAS" >/dev/null 2>&1; then
+            final_different="$(jq -r '.counts.different // -1' "$FINAL_CANVAS")"
+          fi
+          if [[ "$stabilized" == '8' && "$final_different" == '0' && -s "$FINAL_STATUS" ]] && grep -Fq 'No differences' "$FINAL_STATUS"; then
+            verdict='EIGHT_CANVAS_COMPONENT_DETERMINISTIC_BASELINE_STABILIZATION_PROVEN'
+          fi
+          jq -n \
+            --arg status PASS \
+            --arg verdict "$verdict" \
+            --argjson stabilized "$stabilized" \
+            --argjson final_different "$final_different" \
+            '{status:$status, verdict:$verdict, stabilized:$stabilized, final_different:$final_different,
+              constraints:{proof_only:true, repository_write_used:false, config_export_used:false,
+                config_language_lock_activation_allowed:false, production_access_allowed:false}}' > "$SUMMARY_JSON"
+          cat "$SUMMARY_JSON"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "stabilized=$stabilized" >> "$GITHUB_OUTPUT"
+          echo "final_different=$final_different" >> "$GITHUB_OUTPUT"
+
+      - name: Stage proof artifact files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/canvas-stabilization-artifact"
+          mkdir -p "$artifact_dir"
+          for file in \
+            canvas-stabilization-writer-720.json \
+            canvas-stabilization-before.json \
+            canvas-stabilization-second-status.txt \
+            canvas-stabilization-result.json \
+            canvas-stabilization-final-status.txt \
+            canvas-stabilization-final-canvas.json \
+            canvas-stabilization-final-720-verify.json \
+            canvas-stabilization-summary.json; do
+            if [[ -f "${RUNNER_TEMP}/${file}" ]]; then
+              cp "${RUNNER_TEMP}/${file}" "$artifact_dir/$file"
+            fi
+          done
+
+      - name: Upload Canvas stabilization proof artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-canvas-stabilization-733-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/canvas-stabilization-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          ddev delete --omit-snapshot --yes
+          rm -f .ddev/config.gate-config-language-canvas-stabilization.yaml
+          git reset --hard HEAD >/dev/null 2>&1 || true
+          git clean -fd -- .ddev config/sync docs/evidence/configuration-language-translated-canonical-cohort-720.yml >/dev/null 2>&1 || true
+
+  report:
+    name: Publish Canvas stabilization proof result
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prove
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Comment proof result on #733
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.prove.result }}
+          VERDICT: ${{ needs.prove.outputs.verdict }}
+          STABILIZED: ${{ needs.prove.outputs.stabilized }}
+          FINAL_DIFFERENT: ${{ needs.prove.outputs.final_different }}
+        run: |
+          set -euo pipefail
+          body="$(cat <<EOF_BODY
+          ### Canvas deterministic baseline stabilization proof
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          verdict: \`${VERDICT:-n/a}\`
+          stabilized: \`${STABILIZED:-0}\`
+          final_different: \`${FINAL_DIFFERENT:-n/a}\`
+
+          This route is proof-only. It reproduces #720 in disposable DDEV, stabilizes only the exact eight #728 Canvas components in local sync, performs a third fresh install and never pushes, runs cex, enables Config Language Lock or accesses production.
+          EOF_BODY
+          )"
+          gh issue comment 733 --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/scripts/runner/stabilize-configuration-language-canvas-components.php
+++ b/scripts/runner/stabilize-configuration-language-canvas-components.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Stabilizes the exact eight Canvas component configs in disposable sync.
+ */
+
+use Drupal\Core\Config\StorageInterface;
+
+$names = [
+  'canvas.component.block.help_block',
+  'canvas.component.block.language_block.language_content',
+  'canvas.component.block.local_actions_block',
+  'canvas.component.block.page_title_block',
+  'canvas.component.block.system_branding_block',
+  'canvas.component.block.system_breadcrumb_block',
+  'canvas.component.block.system_powered_by_block',
+  'canvas.component.block.views_block.content_recent-block_1',
+];
+
+$activeStorage = \Drupal::service('config.storage');
+$syncStorage = \Drupal::service('config.storage.sync');
+if (!$activeStorage instanceof StorageInterface || !$syncStorage instanceof StorageInterface) {
+  throw new RuntimeException('Expected Drupal active and sync configuration storages.');
+}
+
+$normalize = NULL;
+$normalize = static function (mixed $value) use (&$normalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($normalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $normalize($child);
+  }
+  return $value;
+};
+
+$fingerprint = static function (mixed $value) use ($normalize): string {
+  return hash('sha256', json_encode(
+    $normalize($value),
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ));
+};
+
+$items = [];
+$paths = [];
+foreach ($names as $name) {
+  $active = $activeStorage->read($name);
+  $sync = $syncStorage->read($name);
+  if (!is_array($active) || !is_array($sync)) {
+    throw new RuntimeException("Missing active or sync Canvas component: $name");
+  }
+  if (($active['langcode'] ?? NULL) !== 'fr' || ($sync['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Canvas stabilization must preserve FR langcode: $name");
+  }
+
+  $activeVersion = $active['active_version'] ?? NULL;
+  $syncVersion = $sync['active_version'] ?? NULL;
+  if (!is_string($activeVersion) || !is_string($syncVersion) || $activeVersion === $syncVersion) {
+    throw new RuntimeException("Expected deterministic Canvas active_version drift: $name");
+  }
+
+  $activeLabel = $active['label'] ?? NULL;
+  $syncLabel = $sync['label'] ?? NULL;
+  $activeDefaultLabel = $active['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL;
+  $syncDefaultLabel = $sync['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL;
+  if (!is_string($activeLabel) || !is_string($syncLabel)
+    || !is_string($activeDefaultLabel) || !is_string($syncDefaultLabel)
+    || $activeLabel === $syncLabel || $activeDefaultLabel === $syncDefaultLabel) {
+    throw new RuntimeException("Expected deterministic Canvas label drift: $name");
+  }
+
+  $historical = $active['versioned_properties'][$syncVersion] ?? NULL;
+  $syncActive = $sync['versioned_properties']['active'] ?? NULL;
+  if (!is_array($historical) || !is_array($syncActive) || $historical !== $syncActive) {
+    throw new RuntimeException("Expected old sync version to be retained as Canvas history: $name");
+  }
+
+  $beforeFingerprint = $fingerprint($sync);
+  $activeFingerprint = $fingerprint($active);
+  if ($beforeFingerprint === $activeFingerprint) {
+    throw new RuntimeException("Canvas component is unexpectedly already stable: $name");
+  }
+
+  if (!$syncStorage->write($name, $active)) {
+    throw new RuntimeException("Unable to write stabilized Canvas sync config: $name");
+  }
+  $written = $syncStorage->read($name);
+  if (!is_array($written) || $fingerprint($written) !== $activeFingerprint) {
+    throw new RuntimeException("Canvas stabilization writeback mismatch: $name");
+  }
+  if (($written['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Canvas stabilization changed langcode: $name");
+  }
+
+  $path = 'config/sync/' . $name . '.yml';
+  $paths[] = $path;
+  $items[] = [
+    'name' => $name,
+    'path' => $path,
+    'langcode' => 'fr',
+    'before_fingerprint' => $beforeFingerprint,
+    'after_fingerprint' => $activeFingerprint,
+    'sync_active_version_before' => $syncVersion,
+    'active_version_after' => $activeVersion,
+    'sync_label_before' => $syncLabel,
+    'active_label_after' => $activeLabel,
+    'sync_default_label_before' => $syncDefaultLabel,
+    'active_default_label_after' => $activeDefaultLabel,
+  ];
+}
+
+sort($paths, SORT_STRING);
+$result = [
+  'status' => 'PASS',
+  'verdict' => 'EIGHT_CANVAS_COMPONENT_STABILIZATION_PATCH_PREPARED',
+  'counts' => [
+    'expected' => 8,
+    'stabilized' => count($items),
+    'paths_changed' => count($paths),
+    'problem_count' => 0,
+  ],
+  'paths' => $paths,
+  'items' => $items,
+  'constraints' => [
+    'exact_eight_only' => TRUE,
+    'langcode_preserved_fr' => TRUE,
+    'drupal_sync_storage_used' => TRUE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'repository_push_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+  ],
+  'problems' => [],
+];
+
+print json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasStabilizationProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasStabilizationProofWorkflowTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the exact #733 Canvas stabilization proof route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language_governance
+ */
+final class ConfigurationLanguageCanvasStabilizationProofWorkflowTest extends TestCase {
+
+  /**
+   * The stabilizer is restricted to the exact eight Canvas configs.
+   */
+  public function testCanvasStabilizerIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $script = (string) file_get_contents(
+      $root . '/scripts/runner/stabilize-configuration-language-canvas-components.php',
+    );
+
+    self::assertIsArray(token_get_all($script, TOKEN_PARSE));
+    self::assertStringContainsString("\\Drupal::service('config.storage')", $script);
+    self::assertStringContainsString("\\Drupal::service('config.storage.sync')", $script);
+    self::assertStringContainsString('$syncStorage->write($name, $active)', $script);
+    self::assertStringContainsString('langcode_preserved_fr', $script);
+    self::assertStringContainsString('EIGHT_CANVAS_COMPONENT_STABILIZATION_PATCH_PREPARED', $script);
+
+    foreach ([
+      'canvas.component.block.help_block',
+      'canvas.component.block.language_block.language_content',
+      'canvas.component.block.local_actions_block',
+      'canvas.component.block.page_title_block',
+      'canvas.component.block.system_branding_block',
+      'canvas.component.block.system_breadcrumb_block',
+      'canvas.component.block.system_powered_by_block',
+      'canvas.component.block.views_block.content_recent-block_1',
+    ] as $name) {
+      self::assertStringContainsString($name, $script);
+    }
+
+    foreach ([
+      'file_put_contents',
+      'Yaml::dump',
+      'drush cex',
+      'config:set',
+      'pm:enable',
+      'config_language_lock.settings',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route proves third-fresh convergence and never pushes.
+   */
+  public function testTrustedCanvasStabilizationProofIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/trusted-configuration-language-canvas-stabilization-proof.yml',
+    );
+
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      "github.event.comment.body == '/agency-config-language-canvas-stabilization prove'",
+      $workflow,
+    );
+    self::assertStringContainsString('[[ "$ISSUE_NUMBER" == \'733\' ]]', $workflow);
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertGreaterThanOrEqual(3, substr_count($workflow, 'site:install --existing-config'));
+    self::assertStringContainsString('[[ "${#expected_config_paths[@]}" -eq 361 ]]', $workflow);
+    self::assertStringContainsString('[[ "${#expected_all_paths[@]}" -eq 362 ]]', $workflow);
+    self::assertStringContainsString('.counts.different == 8', $workflow);
+    self::assertStringContainsString('.counts.different == 0', $workflow);
+    self::assertStringContainsString(
+      'EIGHT_CANVAS_COMPONENT_DETERMINISTIC_BASELINE_STABILIZATION_PROVEN',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ONE_HUNDRED_SEVENTY_THREE_TRANSLATED_CANONICAL_PROMOTION_VERIFIED',
+      $workflow,
+    );
+    self::assertStringContainsString('actions/upload-artifact@v4', $workflow);
+    self::assertStringContainsString('gh issue comment 733', $workflow);
+
+    foreach ([
+      'git push ',
+      'contents: write',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds a proof-only route for the exact eight non-convergent Canvas components proven by #728.

The route:

- reproduces the frozen #720 173/930/353 patch in disposable DDEV;
- requires the exact 8-component Canvas drift;
- stabilizes only those 8 local sync objects from their deterministic active state via Drupal storage;
- requires 361 config paths total (353 #720 + 8 Canvas) and 362 paths including the existing #720 manifest;
- performs a third fresh `site:install --existing-config` / `cim` / `cr`;
- requires `config:status` clean;
- runs the existing #720 verifier and requires the 173 promotion proof to remain green;
- requires the 8-component Canvas diagnostic to report zero remaining differences;
- never pushes a migration branch, runs cex, enables Config Language Lock or accesses production.

No `config/sync` file is changed by this PR.

Refs #733 #728 #720 #692 #609.