### PR TITLE
Issue #754: promouvoir les 17 bases FR sûres vers le canonique EN

### DIFF
--- a/.github/workflows/trusted-configuration-language-safe-provenance-754-verify.yml
+++ b/.github/workflows/trusted-configuration-language-safe-provenance-754-verify.yml
@@ -1,0 +1,215 @@
+name: Agency trusted safe provenance canonical verification
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #754 live-main target
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.number == 754 && github.event.comment.body == '/agency-config-language-safe-provenance verify' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '754'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-safe-provenance verify'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/754" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Verify 17 safe canonical promotions in fresh DDEV
+    needs: validate-target
+    timeout-minutes: 30
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    permissions:
+      contents: read
+    outputs:
+      verdict: ${{ steps.verify.outputs.verdict }}
+      remaining_fr: ${{ steps.verify.outputs.remaining_fr }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable target and bounded canonical state
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f docs/evidence/configuration-language-safe-provenance-cohort-754.yml
+          test -f scripts/runner/configuration-language-safe-provenance-cohort-754-verify.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-safe-provenance-754.yaml <<EOF
+          name: agency-config-language-safe-provenance-754-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-language-safe-provenance-754-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/config-language-safe-provenance-754
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-safe-provenance-cohort-754-verify.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-safe-provenance-754/config-status.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Verify safe provenance cohort
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-safe-provenance-754'
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-safe-provenance-cohort-754-verify.php \
+            > "$root/result.json"
+
+          jq -e '.status == "PASS"' "$root/result.json" >/dev/null
+          jq -e '.verdict == "SEVENTEEN_SAFE_PROVENANCE_PROMOTIONS_VERIFIED"' "$root/result.json" >/dev/null
+          jq -e '.verified == 17' "$root/result.json" >/dev/null
+          jq -e '.remaining_fr_review_required == 122' "$root/result.json" >/dev/null
+          jq -e '.repository_distribution == {"__none__":59,"en":413,"fr":122,"und":1}' "$root/result.json" >/dev/null
+          jq -e '.active_distribution == {"__none__":59,"en":413,"fr":122,"und":1}' "$root/result.json" >/dev/null
+          jq -e '.problems == []' "$root/result.json" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "verdict=$(jq -r '.verdict' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "remaining_fr=$(jq -r '.remaining_fr_review_required' "$root/result.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-safe-provenance-754-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-safe-provenance-754
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-language-safe-provenance-754-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-safe-provenance-754.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-safe-provenance-754
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #754 verification verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - verify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          MACHINE_VERDICT: ${{ needs.verify.outputs.verdict }}
+          REMAINING_FR: ${{ needs.verify.outputs.remaining_fr }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$VERIFY_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 754 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### Safe provenance canonical promotion verification ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${VERIFY_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          promoted: \`17\`
+          remaining_fr_review_required: \`${REMAINING_FR:-n/a}\`
+          expected_distribution: \`__none__=59, en=413, fr=122, und=1\`
+          artifact: \`agency-config-language-safe-provenance-754-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Fresh-DDEV verification only. Configuration Language Lock remains disabled; no cex, production access, provider secret or repository write from the self-hosted runner is permitted.
+          EOF
+          )"
+          test "$VERIFY_RESULT" = 'success'

--- a/config/sync/canvas.asset_library.global.yml
+++ b/config/sync/canvas.asset_library.global.yml
@@ -1,5 +1,5 @@
 uuid: d6ee927f-bee4-438e-8368-9c8884bdc0a8
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/canvas.brand_kit.global.yml
+++ b/config/sync/canvas.brand_kit.global.yml
@@ -1,5 +1,5 @@
 uuid: 6e04ef2d-51b3-417d-9987-6e7cc5559b42
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/core.entity_form_mode.media.media_library.yml
+++ b/config/sync/core.entity_form_mode.media.media_library.yml
@@ -1,5 +1,5 @@
 uuid: 8f0c092c-e4cd-4a60-9629-c9372b6c0920
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.entity_view_mode.media.full.yml
+++ b/config/sync/core.entity_view_mode.media.full.yml
@@ -1,5 +1,5 @@
 uuid: b8bd4ded-336c-410d-8da2-65ab621ed18d
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:

--- a/config/sync/core.entity_view_mode.media.media_library.yml
+++ b/config/sync/core.entity_view_mode.media.media_library.yml
@@ -1,5 +1,5 @@
 uuid: d0b77c71-d53f-462f-80b3-306038868454
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/editor.editor.canvas_html_block.yml
+++ b/config/sync/editor.editor.canvas_html_block.yml
@@ -1,5 +1,5 @@
 uuid: 3d9dd06d-a448-47a6-9c18-cf41548594c9
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/editor.editor.canvas_html_inline.yml
+++ b/config/sync/editor.editor.canvas_html_inline.yml
@@ -1,5 +1,5 @@
 uuid: 35a98f89-5e5a-4b32-b54a-4b70ae9978d0
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/field.field.media.document.field_media_document.yml
+++ b/config/sync/field.field.media.document.field_media_document.yml
@@ -1,5 +1,5 @@
 uuid: d45e00bf-9433-4b6d-9c48-4c2cab81842f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/field.field.media.image.field_media_image.yml
+++ b/config/sync/field.field.media.image.field_media_image.yml
@@ -1,5 +1,5 @@
 uuid: d2efd345-6dc6-4992-ab86-eebd203b7403
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/filter.format.canvas_html_block.yml
+++ b/config/sync/filter.format.canvas_html_block.yml
@@ -1,5 +1,5 @@
 uuid: bfbc7bf8-fde4-4c03-ab04-db7a96ce6439
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/filter.format.canvas_html_inline.yml
+++ b/config/sync/filter.format.canvas_html_inline.yml
@@ -1,5 +1,5 @@
 uuid: b3ef4431-03e5-4d91-ab35-0a896b7a2708
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/filter.format.webform_default.yml
+++ b/config/sync/filter.format.webform_default.yml
@@ -1,5 +1,5 @@
 uuid: 40cff7d0-ae79-4a77-87a5-7a29238400ce
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/image.style.canvas_avatar.yml
+++ b/config/sync/image.style.canvas_avatar.yml
@@ -1,5 +1,5 @@
 uuid: d0dd58e4-24f8-42fe-b26a-260b8e7d2a39
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/image.style.canvas_parametrized_width.yml
+++ b/config/sync/image.style.canvas_parametrized_width.yml
@@ -1,5 +1,5 @@
 uuid: afacf01f-32f2-4341-a8e3-571021bc9c1e
-langcode: fr
+langcode: en
 status: true
 dependencies:
   enforced:

--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -1,5 +1,5 @@
 uuid: 2e5d95c7-bab9-49ab-b1d8-f465b8066f8a
-langcode: fr
+langcode: en
 status: true
 dependencies: {  }
 id: global

--- a/config/sync/system.action.automator_chain_delete_action.yml
+++ b/config/sync/system.action.automator_chain_delete_action.yml
@@ -1,5 +1,5 @@
 uuid: 4ce819d0-5302-4242-b4c0-876cb8cbe73f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/views.view.canvas_pages.yml
+++ b/config/sync/views.view.canvas_pages.yml
@@ -1,5 +1,5 @@
 uuid: 1d3ef225-9b97-4f52-ac32-7449be9fdd0f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/docs/evidence/configuration-language-safe-provenance-cohort-754.yml
+++ b/docs/evidence/configuration-language-safe-provenance-cohort-754.yml
@@ -1,0 +1,64 @@
+schema_version: 1
+cohort_id: configuration-language-safe-provenance-754
+source_issue: 748
+source_trusted_run: 32706400681
+source_artifact_id: 9512525119
+source_artifact_digest: 'sha256:54a02cb5bd9d24d0264e3a8b329817c943dd0cc507d01b39c13183d497c7cce0'
+canonical_configuration_language: en
+baseline_before:
+  __none__: 59
+  en: 396
+  fr: 139
+  und: 1
+  total: 595
+expected_after:
+  __none__: 59
+  en: 413
+  fr: 122
+  und: 1
+  total: 595
+items:
+  - name: editor.editor.canvas_html_block
+    classification: no_material_translatable_source_candidate
+  - name: editor.editor.canvas_html_inline
+    classification: no_material_translatable_source_candidate
+  - name: canvas.asset_library.global
+    classification: english_default_exact_match_candidate
+  - name: canvas.brand_kit.global
+    classification: english_default_exact_match_candidate
+  - name: core.entity_form_mode.media.media_library
+    classification: english_default_exact_match_candidate
+  - name: core.entity_view_mode.media.full
+    classification: english_default_exact_match_candidate
+  - name: core.entity_view_mode.media.media_library
+    classification: english_default_exact_match_candidate
+  - name: field.field.media.document.field_media_document
+    classification: english_default_exact_match_candidate
+  - name: field.field.media.image.field_media_image
+    classification: english_default_exact_match_candidate
+  - name: filter.format.canvas_html_block
+    classification: english_default_exact_match_candidate
+  - name: filter.format.canvas_html_inline
+    classification: english_default_exact_match_candidate
+  - name: filter.format.webform_default
+    classification: english_default_exact_match_candidate
+  - name: image.style.canvas_avatar
+    classification: english_default_exact_match_candidate
+  - name: image.style.canvas_parametrized_width
+    classification: english_default_exact_match_candidate
+  - name: metatag.metatag_defaults.global
+    classification: english_default_exact_match_candidate
+  - name: system.action.automator_chain_delete_action
+    classification: english_default_exact_match_candidate
+  - name: views.view.canvas_pages
+    classification: english_default_exact_match_candidate
+excluded:
+  - name: system.action.agency_ai_translate_nodes_bulk_action
+    reason: corrected_separately_by_issue_752
+constraints:
+  langcode_only_promotion: true
+  textual_value_changes_allowed: false
+  translation_override_changes_allowed: false
+  config_language_lock_activation_allowed: false
+  production_mutation_allowed: false
+remaining_review_required: 122

--- a/scripts/runner/configuration-language-safe-provenance-cohort-754-verify.php
+++ b/scripts/runner/configuration-language-safe-provenance-cohort-754-verify.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/configuration-language-safe-provenance-cohort-754.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #754 configuration or manifest is missing.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #754 manifest must be a mapping.');
+}
+
+$items = $manifest['items'] ?? [];
+if (!is_array($items) || count($items) !== 17) {
+  throw new RuntimeException('Issue #754 manifest must contain exactly 17 items.');
+}
+
+$names = [];
+foreach ($items as $item) {
+  if (!is_array($item) || !isset($item['name']) || !is_string($item['name'])) {
+    throw new RuntimeException('Issue #754 manifest item is invalid.');
+  }
+  $names[] = $item['name'];
+}
+if (count(array_unique($names)) !== 17) {
+  throw new RuntimeException('Issue #754 manifest contains duplicate names.');
+}
+sort($names, SORT_STRING);
+
+$countByLangcode = static function (array $configs): array {
+  $counts = [];
+  foreach ($configs as $data) {
+    if (!is_array($data)) {
+      continue;
+    }
+    $langcode = isset($data['langcode']) && is_string($data['langcode'])
+      ? $data['langcode']
+      : '__none__';
+    $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+  }
+  ksort($counts, SORT_STRING);
+  return $counts;
+};
+
+$repositoryConfigs = [];
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate repository configuration.');
+}
+sort($baseFiles, SORT_STRING);
+foreach ($baseFiles as $path) {
+  $name = basename($path, '.yml');
+  $data = Yaml::parseFile($path);
+  if (!is_array($data)) {
+    throw new RuntimeException("Repository configuration $name is not a mapping.");
+  }
+  $repositoryConfigs[$name] = $data;
+}
+ksort($repositoryConfigs, SORT_STRING);
+
+$activeStorage = \Drupal::service('config.storage');
+$activeConfigs = [];
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    throw new RuntimeException("Active configuration $name cannot be read.");
+  }
+  $activeConfigs[$name] = $data;
+}
+
+$expected = [
+  '__none__' => 59,
+  'en' => 413,
+  'fr' => 122,
+  'und' => 1,
+];
+$repositoryDistribution = $countByLangcode($repositoryConfigs);
+$activeDistribution = $countByLangcode($activeConfigs);
+
+$problems = [];
+if (count($repositoryConfigs) !== 595) {
+  $problems[] = 'repository_total_not_595';
+}
+if (count($activeConfigs) !== 595) {
+  $problems[] = 'active_total_not_595';
+}
+if ($repositoryDistribution !== $expected) {
+  $problems[] = 'repository_distribution_mismatch';
+}
+if ($activeDistribution !== $expected) {
+  $problems[] = 'active_distribution_mismatch';
+}
+
+$verifiedItems = [];
+foreach ($names as $name) {
+  $repositoryData = $repositoryConfigs[$name] ?? NULL;
+  $activeData = $activeConfigs[$name] ?? NULL;
+  $itemProblems = [];
+
+  if (!is_array($repositoryData)) {
+    $itemProblems[] = 'repository_missing';
+  }
+  elseif (($repositoryData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'repository_langcode_not_en';
+  }
+
+  if (!is_array($activeData)) {
+    $itemProblems[] = 'active_missing';
+  }
+  elseif (($activeData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'active_langcode_not_en';
+  }
+
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    $itemProblems[] = 'unexpected_en_override';
+  }
+
+  if ($itemProblems !== []) {
+    foreach ($itemProblems as $problem) {
+      $problems[] = $name . ':' . $problem;
+    }
+  }
+
+  $verifiedItems[] = [
+    'name' => $name,
+    'repository_langcode' => is_array($repositoryData)
+      ? ($repositoryData['langcode'] ?? NULL)
+      : NULL,
+    'active_langcode' => is_array($activeData)
+      ? ($activeData['langcode'] ?? NULL)
+      : NULL,
+    'en_override_present' => is_file(
+      $configDirectory . '/language/en/' . $name . '.yml',
+    ),
+    'problems' => $itemProblems,
+  ];
+}
+
+$coreExtension = $repositoryConfigs['core.extension'] ?? [];
+if (isset($coreExtension['module']['config_language_lock'])) {
+  $problems[] = 'config_language_lock_persisted';
+}
+if (is_file($configDirectory . '/config_language_lock.settings.yml')) {
+  $problems[] = 'config_language_lock_settings_persisted';
+}
+
+$systemSite = $repositoryConfigs['system.site'] ?? [];
+if (($systemSite['default_langcode'] ?? NULL) !== 'fr') {
+  $problems[] = 'site_default_language_not_fr';
+}
+$footerMenu = $repositoryConfigs['system.menu.footer'] ?? [];
+if (($footerMenu['langcode'] ?? NULL) !== 'und') {
+  $problems[] = 'footer_menu_special_langcode_not_und';
+}
+foreach (['und', 'zxx'] as $semanticLanguage) {
+  $language = $repositoryConfigs['language.entity.' . $semanticLanguage] ?? [];
+  if (($language['id'] ?? NULL) !== $semanticLanguage) {
+    $problems[] = 'semantic_language_identity_changed:' . $semanticLanguage;
+  }
+}
+
+$excludedName = 'system.action.agency_ai_translate_nodes_bulk_action';
+$excluded = $repositoryConfigs[$excludedName] ?? [];
+if (($excluded['langcode'] ?? NULL) !== 'en') {
+  $problems[] = 'issue_752_excluded_action_not_en';
+}
+if (!is_file($configDirectory . '/language/fr/' . $excludedName . '.yml')) {
+  $problems[] = 'issue_752_french_override_missing';
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $problems === []
+  ? 'SEVENTEEN_SAFE_PROVENANCE_PROMOTIONS_VERIFIED'
+  : 'SAFE_PROVENANCE_PROMOTION_VERIFICATION_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'verified' => count($verifiedItems),
+  'remaining_fr_review_required' => 122,
+  'repository_total' => count($repositoryConfigs),
+  'active_total' => count($activeConfigs),
+  'repository_distribution' => $repositoryDistribution,
+  'active_distribution' => $activeDistribution,
+  'items' => $verifiedItems,
+  'problems' => $problems,
+  'constraints' => [
+    'config_language_lock_enabled_canonically' => FALSE,
+    'site_default_language' => 'fr',
+    'translation_override_mutation_permitted' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #754 safe provenance promotion cohort.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
+
+  /**
+   * The manifest and repository contain exactly the proven 17-item cohort.
+   */
+  public function testExactCohortIsCanonicalEnglish(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $manifestPath = $root
+      . '/docs/evidence/configuration-language-safe-provenance-cohort-754.yml';
+    self::assertFileExists($manifestPath);
+
+    $manifest = DrupalYaml::decode((string) file_get_contents($manifestPath));
+    self::assertIsArray($manifest);
+
+    $expected = [
+      'canvas.asset_library.global',
+      'canvas.brand_kit.global',
+      'core.entity_form_mode.media.media_library',
+      'core.entity_view_mode.media.full',
+      'core.entity_view_mode.media.media_library',
+      'editor.editor.canvas_html_block',
+      'editor.editor.canvas_html_inline',
+      'field.field.media.document.field_media_document',
+      'field.field.media.image.field_media_image',
+      'filter.format.canvas_html_block',
+      'filter.format.canvas_html_inline',
+      'filter.format.webform_default',
+      'image.style.canvas_avatar',
+      'image.style.canvas_parametrized_width',
+      'metatag.metatag_defaults.global',
+      'system.action.automator_chain_delete_action',
+      'views.view.canvas_pages',
+    ];
+    sort($expected, SORT_STRING);
+
+    $items = $manifest['items'] ?? [];
+    self::assertIsArray($items);
+    self::assertCount(17, $items);
+    $names = array_map(
+      static fn(array $item): string => (string) ($item['name'] ?? ''),
+      $items,
+    );
+    sort($names, SORT_STRING);
+    self::assertSame($expected, $names);
+
+    foreach ($expected as $name) {
+      $path = $root . '/config/sync/' . $name . '.yml';
+      self::assertFileExists($path, $name);
+      $data = DrupalYaml::decode((string) file_get_contents($path));
+      self::assertIsArray($data);
+      self::assertSame('en', $data['langcode'] ?? NULL, $name);
+      self::assertFileDoesNotExist(
+        $root . '/config/sync/language/en/' . $name . '.yml',
+        $name,
+      );
+    }
+
+    self::assertSame(122, $manifest['remaining_review_required'] ?? NULL);
+    self::assertSame(
+      'system.action.agency_ai_translate_nodes_bulk_action',
+      $manifest['excluded'][0]['name'] ?? NULL,
+    );
+  }
+
+  /**
+   * Repository-wide language distribution reflects only the 17 promotions.
+   */
+  public function testRepositoryDistributionAfterPromotion(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $files = glob($root . '/config/sync/*.yml');
+    self::assertIsArray($files);
+    self::assertCount(595, $files);
+
+    $counts = [];
+    foreach ($files as $path) {
+      $data = DrupalYaml::decode((string) file_get_contents($path));
+      self::assertIsArray($data, $path);
+      $langcode = isset($data['langcode']) && is_string($data['langcode'])
+        ? $data['langcode']
+        : '__none__';
+      $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+    }
+    ksort($counts, SORT_STRING);
+
+    self::assertSame([
+      '__none__' => 59,
+      'en' => 413,
+      'fr' => 122,
+      'und' => 1,
+    ], $counts);
+
+    $coreExtension = DrupalYaml::decode((string) file_get_contents(
+      $root . '/config/sync/core.extension.yml',
+    ));
+    self::assertIsArray($coreExtension);
+    self::assertArrayNotHasKey(
+      'config_language_lock',
+      $coreExtension['module'] ?? [],
+    );
+    self::assertFileDoesNotExist(
+      $root . '/config/sync/config_language_lock.settings.yml',
+    );
+  }
+
+  /**
+   * The trusted route is fixed to #754 and fresh-DDEV read-only verification.
+   */
+  public function testTrustedVerificationRouteIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $workflowPath = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-safe-provenance-754-verify.yml';
+    self::assertFileExists($workflowPath);
+
+    $workflow = (string) file_get_contents($workflowPath);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString('github.event.issue.number == 754', $workflow);
+    self::assertStringContainsString(
+      "'/agency-config-language-safe-provenance verify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('ddev drush site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString("grep -Fq 'No differences'", $workflow);
+    self::assertStringContainsString(
+      'SEVENTEEN_SAFE_PROVENANCE_PROMOTIONS_VERIFIED',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '"__none__":59,"en":413,"fr":122,"und":1',
+      $workflow,
+    );
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'drush cex',
+      'php --version',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'git push',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Résumé

Promu uniquement la cohorte de 17 bases FR déjà prouvée sûre par #748 après la correction séparée #752.

### Mutation bornée

Pour chacun des 17 fichiers `config/sync`, le diff est exactement :

`langcode: fr` → `langcode: en`

Chaque fichier affiche `+1/-1`. Aucune autre valeur YAML n'est modifiée et aucun override de traduction n'est ajouté, supprimé ou déplacé.

### Preuve durable

Ajoute :
- `docs/evidence/configuration-language-safe-provenance-cohort-754.yml` ;
- verifier fresh-DDEV `configuration-language-safe-provenance-cohort-754-verify.php` ;
- route trusted owner-only/live-main-only `/agency-config-language-safe-provenance verify` ;
- test de contrat du cohort, de la distribution et de la route.

Distribution attendue : `__none__=59, en=413, fr=122, und=1` (595 total).

Les 122 bases FR restantes restent explicitement review-required. `system.action.agency_ai_translate_nodes_bulk_action` est hors cohorte car déjà corrigée par #752.

Configuration Language Lock reste désactivé ; aucun `cex`, aucune production, aucun secret/provider.

Closes #754
Refs #609 #748 #752 #720 #744.