### PR TITLE
Issue #760: govern base-field runtime canonical promotion

### DIFF
--- a/.github/workflows/governed-configuration-language-base-field-runtime-cohort-760.yml
+++ b/.github/workflows/governed-configuration-language-base-field-runtime-cohort-760.yml
@@ -1,0 +1,437 @@
+name: Agency governed base-field runtime canonical promotion
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate fixed #760 live-main migration request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 760 &&
+        github.event.comment.body == '/agency-config-language-base-field-runtime migrate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and immutable live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '760' ]]
+          [[ "$TRIGGER_COMMENT" == '/agency-config-language-base-field-runtime migrate' ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/760")"
+          [[ "$(jq -r '.state' <<<"$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<<"$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<<"$issue_json")" == 'E-merging-digital' ]]
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]] || {
+            echo 'Issue #760 migration must start from exact live main.' >&2
+            exit 1
+          }
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prepare-and-push:
+    name: Replay #756, prepare 53-object patch and fresh-verify
+    needs: validate-request
+    timeout-minutes: 55
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: write
+    outputs:
+      branch: ${{ steps.commit.outputs.branch }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      status: ${{ steps.summary.outputs.status }}
+      prepared: ${{ steps.summary.outputs.prepared }}
+      exact_match: ${{ steps.summary.outputs.exact_match }}
+      localized_exception: ${{ steps.summary.outputs.localized_exception }}
+      verification: ${{ steps.summary.outputs.verification }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          command -v git
+          git --version
+          command -v docker
+          docker --version
+          command -v ddev
+          ddev version
+          command -v jq
+
+      - name: Checkout exact live main with bounded write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Verify immutable #760 tooling and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          test -f docs/evidence/configuration-language-base-field-runtime-cohort-760.yml
+          test -f scripts/runner/configuration-language-base-field-runtime-provenance.php
+          test -f scripts/runner/apply-configuration-language-base-field-runtime-cohort-760.php
+          test -f scripts/runner/configuration-language-base-field-runtime-cohort-760-verify.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate fresh DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-base-field-runtime-760.yaml <<EOF_CONFIG
+          name: agency-config-base-field-runtime-760-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-base-field-runtime-760-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact pre-migration baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/config-language-base-field-runtime-760
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-base-field-runtime-provenance.php >/dev/null
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-base-field-runtime-cohort-760.php >/dev/null
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-base-field-runtime-cohort-760-verify.php >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" \
+            > artifacts/config-language-base-field-runtime-760/config-status-before.txt
+          grep -Fq 'No differences' <<<"$config_status"
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must be disabled before #760.' >&2
+            exit 1
+          fi
+
+      - name: Replay exact #756 runtime provenance before mutation
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-base-field-runtime-760'
+          provenance="$root/provenance-before.json"
+          manifest_json="$root/manifest.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-base-field-runtime-provenance.php \
+            > "$provenance"
+          ddev exec php -r \
+            'require "/var/www/html/vendor/autoload.php"; echo json_encode(Symfony\Component\Yaml\Yaml::parseFile("/var/www/html/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml"), JSON_THROW_ON_ERROR);' \
+            > "$manifest_json"
+
+          jq -e '.status == "PASS"' "$provenance" >/dev/null
+          jq -e '.verdict == "BASE_FIELD_RUNTIME_PROVENANCE_CLASSIFIED"' "$provenance" >/dev/null
+          jq -e '.counts.candidate_core_base_field_override_fr_without_en_override == 53' "$provenance" >/dev/null
+          jq -e '.counts.classified == 53' "$provenance" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$provenance" >/dev/null
+          jq -e '.counts.runtime_base_definition_exact_match_candidate == 52' "$provenance" >/dev/null
+          jq -e '.counts.runtime_base_definition_review_required == 1' "$provenance" >/dev/null
+          jq -e '.counts.runtime_base_definition_unresolved_review_required == 0' "$provenance" >/dev/null
+          jq -e '.baseline_problems == []' "$provenance" >/dev/null
+          jq -e '.names_by_classification.runtime_base_definition_review_required == ["core.base_field_override.canvas_page.canvas_page.components"]' "$provenance" >/dev/null
+          jq -e '.names_by_classification.runtime_base_definition_unresolved_review_required == []' "$provenance" >/dev/null
+          jq -e '.cohort.total == 53 and .cohort.exact_runtime_source_match == 52 and .cohort.review_exception == 1 and .cohort.unresolved == 0' "$manifest_json" >/dev/null
+
+          diff -u \
+            <(jq -r '.names_by_classification.runtime_base_definition_exact_match_candidate[]' "$provenance" | sort) \
+            <(jq -r '.cohort.exact_match_names[]' "$manifest_json" | sort)
+          test -z "$(git status --short config/sync)"
+
+      - name: Apply strict textual #760 writer
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-base-field-runtime-760'
+          result="$root/writer-result.json"
+
+          ddev exec php \
+            /var/www/html/scripts/runner/apply-configuration-language-base-field-runtime-cohort-760.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PATCH_PREPARED"' "$result" >/dev/null
+          jq -e '.counts.expected == 53 and .counts.prepared == 53' "$result" >/dev/null
+          jq -e '.counts.runtime_exact_match == 52 and .counts.localized_exception == 1' "$result" >/dev/null
+          jq -e '.counts.fr_overrides_created == 1 and .counts.problem_count == 0 and .problems == []' "$result" >/dev/null
+          jq -e '.target.total == 595' "$result" >/dev/null
+          jq -e '.target.distribution == {"__none__":59,"en":466,"fr":69,"und":1}' "$result" >/dev/null
+          jq -e '.constraints.textual_replacements_only == true' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e '.constraints.config_language_lock_activation_allowed == false' "$result" >/dev/null
+
+          mapfile -t expected_paths < <(
+            jq -r '.paths.modified_base[], .paths.fr_override' "$result" | sort
+          )
+          mapfile -t changed_paths < <(
+            git status --porcelain --untracked-files=all -- config/sync \
+              | awk '{print $2}' \
+              | sort
+          )
+          [[ "${#expected_paths[@]}" -eq 54 ]]
+          [[ "${#changed_paths[@]}" -eq 54 ]]
+          diff -u \
+            <(printf '%s\n' "${expected_paths[@]}") \
+            <(printf '%s\n' "${changed_paths[@]}")
+
+          exception_path='config/sync/core.base_field_override.canvas_page.canvas_page.components.yml'
+          override_path='config/sync/language/fr/core.base_field_override.canvas_page.canvas_page.components.yml'
+          [[ "$(git diff --name-only -- config/sync | wc -l)" -eq 53 ]]
+          git diff --numstat -- config/sync \
+            | awk -v exception="$exception_path" '
+                BEGIN {exact=0; localized=0; total=0}
+                {
+                  total++
+                  if ($3 == exception) {
+                    if ($1 != 2 || $2 != 2) exit 1
+                    localized++
+                  }
+                  else {
+                    if ($1 != 1 || $2 != 1) exit 1
+                    exact++
+                  }
+                }
+                END {exit (total == 53 && exact == 52 && localized == 1) ? 0 : 1}
+              '
+          test "$(git status --porcelain -- "$override_path")" = "?? $override_path"
+          [[ -z "$(git diff --name-only -- config/sync/core.extension.yml)" ]]
+          [[ "$(git status --porcelain --untracked-files=all -- config/sync/language | wc -l)" -eq 1 ]]
+          git diff --check
+          git diff -- config/sync > "$root/config-diff.patch"
+          git status --porcelain --untracked-files=all -- config/sync > "$root/config-status-git.txt"
+
+      - name: Rebuild second fresh Drupal and verify exact target
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-base-field-runtime-760'
+          verify="$root/verify-result.json"
+
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status-after.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-base-field-runtime-cohort-760-verify.php \
+            > "$verify"
+          jq -e '.status == "PASS"' "$verify" >/dev/null
+          jq -e '.verdict == "FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PROMOTIONS_VERIFIED"' "$verify" >/dev/null
+          jq -e '.verified == 53 and .remaining_fr_review_required == 69' "$verify" >/dev/null
+          jq -e '.repository_total == 595 and .active_total == 595' "$verify" >/dev/null
+          jq -e '.repository_distribution == {"__none__":59,"en":466,"fr":69,"und":1}' "$verify" >/dev/null
+          jq -e '.active_distribution == {"__none__":59,"en":466,"fr":69,"und":1}' "$verify" >/dev/null
+          jq -e '.exception.name == "core.base_field_override.canvas_page.canvas_page.components"' "$verify" >/dev/null
+          jq -e '.exception.base_label == "Components"' "$verify" >/dev/null
+          jq -e '.exception.fr_override == {"label":"Composants"}' "$verify" >/dev/null
+          jq -e '.problems == []' "$verify" >/dev/null
+          jq -e '.constraints.runtime_source_uses_untranslated_translatable_markup == true' "$verify" >/dev/null
+          jq -e '.constraints.semantic_und_zxx_preserved == true' "$verify" >/dev/null
+          jq -e '.constraints.config_language_lock_enabled_canonically == false' "$verify" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$verify" >/dev/null
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must remain disabled after #760.' >&2
+            exit 1
+          fi
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Commit and push only the bounded generated branch
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch='feature/760-promote-base-field-runtime-cohort'
+          result='artifacts/config-language-base-field-runtime-760/writer-result.json'
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing branch $branch" >&2
+            exit 1
+          fi
+
+          git switch -c "$branch"
+          mapfile -t paths < <(jq -r '.paths.modified_base[], .paths.fr_override' "$result")
+          [[ "${#paths[@]}" -eq 54 ]]
+          git add -- "${paths[@]}"
+
+          [[ "$(git diff --cached --name-only | wc -l)" -eq 54 ]]
+          [[ "$(git diff --cached --name-only -- config/sync/core.base_field_override.*.yml | wc -l)" -eq 53 ]]
+          [[ "$(git diff --cached --name-only -- config/sync/language/fr/core.base_field_override.canvas_page.canvas_page.components.yml | wc -l)" -eq 1 ]]
+          [[ -z "$(git diff --cached --name-only -- config/sync/core.extension.yml)" ]]
+          git diff --cached --check
+
+          git config user.name 'E-merging Digital Automation'
+          git config user.email 'actions@users.noreply.github.com'
+          git commit -m 'Issue #760: promote 53 base-field overrides to canonical EN'
+          git push origin "HEAD:refs/heads/$branch"
+
+          commit_sha="$(git rev-parse HEAD)"
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #760 governed preparation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-base-field-runtime-cohort-760-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-base-field-runtime-760
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Summarize #760 governed preparation
+        id: summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result='artifacts/config-language-base-field-runtime-760/writer-result.json'
+          verify='artifacts/config-language-base-field-runtime-760/verify-result.json'
+          status='MISSING'
+          prepared='0'
+          exact_match='0'
+          localized_exception='0'
+          verification='MISSING'
+          if [[ -s "$result" ]] && jq -e . "$result" >/dev/null 2>&1; then
+            status="$(jq -r '.status // "UNKNOWN"' "$result")"
+            prepared="$(jq -r '.counts.prepared // 0' "$result")"
+            exact_match="$(jq -r '.counts.runtime_exact_match // 0' "$result")"
+            localized_exception="$(jq -r '.counts.localized_exception // 0' "$result")"
+          fi
+          if [[ -s "$verify" ]] && jq -e . "$verify" >/dev/null 2>&1; then
+            verification="$(jq -r '.status // "UNKNOWN"' "$verify")"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "prepared=$prepared" >> "$GITHUB_OUTPUT"
+          echo "exact_match=$exact_match" >> "$GITHUB_OUTPUT"
+          echo "localized_exception=$localized_exception" >> "$GITHUB_OUTPUT"
+          echo "verification=$verification" >> "$GITHUB_OUTPUT"
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-base-field-runtime-760-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-base-field-runtime-760.yaml
+          rm -rf artifacts/config-language-base-field-runtime-760
+          rmdir artifacts 2>/dev/null || true
+          git restore --worktree -- web/robots.txt 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report:
+    name: Publish #760 governed preparation verdict
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prepare-and-push
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment terminal branch result on #760
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ needs.validate-request.outputs.main_sha }}
+          OUTCOME: ${{ needs.prepare-and-push.result }}
+          STATUS: ${{ needs.prepare-and-push.outputs.status }}
+          PREPARED: ${{ needs.prepare-and-push.outputs.prepared }}
+          EXACT_MATCH: ${{ needs.prepare-and-push.outputs.exact_match }}
+          LOCALIZED_EXCEPTION: ${{ needs.prepare-and-push.outputs.localized_exception }}
+          VERIFICATION: ${{ needs.prepare-and-push.outputs.verification }}
+          BRANCH: ${{ needs.prepare-and-push.outputs.branch }}
+          COMMIT_SHA: ${{ needs.prepare-and-push.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          heading='### Base-field runtime canonical branch FAIL'
+          if [[ "$OUTCOME" == 'success' && "$STATUS" == 'PASS' && "$PREPARED" == '53' && "$VERIFICATION" == 'PASS' ]]; then
+            heading='### Base-field runtime canonical branch PREPARED'
+          fi
+          body="$(cat <<EOF_BODY
+          ${heading}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${OUTCOME:-unknown}\`
+          writer_status: \`${STATUS:-unknown}\`
+          prepared: \`${PREPARED:-0}\`
+          runtime_exact_match: \`${EXACT_MATCH:-0}\`
+          localized_exception: \`${LOCALIZED_EXCEPTION:-0}\`
+          verification: \`${VERIFICATION:-unknown}\`
+          branch: \`${BRANCH:-n/a}\`
+          commit_sha: \`${COMMIT_SHA:-n/a}\`
+          target_distribution: \`__none__=59 en=466 fr=69 und=1 total=595\`
+          artifact: \`agency-config-language-base-field-runtime-cohort-760-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          The writer replays the exact #756 runtime-source provenance before mutation, uses only strict textual replacements for the 53-name manifest, fresh-rebuilds the generated configuration, and refuses to overwrite the fixed generated branch. No config export, lock activation, production access, provider secret or arbitrary push is permitted.
+          EOF_BODY
+          )"
+          gh issue comment 760 --repo "$GITHUB_REPOSITORY" --body "$body"
+          test "$OUTCOME" = 'success'
+          test "$STATUS" = 'PASS'
+          test "$PREPARED" = '53'
+          test "$EXACT_MATCH" = '52'
+          test "$LOCALIZED_EXCEPTION" = '1'
+          test "$VERIFICATION" = 'PASS'

--- a/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml
+++ b/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml
@@ -1,0 +1,96 @@
+schema_version: 1
+issue: 760
+parent_issue: 609
+source_proof:
+  issue: 756
+  run_id: 32710152174
+  artifact_id: 9513880054
+  artifact_digest: 'sha256:a639a37e1b37125eeb68c14bbac15879f834852a0266bc526a2a3a263ae02849'
+  trusted_main: 4b0eed9d848891de169964228add031aaad42197
+baseline:
+  total_config: 595
+  distribution:
+    __none__: 59
+    en: 413
+    fr: 122
+    und: 1
+target:
+  total_config: 595
+  distribution:
+    __none__: 59
+    en: 466
+    fr: 69
+    und: 1
+cohort:
+  total: 53
+  exact_runtime_source_match: 52
+  review_exception: 1
+  unresolved: 0
+  names_sha256: 72d2e6f904c99bfd426f6ca58e2c3e7c277beb36eff62eed269a793ff5846535
+  exact_match_names_sha256: fc71d904d034fb657ce0dc6d61528d2e8e50e9ede1b838ab4d91842f821cfcbf
+  exact_match_names:
+    - core.base_field_override.block_content.basic.changed
+    - core.base_field_override.block_content.basic.info
+    - core.base_field_override.block_content.basic.metatag
+    - core.base_field_override.block_content.basic.status
+    - core.base_field_override.comment.comment.changed
+    - core.base_field_override.comment.comment.created
+    - core.base_field_override.comment.comment.homepage
+    - core.base_field_override.comment.comment.hostname
+    - core.base_field_override.comment.comment.mail
+    - core.base_field_override.comment.comment.name
+    - core.base_field_override.comment.comment.status
+    - core.base_field_override.comment.comment.subject
+    - core.base_field_override.comment.comment.uid
+    - core.base_field_override.menu_link_content.menu_link_content.changed
+    - core.base_field_override.menu_link_content.menu_link_content.description
+    - core.base_field_override.menu_link_content.menu_link_content.metatag
+    - core.base_field_override.menu_link_content.menu_link_content.title
+    - core.base_field_override.shortcut.default.metatag
+    - core.base_field_override.shortcut.default.title
+    - core.base_field_override.taxonomy_term.localisation.changed
+    - core.base_field_override.taxonomy_term.localisation.description
+    - core.base_field_override.taxonomy_term.localisation.metatag
+    - core.base_field_override.taxonomy_term.localisation.name
+    - core.base_field_override.taxonomy_term.localisation.path
+    - core.base_field_override.taxonomy_term.localisation.status
+    - core.base_field_override.taxonomy_term.secteur.changed
+    - core.base_field_override.taxonomy_term.secteur.description
+    - core.base_field_override.taxonomy_term.secteur.metatag
+    - core.base_field_override.taxonomy_term.secteur.name
+    - core.base_field_override.taxonomy_term.secteur.path
+    - core.base_field_override.taxonomy_term.secteur.status
+    - core.base_field_override.taxonomy_term.tags.changed
+    - core.base_field_override.taxonomy_term.tags.description
+    - core.base_field_override.taxonomy_term.tags.metatag
+    - core.base_field_override.taxonomy_term.tags.name
+    - core.base_field_override.taxonomy_term.tags.path
+    - core.base_field_override.taxonomy_term.tags.status
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.changed
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.description
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.metatag
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.name
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.path
+    - core.base_field_override.taxonomy_term.type_fonctionnalite_ia.status
+    - core.base_field_override.taxonomy_term.type_service.changed
+    - core.base_field_override.taxonomy_term.type_service.description
+    - core.base_field_override.taxonomy_term.type_service.metatag
+    - core.base_field_override.taxonomy_term.type_service.name
+    - core.base_field_override.taxonomy_term.type_service.path
+    - core.base_field_override.taxonomy_term.type_service.status
+    - core.base_field_override.user.user.changed
+    - core.base_field_override.user.user.metatag
+    - core.base_field_override.user.user.path
+  exception:
+    name: core.base_field_override.canvas_page.canvas_page.components
+    path: label
+    current_config_value: Composants
+    runtime_untranslated_source_value: Components
+    target_base_value: Components
+    target_fr_override_value: Composants
+constraints:
+  exact_match_mutation: langcode_only
+  exception_mutation: langcode_and_label_with_fr_override
+  natural_language_heuristic_used: false
+  config_export_allowed: false
+  config_language_lock_activation_allowed: false

--- a/scripts/runner/apply-configuration-language-base-field-runtime-cohort-760.php
+++ b/scripts/runner/apply-configuration-language-base-field-runtime-cohort-760.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(__DIR__, 2);
+$autoload = $projectRoot . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+  throw new RuntimeException('Composer autoload is missing.');
+}
+require_once $autoload;
+
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot . '/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #760 configuration or cohort manifest is missing.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #760 cohort manifest must be a mapping.');
+}
+
+$expectedBaseline = [
+  '__none__' => 59,
+  'en' => 413,
+  'fr' => 122,
+  'und' => 1,
+];
+$expectedTarget = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+$expectedException = 'core.base_field_override.canvas_page.canvas_page.components';
+$expectedNamesHash = '72d2e6f904c99bfd426f6ca58e2c3e7c277beb36eff62eed269a793ff5846535';
+$expectedExactHash = 'fc71d904d034fb657ce0dc6d61528d2e8e50e9ede1b838ab4d91842f821cfcbf';
+
+if (($manifest['issue'] ?? NULL) !== 760
+  || ($manifest['parent_issue'] ?? NULL) !== 609
+  || ($manifest['cohort']['total'] ?? NULL) !== 53
+  || ($manifest['cohort']['exact_runtime_source_match'] ?? NULL) !== 52
+  || ($manifest['cohort']['review_exception'] ?? NULL) !== 1
+  || ($manifest['cohort']['unresolved'] ?? NULL) !== 0
+  || ($manifest['cohort']['names_sha256'] ?? NULL) !== $expectedNamesHash
+  || ($manifest['cohort']['exact_match_names_sha256'] ?? NULL) !== $expectedExactHash
+  || ($manifest['baseline']['total_config'] ?? NULL) !== 595
+  || ($manifest['baseline']['distribution'] ?? NULL) !== $expectedBaseline
+  || ($manifest['target']['total_config'] ?? NULL) !== 595
+  || ($manifest['target']['distribution'] ?? NULL) !== $expectedTarget
+  || ($manifest['constraints']['exact_match_mutation'] ?? NULL) !== 'langcode_only'
+  || ($manifest['constraints']['exception_mutation'] ?? NULL) !== 'langcode_and_label_with_fr_override'
+  || ($manifest['constraints']['natural_language_heuristic_used'] ?? TRUE) !== FALSE
+  || ($manifest['constraints']['config_export_allowed'] ?? TRUE) !== FALSE
+  || ($manifest['constraints']['config_language_lock_activation_allowed'] ?? TRUE) !== FALSE) {
+  throw new RuntimeException('Issue #760 cohort contract drifted.');
+}
+
+$exactNames = $manifest['cohort']['exact_match_names'] ?? NULL;
+$exception = $manifest['cohort']['exception'] ?? NULL;
+if (!is_array($exactNames) || count($exactNames) !== 52 || !is_array($exception)) {
+  throw new RuntimeException('Issue #760 cohort membership is invalid.');
+}
+foreach ($exactNames as $name) {
+  if (!is_string($name) || $name === '') {
+    throw new RuntimeException('Issue #760 exact-match cohort contains an invalid name.');
+  }
+}
+if (count(array_unique($exactNames)) !== 52) {
+  throw new RuntimeException('Issue #760 exact-match cohort contains duplicate names.');
+}
+sort($exactNames, SORT_STRING);
+
+$exceptionName = $exception['name'] ?? NULL;
+if ($exceptionName !== $expectedException
+  || ($exception['path'] ?? NULL) !== 'label'
+  || ($exception['current_config_value'] ?? NULL) !== 'Composants'
+  || ($exception['runtime_untranslated_source_value'] ?? NULL) !== 'Components'
+  || ($exception['target_base_value'] ?? NULL) !== 'Components'
+  || ($exception['target_fr_override_value'] ?? NULL) !== 'Composants'
+  || in_array($exceptionName, $exactNames, TRUE)) {
+  throw new RuntimeException('Issue #760 localized exception contract drifted.');
+}
+
+$allNames = [...$exactNames, $exceptionName];
+sort($allNames, SORT_STRING);
+if (count($allNames) !== 53 || count(array_unique($allNames)) !== 53) {
+  throw new RuntimeException('Issue #760 must contain exactly 53 unique names.');
+}
+$hashNames = static fn(array $names): string => hash('sha256', implode("\n", $names) . "\n");
+if ($hashNames($allNames) !== $expectedNamesHash || $hashNames($exactNames) !== $expectedExactHash) {
+  throw new RuntimeException('Issue #760 cohort identity hash mismatch.');
+}
+
+$countRepositoryDistribution = static function (string $directory): array {
+  $files = glob($directory . '/*.yml');
+  if ($files === FALSE) {
+    throw new RuntimeException('Unable to enumerate repository configuration.');
+  }
+  sort($files, SORT_STRING);
+  $counts = [];
+  foreach ($files as $path) {
+    $data = Yaml::parseFile($path);
+    if (!is_array($data)) {
+      throw new RuntimeException('Repository configuration is not a mapping: ' . basename($path));
+    }
+    $langcode = isset($data['langcode']) && is_string($data['langcode'])
+      ? $data['langcode']
+      : '__none__';
+    $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+  }
+  ksort($counts, SORT_STRING);
+  return [count($files), $counts];
+};
+
+[$baselineTotal, $baselineDistribution] = $countRepositoryDistribution($configDirectory);
+if ($baselineTotal !== 595 || $baselineDistribution !== $expectedBaseline) {
+  throw new RuntimeException('Issue #760 repository baseline distribution drifted.');
+}
+
+$coreExtension = Yaml::parseFile($configDirectory . '/core.extension.yml');
+if (!is_array($coreExtension)) {
+  throw new RuntimeException('core.extension configuration is invalid.');
+}
+if (isset($coreExtension['module']['config_language_lock'])
+  || is_file($configDirectory . '/config_language_lock.settings.yml')) {
+  throw new RuntimeException('Configuration Language Lock must remain disabled for #760.');
+}
+$systemSite = Yaml::parseFile($configDirectory . '/system.site.yml');
+if (!is_array($systemSite) || ($systemSite['default_langcode'] ?? NULL) !== 'fr') {
+  throw new RuntimeException('system.site.default_langcode must remain fr.');
+}
+
+$prepared = [];
+foreach ($allNames as $name) {
+  $path = $configDirectory . '/' . $name . '.yml';
+  if (!is_file($path)) {
+    throw new RuntimeException("Missing #760 base configuration: $name");
+  }
+  $content = file_get_contents($path);
+  if (!is_string($content)) {
+    throw new RuntimeException("Unable to read #760 base configuration: $name");
+  }
+  if (str_contains($content, "\r")) {
+    throw new RuntimeException("Unexpected CR line endings in #760 base configuration: $name");
+  }
+  if (preg_match_all('/^langcode: fr$/m', $content) !== 1) {
+    throw new RuntimeException("Expected exactly one top-level langcode: fr line in $name");
+  }
+  $data = Yaml::parse($content);
+  if (!is_array($data) || ($data['langcode'] ?? NULL) !== 'fr') {
+    throw new RuntimeException("Unexpected parsed baseline langcode in $name");
+  }
+
+  $enOverride = $configDirectory . '/language/en/' . $name . '.yml';
+  if (is_file($enOverride)) {
+    throw new RuntimeException("Unexpected EN override for #760 target: $name");
+  }
+  $frOverride = $configDirectory . '/language/fr/' . $name . '.yml';
+  if (is_file($frOverride)) {
+    throw new RuntimeException("Unexpected pre-existing FR override for #760 target: $name");
+  }
+
+  if ($name === $exceptionName) {
+    if (($data['label'] ?? NULL) !== 'Composants'
+      || preg_match_all('/^label: Composants$/m', $content) !== 1) {
+      throw new RuntimeException('The #760 Canvas components exception no longer has the exact French label.');
+    }
+  }
+
+  $prepared[$name] = [
+    'path' => $path,
+    'relative_path' => 'config/sync/' . $name . '.yml',
+    'content' => $content,
+    'data' => $data,
+  ];
+}
+
+$items = [];
+foreach ($exactNames as $name) {
+  $entry = $prepared[$name];
+  $count = 0;
+  $after = preg_replace('/^langcode: fr$/m', 'langcode: en', $entry['content'], 1, $count);
+  if (!is_string($after) || $count !== 1) {
+    throw new RuntimeException("Unable to prepare exact langcode replacement for $name");
+  }
+  $afterData = Yaml::parse($after);
+  $expectedData = $entry['data'];
+  $expectedData['langcode'] = 'en';
+  if (!is_array($afterData) || $afterData !== $expectedData) {
+    throw new RuntimeException("Unexpected semantic change while preparing $name");
+  }
+  if (file_put_contents($entry['path'], $after) !== strlen($after)) {
+    throw new RuntimeException("Unable to write prepared #760 configuration: $name");
+  }
+  $items[] = [
+    'name' => $name,
+    'path' => $entry['relative_path'],
+    'classification' => 'runtime_exact_match',
+    'before_langcode' => 'fr',
+    'after_langcode' => 'en',
+    'text_mutation' => 'langcode_only',
+  ];
+}
+
+$entry = $prepared[$exceptionName];
+$countLangcode = 0;
+$after = preg_replace('/^langcode: fr$/m', 'langcode: en', $entry['content'], 1, $countLangcode);
+$countLabel = 0;
+$after = is_string($after)
+  ? preg_replace('/^label: Composants$/m', 'label: Components', $after, 1, $countLabel)
+  : NULL;
+if (!is_string($after) || $countLangcode !== 1 || $countLabel !== 1) {
+  throw new RuntimeException('Unable to prepare the exact #760 Canvas exception replacements.');
+}
+$afterData = Yaml::parse($after);
+$expectedData = $entry['data'];
+$expectedData['langcode'] = 'en';
+$expectedData['label'] = 'Components';
+if (!is_array($afterData) || $afterData !== $expectedData) {
+  throw new RuntimeException('Unexpected semantic change in the #760 Canvas exception.');
+}
+if (file_put_contents($entry['path'], $after) !== strlen($after)) {
+  throw new RuntimeException('Unable to write the #760 Canvas exception base configuration.');
+}
+
+$frOverridePath = $configDirectory . '/language/fr/' . $exceptionName . '.yml';
+$frOverrideRelative = 'config/sync/language/fr/' . $exceptionName . '.yml';
+$frOverrideContent = "label: Composants\n";
+if (is_file($frOverridePath)) {
+  throw new RuntimeException('Refusing to overwrite a pre-existing #760 French exception override.');
+}
+if (file_put_contents($frOverridePath, $frOverrideContent, LOCK_EX) !== strlen($frOverrideContent)) {
+  throw new RuntimeException('Unable to create the #760 French exception override.');
+}
+$overrideData = Yaml::parseFile($frOverridePath);
+if ($overrideData !== ['label' => 'Composants']) {
+  throw new RuntimeException('The #760 French exception override is not minimal and exact.');
+}
+$items[] = [
+  'name' => $exceptionName,
+  'path' => $entry['relative_path'],
+  'classification' => 'localized_runtime_exception',
+  'before_langcode' => 'fr',
+  'after_langcode' => 'en',
+  'before_label' => 'Composants',
+  'after_label' => 'Components',
+  'fr_override_path' => $frOverrideRelative,
+  'fr_override_label' => 'Composants',
+  'text_mutation' => 'langcode_and_label_with_fr_override',
+];
+
+usort($items, static fn(array $left, array $right): int => $left['name'] <=> $right['name']);
+
+[$targetTotal, $targetDistribution] = $countRepositoryDistribution($configDirectory);
+if ($targetTotal !== 595 || $targetDistribution !== $expectedTarget) {
+  throw new RuntimeException('Issue #760 target repository distribution is not exact.');
+}
+
+$coreExtensionAfter = Yaml::parseFile($configDirectory . '/core.extension.yml');
+if (!is_array($coreExtensionAfter)
+  || isset($coreExtensionAfter['module']['config_language_lock'])
+  || is_file($configDirectory . '/config_language_lock.settings.yml')) {
+  throw new RuntimeException('Configuration Language Lock changed during #760 preparation.');
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => 'PASS',
+  'verdict' => 'FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PATCH_PREPARED',
+  'counts' => [
+    'expected' => 53,
+    'prepared' => count($items),
+    'runtime_exact_match' => 52,
+    'localized_exception' => 1,
+    'fr_overrides_created' => 1,
+    'problem_count' => 0,
+  ],
+  'baseline' => [
+    'total' => $baselineTotal,
+    'distribution' => $baselineDistribution,
+  ],
+  'target' => [
+    'total' => $targetTotal,
+    'distribution' => $targetDistribution,
+  ],
+  'cohort' => [
+    'names_sha256' => $expectedNamesHash,
+    'exact_match_names_sha256' => $expectedExactHash,
+  ],
+  'paths' => [
+    'modified_base' => array_values(array_map(
+      static fn(array $item): string => $item['path'],
+      $items,
+    )),
+    'fr_override' => $frOverrideRelative,
+    'manifest' => 'docs/evidence/configuration-language-base-field-runtime-cohort-760.yml',
+  ],
+  'items' => $items,
+  'problems' => [],
+  'constraints' => [
+    'textual_replacements_only' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_used' => FALSE,
+    'provider_secret_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/configuration-language-base-field-runtime-cohort-760-verify.php
+++ b/scripts/runner/configuration-language-base-field-runtime-cohort-760-verify.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot . '/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #760 configuration or cohort manifest is missing.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #760 cohort manifest must be a mapping.');
+}
+
+$expectedDistribution = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+$expectedException = 'core.base_field_override.canvas_page.canvas_page.components';
+$exactNames = $manifest['cohort']['exact_match_names'] ?? NULL;
+$exception = $manifest['cohort']['exception'] ?? NULL;
+if (($manifest['issue'] ?? NULL) !== 760
+  || ($manifest['cohort']['total'] ?? NULL) !== 53
+  || ($manifest['cohort']['exact_runtime_source_match'] ?? NULL) !== 52
+  || ($manifest['cohort']['review_exception'] ?? NULL) !== 1
+  || ($manifest['cohort']['unresolved'] ?? NULL) !== 0
+  || ($manifest['target']['total_config'] ?? NULL) !== 595
+  || ($manifest['target']['distribution'] ?? NULL) !== $expectedDistribution
+  || !is_array($exactNames)
+  || count($exactNames) !== 52
+  || !is_array($exception)
+  || ($exception['name'] ?? NULL) !== $expectedException) {
+  throw new RuntimeException('Issue #760 verifier contract drifted.');
+}
+foreach ($exactNames as $name) {
+  if (!is_string($name) || $name === '') {
+    throw new RuntimeException('Issue #760 verifier found an invalid cohort name.');
+  }
+}
+$allNames = [...$exactNames, $expectedException];
+sort($allNames, SORT_STRING);
+if (count($allNames) !== 53 || count(array_unique($allNames)) !== 53) {
+  throw new RuntimeException('Issue #760 verifier requires 53 unique names.');
+}
+
+$countByLangcode = static function (array $configs): array {
+  $counts = [];
+  foreach ($configs as $data) {
+    if (!is_array($data)) {
+      continue;
+    }
+    $langcode = isset($data['langcode']) && is_string($data['langcode'])
+      ? $data['langcode']
+      : '__none__';
+    $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+  }
+  ksort($counts, SORT_STRING);
+  return $counts;
+};
+
+$repositoryConfigs = [];
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate repository configuration.');
+}
+sort($baseFiles, SORT_STRING);
+foreach ($baseFiles as $path) {
+  $name = basename($path, '.yml');
+  $data = Yaml::parseFile($path);
+  if (!is_array($data)) {
+    throw new RuntimeException("Repository configuration $name is not a mapping.");
+  }
+  $repositoryConfigs[$name] = $data;
+}
+ksort($repositoryConfigs, SORT_STRING);
+
+$activeStorage = \Drupal::service('config.storage');
+if (!$activeStorage instanceof StorageInterface) {
+  throw new RuntimeException('Active configuration storage is unavailable.');
+}
+$activeConfigs = [];
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    throw new RuntimeException("Active configuration $name cannot be read.");
+  }
+  $activeConfigs[$name] = $data;
+}
+$activeEnglish = $activeStorage->createCollection('language.en');
+$activeFrench = $activeStorage->createCollection('language.fr');
+
+$repositoryDistribution = $countByLangcode($repositoryConfigs);
+$activeDistribution = $countByLangcode($activeConfigs);
+$problems = [];
+if (count($repositoryConfigs) !== 595) {
+  $problems[] = 'repository_total_not_595';
+}
+if (count($activeConfigs) !== 595) {
+  $problems[] = 'active_total_not_595';
+}
+if ($repositoryDistribution !== $expectedDistribution) {
+  $problems[] = 'repository_distribution_mismatch';
+}
+if ($activeDistribution !== $expectedDistribution) {
+  $problems[] = 'active_distribution_mismatch';
+}
+
+$coreExtension = $repositoryConfigs['core.extension'] ?? [];
+$activeCoreExtension = $activeConfigs['core.extension'] ?? [];
+if (isset($coreExtension['module']['config_language_lock'])) {
+  $problems[] = 'repository_config_language_lock_persisted';
+}
+if (isset($activeCoreExtension['module']['config_language_lock'])) {
+  $problems[] = 'active_config_language_lock_enabled';
+}
+if (\Drupal::moduleHandler()->moduleExists('config_language_lock')) {
+  $problems[] = 'runtime_config_language_lock_enabled';
+}
+if (is_file($configDirectory . '/config_language_lock.settings.yml')) {
+  $problems[] = 'config_language_lock_settings_persisted';
+}
+
+$systemSite = $repositoryConfigs['system.site'] ?? [];
+$activeSystemSite = $activeConfigs['system.site'] ?? [];
+if (($systemSite['default_langcode'] ?? NULL) !== 'fr'
+  || ($activeSystemSite['default_langcode'] ?? NULL) !== 'fr') {
+  $problems[] = 'site_default_language_not_fr';
+}
+$footerMenu = $repositoryConfigs['system.menu.footer'] ?? [];
+$activeFooterMenu = $activeConfigs['system.menu.footer'] ?? [];
+if (($footerMenu['langcode'] ?? NULL) !== 'und'
+  || ($activeFooterMenu['langcode'] ?? NULL) !== 'und') {
+  $problems[] = 'footer_menu_special_langcode_not_und';
+}
+foreach (['und', 'zxx'] as $semanticLanguage) {
+  $repositoryLanguage = $repositoryConfigs['language.entity.' . $semanticLanguage] ?? [];
+  $activeLanguage = $activeConfigs['language.entity.' . $semanticLanguage] ?? [];
+  if (($repositoryLanguage['id'] ?? NULL) !== $semanticLanguage
+    || ($activeLanguage['id'] ?? NULL) !== $semanticLanguage) {
+    $problems[] = 'semantic_language_identity_changed:' . $semanticLanguage;
+  }
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$entityFieldManager = \Drupal::service('entity_field.manager');
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (!isset($definition['translatable']) || !$definition['translatable']) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$resolveSourceValue = static function (mixed $value): array {
+  if ($value instanceof TranslatableMarkup) {
+    return [
+      'resolved' => TRUE,
+      'value' => $value->getUntranslatedString(),
+      'source_kind' => 'translatable_markup_untranslated_source',
+    ];
+  }
+  if ($value === NULL || is_scalar($value)) {
+    return [
+      'resolved' => TRUE,
+      'value' => $value,
+      'source_kind' => 'scalar_runtime_value',
+    ];
+  }
+  return [
+    'resolved' => FALSE,
+    'value' => NULL,
+    'source_kind' => get_debug_type($value),
+  ];
+};
+
+$verifiedItems = [];
+$verified = 0;
+foreach ($allNames as $name) {
+  $repositoryData = $repositoryConfigs[$name] ?? NULL;
+  $activeData = $activeConfigs[$name] ?? NULL;
+  $itemProblems = [];
+  $comparisons = [];
+
+  if (!is_array($repositoryData)) {
+    $itemProblems[] = 'repository_missing';
+  }
+  elseif (($repositoryData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'repository_langcode_not_en';
+  }
+  if (!is_array($activeData)) {
+    $itemProblems[] = 'active_missing';
+  }
+  elseif (($activeData['langcode'] ?? NULL) !== 'en') {
+    $itemProblems[] = 'active_langcode_not_en';
+  }
+  if (is_array($repositoryData) && is_array($activeData) && $repositoryData != $activeData) {
+    $itemProblems[] = 'active_repository_data_mismatch';
+  }
+
+  $repoEnPath = $configDirectory . '/language/en/' . $name . '.yml';
+  $repoFrPath = $configDirectory . '/language/fr/' . $name . '.yml';
+  if (is_file($repoEnPath) || $activeEnglish->exists($name)) {
+    $itemProblems[] = 'unexpected_en_override';
+  }
+
+  if ($name === $expectedException) {
+    if (!is_array($repositoryData) || ($repositoryData['label'] ?? NULL) !== 'Components') {
+      $itemProblems[] = 'exception_base_label_not_components';
+    }
+    $repoFr = is_file($repoFrPath) ? Yaml::parseFile($repoFrPath) : NULL;
+    $activeFr = $activeFrench->read($name);
+    if ($repoFr !== ['label' => 'Composants']) {
+      $itemProblems[] = 'exception_repository_fr_override_not_exact';
+    }
+    if ($activeFr !== ['label' => 'Composants']) {
+      $itemProblems[] = 'exception_active_fr_override_not_exact';
+    }
+  }
+  elseif (is_file($repoFrPath) || $activeFrench->exists($name)) {
+    $itemProblems[] = 'unexpected_fr_override';
+  }
+
+  if (is_array($repositoryData)) {
+    $entityTypeId = isset($repositoryData['entity_type']) && is_string($repositoryData['entity_type'])
+      ? $repositoryData['entity_type']
+      : '';
+    $fieldName = isset($repositoryData['field_name']) && is_string($repositoryData['field_name'])
+      ? $repositoryData['field_name']
+      : '';
+    if ($entityTypeId === '' || $fieldName === '') {
+      $itemProblems[] = 'override_identity_incomplete';
+    }
+    elseif (!$typedConfigManager->hasConfigSchema($name)) {
+      $itemProblems[] = 'config_schema_missing';
+    }
+    else {
+      try {
+        $typedSource = $typedConfigManager->createFromNameAndData($name, $repositoryData);
+        $allLeaves = $collectTranslatableLeaves($typedSource);
+        $materialLeaves = array_values(array_filter(
+          $allLeaves,
+          static fn(array $leaf): bool => $isMaterial($leaf['value']),
+        ));
+        usort(
+          $materialLeaves,
+          static fn(array $left, array $right): int => $left['path'] <=> $right['path'],
+        );
+        if ($materialLeaves === []) {
+          $itemProblems[] = 'no_material_translatable_source_leaves';
+        }
+
+        $baseDefinitions = $entityFieldManager->getBaseFieldDefinitions($entityTypeId);
+        $baseDefinition = $baseDefinitions[$fieldName] ?? NULL;
+        if ($baseDefinition === NULL) {
+          $itemProblems[] = 'base_field_definition_missing';
+        }
+        else {
+          $settings = $baseDefinition->getSettings();
+          foreach ($materialLeaves as $leaf) {
+            $segments = $leaf['segments'];
+            $runtimeRaw = NULL;
+            $runtimeFound = TRUE;
+            $resolver = NULL;
+            if ($segments === ['label']) {
+              $runtimeRaw = $baseDefinition->getLabel();
+              $resolver = 'base_definition.label';
+            }
+            elseif ($segments === ['description']) {
+              $runtimeRaw = $baseDefinition->getDescription();
+              $resolver = 'base_definition.description';
+            }
+            elseif (($segments[0] ?? NULL) === 'settings' && count($segments) > 1) {
+              $relativeSegments = array_slice($segments, 1);
+              $runtimeRaw = NestedArray::getValue($settings, $relativeSegments, $runtimeFound);
+              $resolver = 'base_definition.settings';
+            }
+            else {
+              $runtimeFound = FALSE;
+              $resolver = 'unsupported_typed_path';
+            }
+
+            if (!$runtimeFound) {
+              $itemProblems[] = 'runtime_source_unresolved:' . $leaf['path'];
+              $comparisons[] = [
+                'path' => $leaf['path'],
+                'config_value' => $leaf['value'],
+                'runtime_source_value' => NULL,
+                'resolver' => $resolver,
+                'resolved' => FALSE,
+                'matches' => FALSE,
+              ];
+              continue;
+            }
+
+            $resolved = $resolveSourceValue($runtimeRaw);
+            $matches = $resolved['resolved'] && $resolved['value'] === $leaf['value'];
+            if (!$matches) {
+              $itemProblems[] = 'runtime_source_mismatch:' . $leaf['path'];
+            }
+            $comparisons[] = [
+              'path' => $leaf['path'],
+              'config_value' => $leaf['value'],
+              'runtime_source_value' => $resolved['value'],
+              'resolver' => $resolver,
+              'source_kind' => $resolved['source_kind'],
+              'resolved' => $resolved['resolved'],
+              'matches' => $matches,
+            ];
+          }
+        }
+      }
+      catch (Throwable $exception) {
+        $itemProblems[] = 'runtime_verification_exception:' . $exception::class;
+      }
+    }
+  }
+
+  $itemProblems = array_values(array_unique($itemProblems));
+  if ($itemProblems === []) {
+    $verified++;
+  }
+  else {
+    foreach ($itemProblems as $problem) {
+      $problems[] = $name . ':' . $problem;
+    }
+  }
+
+  $verifiedItems[] = [
+    'name' => $name,
+    'repository_langcode' => is_array($repositoryData) ? ($repositoryData['langcode'] ?? NULL) : NULL,
+    'active_langcode' => is_array($activeData) ? ($activeData['langcode'] ?? NULL) : NULL,
+    'runtime_comparisons' => $comparisons,
+    'problems' => $itemProblems,
+  ];
+}
+
+if ($verified !== 53) {
+  $problems[] = 'verified_count_not_53';
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $problems === []
+  ? 'FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PROMOTIONS_VERIFIED'
+  : 'BASE_FIELD_RUNTIME_CANONICAL_PROMOTION_VERIFICATION_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'verified' => $verified,
+  'remaining_fr_review_required' => 69,
+  'repository_total' => count($repositoryConfigs),
+  'active_total' => count($activeConfigs),
+  'repository_distribution' => $repositoryDistribution,
+  'active_distribution' => $activeDistribution,
+  'items' => $verifiedItems,
+  'exception' => [
+    'name' => $expectedException,
+    'base_label' => $repositoryConfigs[$expectedException]['label'] ?? NULL,
+    'fr_override' => is_file($configDirectory . '/language/fr/' . $expectedException . '.yml')
+      ? Yaml::parseFile($configDirectory . '/language/fr/' . $expectedException . '.yml')
+      : NULL,
+  ],
+  'problems' => $problems,
+  'constraints' => [
+    'runtime_source_uses_untranslated_translatable_markup' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'config_language_lock_enabled_canonically' => FALSE,
+    'site_default_language' => 'fr',
+    'semantic_und_zxx_preserved' => TRUE,
+    'config_export_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;
+
+if ($status !== 'PASS') {
+  exit(1);
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #760 runtime-provenance canonical promotion tooling.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest extends TestCase {
+
+  /**
+   * The durable manifest fixes the exact 53-name identity and target state.
+   */
+  public function testManifestFixesExactCohortAndDistribution(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/docs/evidence/configuration-language-base-field-runtime-cohort-760.yml';
+    self::assertFileExists($path);
+
+    $manifest = DrupalYaml::decode((string) file_get_contents($path));
+    self::assertIsArray($manifest);
+    self::assertSame(760, $manifest['issue'] ?? NULL);
+    self::assertSame(609, $manifest['parent_issue'] ?? NULL);
+    self::assertSame(53, $manifest['cohort']['total'] ?? NULL);
+    self::assertSame(52, $manifest['cohort']['exact_runtime_source_match'] ?? NULL);
+    self::assertSame(1, $manifest['cohort']['review_exception'] ?? NULL);
+    self::assertSame(0, $manifest['cohort']['unresolved'] ?? NULL);
+
+    $exactNames = $manifest['cohort']['exact_match_names'] ?? NULL;
+    self::assertIsArray($exactNames);
+    self::assertCount(52, $exactNames);
+    self::assertCount(52, array_unique($exactNames));
+    sort($exactNames, SORT_STRING);
+
+    $exception = $manifest['cohort']['exception'] ?? NULL;
+    self::assertIsArray($exception);
+    self::assertSame(
+      'core.base_field_override.canvas_page.canvas_page.components',
+      $exception['name'] ?? NULL,
+    );
+    self::assertSame('Composants', $exception['current_config_value'] ?? NULL);
+    self::assertSame(
+      'Components',
+      $exception['runtime_untranslated_source_value'] ?? NULL,
+    );
+    self::assertSame('Components', $exception['target_base_value'] ?? NULL);
+    self::assertSame('Composants', $exception['target_fr_override_value'] ?? NULL);
+
+    $allNames = [...$exactNames, (string) $exception['name']];
+    sort($allNames, SORT_STRING);
+    self::assertCount(53, $allNames);
+    self::assertCount(53, array_unique($allNames));
+    self::assertSame(
+      '72d2e6f904c99bfd426f6ca58e2c3e7c277beb36eff62eed269a793ff5846535',
+      hash('sha256', implode("\n", $allNames) . "\n"),
+    );
+    self::assertSame(
+      'fc71d904d034fb657ce0dc6d61528d2e8e50e9ede1b838ab4d91842f821cfcbf',
+      hash('sha256', implode("\n", $exactNames) . "\n"),
+    );
+    self::assertSame([
+      '__none__' => 59,
+      'en' => 413,
+      'fr' => 122,
+      'und' => 1,
+    ], $manifest['baseline']['distribution'] ?? NULL);
+    self::assertSame([
+      '__none__' => 59,
+      'en' => 466,
+      'fr' => 69,
+      'und' => 1,
+    ], $manifest['target']['distribution'] ?? NULL);
+    self::assertFalse($manifest['constraints']['natural_language_heuristic_used'] ?? TRUE);
+    self::assertFalse($manifest['constraints']['config_export_allowed'] ?? TRUE);
+    self::assertFalse(
+      $manifest['constraints']['config_language_lock_activation_allowed'] ?? TRUE,
+    );
+  }
+
+  /**
+   * The governed route is fixed to #760 and a single bounded generated ref.
+   */
+  public function testWorkflowIsLiveMainGuardedAndBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'governed-configuration-language-base-field-runtime-cohort-760.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString('github.event.issue.number == 760', $workflow);
+    self::assertStringContainsString(
+      "'/agency-config-language-base-field-runtime migrate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$GITHUB_ACTOR" == \'E-merging-digital\' ]]',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '[[ "$EVENT_DEFAULT_SHA" == "$main_sha" ]]',
+      $workflow,
+    );
+    self::assertStringContainsString('ref: ${{ needs.validate-request.outputs.main_sha }}', $workflow);
+    self::assertStringContainsString('persist-credentials: true', $workflow);
+    self::assertSame(1, substr_count($workflow, 'contents: write'));
+    self::assertStringContainsString(
+      '.counts.runtime_base_definition_exact_match_candidate == 52',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.runtime_base_definition_review_required == 1',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.runtime_base_definition_unresolved_review_required == 0',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'core.base_field_override.canvas_page.canvas_page.components',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'feature/760-promote-base-field-runtime-cohort',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git ls-remote --exit-code --heads origin "$branch"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'git push origin "HEAD:refs/heads/$branch"',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush site:install --existing-config', $workflow);
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString("grep -Fq 'No differences'", $workflow);
+    self::assertStringContainsString(
+      '.repository_distribution == {"__none__":59,"en":466,"fr":69,"und":1}',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev exec php -l', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'php --version',
+      'drush cex',
+      'pm:enable config_language_lock',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The writer is strict, textual and refuses all unproven widening.
+   */
+  public function testWriterIsStrictTextualAndLockFree(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'apply-configuration-language-base-field-runtime-cohort-760.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("'/^langcode: fr$/m'", $script);
+    self::assertStringContainsString("'/^label: Composants$/m'", $script);
+    self::assertStringContainsString("'langcode: en'", $script);
+    self::assertStringContainsString("'label: Components'", $script);
+    self::assertStringContainsString('"label: Composants\\n"', $script);
+    self::assertStringContainsString("'runtime_exact_match'", $script);
+    self::assertStringContainsString("'localized_runtime_exception'", $script);
+    self::assertStringContainsString(
+      "'FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PATCH_PREPARED'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString("'config_export_used' => FALSE", $script);
+    self::assertStringContainsString(
+      "'config_language_lock_activation_allowed' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      'config.storage.sync',
+      '->save(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The verifier rechecks active/repository parity and untranslated runtime source.
+   */
+  public function testVerifierRechecksRuntimeAndTargetDistribution(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-base-field-runtime-cohort-760-verify.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("\\Drupal::service('config.typed')", $script);
+    self::assertStringContainsString(
+      "\\Drupal::service('entity_field.manager')",
+      $script,
+    );
+    self::assertStringContainsString('getBaseFieldDefinitions($entityTypeId)', $script);
+    self::assertStringContainsString('getUntranslatedString()', $script);
+    self::assertStringContainsString('NestedArray::getValue(', $script);
+    self::assertStringContainsString("'Components'", $script);
+    self::assertStringContainsString("['label' => 'Composants']", $script);
+    self::assertStringContainsString("'verified' => \$verified", $script);
+    self::assertStringContainsString("'remaining_fr_review_required' => 69", $script);
+    self::assertStringContainsString(
+      "'FIFTY_THREE_BASE_FIELD_RUNTIME_CANONICAL_PROMOTIONS_VERIFIED'",
+      $script,
+    );
+    self::assertStringContainsString("'semantic_und_zxx_preserved' => TRUE", $script);
+    self::assertStringContainsString(
+      "'config_language_lock_enabled_canonically' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
@@ -206,7 +206,8 @@ final class ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest extends T
   }
 
   /**
-   * The verifier rechecks active/repository parity and untranslated runtime source.
+   * The verifier rechecks active/repository parity and untranslated runtime
+   * source.
    */
   public function testVerifierRechecksRuntimeAndTargetDistribution(): void {
     $root = dirname(DRUPAL_ROOT);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest.php
@@ -206,8 +206,7 @@ final class ConfigurationLanguageBaseFieldRuntimeCohort760WorkflowTest extends T
   }
 
   /**
-   * The verifier rechecks active/repository parity and untranslated runtime
-   * source.
+   * Rechecks active/repository parity and untranslated runtime source.
    */
   public function testVerifierRechecksRuntimeAndTargetDistribution(): void {
     $root = dirname(DRUPAL_ROOT);


### PR DESCRIPTION
## Scope

Tooling-only preparation for #760, based on the proven #756 runtime provenance cohort.

This PR adds exactly:
- the frozen 53-name cohort manifest;
- a strict textual writer;
- a fresh-DDEV runtime verifier;
- the governed `/agency-config-language-base-field-runtime migrate` route;
- unit coverage for the governance contract.

## Safety boundaries

- no `config/sync` mutation in this PR;
- no `drush cex`;
- no Configuration Language Lock activation;
- no production access or provider secrets;
- generated migration branch fixed to `feature/760-promote-base-field-runtime-cohort` and existing-branch overwrite refused;
- runtime #756 provenance must replay as exactly 52 exact matches / 1 known exception / 0 unresolved before any generated migration is written.

## Target generated state

`__none__=59, en=466, fr=69, und=1, total=595`, with `system.site.default_langcode=fr` and the Canvas components French override preserved.

Refs #760 #756 #609