### PR TITLE
Issue #752: corriger la source canonique de l’action bulk IA

### DIFF
--- a/config/sync/language/fr/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/config/sync/language/fr/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -1,0 +1,1 @@
+label: 'Traduire avec IA vers une langue cible'

--- a/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/config/sync/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -1,12 +1,12 @@
 uuid: afb95202-30af-48d0-b654-a328c7fcc359
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:
     - agency_ai_translation
     - node
 id: agency_ai_translate_nodes_bulk_action
-label: 'Traduire avec IA vers une langue cible'
+label: 'Translate with AI to a target language'
 type: node
 plugin: agency_ai_translate_nodes_bulk_action
 configuration:

--- a/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
+++ b/web/modules/custom/agency_ai_translation/config/install/system.action.agency_ai_translate_nodes_bulk_action.yml
@@ -5,7 +5,7 @@ dependencies:
     - agency_ai_translation
     - node
 id: agency_ai_translate_nodes_bulk_action
-label: 'Traduire avec IA vers une langue cible'
+label: 'Translate with AI to a target language'
 type: node
 plugin: agency_ai_translate_nodes_bulk_action
 configuration:

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AiBulkActionCanonicalConfigurationLanguageTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AiBulkActionCanonicalConfigurationLanguageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the canonical source language of the AI bulk action config.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class AiBulkActionCanonicalConfigurationLanguageTest extends TestCase {
+
+  /**
+   * The module default and canonical base are EN while FR remains translated.
+   */
+  public function testCanonicalEnglishSourcePreservesFrenchTranslation(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $relative = 'system.action.agency_ai_translate_nodes_bulk_action.yml';
+
+    $default = DrupalYaml::decode((string) file_get_contents(
+      $root . '/web/modules/custom/agency_ai_translation/config/install/' . $relative,
+    ));
+    $canonical = DrupalYaml::decode((string) file_get_contents(
+      $root . '/config/sync/' . $relative,
+    ));
+    $french = DrupalYaml::decode((string) file_get_contents(
+      $root . '/config/sync/language/fr/' . $relative,
+    ));
+
+    self::assertIsArray($default);
+    self::assertIsArray($canonical);
+    self::assertIsArray($french);
+
+    foreach ([$default, $canonical] as $source) {
+      self::assertSame('en', $source['langcode'] ?? NULL);
+      self::assertSame(
+        'Translate with AI to a target language',
+        $source['label'] ?? NULL,
+      );
+      self::assertSame(
+        'agency_ai_translate_nodes_bulk_action',
+        $source['plugin'] ?? NULL,
+      );
+      self::assertSame('node', $source['type'] ?? NULL);
+      self::assertSame('fr', $source['configuration']['source_langcode'] ?? NULL);
+      self::assertSame('', $source['configuration']['target_langcode'] ?? NULL);
+    }
+
+    self::assertSame(
+      ['label' => 'Traduire avec IA vers une langue cible'],
+      $french,
+    );
+  }
+
+}


### PR DESCRIPTION
## Résumé

Corrige l’unique anomalie mise en évidence par la preuve #748 : `system.action.agency_ai_translate_nodes_bulk_action` était déclaré source EN dans le default du module tout en portant un label source français.

### Changements

- default module : `langcode: en` conservé, label source -> `Translate with AI to a target language` ;
- base canonique : `langcode: fr -> en`, même label EN ;
- nouvel override FR minimal : `Traduire avec IA vers une langue cible` ;
- test de contrat protégeant source EN, traduction FR et `configuration.source_langcode: fr`.

### Invariants

- `configuration.source_langcode` reste `fr` ;
- `target_langcode` reste vide ;
- UUID, plugin, type et dépendances préservés ;
- aucun changement du plugin PHP ou de ses autres chaînes UI ;
- Config Language Lock reste désactivé.

4 fichiers uniquement, dont 1 test.

Closes #752
Refs #609 #748 #720 #744.