### PR TITLE
Issue #760: promote 53 base-field overrides to canonical EN

### DIFF
--- a/config/sync/core.base_field_override.block_content.basic.changed.yml
+++ b/config/sync/core.base_field_override.block_content.basic.changed.yml
@@ -1,5 +1,5 @@
 uuid: cf46bda0-731f-4831-abb2-427dbbd1bbe3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.block_content.basic.info.yml
+++ b/config/sync/core.base_field_override.block_content.basic.info.yml
@@ -1,5 +1,5 @@
 uuid: 08e067f6-b400-403e-abe0-73d4fa5610b0
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.block_content.basic.metatag.yml
+++ b/config/sync/core.base_field_override.block_content.basic.metatag.yml
@@ -1,5 +1,5 @@
 uuid: d523e63e-8f06-4507-b5d6-f60872a7d849
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.block_content.basic.status.yml
+++ b/config/sync/core.base_field_override.block_content.basic.status.yml
@@ -1,5 +1,5 @@
 uuid: 94cf709e-73ca-4d3b-b249-119fd1edd4cf
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.canvas_page.canvas_page.components.yml
+++ b/config/sync/core.base_field_override.canvas_page.canvas_page.components.yml
@@ -1,5 +1,5 @@
 uuid: e98ee7e3-e16e-4243-a505-f2a4a46f0049
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:
@@ -14,7 +14,7 @@ id: canvas_page.canvas_page.components
 field_name: components
 entity_type: canvas_page
 bundle: canvas_page
-label: Composants
+label: Components
 description: ''
 required: false
 translatable: true

--- a/config/sync/core.base_field_override.comment.comment.changed.yml
+++ b/config/sync/core.base_field_override.comment.comment.changed.yml
@@ -1,5 +1,5 @@
 uuid: a8a3b9fb-7104-44ae-a217-458d14dd006c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.created.yml
+++ b/config/sync/core.base_field_override.comment.comment.created.yml
@@ -1,5 +1,5 @@
 uuid: 0fda1665-be3e-41ad-ace9-81918257461f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.homepage.yml
+++ b/config/sync/core.base_field_override.comment.comment.homepage.yml
@@ -1,5 +1,5 @@
 uuid: 269a8baf-a717-46a2-808b-18d9244776fd
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.hostname.yml
+++ b/config/sync/core.base_field_override.comment.comment.hostname.yml
@@ -1,5 +1,5 @@
 uuid: 8ed3dc8d-0d93-48be-9a3b-0878ffe161d7
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.mail.yml
+++ b/config/sync/core.base_field_override.comment.comment.mail.yml
@@ -1,5 +1,5 @@
 uuid: 8feff65a-4c10-46b2-816e-9caade6b5dd8
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.name.yml
+++ b/config/sync/core.base_field_override.comment.comment.name.yml
@@ -1,5 +1,5 @@
 uuid: b96f5758-0473-4d45-af06-c0636c9b4da7
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.status.yml
+++ b/config/sync/core.base_field_override.comment.comment.status.yml
@@ -1,5 +1,5 @@
 uuid: a9f25498-eb03-4f64-b2f9-df8a2b15d950
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.subject.yml
+++ b/config/sync/core.base_field_override.comment.comment.subject.yml
@@ -1,5 +1,5 @@
 uuid: 708e3b19-7e76-43e4-89ed-1fe9fd1b2567
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.comment.comment.uid.yml
+++ b/config/sync/core.base_field_override.comment.comment.uid.yml
@@ -1,5 +1,5 @@
 uuid: 0662f16b-9552-4100-8f47-21c6cce55dd1
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,5 +1,5 @@
 uuid: 2ba42b43-191b-4055-b280-ecaabb1fe3ce
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.description.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.description.yml
@@ -1,5 +1,5 @@
 uuid: 903f4a28-e3c9-48ed-9ef7-e866f4bd4e66
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.metatag.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.metatag.yml
@@ -1,5 +1,5 @@
 uuid: cb8751d0-f7ef-4297-bdd0-547df91032c4
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.menu_link_content.menu_link_content.title.yml
+++ b/config/sync/core.base_field_override.menu_link_content.menu_link_content.title.yml
@@ -1,5 +1,5 @@
 uuid: 99e1381a-aff1-471e-9d6a-e5b3cbc5a826
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.shortcut.default.metatag.yml
+++ b/config/sync/core.base_field_override.shortcut.default.metatag.yml
@@ -1,5 +1,5 @@
 uuid: d366726f-3639-44bb-818e-61406f6047b3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.shortcut.default.title.yml
