### PR TITLE
Issue #748: classifier les 140 bases FR restantes par provenance

### DIFF
--- a/.github/workflows/trusted-configuration-language-review-required-provenance.yml
+++ b/.github/workflows/trusted-configuration-language-review-required-provenance.yml
@@ -1,0 +1,227 @@
+name: Agency trusted configuration-language review-required provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #748 live-main target
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.number == 748 && github.event.comment.body == '/agency-config-language-review-required classify-provenance' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '748'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-review-required classify-provenance'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/748" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Classify 140 FR review-required configs by typed data and provenance
+    needs: validate-target
+    timeout-minutes: 30
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    permissions:
+      contents: read
+    outputs:
+      no_material: ${{ steps.classify.outputs.no_material }}
+      default_match: ${{ steps.classify.outputs.default_match }}
+      material_review: ${{ steps.classify.outputs.material_review }}
+      unresolved: ${{ steps.classify.outputs.unresolved }}
+      verdict: ${{ steps.classify.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+          php --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable post-#720 target
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f scripts/runner/configuration-language-review-required-provenance.php
+          test -f docs/evidence/configuration-language-translated-canonical-cohort-720.yml
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-review-provenance.yaml <<EOF
+          name: agency-config-language-review-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-language-review-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/config-language-review-provenance
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-review-required-provenance.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-review-provenance/config-status.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Classify review-required provenance
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-review-provenance'
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-review-required-provenance.php \
+            > "$root/result.json"
+
+          jq -e '.status == "PASS"' "$root/result.json" >/dev/null
+          jq -e '.verdict == "REVIEW_REQUIRED_PROVENANCE_CLASSIFIED"' "$root/result.json" >/dev/null
+          jq -e '.counts.candidate_fr_without_en_override == 140' "$root/result.json" >/dev/null
+          jq -e '.counts.classified == 140' "$root/result.json" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$root/result.json" >/dev/null
+          jq -e '.counts.schema_unresolved_review_required == 0' "$root/result.json" >/dev/null
+          jq -e '.constraints.read_only == true' "$root/result.json" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' "$root/result.json" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "no_material=$(jq -r '.counts.no_material_translatable_source_candidate' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "default_match=$(jq -r '.counts.english_default_exact_match_candidate' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "material_review=$(jq -r '.counts.material_review_required' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$(jq -r '.counts.schema_unresolved_review_required' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$root/result.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload provenance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-review-provenance-748-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-review-provenance
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-language-review-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-review-provenance.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-review-provenance
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #748 provenance verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - evaluate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+          NO_MATERIAL: ${{ needs.evaluate.outputs.no_material }}
+          DEFAULT_MATCH: ${{ needs.evaluate.outputs.default_match }}
+          MATERIAL_REVIEW: ${{ needs.evaluate.outputs.material_review }}
+          UNRESOLVED: ${{ needs.evaluate.outputs.unresolved }}
+          MACHINE_VERDICT: ${{ needs.evaluate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$EVALUATION_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 748 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### Review-required provenance classification ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${EVALUATION_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`140\`
+          no_material: \`${NO_MATERIAL:-n/a}\`
+          english_default_exact_match: \`${DEFAULT_MATCH:-n/a}\`
+          material_review_required: \`${MATERIAL_REVIEW:-n/a}\`
+          schema_unresolved: \`${UNRESOLVED:-n/a}\`
+          artifact: \`agency-config-language-review-provenance-748-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Read-only fresh-DDEV classification only. No lock activation, config export, production access, provider secret or repository mutation is permitted.
+          EOF
+          )"
+          test "$EVALUATION_RESULT" = 'success'

--- a/scripts/runner/configuration-language-review-required-provenance.php
+++ b/scripts/runner/configuration-language-review-required-provenance.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$policyPath = $projectRoot . '/docs/configuration-language-policy.yml';
+$promotionManifest = $projectRoot
+  . '/docs/evidence/configuration-language-translated-canonical-cohort-720.yml';
+
+if (!is_dir($configDirectory) || !is_file($policyPath) || !is_file($promotionManifest)) {
+  throw new RuntimeException('Post-#720 configuration-language baseline is incomplete.');
+}
+
+$policy = Yaml::parseFile($policyPath);
+if (!is_array($policy)) {
+  throw new RuntimeException('Configuration language policy must be a mapping.');
+}
+if (($policy['canonical_configuration_language'] ?? NULL) !== 'en') {
+  throw new RuntimeException('Canonical configuration language must remain en.');
+}
+if (($policy['enforce_consistency'] ?? TRUE) !== FALSE) {
+  throw new RuntimeException('Provenance classification must run before enforcement.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate base configuration.');
+}
+sort($baseFiles, SORT_STRING);
+
+$candidates = [];
+foreach ($baseFiles as $basePath) {
+  $data = Yaml::parseFile($basePath);
+  if (!is_array($data) || ($data['langcode'] ?? NULL) !== 'fr') {
+    continue;
+  }
+
+  $name = basename($basePath, '.yml');
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    continue;
+  }
+  $candidates[$name] = $data;
+}
+ksort($candidates, SORT_STRING);
+
+$candidateNames = array_fill_keys(array_keys($candidates), TRUE);
+$defaultIndex = [];
+$extensionServices = [
+  'module' => 'extension.list.module',
+  'theme' => 'extension.list.theme',
+  'profile' => 'extension.list.profile',
+];
+foreach ($extensionServices as $extensionType => $serviceId) {
+  $extensionList = \Drupal::service($serviceId);
+  foreach ($extensionList->getList() as $extensionName => $extension) {
+    $extensionRoot = DRUPAL_ROOT . '/' . $extension->getPath();
+    foreach (['install', 'optional'] as $directoryKind) {
+      $directory = $extensionRoot . '/config/' . $directoryKind;
+      if (!is_dir($directory)) {
+        continue;
+      }
+      $files = glob($directory . '/*.yml');
+      if ($files === FALSE) {
+        throw new RuntimeException("Unable to enumerate $directory.");
+      }
+      sort($files, SORT_STRING);
+      foreach ($files as $path) {
+        $name = basename($path, '.yml');
+        if (!isset($candidateNames[$name])) {
+          continue;
+        }
+        $data = Yaml::parseFile($path);
+        if (!is_array($data)) {
+          continue;
+        }
+        $defaultIndex[$name][] = [
+          'extension_type' => $extensionType,
+          'extension' => $extensionName,
+          'directory' => $directoryKind,
+          'path' => ltrim(str_replace($projectRoot, '', $path), '/'),
+          'langcode' => isset($data['langcode']) && is_string($data['langcode'])
+            ? $data['langcode']
+            : NULL,
+          'data' => $data,
+        ];
+      }
+    }
+  }
+}
+ksort($defaultIndex, SORT_STRING);
+
+$items = [];
+$baselineProblems = [];
+foreach ($candidates as $name => $repositoryData) {
+  $sourceConfig = $configFactory->getEditable($name);
+  $sourceData = $sourceConfig->get();
+  if ($sourceConfig->isNew() || ($sourceData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => $sourceConfig->isNew()
+        ? 'active_config_missing'
+        : 'active_source_langcode_not_fr',
+    ];
+    continue;
+  }
+  if ($sourceData !== $repositoryData) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_repository_data_mismatch',
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'config_schema_missing',
+      'material_translatable_leaf_count' => 0,
+      'material_translatable_leaves' => [],
+      'english_default_matches' => [],
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData($name, $sourceData);
+    $allLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_unresolved_review_required',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaf_count' => 0,
+      'material_translatable_leaves' => [],
+      'english_default_matches' => [],
+    ];
+    continue;
+  }
+
+  $materialLeaves = [];
+  foreach ($allLeaves as $leaf) {
+    if (!$isMaterial($leaf['value'])) {
+      continue;
+    }
+    $materialLeaves[] = $leaf;
+  }
+  usort(
+    $materialLeaves,
+    static fn(array $left, array $right): int => $left['path'] <=> $right['path'],
+  );
+
+  $defaultMatches = [];
+  foreach ($defaultIndex[$name] ?? [] as $default) {
+    if (!in_array($default['langcode'], ['en', NULL], TRUE)) {
+      continue;
+    }
+
+    $matches = TRUE;
+    foreach ($materialLeaves as $leaf) {
+      $exists = FALSE;
+      $defaultValue = NestedArray::getValue(
+        $default['data'],
+        $leaf['segments'],
+        $exists,
+      );
+      if (!$exists || $defaultValue !== $leaf['value']) {
+        $matches = FALSE;
+        break;
+      }
+    }
+    if ($matches) {
+      $defaultMatches[] = [
+        'extension_type' => $default['extension_type'],
+        'extension' => $default['extension'],
+        'directory' => $default['directory'],
+        'path' => $default['path'],
+        'langcode' => $default['langcode'],
+      ];
+    }
+  }
+
+  if ($materialLeaves === []) {
+    $classification = 'no_material_translatable_source_candidate';
+    $reason = 'typed_schema_has_no_material_translatable_source_leaves';
+  }
+  elseif ($defaultMatches !== []) {
+    $classification = 'english_default_exact_match_candidate';
+    $reason = 'all_material_translatable_leaves_match_extension_default';
+  }
+  else {
+    $classification = 'material_review_required';
+    $reason = 'material_translatable_source_without_exact_english_default';
+  }
+
+  $evidenceLeaves = array_map(
+    static fn(array $leaf): array => [
+      'path' => $leaf['path'],
+      'value' => $leaf['value'],
+    ],
+    $materialLeaves,
+  );
+
+  $items[] = [
+    'name' => $name,
+    'classification' => $classification,
+    'reason' => $reason,
+    'material_translatable_leaf_count' => count($materialLeaves),
+    'material_translatable_leaves' => $evidenceLeaves,
+    'english_default_matches' => $defaultMatches,
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int => $left['name'] <=> $right['name'],
+);
+
+$counts = [
+  'candidate_fr_without_en_override' => count($candidates),
+  'classified' => count($items),
+  'baseline_problem' => count($baselineProblems),
+  'no_material_translatable_source_candidate' => 0,
+  'english_default_exact_match_candidate' => 0,
+  'material_review_required' => 0,
+  'schema_unresolved_review_required' => 0,
+];
+$namesByClassification = [
+  'no_material_translatable_source_candidate' => [],
+  'english_default_exact_match_candidate' => [],
+  'material_review_required' => [],
+  'schema_unresolved_review_required' => [],
+];
+foreach ($items as $item) {
+  $classification = (string) $item['classification'];
+  $counts[$classification]++;
+  $namesByClassification[$classification][] = $item['name'];
+}
+
+$status = 'PASS';
+$verdict = 'REVIEW_REQUIRED_PROVENANCE_CLASSIFIED';
+if (
+  count($candidates) !== 140
+  || count($items) !== 140
+  || $baselineProblems !== []
+  || $counts['schema_unresolved_review_required'] !== 0
+) {
+  $status = 'FAIL';
+  $verdict = 'REVIEW_REQUIRED_PROVENANCE_CLASSIFICATION_FAILED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'baseline' => [
+    'expected_candidate_count' => 140,
+    'canonical_configuration_language' => 'en',
+    'enforcement_enabled' => FALSE,
+    'promotion_manifest' => 'configuration-language-translated-canonical-cohort-720.yml',
+  ],
+  'counts' => $counts,
+  'names_by_classification' => $namesByClassification,
+  'baseline_problems' => $baselineProblems,
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_mutation_allowed_by_this_proof' => FALSE,
+    'natural_language_heuristic_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageReviewRequiredProvenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageReviewRequiredProvenanceWorkflowTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #748 review-required provenance classification.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageReviewRequiredProvenanceWorkflowTest extends TestCase {
+
+  /**
+   * The gateway is fixed to issue #748, live main and read-only execution.
+   */
+  public function testGatewayIsFixedLiveMainAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-review-required-provenance.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 748',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-review-required classify-provenance'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString(
+      '.counts.candidate_fr_without_en_override == 140',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.schema_unresolved_review_required == 0',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test -z "$(git status --short config/sync)"',
+      $workflow,
+    );
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'git push',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The analyzer uses typed data and exact extension-default provenance only.
+   */
+  public function testAnalyzerIsTypedStrictAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-review-required-provenance.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $script);
+    self::assertStringContainsString('TraversableTypedDataInterface', $script);
+    self::assertStringContainsString("'translatable'", $script);
+    self::assertStringContainsString('NestedArray::getValue(', $script);
+    self::assertStringContainsString("'extension.list.module'", $script);
+    self::assertStringContainsString("'extension.list.theme'", $script);
+    self::assertStringContainsString("'extension.list.profile'", $script);
+    self::assertStringContainsString("['install', 'optional']", $script);
+    self::assertStringContainsString(
+      "'no_material_translatable_source_candidate'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'english_default_exact_match_candidate'",
+      $script,
+    );
+    self::assertStringContainsString("'material_review_required'", $script);
+    self::assertStringContainsString(
+      "'schema_unresolved_review_required'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString('count($candidates) !== 140', $script);
+    self::assertStringContainsString(
+      "'REVIEW_REQUIRED_PROVENANCE_CLASSIFIED'",
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      'config.storage.sync',
+      'drush cex',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+}


### PR DESCRIPTION
## Résumé

Ajoute la tranche read-only qui reclassifie les 140 bases FR restantes après #720 avant toute décision d'enforcement de Configuration Language Lock.

### Analyse

Pour chaque base FR sans override EN, l'analyseur :

- traverse le schéma via `config.typed` ;
- identifie uniquement les feuilles `translatable` matériellement présentes ;
- indexe les defaults `config/install` et `config/optional` des modules, thèmes et profils découverts par Drupal ;
- compare strictement les valeurs de toutes les feuilles traduisibles ;
- classe l'objet en :
  - aucune matière traduisible ;
  - default anglais exact ;
  - matière restant à revoir ;
  - schéma irrésolu (fail-closed).

Aucune heuristique NLP/langue naturelle n'est utilisée.

### Route trusted

Trigger post-merge sur #748 :

`/agency-config-language-review-required classify-provenance`

Le gateway est owner-only/live-main-only. Fresh DDEV, `site:install --existing-config`, `cim`, `config:status` clean, analyse read-only, artifact et cleanup.

### Périmètre

3 nouveaux fichiers uniquement : analyseur, workflow trusted et test unitaire de gouvernance. Aucun `config/sync`, Composer ou code produit modifié. Aucun lock activé, aucun `cex`, aucune production, aucun secret/provider.

Verdict cible : `REVIEW_REQUIRED_PROVENANCE_CLASSIFIED`, 140/140 classés et 0 schéma irrésolu.

Closes #748
Refs #609 #744 #720 #684 #709 #715 #412.