### PR TITLE
Issue #744: prouver le non-enforcing après la migration canonique

### DIFF
--- a/.github/workflows/trusted-config-language-lock-post-migration-evaluation.yml
+++ b/.github/workflows/trusted-config-language-lock-post-migration-evaluation.yml
@@ -1,0 +1,220 @@
+name: Agency trusted post-migration Configuration Language Lock evaluation
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agency-config-language-lock-post-migration-evaluation
+  cancel-in-progress: false
+
+jobs:
+  validate-target:
+    name: Validate fixed #744 post-migration target
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.number == 744 && github.event.comment.body == '/agency-config-language-lock post-migration-evaluate' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+      resolved_version: ${{ steps.validate.outputs.resolved_version }}
+    steps:
+      - name: Checkout trusted main implementation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate actor, issue, live main and candidate state
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '744'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-lock post-migration-evaluate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          [[ "$EVENT_DEFAULT_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          test "$(jq -r '.state' <<<"$issue_json")" = 'open'
+          test "$(jq -r 'has("pull_request")' <<<"$issue_json")" = 'false'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          test "$(git rev-parse HEAD)" = "$main_sha"
+
+          jq -e '.require["drupal/config_language_lock"] == "^1.0"' composer.json >/dev/null
+          resolved_version="$(jq -r '.packages[] | select(.name == "drupal/config_language_lock") | .version' composer.lock | sed 's/^v//')"
+          [[ "$resolved_version" =~ ^1\.0\.[0-9]+$ ]]
+
+          test -f docs/evidence/configuration-language-translated-canonical-cohort-720.yml
+          test -f scripts/runner/config-language-lock-state.php
+          test -f scripts/runner/configuration-language-audit.php
+          test -f scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+          test ! -e config/sync/config_language_lock.settings.yml
+          if grep -Eq '^  config_language_lock:' config/sync/core.extension.yml; then
+            echo 'Configuration Language Lock must remain disabled in canonical config.' >&2
+            exit 1
+          fi
+
+          bash -n scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+          git diff --check
+          test -z "$(git status --porcelain)"
+
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+          echo "resolved_version=$resolved_version" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Prove post-migration non-enforcing behavior
+    needs: validate-target
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+          python3 --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable target
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f docs/evidence/configuration-language-translated-canonical-cohort-720.yml
+          bash -n scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+          git diff --check
+          test -z "$(git status --porcelain)"
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-lock-post-migration.yaml <<EOF_CONFIG
+          name: agency-config-language-lock-post-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-language-lock-post-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Run bounded post-migration evaluation
+        id: proof
+        continue-on-error: true
+        shell: bash
+        env:
+          ARTIFACT_ROOT: artifacts/config-language-lock-post-migration-evaluation
+        run: |
+          set -euo pipefail
+          bash scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+
+      - name: Upload post-migration evaluation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-lock-post-migration-744-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-lock-post-migration-evaluation
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and require clean workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-language-lock-post-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-lock-post-migration.yaml
+          git restore --worktree -- config/sync web/robots.txt
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-lock-post-migration-evaluation
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+      - name: Require proof success
+        if: ${{ always() }}
+        shell: bash
+        env:
+          PROOF_OUTCOME: ${{ steps.proof.outcome }}
+        run: |
+          set -euo pipefail
+          test "$PROOF_OUTCOME" = 'success'
+
+  report-result:
+    name: Publish post-migration evaluation verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - evaluate
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+    steps:
+      - name: Publish issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          RESOLVED_VERSION: ${{ needs.validate-target.outputs.resolved_version }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+        run: |
+          set -euo pipefail
+          verdict='POST_MIGRATION_NON_ENFORCING_EVALUATION_FAILED'
+          label='FAIL'
+          if [[ "$EVALUATION_RESULT" == 'success' ]]; then
+            verdict='POST_MIGRATION_NON_ENFORCING_BEHAVIOR_PROVEN'
+            label='PASS'
+          fi
+          gh issue comment 744 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_COMMENT
+          ### Configuration Language Lock post-migration evaluation ${label}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${EVALUATION_RESULT}\`
+          module: \`${RESOLVED_VERSION}\`
+          verdict: \`${verdict}\`
+          baseline_distribution: \`__none__=59, en=395, fr=140, und=1\`
+
+          Fresh-DDEV proof only. The module is not persisted in canonical config; no cex, production access, provider secret or repository write from the self-hosted runner is permitted. Inspect the run artifact for fingerprints, Locale transitions, uninstall and canonical-restore evidence.
+          EOF_COMMENT
+          )"
+          test "$EVALUATION_RESULT" = 'success'

--- a/scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+++ b/scripts/runner/run-config-language-lock-post-migration-evaluation.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_root="${ARTIFACT_ROOT:-artifacts/config-language-lock-post-migration-evaluation}"
+mkdir -p "$artifact_root"
+
+state_script='/var/www/html/scripts/runner/config-language-lock-state.php'
+audit_script='/var/www/html/scripts/runner/configuration-language-audit.php'
+
+capture_status() {
+  local target="$1"
+  local status
+  status="$(ddev drush config:status 2>&1)"
+  printf '%s\n' "$status" > "$target"
+  grep -Fq 'No differences' <<<"$status"
+}
+
+capture_state() {
+  local state_target="$1"
+  local audit_target="$2"
+  ddev drush php:script "$state_script" > "$state_target"
+  ddev drush php:script "$audit_script" > "$audit_target"
+}
+
+ddev start -y
+ddev composer audit --locked --format=json > "$artifact_root/composer-audit.json"
+jq -e '(.advisories // {}) | length == 0' "$artifact_root/composer-audit.json" >/dev/null
+ddev composer install --no-interaction --no-progress --prefer-dist
+ddev exec php -l "$state_script" >/dev/null
+ddev exec php -l "$audit_script" >/dev/null
+
+admin_pass="$(openssl rand -hex 24)"
+ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+unset admin_pass
+ddev drush cim -y
+ddev drush cr
+capture_status "$artifact_root/config-status-before.txt"
+capture_state "$artifact_root/state-before.json" "$artifact_root/language-before.json"
+
+jq -e '.schema_version == 2 and .total == 595' "$artifact_root/state-before.json" >/dev/null
+jq -e '.site_default_language == "fr"' "$artifact_root/state-before.json" >/dev/null
+jq -e '.config_language_lock_enabled == false' "$artifact_root/state-before.json" >/dev/null
+jq -e '.module_owned == {}' "$artifact_root/state-before.json" >/dev/null
+jq -e '.special.system_menu_footer_langcode == "und"' "$artifact_root/state-before.json" >/dev/null
+jq -e '.special.language_entity_und_id == "und"' "$artifact_root/state-before.json" >/dev/null
+jq -e '.special.language_entity_zxx_id == "zxx"' "$artifact_root/state-before.json" >/dev/null
+jq -e '.repository.summary.total == 595' "$artifact_root/language-before.json" >/dev/null
+jq -e '.active.summary.total == 595' "$artifact_root/language-before.json" >/dev/null
+jq -e '.repository.summary.by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}' "$artifact_root/language-before.json" >/dev/null
+jq -e '.active.summary.by_langcode == {"__none__":59,"en":395,"fr":140,"und":1}' "$artifact_root/language-before.json" >/dev/null
+jq -e '.repository_active_comparison.missing_from_active | length == 0' "$artifact_root/language-before.json" >/dev/null
+jq -e '.repository_active_comparison.missing_from_repository | length == 0' "$artifact_root/language-before.json" >/dev/null
+jq -e '.repository_active_comparison.langcode_mismatches | length == 0' "$artifact_root/language-before.json" >/dev/null
+
+enable_outcome='failure'
+semantics_outcome='skipped'
+uninstall_outcome='skipped'
+restore_outcome='skipped'
+
+if ddev drush pm:enable config_language_lock -y && ddev drush cr; then
+  enable_outcome='success'
+  capture_state "$artifact_root/state-enabled.json" "$artifact_root/language-enabled.json"
+  test -z "$(git status --short config/sync)"
+
+  if python3 - "$artifact_root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
+enabled = json.loads((root / 'state-enabled.json').read_text(encoding='utf-8'))
+language_before = json.loads((root / 'language-before.json').read_text(encoding='utf-8'))
+language_enabled = json.loads((root / 'language-enabled.json').read_text(encoding='utf-8'))
+
+errors = []
+if enabled.get('config_language_lock_enabled') is not True:
+    errors.append('config_language_lock was not enabled')
+if enabled.get('site_default_language') != before.get('site_default_language'):
+    errors.append('site default language changed during enable')
+
+before_entries = before['entries']
+enabled_entries = enabled['entries']
+before_names = set(before_entries)
+enabled_names = set(enabled_entries)
+removed = sorted(before_names - enabled_names)
+added = sorted(enabled_names - before_names)
+changed_hash = sorted(
+    name for name in before_names & enabled_names
+    if before_entries[name]['sha256'] != enabled_entries[name]['sha256']
+)
+langcode_transitions = []
+for name in sorted(before_names & enabled_names):
+    old = before_entries[name].get('langcode')
+    new = enabled_entries[name].get('langcode')
+    if old != new:
+        langcode_transitions.append({'name': name, 'before': old, 'after': new})
+
+if removed:
+    errors.append(f'enable removed existing config: {removed}')
+if added != ['config_language_lock.settings']:
+    errors.append(f'unexpected module-install config: {added}')
+
+settings = enabled.get('module_owned', {}).get('config_language_lock.settings')
+if not isinstance(settings, dict):
+    errors.append('config_language_lock.settings was not captured')
+else:
+    if settings.get('locked_langcode') is not None:
+        errors.append(
+            f"locked_langcode is enforcing unexpectedly: {settings.get('locked_langcode')!r}"
+        )
+    if settings.get('follow_site_default') is not False:
+        errors.append('follow_site_default must remain false in non-enforcing mode')
+
+site_default = before.get('site_default_language')
+for transition in langcode_transitions:
+    old = transition['before']
+    new = transition['after']
+    if old not in ('en', None) or new != site_default:
+        errors.append(
+            'non-Locale langcode transition: '
+            f"{transition['name']} {old!r}->{new!r}"
+        )
+
+special = enabled.get('special', {})
+if special.get('system_menu_footer_langcode') != 'und':
+    errors.append('system.menu.footer no longer has langcode und')
+if special.get('language_entity_und_id') != 'und':
+    errors.append('language.entity.und semantic id changed')
+if special.get('language_entity_zxx_id') != 'zxx':
+    errors.append('language.entity.zxx semantic id changed')
+
+mismatch_names = sorted(
+    entry['name']
+    for entry in language_enabled.get('repository_active_comparison', {}).get(
+        'langcode_mismatches', []
+    )
+)
+transition_names = sorted(entry['name'] for entry in langcode_transitions)
+if mismatch_names != transition_names:
+    errors.append(
+        'active/repository langcode mismatches do not equal observed Locale '
+        f'transitions: mismatches={mismatch_names}, transitions={transition_names}'
+    )
+
+if language_enabled.get('translations') != language_before.get('translations'):
+    errors.append('versioned translation-directory inventory changed')
+
+comparison = {
+    'classification': 'DRUPAL_LOCALE_EXTENSION_INSTALL_FOOTPRINT',
+    'site_default_language': site_default,
+    'removed_existing': removed,
+    'added_module_owned': added,
+    'changed_existing_hashes': changed_hash,
+    'langcode_transitions': langcode_transitions,
+    'repository_active_langcode_mismatches': mismatch_names,
+    'module_settings': settings,
+    'special': special,
+    'errors': errors,
+}
+(root / 'enable-comparison.json').write_text(
+    json.dumps(comparison, indent=2, sort_keys=True) + '\n',
+    encoding='utf-8',
+)
+if errors:
+    raise SystemExit('; '.join(errors))
+PY
+  then
+    semantics_outcome='success'
+  else
+    semantics_outcome='failure'
+  fi
+
+  if ddev drush pm:uninstall config_language_lock -y && ddev drush cr; then
+    uninstall_outcome='success'
+    capture_state "$artifact_root/state-after-uninstall.json" "$artifact_root/language-after-uninstall.json"
+    ddev drush config:status > "$artifact_root/config-status-after-uninstall.txt" 2>&1 || true
+
+    if ! python3 - "$artifact_root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+enabled = json.loads((root / 'state-enabled.json').read_text(encoding='utf-8'))
+final = json.loads((root / 'state-after-uninstall.json').read_text(encoding='utf-8'))
+errors = []
+
+if final.get('config_language_lock_enabled') is not False:
+    errors.append('config_language_lock remains enabled after uninstall')
+if final.get('module_owned'):
+    errors.append('module-owned config remains after uninstall')
+
+enabled_entries = enabled['entries']
+final_entries = final['entries']
+expected_names = set(enabled_entries) - {'config_language_lock.settings'}
+if set(final_entries) != expected_names:
+    errors.append('unexpected config add/remove during uninstall')
+
+changed = sorted(
+    name for name in set(final_entries) & set(enabled_entries)
+    if final_entries[name]['sha256'] != enabled_entries[name]['sha256']
+)
+if changed != ['core.extension']:
+    errors.append(f'unexpected post-enable uninstall mutation: {changed}')
+if final.get('special') != enabled.get('special'):
+    errors.append('semantic language/footer state changed during uninstall')
+
+comparison = {
+    'changed_existing': changed,
+    'module_owned_removed': not bool(final.get('module_owned')),
+    'errors': errors,
+}
+(root / 'uninstall-comparison.json').write_text(
+    json.dumps(comparison, indent=2, sort_keys=True) + '\n',
+    encoding='utf-8',
+)
+if errors:
+    raise SystemExit('; '.join(errors))
+PY
+    then
+      uninstall_outcome='failure'
+    fi
+    test -z "$(git status --short config/sync)"
+  fi
+fi
+
+if [[ "$uninstall_outcome" == 'success' ]]; then
+  if ddev drush cim -y && ddev drush cr; then
+    capture_state "$artifact_root/state-restored.json" "$artifact_root/language-restored.json"
+    if capture_status "$artifact_root/config-status-restored.txt" && \
+      python3 - "$artifact_root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+before = json.loads((root / 'state-before.json').read_text(encoding='utf-8'))
+restored = json.loads((root / 'state-restored.json').read_text(encoding='utf-8'))
+if restored.get('config_language_lock_enabled') is not False:
+    raise SystemExit('config_language_lock enabled after canonical restore')
+if restored.get('module_owned'):
+    raise SystemExit('module-owned config remains after canonical restore')
+if restored['entries'] != before['entries']:
+    raise SystemExit('canonical restore did not return exact active config baseline')
+if restored['overall_sha256'] != before['overall_sha256']:
+    raise SystemExit('restored active configuration fingerprint differs from baseline')
+PY
+    then
+      jq -e '.repository_active_comparison.missing_from_active | length == 0' "$artifact_root/language-restored.json" >/dev/null
+      jq -e '.repository_active_comparison.missing_from_repository | length == 0' "$artifact_root/language-restored.json" >/dev/null
+      jq -e '.repository_active_comparison.langcode_mismatches | length == 0' "$artifact_root/language-restored.json" >/dev/null
+      test -z "$(git status --short config/sync)"
+      restore_outcome='success'
+    else
+      restore_outcome='failure'
+    fi
+  fi
+fi
+
+locale_transition_count=0
+changed_hash_count=0
+if [[ -s "$artifact_root/enable-comparison.json" ]]; then
+  locale_transition_count="$(jq -r '.langcode_transitions | length' "$artifact_root/enable-comparison.json")"
+  changed_hash_count="$(jq -r '.changed_existing_hashes | length' "$artifact_root/enable-comparison.json")"
+fi
+baseline_sha="$(jq -r '.overall_sha256' "$artifact_root/state-before.json")"
+restored_sha='n/a'
+if [[ -s "$artifact_root/state-restored.json" ]]; then
+  restored_sha="$(jq -r '.overall_sha256' "$artifact_root/state-restored.json")"
+fi
+
+status='FAIL'
+verdict='POST_MIGRATION_NON_ENFORCING_EVALUATION_FAILED'
+if [[ "$enable_outcome" == 'success' && \
+      "$semantics_outcome" == 'success' && \
+      "$uninstall_outcome" == 'success' && \
+      "$restore_outcome" == 'success' ]]; then
+  status='PASS'
+  verdict='POST_MIGRATION_NON_ENFORCING_BEHAVIOR_PROVEN'
+fi
+
+jq -n \
+  --arg status "$status" \
+  --arg verdict "$verdict" \
+  --arg enable_outcome "$enable_outcome" \
+  --arg semantics_outcome "$semantics_outcome" \
+  --arg uninstall_outcome "$uninstall_outcome" \
+  --arg restore_outcome "$restore_outcome" \
+  --arg baseline_sha256 "$baseline_sha" \
+  --arg restored_sha256 "$restored_sha" \
+  --argjson locale_transition_count "$locale_transition_count" \
+  --argjson changed_hash_count "$changed_hash_count" \
+  '{
+    status:$status,
+    verdict:$verdict,
+    mode:"post_migration_non_enforcing_with_native_locale_footprint",
+    baseline_distribution:{"__none__":59,"en":395,"fr":140,"und":1},
+    enable_outcome:$enable_outcome,
+    semantics_outcome:$semantics_outcome,
+    uninstall_outcome:$uninstall_outcome,
+    restore_outcome:$restore_outcome,
+    baseline_sha256:$baseline_sha256,
+    restored_sha256:$restored_sha256,
+    locale_langcode_transition_count:$locale_transition_count,
+    changed_existing_hash_count:$changed_hash_count,
+    locked_langcode:null,
+    follow_site_default:false
+  }' > "$artifact_root/result.json"
+
+cat "$artifact_root/result.json"
+test "$status" = 'PASS'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockPostMigrationEvaluationWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockPostMigrationEvaluationWorkflowTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded post-migration Configuration Language Lock proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageLockPostMigrationEvaluationWorkflowTest extends TestCase {
+
+  /**
+   * The gateway stays fixed to issue #744 and live main.
+   */
+  public function testGatewayIsIssueOnlyLiveMainAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-config-language-lock-post-migration-evaluation.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.pull_request == null',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'github.event.issue.number == 744',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-lock post-migration-evaluate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$(git rev-parse HEAD)" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'configuration-language-translated-canonical-cohort-720.yml',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'Configuration Language Lock must remain disabled in canonical config.',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.require["drupal/config_language_lock"] == "^1.0"',
+      $workflow,
+    );
+    self::assertStringContainsString('^1\\.0\\.[0-9]+$', $workflow);
+
+    $evaluateStart = strpos($workflow, "  evaluate:\n");
+    $reportStart = strpos($workflow, "  report-result:\n");
+    self::assertIsInt($evaluateStart);
+    self::assertIsInt($reportStart);
+    $evaluate = substr($workflow, $evaluateStart, $reportStart - $evaluateStart);
+
+    self::assertStringContainsString('contents: read', $evaluate);
+    self::assertStringNotContainsString('contents: write', $evaluate);
+    self::assertStringContainsString('persist-credentials: false', $evaluate);
+    self::assertStringContainsString('- self-hosted', $evaluate);
+    self::assertStringContainsString('- agency', $evaluate);
+    self::assertStringContainsString('- ddev', $evaluate);
+    self::assertStringContainsString(
+      'run-config-language-lock-post-migration-evaluation.sh',
+      $evaluate,
+    );
+    self::assertStringContainsString('actions/upload-artifact@v4', $evaluate);
+    self::assertStringContainsString('ddev delete --omit-snapshot --yes', $evaluate);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'git push',
+      'composer require',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The runner proves the post-#720 baseline and reversible non-enforcement.
+   */
+  public function testRunnerIsPostMigrationLocaleAwareAndReversible(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/run-config-language-lock-post-migration-evaluation.sh';
+    self::assertFileExists($path);
+    $runner = (string) file_get_contents($path);
+
+    $output = [];
+    $status = 0;
+    exec('bash -n ' . escapeshellarg($path) . ' 2>&1', $output, $status);
+    self::assertSame(0, $status, implode("\n", $output));
+
+    self::assertStringContainsString('ddev composer audit --locked', $runner);
+    self::assertStringContainsString('site:install --existing-config', $runner);
+    self::assertStringContainsString(
+      '.repository.summary.by_langcode == '
+      . '{"__none__":59,"en":395,"fr":140,"und":1}',
+      $runner,
+    );
+    self::assertStringContainsString(
+      'ddev drush pm:enable config_language_lock -y',
+      $runner,
+    );
+    self::assertStringContainsString(
+      "added != ['config_language_lock.settings']",
+      $runner,
+    );
+    self::assertStringContainsString(
+      "settings.get('locked_langcode') is not None",
+      $runner,
+    );
+    self::assertStringContainsString(
+      "settings.get('follow_site_default') is not False",
+      $runner,
+    );
+    self::assertStringContainsString(
+      "old not in ('en', None) or new != site_default",
+      $runner,
+    );
+    self::assertStringContainsString(
+      "'classification': 'DRUPAL_LOCALE_EXTENSION_INSTALL_FOOTPRINT'",
+      $runner,
+    );
+    self::assertStringContainsString(
+      "special.get('system_menu_footer_langcode') != 'und'",
+      $runner,
+    );
+    self::assertStringContainsString(
+      'ddev drush pm:uninstall config_language_lock -y',
+      $runner,
+    );
+    self::assertStringContainsString(
+      "changed != ['core.extension']",
+      $runner,
+    );
+    self::assertStringContainsString(
+      'canonical restore did not return exact active config baseline',
+      $runner,
+    );
+    self::assertStringContainsString(
+      'POST_MIGRATION_NON_ENFORCING_BEHAVIOR_PROVEN',
+      $runner,
+    );
+    self::assertStringContainsString(
+      'test -z "$(git status --short config/sync)"',
+      $runner,
+    );
+    self::assertGreaterThanOrEqual(2, substr_count($runner, 'ddev drush cim -y'));
+
+    foreach ([
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'SERVER_HOST',
+      'git push',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $runner);
+    }
+  }
+
+}


### PR DESCRIPTION
## Résumé

Ajoute la preuve trusted post-migration requise par #609 après #720, sans activer durablement Configuration Language Lock.

### Route

Trigger fixé sur l’issue #744 :

`/agency-config-language-lock post-migration-evaluate`

Le gateway n’accepte que l’acteur `E-merging-digital`, l’issue #744 ouverte et le `main` live exact. Le job self-hosted est en `contents: read`, checkout read-only, fresh DDEV isolé.

### Preuve runtime

Le runner réutilise les probes read-only existants et exige d’abord le baseline post-#720 exact :

`__none__=59, en=395, fr=140, und=1`

Puis il :

- active éphémèrement `config_language_lock` sans lock ;
- exige `locked_langcode=null` et `follow_site_default=false` ;
- accepte uniquement le footprint natif Locale `en`/absent -> langue site `fr` ;
- préserve `system.menu.footer=und` et les IDs sémantiques `und`/`zxx` ;
- désinstalle le module ;
- restaure le canonique par `cim` dans le DDEV jetable ;
- exige le fingerprint initial exact et `config:status` clean ;
- ne fait aucun `cex`, aucun accès production, aucun secret/provider et aucune écriture Git depuis le runner.

Verdict cible : `POST_MIGRATION_NON_ENFORCING_BEHAVIOR_PROVEN`.

### Périmètre

3 nouveaux fichiers uniquement : workflow, runner et test unitaire de gouvernance. Aucun `config/sync`, Composer ou code produit modifié.

Après CI exacte verte et merge, une seule preuve trusted sera déclenchée sur #744 puis reportée dans #609.

Closes #744
Refs #609 #720 #628 #632 #412.