### PR TITLE
Issue #764: classify the 69 remaining FR configs by provenance

### DIFF
--- a/.github/workflows/trusted-configuration-language-remaining-fr-provenance-764.yml
+++ b/.github/workflows/trusted-configuration-language-remaining-fr-provenance-764.yml
@@ -1,0 +1,265 @@
+name: Agency trusted remaining-FR configuration provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #764 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 764 &&
+        github.event.comment.body == '/agency-config-language-remaining-fr classify-provenance'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '764'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-remaining-fr classify-provenance'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/764" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  classify:
+    name: Classify exact 69 remaining FR configs in fresh DDEV
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      exact_default: ${{ steps.classify.outputs.exact_default }}
+      diverged_default: ${{ steps.classify.outputs.diverged_default }}
+      runtime_source: ${{ steps.classify.outputs.runtime_source }}
+      custom_review: ${{ steps.classify.outputs.custom_review }}
+      unresolved: ${{ steps.classify.outputs.unresolved }}
+      verdict: ${{ steps.classify.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #764 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            docs/evidence/configuration-language-remaining-fr-provenance-cohort-764.yml
+          test -f \
+            scripts/runner/configuration-language-remaining-fr-provenance-764.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-remaining-fr-764.yaml <<EOF_CONFIG
+          name: agency-config-remaining-fr-764-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-remaining-fr-764-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-remaining-fr-764'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-remaining-fr-provenance-764.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Classify bounded remaining-FR provenance
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-remaining-fr-764'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-remaining-fr-provenance-764.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "REMAINING_FR_PROVENANCE_CLASSIFIED"' "$result" \
+            >/dev/null
+          jq -e '.counts.candidate_total == 69' "$result" >/dev/null
+          jq -e '.counts.classified == 69' "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.schema_or_provenance_unresolved == 0' "$result" \
+            >/dev/null
+          jq -e '.focus.canvas_component.count == 30' "$result" >/dev/null
+          jq -e '.focus.canvas_folder.count == 13' "$result" >/dev/null
+          jq -e '.focus.other.count == 26' "$result" >/dev/null
+          jq -e '.baseline.repository_total == 595' "$result" >/dev/null
+          jq -e '.baseline.active_total == 595' "$result" >/dev/null
+          jq -e \
+            '.baseline.repository_distribution == {"__none__":59,"en":466,"fr":69,"und":1}' \
+            "$result" >/dev/null
+          jq -e \
+            '.baseline.active_distribution == {"__none__":59,"en":466,"fr":69,"und":1}' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_proof == false' \
+            "$result" >/dev/null
+          jq -e \
+            '.constraints.config_language_lock_enabled_canonically == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "exact_default=$(jq -r '.counts.english_default_exact_match' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "diverged_default=$(jq -r '.counts.extension_default_present_but_values_diverged' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "runtime_source=$(jq -r '.counts.runtime_source_candidate' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "custom_review=$(jq -r '.counts.project_custom_or_editorial_review_required' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "unresolved=$(jq -r '.counts.schema_or_provenance_unresolved' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #764 provenance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-remaining-fr-764-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-remaining-fr-764
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-remaining-fr-764-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-remaining-fr-764.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-remaining-fr-764
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #764 provenance verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - classify
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          EXACT_DEFAULT: ${{ needs.classify.outputs.exact_default }}
+          DIVERGED_DEFAULT: ${{ needs.classify.outputs.diverged_default }}
+          RUNTIME_SOURCE: ${{ needs.classify.outputs.runtime_source }}
+          CUSTOM_REVIEW: ${{ needs.classify.outputs.custom_review }}
+          UNRESOLVED: ${{ needs.classify.outputs.unresolved }}
+          MACHINE_VERDICT: ${{ needs.classify.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CLASSIFY_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 764 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Remaining-FR provenance classification ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CLASSIFY_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`69\`
+          english_default_exact_match: \`${EXACT_DEFAULT:-n/a}\`
+          extension_default_present_but_values_diverged: \`${DIVERGED_DEFAULT:-n/a}\`
+          runtime_source_candidate: \`${RUNTIME_SOURCE:-n/a}\`
+          project_custom_or_editorial_review_required: \`${CUSTOM_REVIEW:-n/a}\`
+          schema_or_provenance_unresolved: \`${UNRESOLVED:-n/a}\`
+          expected_distribution: \`__none__=59, en=466, fr=69, und=1\`
+          artifact: \`agency-config-language-remaining-fr-764-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Read-only fresh-DDEV proof. No migration, config export, Configuration Language Lock activation, production access, provider secret or repository mutation is permitted.
+          EOF_BODY
+          )"
+          test "$CLASSIFY_RESULT" = 'success'

--- a/docs/evidence/configuration-language-remaining-fr-provenance-cohort-764.yml
+++ b/docs/evidence/configuration-language-remaining-fr-provenance-cohort-764.yml
@@ -1,0 +1,114 @@
+schema_version: 1
+issue: 764
+parent_issue: 609
+source:
+  issue: 748
+  run_id: 32706400681
+  artifact_id: 9512525119
+  artifact_name: agency-config-language-review-provenance-748-32706400681-1
+  artifact_digest: sha256:54a02cb5bd9d24d0264e3a8b329817c943dd0cc507d01b39c13183d497c7cce0
+  source_classification: material_review_required
+  excluded_resolved_prefix: core.base_field_override.
+baseline:
+  trusted_main: a7c26c1817195b5f8f213a26633ceca11c305bff
+  total_config: 595
+  distribution:
+    __none__: 59
+    en: 466
+    fr: 69
+    und: 1
+cohort:
+  total: 69
+  names_sha256: 3386c99b57a7c3de9191107664e51ca80336e1d40557b717be8faf7b3c9c7a07
+  groups:
+    canvas_component: 30
+    canvas_folder: 13
+    media_type: 5
+    field_field: 4
+    system_action: 4
+    ai_automator: 2
+    block: 2
+    node_type: 2
+    pathauto_pattern: 2
+    view: 2
+    image_style: 1
+    language_entity: 1
+    system_site: 1
+  names:
+    - ai_automators.ai_automator.node.article.field_feature_image.default
+    - ai_automators.ai_automator.node.article.field_short_description.default
+    - block.block.emerging_digital_chatbot_widget
+    - block.block.emerging_digital_languagedropdownswitchercontent
+    - canvas.component.block.announce_block
+    - canvas.component.block.emerging_digital_language_switcher
+    - canvas.component.block.help_block
+    - canvas.component.block.language_block.language_content
+    - canvas.component.block.language_block.language_interface
+    - canvas.component.block.local_actions_block
+    - canvas.component.block.local_tasks_block
+    - canvas.component.block.page_title_block
+    - canvas.component.block.shortcuts
+    - canvas.component.block.system_branding_block
+    - canvas.component.block.system_breadcrumb_block
+    - canvas.component.block.system_clear_cache_block
+    - canvas.component.block.system_menu_block.account
+    - canvas.component.block.system_menu_block.admin
+    - canvas.component.block.system_menu_block.footer
+    - canvas.component.block.system_menu_block.main
+    - canvas.component.block.system_menu_block.online-presence
+    - canvas.component.block.system_menu_block.tools
+    - canvas.component.block.system_messages_block
+    - canvas.component.block.system_powered_by_block
+    - canvas.component.block.user_login_block
+    - canvas.component.block.views_block.comments_recent-block_1
+    - canvas.component.block.views_block.content_recent-block_1
+    - canvas.component.block.views_block.who_s_new-block_1
+    - canvas.component.block.views_block.who_s_online-who_s_online_block
+    - canvas.component.block.webform_block
+    - canvas.component.sdc.emerging_digital.cta
+    - canvas.component.sdc.emerging_digital.hero
+    - canvas.component.sdc.emerging_digital.trust-list
+    - canvas.component.sdc.olivero.teaser
+    - canvas.folder.03defdd3-dea9-425d-9c90-46b02bc37817
+    - canvas.folder.0d5d5129-0d2e-41f3-a6d5-0211018bd59f
+    - canvas.folder.1e12db1e-d732-42bb-bcab-cb8a17035f75
+    - canvas.folder.3ada2cbb-43cc-46cb-993a-6d5a6b41d4d6
+    - canvas.folder.4da10d5f-e7eb-40fe-a3c5-a74f580fd5d0
+    - canvas.folder.614ea4f1-16fc-4c8e-8588-9beee8d7c77e
+    - canvas.folder.674648e0-ab48-4005-8544-eb3cda63e8c0
+    - canvas.folder.809a63d3-9eca-447d-8fe3-a854ff8084cb
+    - canvas.folder.a1893971-0c01-42f6-88d1-9d0bfaa392b5
+    - canvas.folder.cdf409dd-7bb8-4668-b2eb-2fa771bcab33
+    - canvas.folder.cf2cc6af-a4b8-41db-80f3-98252aac22a7
+    - canvas.folder.d089a30d-c78f-46ea-9fbb-7aee85564e8b
+    - canvas.folder.fbb161e9-0cca-4f81-99e4-34522e274752
+    - field.field.media.audio.field_media_audio_file
+    - field.field.media.remote_video.field_media_oembed_video
+    - field.field.media.video.field_media_video_file
+    - field.field.node.article.ai_automator_status
+    - image.style.media_library
+    - language.entity.fr
+    - media.type.audio
+    - media.type.document
+    - media.type.image
+    - media.type.remote_video
+    - media.type.video
+    - node.type.article
+    - node.type.page
+    - pathauto.pattern.content_path_pattern_article
+    - pathauto.pattern.content_path_pattern_article_en
+    - system.action.media_delete_action
+    - system.action.media_publish_action
+    - system.action.media_save_action
+    - system.action.media_unpublish_action
+    - system.site
+    - views.view.media
+    - views.view.media_library
+constraints:
+  read_only: true
+  migration_allowed: false
+  config_export_allowed: false
+  config_language_lock_activation_allowed: false
+  production_access_allowed: false
+  provider_secret_allowed: false
+  natural_language_heuristic_used: false

--- a/scripts/runner/configuration-language-remaining-fr-provenance-764.php
+++ b/scripts/runner/configuration-language-remaining-fr-provenance-764.php
@@ -1,0 +1,562 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/'
+  . 'configuration-language-remaining-fr-provenance-cohort-764.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #764 provenance baseline is incomplete.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #764 manifest must be a mapping.');
+}
+if (($manifest['issue'] ?? NULL) !== 764) {
+  throw new RuntimeException('Issue #764 manifest identity mismatch.');
+}
+if (($manifest['parent_issue'] ?? NULL) !== 609) {
+  throw new RuntimeException('Issue #764 parent identity mismatch.');
+}
+if (($manifest['cohort']['total'] ?? NULL) !== 69) {
+  throw new RuntimeException('Issue #764 cohort must contain 69 names.');
+}
+
+$manifestNames = $manifest['cohort']['names'] ?? NULL;
+if (!is_array($manifestNames) || count($manifestNames) !== 69) {
+  throw new RuntimeException('Issue #764 manifest names are incomplete.');
+}
+$manifestNames = array_values(array_map('strval', $manifestNames));
+sort($manifestNames, SORT_STRING);
+if (count(array_unique($manifestNames)) !== 69) {
+  throw new RuntimeException('Issue #764 manifest names must be unique.');
+}
+
+$manifestHash = hash(
+  'sha256',
+  implode("\n", $manifestNames) . "\n",
+);
+$expectedHash = $manifest['cohort']['names_sha256'] ?? NULL;
+if ($manifestHash !== $expectedHash) {
+  throw new RuntimeException('Issue #764 manifest names hash mismatch.');
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$configFactory = \Drupal::service('config.factory');
+$activeStorage = \Drupal::service('config.storage');
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach (
+        $collectTranslatableLeaves($child, [...$segments, $key])
+        as $leaf
+      ) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (empty($definition['translatable'])) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$baseFiles = glob($configDirectory . '/*.yml');
+if ($baseFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate base configuration.');
+}
+sort($baseFiles, SORT_STRING);
+
+$repositoryDistribution = [
+  '__none__' => 0,
+  'en' => 0,
+  'fr' => 0,
+  'und' => 0,
+];
+$repositoryDataByName = [];
+$repositoryFrNames = [];
+foreach ($baseFiles as $basePath) {
+  $data = Yaml::parseFile($basePath);
+  if (!is_array($data)) {
+    throw new RuntimeException("Invalid configuration YAML: $basePath");
+  }
+  $name = basename($basePath, '.yml');
+  $repositoryDataByName[$name] = $data;
+  $langcode = $data['langcode'] ?? NULL;
+  $key = is_string($langcode) ? $langcode : '__none__';
+  if (!array_key_exists($key, $repositoryDistribution)) {
+    $repositoryDistribution[$key] = 0;
+  }
+  $repositoryDistribution[$key]++;
+  if ($langcode === 'fr') {
+    $repositoryFrNames[] = $name;
+  }
+}
+ksort($repositoryDistribution, SORT_STRING);
+sort($repositoryFrNames, SORT_STRING);
+
+$expectedDistribution = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+ksort($expectedDistribution, SORT_STRING);
+
+$baselineProblems = [];
+if (count($baseFiles) !== 595) {
+  $baselineProblems[] = [
+    'reason' => 'repository_total_mismatch',
+    'actual' => count($baseFiles),
+    'expected' => 595,
+  ];
+}
+if ($repositoryDistribution !== $expectedDistribution) {
+  $baselineProblems[] = [
+    'reason' => 'repository_distribution_mismatch',
+    'actual' => $repositoryDistribution,
+    'expected' => $expectedDistribution,
+  ];
+}
+if ($repositoryFrNames !== $manifestNames) {
+  $baselineProblems[] = [
+    'reason' => 'remaining_fr_name_set_mismatch',
+    'missing' => array_values(array_diff($manifestNames, $repositoryFrNames)),
+    'unexpected' => array_values(array_diff(
+      $repositoryFrNames,
+      $manifestNames,
+    )),
+  ];
+}
+
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+$activeDistribution = [
+  '__none__' => 0,
+  'en' => 0,
+  'fr' => 0,
+  'und' => 0,
+];
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_config_unreadable',
+    ];
+    continue;
+  }
+  $langcode = $data['langcode'] ?? NULL;
+  $key = is_string($langcode) ? $langcode : '__none__';
+  if (!array_key_exists($key, $activeDistribution)) {
+    $activeDistribution[$key] = 0;
+  }
+  $activeDistribution[$key]++;
+}
+ksort($activeDistribution, SORT_STRING);
+if (count($activeNames) !== 595) {
+  $baselineProblems[] = [
+    'reason' => 'active_total_mismatch',
+    'actual' => count($activeNames),
+    'expected' => 595,
+  ];
+}
+if ($activeDistribution !== $expectedDistribution) {
+  $baselineProblems[] = [
+    'reason' => 'active_distribution_mismatch',
+    'actual' => $activeDistribution,
+    'expected' => $expectedDistribution,
+  ];
+}
+
+$candidateNames = array_fill_keys($manifestNames, TRUE);
+$defaultIndex = [];
+$extensionServices = [
+  'module' => 'extension.list.module',
+  'theme' => 'extension.list.theme',
+  'profile' => 'extension.list.profile',
+];
+foreach ($extensionServices as $extensionType => $serviceId) {
+  $extensionList = \Drupal::service($serviceId);
+  foreach ($extensionList->getList() as $extensionName => $extension) {
+    $extensionRoot = DRUPAL_ROOT . '/' . $extension->getPath();
+    foreach (['install', 'optional'] as $directoryKind) {
+      $directory = $extensionRoot . '/config/' . $directoryKind;
+      if (!is_dir($directory)) {
+        continue;
+      }
+      $files = glob($directory . '/*.yml');
+      if ($files === FALSE) {
+        throw new RuntimeException("Unable to enumerate $directory.");
+      }
+      sort($files, SORT_STRING);
+      foreach ($files as $path) {
+        $name = basename($path, '.yml');
+        if (!isset($candidateNames[$name])) {
+          continue;
+        }
+        $data = Yaml::parseFile($path);
+        if (!is_array($data)) {
+          continue;
+        }
+        $langcode = isset($data['langcode'])
+          && is_string($data['langcode'])
+            ? $data['langcode']
+            : NULL;
+        if (!in_array($langcode, ['en', NULL], TRUE)) {
+          continue;
+        }
+        $defaultIndex[$name][] = [
+          'extension_type' => $extensionType,
+          'extension' => $extensionName,
+          'directory' => $directoryKind,
+          'path' => ltrim(str_replace($projectRoot, '', $path), '/'),
+          'langcode' => $langcode,
+          'data' => $data,
+        ];
+      }
+    }
+  }
+}
+ksort($defaultIndex, SORT_STRING);
+
+$items = [];
+foreach ($manifestNames as $name) {
+  $repositoryData = $repositoryDataByName[$name] ?? NULL;
+  if (!is_array($repositoryData)) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'repository_config_missing',
+    ];
+    continue;
+  }
+  if (($repositoryData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'repository_langcode_not_fr',
+    ];
+    continue;
+  }
+  if (is_file($configDirectory . '/language/en/' . $name . '.yml')) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'unexpected_en_override',
+    ];
+    continue;
+  }
+
+  $activeConfig = $configFactory->getEditable($name);
+  $activeData = $activeConfig->get();
+  if ($activeConfig->isNew()) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_config_missing',
+    ];
+    continue;
+  }
+  if ($activeData !== $repositoryData) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_repository_data_mismatch',
+    ];
+    continue;
+  }
+
+  if (!$typedConfigManager->hasConfigSchema($name)) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_or_provenance_unresolved',
+      'reason' => 'config_schema_missing',
+      'material_translatable_leaves' => [],
+      'english_defaults' => [],
+    ];
+    continue;
+  }
+
+  try {
+    $typedSource = $typedConfigManager->createFromNameAndData(
+      $name,
+      $activeData,
+    );
+    $allLeaves = $collectTranslatableLeaves($typedSource);
+  }
+  catch (Throwable $exception) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_or_provenance_unresolved',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+      'material_translatable_leaves' => [],
+      'english_defaults' => [],
+    ];
+    continue;
+  }
+
+  $materialLeaves = [];
+  foreach ($allLeaves as $leaf) {
+    if (!$isMaterial($leaf['value'])) {
+      continue;
+    }
+    $materialLeaves[] = $leaf;
+  }
+  usort(
+    $materialLeaves,
+    static fn(array $left, array $right): int =>
+      $left['path'] <=> $right['path'],
+  );
+
+  if ($materialLeaves === []) {
+    $items[] = [
+      'name' => $name,
+      'classification' => 'schema_or_provenance_unresolved',
+      'reason' => 'historical_material_source_disappeared',
+      'material_translatable_leaves' => [],
+      'english_defaults' => [],
+    ];
+    continue;
+  }
+
+  $englishDefaults = [];
+  $exactDefaults = [];
+  foreach ($defaultIndex[$name] ?? [] as $default) {
+    $divergences = [];
+    foreach ($materialLeaves as $leaf) {
+      $exists = FALSE;
+      $defaultValue = NestedArray::getValue(
+        $default['data'],
+        $leaf['segments'],
+        $exists,
+      );
+      if (!$exists || $defaultValue !== $leaf['value']) {
+        $divergences[] = [
+          'path' => $leaf['path'],
+          'repository_value' => $leaf['value'],
+          'default_value_present' => $exists,
+          'default_value' => $exists ? $defaultValue : NULL,
+        ];
+      }
+    }
+    $summary = [
+      'extension_type' => $default['extension_type'],
+      'extension' => $default['extension'],
+      'directory' => $default['directory'],
+      'path' => $default['path'],
+      'langcode' => $default['langcode'],
+      'divergences' => $divergences,
+    ];
+    $englishDefaults[] = $summary;
+    if ($divergences === []) {
+      $exactDefaults[] = $summary;
+    }
+  }
+
+  $runtimeSource = NULL;
+  if (str_starts_with($name, 'canvas.component.')) {
+    $source = $repositoryData['source'] ?? NULL;
+    $sourceLocalId = $repositoryData['source_local_id'] ?? NULL;
+    $provider = $repositoryData['provider'] ?? NULL;
+    if (
+      is_string($source)
+      && $source !== ''
+      && is_string($sourceLocalId)
+      && $sourceLocalId !== ''
+      && is_string($provider)
+      && $provider !== ''
+    ) {
+      $runtimeSource = [
+        'source' => $source,
+        'source_local_id' => $sourceLocalId,
+        'provider' => $provider,
+      ];
+    }
+  }
+
+  if ($exactDefaults !== []) {
+    $classification = 'english_default_exact_match';
+    $reason = 'all_material_leaves_match_extension_default';
+  }
+  elseif ($englishDefaults !== []) {
+    $classification = 'extension_default_present_but_values_diverged';
+    $reason = 'extension_default_exists_but_material_leaves_diverge';
+  }
+  elseif ($runtimeSource !== NULL) {
+    $classification = 'runtime_source_candidate';
+    $reason = 'canvas_component_exposes_explicit_runtime_source_reference';
+  }
+  else {
+    $classification = 'project_custom_or_editorial_review_required';
+    $reason = 'no_authoritative_english_default_or_runtime_reference_proven';
+  }
+
+  $evidenceLeaves = array_map(
+    static fn(array $leaf): array => [
+      'path' => $leaf['path'],
+      'value' => $leaf['value'],
+    ],
+    $materialLeaves,
+  );
+
+  $items[] = [
+    'name' => $name,
+    'classification' => $classification,
+    'reason' => $reason,
+    'material_translatable_leaf_count' => count($materialLeaves),
+    'material_translatable_leaves' => $evidenceLeaves,
+    'english_defaults' => $englishDefaults,
+    'runtime_source' => $runtimeSource,
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int => $left['name'] <=> $right['name'],
+);
+
+$classifications = [
+  'english_default_exact_match',
+  'extension_default_present_but_values_diverged',
+  'runtime_source_candidate',
+  'project_custom_or_editorial_review_required',
+  'schema_or_provenance_unresolved',
+];
+$counts = [
+  'candidate_total' => 69,
+  'classified' => count($items),
+  'baseline_problem' => count($baselineProblems),
+];
+$namesByClassification = [];
+foreach ($classifications as $classification) {
+  $counts[$classification] = 0;
+  $namesByClassification[$classification] = [];
+}
+foreach ($items as $item) {
+  $classification = (string) $item['classification'];
+  $counts[$classification]++;
+  $namesByClassification[$classification][] = $item['name'];
+}
+
+$focus = [
+  'canvas_component' => [],
+  'canvas_folder' => [],
+  'other' => [],
+];
+foreach ($items as $item) {
+  $name = (string) $item['name'];
+  if (str_starts_with($name, 'canvas.component.')) {
+    $focus['canvas_component'][] = $name;
+  }
+  elseif (str_starts_with($name, 'canvas.folder.')) {
+    $focus['canvas_folder'][] = $name;
+  }
+  else {
+    $focus['other'][] = $name;
+  }
+}
+foreach ($focus as $key => $names) {
+  sort($names, SORT_STRING);
+  $focus[$key] = [
+    'count' => count($names),
+    'names' => $names,
+  ];
+}
+
+$lockEnabled = is_file($configDirectory . '/config_language_lock.settings.yml')
+  || str_contains(
+    (string) file_get_contents($configDirectory . '/core.extension.yml'),
+    "  config_language_lock:",
+  );
+
+$status = 'PASS';
+$verdict = 'REMAINING_FR_PROVENANCE_CLASSIFIED';
+if (
+  $baselineProblems !== []
+  || count($items) !== 69
+  || $counts['schema_or_provenance_unresolved'] !== 0
+  || $focus['canvas_component']['count'] !== 30
+  || $focus['canvas_folder']['count'] !== 13
+  || $focus['other']['count'] !== 26
+  || $lockEnabled
+) {
+  $status = 'FAIL';
+  $verdict = 'REMAINING_FR_PROVENANCE_CLASSIFICATION_FAILED';
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'baseline' => [
+    'manifest' => basename($manifestPath),
+    'manifest_names_sha256' => $manifestHash,
+    'repository_total' => count($baseFiles),
+    'active_total' => count($activeNames),
+    'repository_distribution' => $repositoryDistribution,
+    'active_distribution' => $activeDistribution,
+  ],
+  'counts' => $counts,
+  'focus' => $focus,
+  'names_by_classification' => $namesByClassification,
+  'baseline_problems' => $baselineProblems,
+  'items' => $items,
+  'constraints' => [
+    'read_only' => TRUE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'config_language_lock_enabled_canonically' => $lockEnabled,
+    'config_language_lock_activation_allowed_by_this_proof' => FALSE,
+    'config_export_allowed_by_this_proof' => FALSE,
+    'production_access_allowed_by_this_proof' => FALSE,
+    'provider_secret_allowed_by_this_proof' => FALSE,
+    'natural_language_heuristic_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageRemainingFrProvenance764Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageRemainingFrProvenance764Test.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #764 remaining-FR provenance proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageRemainingFrProvenance764Test extends TestCase {
+
+  /**
+   * The manifest fixes the exact 69-name cohort and baseline distribution.
+   */
+  public function testManifestFixesExactRemainingCohort(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/docs/evidence/'
+      . 'configuration-language-remaining-fr-provenance-cohort-764.yml';
+    self::assertFileExists($path);
+
+    $manifest = DrupalYaml::decode((string) file_get_contents($path));
+    self::assertIsArray($manifest);
+    self::assertSame(764, $manifest['issue'] ?? NULL);
+    self::assertSame(609, $manifest['parent_issue'] ?? NULL);
+    self::assertSame(69, $manifest['cohort']['total'] ?? NULL);
+    self::assertSame([
+      '__none__' => 59,
+      'en' => 466,
+      'fr' => 69,
+      'und' => 1,
+    ], $manifest['baseline']['distribution'] ?? NULL);
+
+    $names = $manifest['cohort']['names'] ?? NULL;
+    self::assertIsArray($names);
+    self::assertCount(69, $names);
+    self::assertCount(69, array_unique($names));
+    sort($names, SORT_STRING);
+    self::assertSame(
+      '3386c99b57a7c3de9191107664e51ca80336e1d40557b717be8faf7b3c9c7a07',
+      hash('sha256', implode("\n", $names) . "\n"),
+    );
+    self::assertSame(
+      30,
+      $manifest['cohort']['groups']['canvas_component'] ?? NULL,
+    );
+    self::assertSame(
+      13,
+      $manifest['cohort']['groups']['canvas_folder'] ?? NULL,
+    );
+    self::assertFalse($manifest['constraints']['migration_allowed'] ?? TRUE);
+    self::assertFalse(
+      $manifest['constraints']['natural_language_heuristic_used'] ?? TRUE,
+    );
+  }
+
+  /**
+   * The analyzer is read-only, typed-config based and fail-closed.
+   */
+  public function testAnalyzerUsesBoundedAuthoritativeProvenance(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-remaining-fr-provenance-764.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      "\\Drupal::service('config.typed')",
+      $script,
+    );
+    self::assertStringContainsString(
+      "\\Drupal::service('config.storage')",
+      $script,
+    );
+    self::assertStringContainsString('extension.list.module', $script);
+    self::assertStringContainsString('extension.list.theme', $script);
+    self::assertStringContainsString('extension.list.profile', $script);
+    self::assertStringContainsString('runtime_source_candidate', $script);
+    self::assertStringContainsString(
+      'canvas_component_exposes_explicit_runtime_source_reference',
+      $script,
+    );
+    self::assertStringContainsString(
+      'extension_default_present_but_values_diverged',
+      $script,
+    );
+    self::assertStringContainsString(
+      'project_custom_or_editorial_review_required',
+      $script,
+    );
+    self::assertStringContainsString(
+      'schema_or_provenance_unresolved',
+      $script,
+    );
+    self::assertStringContainsString(
+      'REMAINING_FR_PROVENANCE_CLASSIFIED',
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route is owner-only, live-main-only and runner read-only.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-remaining-fr-provenance-764.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 764',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-remaining-fr classify-provenance'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      "grep -Fq 'No differences'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'REMAINING_FR_PROVENANCE_CLASSIFIED',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.focus.canvas_component.count == 30',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.focus.canvas_folder.count == 13',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '"__none__":59,"en":466,"fr":69,"und":1',
+      $workflow,
+    );
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Read-only tooling for #764, based on the trusted #748 cohort after subtracting the 53 `core.base_field_override.*` resolved by #756/#760.

This PR adds only:
- a durable exact-name manifest for the remaining 69 FR bases;
- a typed-config/provenance analyzer;
- an owner-only/live-main-only trusted fresh-DDEV route;
- contract tests.

## Baseline fixed by the manifest

- trusted starting main: `a7c26c1817195b5f8f213a26633ceca11c305bff`;
- total config: 595;
- distribution: `__none__=59, en=466, fr=69, und=1`;
- exact remaining-name SHA-256: `3386c99b57a7c3de9191107664e51ca80336e1d40557b717be8faf7b3c9c7a07`;
- focus: 30 Canvas components, 13 Canvas folders, 26 other configs.

## Classification contract

For every one of the 69 names the analyzer inventories material translatable leaves via `config.typed`, reuses extension/profile defaults, and emits one of:
- `english_default_exact_match`;
- `extension_default_present_but_values_diverged`;
- `runtime_source_candidate` only when a Canvas component exposes explicit `source`, `source_local_id` and `provider` references;
- `project_custom_or_editorial_review_required`;
- `schema_or_provenance_unresolved` (fail-closed).

No migration is authorized by this proof.

## Safety

No `config/sync` mutation, no `cex`, no Configuration Language Lock activation, no production access, no provider secret, no natural-language heuristic. The self-hosted job uses `contents: read` and `persist-credentials: false`; only the hosted report job can write the terminal issue comment.

Refs #764 #609 #748 #756 #760