### PR TITLE
Issue #746: corriger la précondition module-owned du probe #744

### DIFF
--- a/scripts/runner/run-config-language-lock-post-migration-evaluation.sh
+++ b/scripts/runner/run-config-language-lock-post-migration-evaluation.sh
@@ -40,7 +40,7 @@ capture_state "$artifact_root/state-before.json" "$artifact_root/language-before
 jq -e '.schema_version == 2 and .total == 595' "$artifact_root/state-before.json" >/dev/null
 jq -e '.site_default_language == "fr"' "$artifact_root/state-before.json" >/dev/null
 jq -e '.config_language_lock_enabled == false' "$artifact_root/state-before.json" >/dev/null
-jq -e '.module_owned == {}' "$artifact_root/state-before.json" >/dev/null
+jq -e '(.module_owned | length) == 0' "$artifact_root/state-before.json" >/dev/null
 jq -e '.special.system_menu_footer_langcode == "und"' "$artifact_root/state-before.json" >/dev/null
 jq -e '.special.language_entity_und_id == "und"' "$artifact_root/state-before.json" >/dev/null
 jq -e '.special.language_entity_zxx_id == "zxx"' "$artifact_root/state-before.json" >/dev/null

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockPostMigrationBaselineShapeTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageLockPostMigrationBaselineShapeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects shape-agnostic empty module-owned baseline validation.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageLockPostMigrationBaselineShapeTest extends TestCase {
+
+  /**
+   * Empty module-owned state is checked semantically, not by JSON shape.
+   */
+  public function testEmptyModuleOwnedCheckUsesCardinality(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/run-config-language-lock-post-migration-evaluation.sh';
+    self::assertFileExists($path);
+
+    $runner = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      "jq -e '(.module_owned | length) == 0'",
+      $runner,
+    );
+    self::assertStringNotContainsString(
+      "jq -e '.module_owned == {}'",
+      $runner,
+    );
+  }
+
+}


### PR DESCRIPTION
## Résumé

Corrige le défaut de harness exact observé par le premier run trusted #744 (`32674948635`).

L'artifact `9502420683` prouve que le baseline post-#720 était entièrement valide mais que `module_owned` vide est sérialisé en `[]`. Le runner exigeait à tort la forme JSON `{}` et s'arrêtait donc avant toute activation du module.

### Correction

- remplace `jq -e '.module_owned == {}'` par `jq -e '(.module_owned | length) == 0'` ;
- ajoute un test unitaire qui exige la validation sémantique par cardinalité et interdit le retour à l'égalité de forme.

### Périmètre

Exactement 2 fichiers :

- `scripts/runner/run-config-language-lock-post-migration-evaluation.sh` : 1 ligne remplacée ;
- nouveau test de non-régression.

Aucune modification du gateway, de `config/sync`, de Composer ou du code produit.

Après CI exacte verte et merge, un unique recovery trigger #744 sera autorisé.

Closes #746
Refs #744 #609 #720.