### PR TITLE
Issue #742: rebaseliner les tests après la promotion canonique

### DIFF
--- a/web/modules/custom/agency_project_tests/tests/src/Functional/ContactFormTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/ContactFormTest.php
@@ -38,6 +38,16 @@ final class ContactFormTest extends BrowserTestBase {
   private Webform $contactWebform;
 
   /**
+   * Libellé de soumission porté par la configuration canonique testée.
+   */
+  private string $submitLabel;
+
+  /**
+   * Première ligne du message de confirmation canonique testé.
+   */
+  private string $confirmationText;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -48,6 +58,22 @@ final class ContactFormTest extends BrowserTestBase {
 
     $configuration = Yaml::parseFile($config_file);
     self::assertIsArray($configuration);
+
+    $elements = Yaml::parse((string) ($configuration['elements'] ?? ''));
+    self::assertIsArray($elements);
+    $submit_label = $elements['actions']['#submit__label'] ?? NULL;
+    self::assertIsString($submit_label);
+    self::assertNotSame('', trim($submit_label));
+    $this->submitLabel = $submit_label;
+
+    $confirmation_message = $configuration['settings']['confirmation_message'] ?? NULL;
+    self::assertIsString($confirmation_message);
+    $confirmation_line = trim((string) strtok(
+      str_replace(["\r\n", "\r"], "\n", $confirmation_message),
+      "\n",
+    ));
+    self::assertNotSame('', $confirmation_line);
+    $this->confirmationText = $confirmation_line;
 
     // Les handlers email appartiennent au comportement de production. Le test
     // fonctionnel vérifie le formulaire et la persistance sans envoyer d'email.
@@ -76,7 +102,7 @@ final class ContactFormTest extends BrowserTestBase {
     $this->assertSession()->fieldExists('subject');
     $this->assertSession()->fieldExists('message');
     $this->assertSession()->fieldExists('rgpd_consent');
-    $this->assertSession()->buttonExists('Envoyer le message');
+    $this->assertSession()->buttonExists($this->submitLabel);
 
     $this->submitForm([
       'name' => 'Test Contact',
@@ -84,7 +110,7 @@ final class ContactFormTest extends BrowserTestBase {
       'subject' => 'Sujet test',
       'message' => 'Message test',
       'rgpd_consent' => '1',
-    ], 'Envoyer le message');
+    ], $this->submitLabel);
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->elementExists('css', '[role="alert"]');
     self::assertSame(0, $this->countContactSubmissions());
@@ -95,9 +121,9 @@ final class ContactFormTest extends BrowserTestBase {
       'subject' => 'Sujet valide',
       'message' => 'Message valide',
       'rgpd_consent' => '1',
-    ], 'Envoyer le message');
+    ], $this->submitLabel);
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('Merci, votre demande a bien été enregistrée.');
+    $this->assertSession()->pageTextContains($this->confirmationText);
     self::assertSame(1, $this->countContactSubmissions());
   }
 

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/ContactFormTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/ContactFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Functional;
 
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\webform\Entity\Webform;
 use PHPUnit\Framework\Attributes\Group;
