### PR TITLE
Issue #737: expose final #720 staging diagnostics

### DIFF
--- a/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
+++ b/.github/workflows/governed-configuration-language-translated-canonical-migration.yml
@@ -363,6 +363,24 @@ jobs:
           )
           git add -- "${paths[@]}"
           mapfile -t staged_paths < <(git diff --cached --name-only | sort)
+
+          staged_added="$(git diff --cached --diff-filter=A --name-only | wc -l)"
+          staged_modified="$(git diff --cached --diff-filter=M --name-only | wc -l)"
+          staged_deleted="$(git diff --cached --diff-filter=D --name-only | wc -l)"
+          printf 'final_staging_expected_paths=%s\n' "${#paths[@]}"
+          printf 'final_staging_staged_paths=%s\n' "${#staged_paths[@]}"
+          printf 'final_staging_status_counts added=%s modified=%s deleted=%s\n' \
+            "$staged_added" "$staged_modified" "$staged_deleted"
+          echo '--- final staged name-status ---'
+          git diff --cached --name-status
+          echo '--- final unstaged tracked name-status ---'
+          git diff --name-status
+          echo '--- final untracked migration surfaces ---'
+          git ls-files --others --exclude-standard -- \
+            config/sync \
+            docs/evidence/configuration-language-translated-canonical-cohort-720.yml \
+            || true
+
           [[ "${#paths[@]}" -eq 362 ]]
           [[ "${#staged_paths[@]}" -eq 362 ]]
           diff -u \

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest.php
@@ -38,6 +38,22 @@ final class ConfigurationLanguageTranslatedCanonicalPathScopeWorkflowTest extend
       'mapfile -t staged_paths < <(git diff --cached --name-only | sort)',
       $workflow,
     );
+    self::assertStringContainsString(
+      'final_staging_expected_paths=%s',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'final_staging_staged_paths=%s',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'final_staging_status_counts added=%s modified=%s deleted=%s',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git diff --cached --name-status',
+      $workflow,
+    );
     self::assertStringContainsString('diff -u', $workflow);
     self::assertStringContainsString(
       '<(printf \'%s\\n\' "${paths[@]}")',


### PR DESCRIPTION
## Summary

Adds fail-closed observability to the final Git staging gate of the governed #720 migration route after run `32668864309` proved the full 361-config transformation and third fresh-install convergence but failed silently before commit/push.

Scope is exactly two files:
- governed #720 workflow;
- its path-scope contract test.

No assertion is relaxed. Before the existing 362-path checks, the route now prints:
- expected and staged path counts;
- staged A/M/D counts;
- staged `name-status`;
- unstaged tracked `name-status`;
- untracked migration-surface paths.

No `config/sync`, writer, verifier, stabilizer, Config Language Lock or production change.

Refs #737 #720 #735 #733 #609.