+++ b/config/sync/core.base_field_override.shortcut.default.title.yml
@@ -1,5 +1,5 @@
 uuid: 76875437-4276-49d2-ac33-3ee240f8805a
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.changed.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.changed.yml
@@ -1,5 +1,5 @@
 uuid: 04aa93f0-05fa-4b4a-a563-5088a4249a48
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.description.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.description.yml
@@ -1,5 +1,5 @@
 uuid: e24d1a29-01fc-43e4-8f09-3d4eb9f0abe1
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.metatag.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.metatag.yml
@@ -1,5 +1,5 @@
 uuid: fcec7b1c-ac33-4329-b862-3c5bd5021cc2
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.name.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.name.yml
@@ -1,5 +1,5 @@
 uuid: 680e71d6-5fde-4b6e-b81d-b2d507375e3f
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.path.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.path.yml
@@ -1,5 +1,5 @@
 uuid: dbac9617-3267-47ca-ab8c-482fdc08bc7b
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.localisation.status.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.localisation.status.yml
@@ -1,5 +1,5 @@
 uuid: 448b5b43-5a81-45f2-9195-7da83d29a1bb
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.changed.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.changed.yml
@@ -1,5 +1,5 @@
 uuid: cbaa3396-d34b-4182-95e1-f56a1b6fef94
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.description.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.description.yml
@@ -1,5 +1,5 @@
 uuid: 87c4bff2-b86d-4fe8-b909-37857ef7149a
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.metatag.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.metatag.yml
@@ -1,5 +1,5 @@
 uuid: 24450fee-b5c6-4da7-9f1a-bb1df9e9e831
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.name.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.name.yml
@@ -1,5 +1,5 @@
 uuid: f926f68e-d420-4d20-8c55-d9f71d4482d7
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.path.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.path.yml
@@ -1,5 +1,5 @@
 uuid: bf4315e4-1eb6-4d4c-8f25-4f7d32f08777
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.secteur.status.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.secteur.status.yml
@@ -1,5 +1,5 @@
 uuid: 43650592-d1c1-450a-9675-976a48491ae3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.changed.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.changed.yml
@@ -1,5 +1,5 @@
 uuid: 55b4b4ff-783e-4306-9a0b-8e6f1f2b46c0
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.description.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.description.yml
@@ -1,5 +1,5 @@
 uuid: 00e53453-1413-491c-908b-520e7cb29a27
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.metatag.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.metatag.yml
@@ -1,5 +1,5 @@
 uuid: 4019024f-5e26-4214-ac04-baa97a6f6c6b
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.name.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.name.yml
@@ -1,5 +1,5 @@
 uuid: b795de9b-ccec-4c8f-9395-0cb1d7bb87da
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.path.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.path.yml
@@ -1,5 +1,5 @@
 uuid: 04f88cc9-f42a-4167-b107-4feb14a1849d
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.tags.status.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.tags.status.yml
@@ -1,5 +1,5 @@
 uuid: 4a3654c3-dd77-457c-a586-cc08653ee093
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.changed.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.changed.yml
@@ -1,5 +1,5 @@
 uuid: a68fef5b-d49b-4e2c-88a2-a6d6461d8a48
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.description.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.description.yml
@@ -1,5 +1,5 @@
 uuid: f245a7a1-82e6-487a-b38f-3363b802f4fb
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.metatag.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.metatag.yml
@@ -1,5 +1,5 @@
 uuid: b5977fdc-3e49-4e22-b270-064ba80ac816
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.name.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.name.yml
@@ -1,5 +1,5 @@
 uuid: 29e31261-5755-4548-83e8-8b759df6b49c
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.path.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.path.yml
@@ -1,5 +1,5 @@
 uuid: 48295c66-a5aa-4fa0-bbdf-7b6f9ae8d592
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.status.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_fonctionnalite_ia.status.yml
@@ -1,5 +1,5 @@
 uuid: b2c6a0c0-bb62-4689-b180-50dff384e6ea
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.changed.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.changed.yml
@@ -1,5 +1,5 @@
 uuid: 15499a7c-404f-4b59-9d74-07706940fa36
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.description.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.description.yml
@@ -1,5 +1,5 @@
 uuid: 3eb46065-2941-41ac-8f13-14b99b3c90d0
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.metatag.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.metatag.yml
@@ -1,5 +1,5 @@
 uuid: c22541f5-6c1d-4b2e-a0f2-89569faa2d82
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.name.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.name.yml
@@ -1,5 +1,5 @@
 uuid: 34ae08c8-de9c-481a-aa86-d0e6ea844ceb
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.path.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.path.yml
@@ -1,5 +1,5 @@
 uuid: d86e04c5-939c-4834-9e58-ba7da3ff1eca
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.taxonomy_term.type_service.status.yml
+++ b/config/sync/core.base_field_override.taxonomy_term.type_service.status.yml
@@ -1,5 +1,5 @@
 uuid: 79fcdcee-e92c-4a62-9702-b7483cacdc97