@@ -59,7 +60,7 @@ final class ContactFormTest extends BrowserTestBase {
     $configuration = Yaml::parseFile($config_file);
     self::assertIsArray($configuration);
 
-    $elements = Yaml::parse((string) ($configuration['elements'] ?? ''));
+    $elements = DrupalYaml::decode((string) ($configuration['elements'] ?? ''));
     self::assertIsArray($elements);
     $submit_label = $elements['actions']['#submit__label'] ?? NULL;
     self::assertIsString($submit_label);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageExceptionCoverageWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageExceptionCoverageWorkflowTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Protects the two explicit EN exception overrides and their trusted proof.
+ * Protects explicit exception coverage across the #720 canonical transition.
  *
  * @group agency_project_tests
  * @group configuration_language_governance
@@ -17,16 +17,40 @@ use Symfony\Component\Yaml\Yaml;
 final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase {
 
   /**
-   * The two EN overrides remain sparse and contain only approved leaves.
+   * Exception overrides match the legacy or promoted canonical state.
    */
   public function testExceptionOverridesAreMinimal(): void {
     $root = dirname(DRUPAL_ROOT);
-
-    $formOverride = Yaml::parseFile(
-      $root
+    $formOverridePath = $root
       . '/config/sync/language/en/'
-      . 'core.entity_form_display.node.page.default.yml',
-    );
+      . 'core.entity_form_display.node.page.default.yml';
+    $statusOverridePath = $root
+      . '/config/sync/language/en/'
+      . 'field.storage.node.ai_automator_status.yml';
+
+    if ($this->canonicalPromotionApplied($root)) {
+      self::assertFileDoesNotExist($formOverridePath);
+      self::assertFileDoesNotExist($statusOverridePath);
+
+      $formFrOverride = Yaml::parseFile(
+        $root
+        . '/config/sync/language/fr/'
+        . 'core.entity_form_display.node.page.default.yml',
+      );
+      self::assertSame([
+        'content' => [
+          'field_home_components' => [
+            'settings' => [
+              'title' => 'Paragraphe',
+              'title_plural' => 'Paragraphes',
+            ],
+          ],
+        ],
+      ], $formFrOverride);
+      return;
+    }
+
+    $formOverride = Yaml::parseFile($formOverridePath);
     self::assertSame([
       'content' => [
         'field_home_components' => [
@@ -38,11 +62,7 @@ final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase 
       ],
     ], $formOverride);
 
-    $statusOverride = Yaml::parseFile(
-      $root
-      . '/config/sync/language/en/'
-      . 'field.storage.node.ai_automator_status.yml',
-    );
+    $statusOverride = Yaml::parseFile($statusOverridePath);
     self::assertSame([
       'settings' => [
         'allowed_values' => [
@@ -56,9 +76,9 @@ final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase 
   }
 
   /**
-   * The source configs stay FR and retain the approved source values.
+   * Source configs match the legacy or promoted canonical state.
    */
-  public function testExceptionSourceConfigsRemainUnmigrated(): void {
+  public function testExceptionSourceConfigsRemainConsistent(): void {
     $root = dirname(DRUPAL_ROOT);
     $form = Yaml::parseFile(
       $root . '/config/sync/core.entity_form_display.node.page.default.yml',
@@ -67,18 +87,33 @@ final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase 
       $root . '/config/sync/field.storage.node.ai_automator_status.yml',
     );
 
-    self::assertSame('fr', $form['langcode'] ?? NULL);
-    self::assertSame(
-      'Paragraphe',
-      $form['content']['field_home_components']['settings']['title'] ?? NULL,
-    );
-    self::assertSame(
-      'Paragraphes',
-      $form['content']['field_home_components']['settings']['title_plural']
-        ?? NULL,
-    );
+    if ($this->canonicalPromotionApplied($root)) {
+      self::assertSame('en', $form['langcode'] ?? NULL);
+      self::assertSame(
+        'Paragraph',
+        $form['content']['field_home_components']['settings']['title'] ?? NULL,
+      );
+      self::assertSame(
+        'Paragraphs',
+        $form['content']['field_home_components']['settings']['title_plural']
+          ?? NULL,
+      );
+      self::assertSame('en', $status['langcode'] ?? NULL);
+    }
+    else {
+      self::assertSame('fr', $form['langcode'] ?? NULL);
+      self::assertSame(
+        'Paragraphe',
+        $form['content']['field_home_components']['settings']['title'] ?? NULL,
+      );
+      self::assertSame(
+        'Paragraphes',
+        $form['content']['field_home_components']['settings']['title_plural']
+          ?? NULL,
+      );
+      self::assertSame('fr', $status['langcode'] ?? NULL);
+    }
 
-    self::assertSame('fr', $status['langcode'] ?? NULL);
     self::assertSame([
       ['value' => 'pending', 'label' => 'Pending'],
       ['value' => 'processing', 'label' => 'Processing'],
@@ -207,6 +242,17 @@ final class ConfigurationLanguageExceptionCoverageWorkflowTest extends TestCase 
     $status = 0;
     exec('bash -n ' . escapeshellarg($runnerPath) . ' 2>&1', $output, $status);
     self::assertSame(0, $status, implode("\n", $output));
+  }
+
+  /**
+   * Returns whether the governed #720 promotion evidence is present.
+   */
+  private function canonicalPromotionApplied(string $root): bool {
+    return is_file(
+      $root
+      . '/docs/evidence/'
+      . 'configuration-language-translated-canonical-cohort-720.yml',
+    );
   }
 
 }


### PR DESCRIPTION
## Résumé

Corrige uniquement les attentes de tests rendues obsolètes par la promotion canonique #720, sans modifier les 362 fichiers gouvernés de #741.

- `ConfigurationLanguageExceptionCoverageWorkflowTest` devient transitionnel : il protège l’état legacy avant présence du manifeste #720, puis exige l’état promu (bases EN, overrides EN supprimés, override FR nécessaire présent) après migration.
- `ContactFormTest` dérive désormais le libellé de soumission et le message de confirmation de la configuration canonique qu’il instancie réellement, au lieu de supposer que le canonique est toujours FR.

## Bornes

- 2 fichiers de tests uniquement ;
- aucun fichier `config/sync` ;
- aucune modification de la branche #720 ;
- aucune réduction du comportement testé : rendu, validation invalide, soumission valide et persistance restent couverts.

## Validation attendue

1. CI verte contre `main` pré-#720 ;
2. merge de cette PR ;
3. nouvelle CI de #741 contre `main` mis à jour, où les mêmes tests doivent valider l’état promu.

Closes #742
Refs #720 #741 #711.