### PR TITLE
Issue #750: supprimer la dépendance PHP hôte du probe #748

### DIFF
--- a/.github/workflows/trusted-configuration-language-review-required-provenance.yml
+++ b/.github/workflows/trusted-configuration-language-review-required-provenance.yml
@@ -71,7 +71,6 @@ jobs:
           docker --version
           ddev version
           jq --version
-          php --version
 
       - name: Checkout exact trusted main read-only
         uses: actions/checkout@v6

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageReviewRequiredProvenanceHostRuntimeTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageReviewRequiredProvenanceHostRuntimeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the DDEV-owned PHP runtime for the #748 trusted proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageReviewRequiredProvenanceHostRuntimeTest extends TestCase {
+
+  /**
+   * The host preflight must not require PHP outside DDEV.
+   */
+  public function testPhpRuntimeIsValidatedInsideDdevOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-review-required-provenance.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertStringNotContainsString("          php --version\n", $workflow);
+    self::assertStringContainsString(
+      'ddev exec php -l \\',
+      $workflow,
+    );
+  }
+
+}


### PR DESCRIPTION
## Résumé

Corrige le défaut de harness exact du run trusted #748 `32679239466`.

Le runner self-hosted Agency fournit PHP via DDEV, pas comme binaire hôte. Le preflight échouait donc sur `php --version` avant checkout, alors que la route valide déjà la syntaxe de l'analyseur après `ddev start` avec `ddev exec php -l`.

### Correction

- suppression unique de `php --version` du preflight hôte ;
- ajout d'un test de non-régression qui interdit cette dépendance et exige le contrôle PHP dans DDEV.

### Périmètre

Exactement 2 fichiers : 1 ligne supprimée du workflow #748 et 1 nouveau test. Aucune modification de l'analyseur, de `config/sync`, Composer ou du code produit.

Après CI exacte verte et merge, un unique recovery trigger #748 sera autorisé.

Closes #750
Refs #748 #609 #744.