-langcode: fr
+langcode: en
 status: true
 dependencies:
   config:

--- a/config/sync/core.base_field_override.user.user.changed.yml
+++ b/config/sync/core.base_field_override.user.user.changed.yml
@@ -1,5 +1,5 @@
 uuid: d2b327ea-79a2-48a4-8bbc-bed60bfde4b9
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.user.user.metatag.yml
+++ b/config/sync/core.base_field_override.user.user.metatag.yml
@@ -1,5 +1,5 @@
 uuid: eabdb27d-01b3-4d4c-94e4-00f24c14d6cc
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/core.base_field_override.user.user.path.yml
+++ b/config/sync/core.base_field_override.user.user.path.yml
@@ -1,5 +1,5 @@
 uuid: 0ac9065f-0e39-4dc4-a63b-501ff2c7dde5
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/language/fr/core.base_field_override.canvas_page.canvas_page.components.yml
+++ b/config/sync/language/fr/core.base_field_override.canvas_page.canvas_page.components.yml
@@ -1,0 +1,1 @@
+label: Composants

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
@@ -78,7 +78,7 @@ final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
   }
 
   /**
-   * Repository-wide language distribution reflects only the 17 promotions.
+   * Repository-wide distribution reflects later governed promotions.
    */
   public function testRepositoryDistributionAfterPromotion(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -99,8 +99,8 @@ final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
 
     self::assertSame([
       '__none__' => 59,
-      'en' => 413,
-      'fr' => 122,
+      'en' => 466,
+      'fr' => 69,
       'und' => 1,
     ], $counts);
 


### PR DESCRIPTION
## Scope

Canonical migration generated by the governed #760 writer from trusted `main@6e76d6cbf97e5e9a4661d0baa7b10d1a4fb3bf3c`, followed by one bounded CI guardrail maintenance commit.

Generated commit `7db862eed2f251d96f7f2ffe4a4f1940127314a3` remains intact and contains exactly:
- 52 exact runtime-source matches: `langcode: fr -> en` only;
- `core.base_field_override.canvas_page.canvas_page.components`: `langcode: fr -> en` and `label: Composants -> Components`;
- one French override added with exactly `label: Composants`.

The second commit `39ec39b8d8fc96acd76772c50a06b89ab05e9603` changes no configuration. It only advances the historical #754 repository-wide distribution guardrail from the previous proven state `en=413 / fr=122` to the #760 target `en=466 / fr=69`, after CI #1372 showed that stale expectation as the sole failure.

## Proven generated state

- writer run: `32714674436`;
- writer: PASS;
- fresh-DDEV verification: PASS;
- runtime exact-match: 52;
- localized exception: 1;
- target distribution: `__none__=59, en=466, fr=69, und=1`, total 595;
- artifact: `agency-config-language-base-field-runtime-cohort-760-32714674436-1`.

## Safety boundaries

The generated configuration patch remains exactly 53 base files plus the single FR override. The follow-up commit is test-only. No `cex`, no Configuration Language Lock activation, no production access and no provider secret.

Refs #760 #756 #754 #609