### PR TITLE
Issue #756: classifier les base-field overrides par provenance runtime

### DIFF
--- a/.github/workflows/trusted-configuration-language-base-field-runtime-provenance.yml
+++ b/.github/workflows/trusted-configuration-language-base-field-runtime-provenance.yml
@@ -1,0 +1,225 @@
+name: Agency trusted base-field runtime configuration-language provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #756 live-main target
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.number == 756 && github.event.comment.body == '/agency-config-language-base-field-provenance classify' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '756'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-base-field-provenance classify'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/756" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Classify 53 FR base-field overrides by runtime source provenance
+    needs: validate-target
+    timeout-minutes: 30
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+      - browser
+    permissions:
+      contents: read
+    outputs:
+      exact_match: ${{ steps.classify.outputs.exact_match }}
+      review_required: ${{ steps.classify.outputs.review_required }}
+      unresolved: ${{ steps.classify.outputs.unresolved }}
+      verdict: ${{ steps.classify.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable post-#754 target
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f scripts/runner/configuration-language-base-field-runtime-provenance.php
+          test -f docs/evidence/configuration-language-safe-provenance-cohort-754.yml
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-base-field-provenance.yaml <<EOF
+          name: agency-config-language-base-field-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF
+          ddev utility configyaml \
+            | grep -F "agency-config-language-base-field-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/config-language-base-field-provenance
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-base-field-runtime-provenance.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-base-field-provenance/config-status.txt
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Classify runtime base-field provenance
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-base-field-provenance'
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-base-field-runtime-provenance.php \
+            > "$root/result.json"
+
+          jq -e '.status == "PASS"' "$root/result.json" >/dev/null
+          jq -e '.verdict == "BASE_FIELD_RUNTIME_PROVENANCE_CLASSIFIED"' "$root/result.json" >/dev/null
+          jq -e '.counts.candidate_core_base_field_override_fr_without_en_override == 53' "$root/result.json" >/dev/null
+          jq -e '.counts.classified == 53' "$root/result.json" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$root/result.json" >/dev/null
+          jq -e '(.counts.runtime_base_definition_exact_match_candidate + .counts.runtime_base_definition_review_required + .counts.runtime_base_definition_unresolved_review_required) == 53' "$root/result.json" >/dev/null
+          jq -e '.constraints.read_only == true' "$root/result.json" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' "$root/result.json" >/dev/null
+          jq -e '.constraints.runtime_source_uses_untranslated_translatable_markup == true' "$root/result.json" >/dev/null
+          jq -e '.constraints.migration_authorized == false' "$root/result.json" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "exact_match=$(jq -r '.counts.runtime_base_definition_exact_match_candidate' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "review_required=$(jq -r '.counts.runtime_base_definition_review_required' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$(jq -r '.counts.runtime_base_definition_unresolved_review_required' "$root/result.json")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$root/result.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload runtime provenance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-base-field-provenance-756-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-base-field-provenance
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-language-base-field-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-base-field-provenance.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-base-field-provenance
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #756 runtime provenance verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - evaluate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+          EXACT_MATCH: ${{ needs.evaluate.outputs.exact_match }}
+          REVIEW_REQUIRED: ${{ needs.evaluate.outputs.review_required }}
+          UNRESOLVED: ${{ needs.evaluate.outputs.unresolved }}
+          MACHINE_VERDICT: ${{ needs.evaluate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$EVALUATION_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 756 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+          ### Base-field runtime provenance classification ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${EVALUATION_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`53\`
+          runtime_exact_match: \`${EXACT_MATCH:-n/a}\`
+          runtime_review_required: \`${REVIEW_REQUIRED:-n/a}\`
+          runtime_unresolved: \`${UNRESOLVED:-n/a}\`
+          artifact: \`agency-config-language-base-field-provenance-756-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Read-only fresh-DDEV classification only. Runtime values use untranslated source strings for TranslatableMarkup. No language heuristic, migration, lock activation, config export, production access, provider secret or repository mutation is permitted.
+          EOF
+          )"
+          test "$EVALUATION_RESULT" = 'success'

--- a/scripts/runner/configuration-language-base-field-runtime-provenance.php
+++ b/scripts/runner/configuration-language-base-field-runtime-provenance.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$policyPath = $projectRoot . '/docs/configuration-language-policy.yml';
+$priorEvidence = $projectRoot . '/docs/evidence/configuration-language-safe-provenance-cohort-754.yml';
+
+if (!is_dir($configDirectory) || !is_file($policyPath) || !is_file($priorEvidence)) {
+  throw new RuntimeException('Post-#754 configuration-language baseline is incomplete.');
+}
+
+$policy = Yaml::parseFile($policyPath);
+if (!is_array($policy)) {
+  throw new RuntimeException('Configuration language policy must be a mapping.');
+}
+if (($policy['canonical_configuration_language'] ?? NULL) !== 'en') {
+  throw new RuntimeException('Canonical configuration language must remain en.');
+}
+if (($policy['enforce_consistency'] ?? TRUE) !== FALSE) {
+  throw new RuntimeException('Runtime provenance classification must run before enforcement.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+$entityFieldManager = \Drupal::service('entity_field.manager');
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$resolveSourceValue = static function (mixed $value): array {
+  if ($value instanceof TranslatableMarkup) {
+    return [
+      'resolved' => TRUE,
+      'value' => $value->getUntranslatedString(),
+      'source_kind' => 'translatable_markup_untranslated_source',
+    ];
+  }
+  if ($value === NULL || is_scalar($value)) {
+    return [
+      'resolved' => TRUE,
+      'value' => $value,
+      'source_kind' => 'scalar_runtime_value',
+    ];
+  }
+
+  return [
+    'resolved' => FALSE,
+    'value' => NULL,
+    'source_kind' => get_debug_type($value),
+  ];
+};
+
+$baseFiles = glob($configDirectory . '/core.base_field_override.*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate core.base_field_override configuration.');
+}
+sort($baseFiles, SORT_STRING);
+
+$candidates = [];
+foreach ($baseFiles as $basePath) {
+  $repositoryData = Yaml::parseFile($basePath);
+  if (!is_array($repositoryData) || ($repositoryData['langcode'] ?? NULL) !== 'fr') {
+    continue;
+  }
+
+  $name = basename($basePath, '.yml');
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    continue;
+  }
+  $candidates[$name] = $repositoryData;
+}
+ksort($candidates, SORT_STRING);
+
+$items = [];
+$baselineProblems = [];
+foreach ($candidates as $name => $repositoryData) {
+  $sourceConfig = $configFactory->getEditable($name);
+  $sourceData = $sourceConfig->get();
+  if ($sourceConfig->isNew() || ($sourceData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => $sourceConfig->isNew()
+        ? 'active_config_missing'
+        : 'active_source_langcode_not_fr',
+    ];
+    continue;
+  }
+  if ($sourceData !== $repositoryData) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_repository_data_mismatch',
+    ];
+    continue;
+  }
+
+  $entityTypeId = isset($sourceData['entity_type']) && is_string($sourceData['entity_type'])
+    ? $sourceData['entity_type']
+    : '';
+  $bundle = isset($sourceData['bundle']) && is_string($sourceData['bundle'])
+    ? $sourceData['bundle']
+    : '';
+  $fieldName = isset($sourceData['field_name']) && is_string($sourceData['field_name'])
+    ? $sourceData['field_name']
+    : '';
+
+  $itemBase = [
+    'name' => $name,
+    'entity_type' => $entityTypeId,
+    'bundle' => $bundle,
+    'field_name' => $fieldName,
+  ];
+
+  if ($entityTypeId === '' || $fieldName === '') {
+    $items[] = $itemBase + [
+      'classification' => 'runtime_base_definition_unresolved_review_required',
+      'reason' => 'override_identity_incomplete',
+      'material_translatable_leaf_count' => 0,
+      'comparisons' => [],
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $items[] = $itemBase + [
+      'classification' => 'runtime_base_definition_unresolved_review_required',
+      'reason' => 'config_schema_missing',
+      'material_translatable_leaf_count' => 0,
+      'comparisons' => [],
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData($name, $sourceData);
+    $allLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $items[] = $itemBase + [
+      'classification' => 'runtime_base_definition_unresolved_review_required',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaf_count' => 0,
+      'comparisons' => [],
+    ];
+    continue;
+  }
+
+  $materialLeaves = [];
+  foreach ($allLeaves as $leaf) {
+    if ($isMaterial($leaf['value'])) {
+      $materialLeaves[] = $leaf;
+    }
+  }
+  usort(
+    $materialLeaves,
+    static fn(array $left, array $right): int => $left['path'] <=> $right['path'],
+  );
+
+  try {
+    $baseDefinitions = $entityFieldManager->getBaseFieldDefinitions($entityTypeId);
+  }
+  catch (Throwable $exception) {
+    $items[] = $itemBase + [
+      'classification' => 'runtime_base_definition_unresolved_review_required',
+      'reason' => 'base_field_definitions_resolution_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaf_count' => count($materialLeaves),
+      'comparisons' => [],
+    ];
+    continue;
+  }
+
+  $baseDefinition = $baseDefinitions[$fieldName] ?? NULL;
+  if ($baseDefinition === NULL) {
+    $items[] = $itemBase + [
+      'classification' => 'runtime_base_definition_unresolved_review_required',
+      'reason' => 'base_field_definition_missing',
+      'material_translatable_leaf_count' => count($materialLeaves),
+      'comparisons' => [],
+    ];
+    continue;
+  }
+
+  $settings = $baseDefinition->getSettings();
+  $comparisons = [];
+  $unresolved = FALSE;
+  $mismatch = FALSE;
+  foreach ($materialLeaves as $leaf) {
+    $segments = $leaf['segments'];
+    $runtimeRaw = NULL;
+    $runtimeFound = TRUE;
+    $resolver = NULL;
+
+    if ($segments === ['label']) {
+      $runtimeRaw = $baseDefinition->getLabel();
+      $resolver = 'base_definition.label';
+    }
+    elseif ($segments === ['description']) {
+      $runtimeRaw = $baseDefinition->getDescription();
+      $resolver = 'base_definition.description';
+    }
+    elseif (($segments[0] ?? NULL) === 'settings' && count($segments) > 1) {
+      $relativeSegments = array_slice($segments, 1);
+      $runtimeRaw = NestedArray::getValue($settings, $relativeSegments, $runtimeFound);
+      $resolver = 'base_definition.settings';
+    }
+    else {
+      $runtimeFound = FALSE;
+      $resolver = 'unsupported_typed_path';
+    }
+
+    if (!$runtimeFound) {
+      $unresolved = TRUE;
+      $comparisons[] = [
+        'path' => $leaf['path'],
+        'config_value' => $leaf['value'],
+        'runtime_source_value' => NULL,
+        'resolver' => $resolver,
+        'resolved' => FALSE,
+        'matches' => FALSE,
+      ];
+      continue;
+    }
+
+    $resolvedSource = $resolveSourceValue($runtimeRaw);
+    if (!$resolvedSource['resolved']) {
+      $unresolved = TRUE;
+      $comparisons[] = [
+        'path' => $leaf['path'],
+        'config_value' => $leaf['value'],
+        'runtime_source_value' => NULL,
+        'resolver' => $resolver,
+        'source_kind' => $resolvedSource['source_kind'],
+        'resolved' => FALSE,
+        'matches' => FALSE,
+      ];
+      continue;
+    }
+
+    $matches = $resolvedSource['value'] === $leaf['value'];
+    if (!$matches) {
+      $mismatch = TRUE;
+    }
+    $comparisons[] = [
+      'path' => $leaf['path'],
+      'config_value' => $leaf['value'],
+      'runtime_source_value' => $resolvedSource['value'],
+      'resolver' => $resolver,
+      'source_kind' => $resolvedSource['source_kind'],
+      'resolved' => TRUE,
+      'matches' => $matches,
+    ];
+  }
+
+  if ($materialLeaves === []) {
+    $classification = 'runtime_base_definition_unresolved_review_required';
+    $reason = 'no_material_translatable_source_leaves';
+  }
+  elseif ($unresolved) {
+    $classification = 'runtime_base_definition_unresolved_review_required';
+    $reason = 'runtime_source_resolution_incomplete';
+  }
+  elseif ($mismatch) {
+    $classification = 'runtime_base_definition_review_required';
+    $reason = 'material_translatable_source_differs_from_runtime_base_definition';
+  }
+  else {
+    $classification = 'runtime_base_definition_exact_match_candidate';
+    $reason = 'all_material_translatable_leaves_match_untranslated_runtime_base_definition';
+  }
+
+  $items[] = $itemBase + [
+    'classification' => $classification,
+    'reason' => $reason,
+    'base_definition_class' => $baseDefinition::class,
+    'material_translatable_leaf_count' => count($materialLeaves),
+    'comparisons' => $comparisons,
+  ];
+}
+
+usort($items, static fn(array $left, array $right): int => $left['name'] <=> $right['name']);
+
+$classificationNames = [
+  'runtime_base_definition_exact_match_candidate' => [],
+  'runtime_base_definition_review_required' => [],
+  'runtime_base_definition_unresolved_review_required' => [],
+];
+foreach ($items as $item) {
+  $classificationNames[$item['classification']][] = $item['name'];
+}
+foreach ($classificationNames as &$names) {
+  sort($names, SORT_STRING);
+}
+unset($names);
+
+$counts = [
+  'candidate_core_base_field_override_fr_without_en_override' => count($candidates),
+  'classified' => count($items),
+  'baseline_problem' => count($baselineProblems),
+  'runtime_base_definition_exact_match_candidate' => count($classificationNames['runtime_base_definition_exact_match_candidate']),
+  'runtime_base_definition_review_required' => count($classificationNames['runtime_base_definition_review_required']),
+  'runtime_base_definition_unresolved_review_required' => count($classificationNames['runtime_base_definition_unresolved_review_required']),
+];
+
+$status = (
+  $counts['candidate_core_base_field_override_fr_without_en_override'] === 53
+  && $counts['classified'] === 53
+  && $counts['baseline_problem'] === 0
+) ? 'PASS' : 'FAIL';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => 'BASE_FIELD_RUNTIME_PROVENANCE_CLASSIFIED',
+  'baseline' => [
+    'expected_total_config' => 595,
+    'expected_distribution' => [
+      '__none__' => 59,
+      'en' => 413,
+      'fr' => 122,
+      'und' => 1,
+    ],
+  ],
+  'counts' => $counts,
+  'names_by_classification' => $classificationNames,
+  'baseline_problems' => $baselineProblems,
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'runtime_source_uses_untranslated_translatable_markup' => TRUE,
+    'configuration_language_lock_enabled_canonically' => FALSE,
+    'migration_authorized' => FALSE,
+  ],
+];
+
+print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+
+if ($status !== 'PASS') {
+  exit(1);
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #756 runtime base-field provenance classification.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest extends TestCase {
+
+  /**
+   * The gateway is fixed to #756, live main and read-only fresh DDEV.
+   */
+  public function testGatewayIsFixedLiveMainAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-base-field-runtime-provenance.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 756',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-base-field-provenance classify'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString('persist-credentials: false', $workflow);
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString(
+      '.counts.candidate_core_base_field_override_fr_without_en_override == 53',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test -z "$(git status --short config/sync)"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev exec php -l',
+      $workflow,
+    );
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'php --version',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'git push',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The analyzer uses untranslated runtime source values and exact equality.
+   */
+  public function testAnalyzerIsRuntimeSourceStrictAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-base-field-runtime-provenance.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $script);
+    self::assertStringContainsString(
+      "\\Drupal::service('entity_field.manager')",
+      $script,
+    );
+    self::assertStringContainsString(
+      'getBaseFieldDefinitions($entityTypeId)',
+      $script,
+    );
+    self::assertStringContainsString('getUntranslatedString()', $script);
+    self::assertStringContainsString('NestedArray::getValue(', $script);
+    self::assertStringContainsString('TraversableTypedDataInterface', $script);
+    self::assertStringContainsString("'translatable'", $script);
+    self::assertStringContainsString(
+      "'runtime_base_definition_exact_match_candidate'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'runtime_base_definition_review_required'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'runtime_base_definition_unresolved_review_required'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'migration_authorized' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'BASE_FIELD_RUNTIME_PROVENANCE_CLASSIFIED'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "$counts['candidate_core_base_field_override_fr_without_en_override'] === 53",
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      'config.storage.sync',
+      'drush cex',
+      'OPENAI_API_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest.php
@@ -121,7 +121,7 @@ final class ConfigurationLanguageBaseFieldRuntimeProvenanceWorkflowTest extends 
       $script,
     );
     self::assertStringContainsString(
-      "$counts['candidate_core_base_field_override_fr_without_en_override'] === 53",
+      "\$counts['candidate_core_base_field_override_fr_without_en_override'] === 53",
       $script,
     );
 


### PR DESCRIPTION
## Résumé

Ajoute un probe strictement read-only pour reclassifier les 53 `core.base_field_override.*` encore FR après #754.

### Provenance

- inventaire typed-config des feuilles traduisibles matérielles ;
- résolution via `entity_field.manager->getBaseFieldDefinitions()` ;
- `TranslatableMarkup` comparé par `getUntranslatedString()`, jamais par rendu FR ;
- support borné à `label`, `description` et `settings.*` ;
- tout chemin/résultat non résolu reste fail-closed.

### Classifications

- `runtime_base_definition_exact_match_candidate` ;
- `runtime_base_definition_review_required` ;
- `runtime_base_definition_unresolved_review_required`.

Aucune catégorie n’autorise une migration dans cette PR.

### Route trusted

`/agency-config-language-base-field-provenance classify`

Issue #756 uniquement, owner-only, live-main-only, fresh DDEV, `site:install --existing-config`, `cim`, `config:status` clean, artifact machine-readable, cleanup.

### Périmètre

3 fichiers uniquement : analyseur, workflow trusted et test de contrat. Aucun `config/sync`, aucun lock, aucun `cex`, aucune production, aucun secret/provider.

Closes #756
Refs #609 #748 #754 #752.