### PR TITLE
Issue #766: map native Canvas runtime source APIs

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-runtime-source-api-766.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-runtime-source-api-766.yml
@@ -1,0 +1,250 @@
+name: Agency trusted Canvas runtime source API proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #766 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 766 &&
+        github.event.comment.body == '/agency-config-language-canvas-runtime-api map'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '766'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-canvas-runtime-api map'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/766" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  map-runtime-api:
+    name: Map exact 30 Canvas runtime source APIs in fresh DDEV
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      source_class_count: ${{ steps.map.outputs.source_class_count }}
+      manager_available: ${{ steps.map.outputs.manager_available }}
+      verdict: ${{ steps.map.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #766 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            docs/evidence/configuration-language-canvas-runtime-source-api-cohort-766.yml
+          test -f \
+            scripts/runner/configuration-language-canvas-runtime-source-api-766.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-runtime-api-766.yaml <<EOF_CONFIG
+          name: agency-config-canvas-api-766-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-api-766-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-runtime-api-766'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-canvas-runtime-source-api-766.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Map bounded Canvas runtime source API
+        id: map
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-runtime-api-766'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-runtime-source-api-766.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "CANVAS_RUNTIME_SOURCE_API_MAPPED"' "$result" \
+            >/dev/null
+          jq -e '.runtime.canvas_version == "1.10.1"' "$result" >/dev/null
+          jq -e '.counts.candidate_total == 30' "$result" >/dev/null
+          jq -e '.counts.mapped == 30' "$result" >/dev/null
+          jq -e '.counts.block == 26' "$result" >/dev/null
+          jq -e '.counts.sdc == 4' "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e '.runtime.component_entity_api.config_prefix == "canvas.component"' \
+            "$result" >/dev/null
+          jq -e \
+            '.runtime.manager_api.component_source_manager.class_available == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_proof == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_creation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "source_class_count=$(jq -r '.counts.source_class_count' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "manager_available=$(jq -r '.runtime.manager_api.component_source_manager.class_available' "$result")" \
+            >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #766 runtime API evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-runtime-api-766-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-runtime-api-766
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-api-766-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-runtime-api-766.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-canvas-runtime-api-766
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #766 runtime API verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - map-runtime-api
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          MAP_RESULT: ${{ needs.map-runtime-api.result }}
+          SOURCE_CLASS_COUNT: ${{ needs.map-runtime-api.outputs.source_class_count }}
+          MANAGER_AVAILABLE: ${{ needs.map-runtime-api.outputs.manager_available }}
+          MACHINE_VERDICT: ${{ needs.map-runtime-api.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$MAP_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 766 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Canvas runtime source API proof ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${MAP_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`30\`
+          source_kinds: \`block=26, sdc=4\`
+          source_class_count: \`${SOURCE_CLASS_COUNT:-n/a}\`
+          component_source_manager_available: \`${MANAGER_AVAILABLE:-n/a}\`
+          artifact: \`agency-config-language-canvas-runtime-api-766-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Read-only fresh-DDEV API mapping only. No source generation, config entity create/update, migration, config export, Configuration Language Lock activation, production access or provider secret is permitted.
+          EOF_BODY
+          )"
+          test "$MAP_RESULT" = 'success'

--- a/docs/evidence/configuration-language-canvas-runtime-source-api-cohort-766.yml
+++ b/docs/evidence/configuration-language-canvas-runtime-source-api-cohort-766.yml
@@ -1,0 +1,66 @@
+schema_version: 1
+issue: 766
+parent_issue: 609
+source:
+  issue: 764
+  run_id: 32718921398
+  artifact_id: 9517057609
+  artifact_name: agency-config-language-remaining-fr-764-32718921398-1
+  artifact_digest: sha256:057ac4998fb9045fd4c5b00df8531b4ffae893ba49383c3190c403076d73573a
+  source_classification: runtime_source_candidate
+baseline:
+  trusted_main: b8f4314c291b32b7230191fa2a17ca932898bf05
+  canvas_version: 1.10.1
+  total_config: 595
+  distribution:
+    __none__: 59
+    en: 466
+    fr: 69
+    und: 1
+cohort:
+  total: 30
+  block: 26
+  sdc: 4
+  names_sha256: b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23
+  names:
+    - canvas.component.block.announce_block
+    - canvas.component.block.emerging_digital_language_switcher
+    - canvas.component.block.help_block
+    - canvas.component.block.language_block.language_content
+    - canvas.component.block.language_block.language_interface
+    - canvas.component.block.local_actions_block
+    - canvas.component.block.local_tasks_block
+    - canvas.component.block.page_title_block
+    - canvas.component.block.shortcuts
+    - canvas.component.block.system_branding_block
+    - canvas.component.block.system_breadcrumb_block
+    - canvas.component.block.system_clear_cache_block
+    - canvas.component.block.system_menu_block.account
+    - canvas.component.block.system_menu_block.admin
+    - canvas.component.block.system_menu_block.footer
+    - canvas.component.block.system_menu_block.main
+    - canvas.component.block.system_menu_block.online-presence
+    - canvas.component.block.system_menu_block.tools
+    - canvas.component.block.system_messages_block
+    - canvas.component.block.system_powered_by_block
+    - canvas.component.block.user_login_block
+    - canvas.component.block.views_block.comments_recent-block_1
+    - canvas.component.block.views_block.content_recent-block_1
+    - canvas.component.block.views_block.who_s_new-block_1
+    - canvas.component.block.views_block.who_s_online-who_s_online_block
+    - canvas.component.block.webform_block
+    - canvas.component.sdc.emerging_digital.cta
+    - canvas.component.sdc.emerging_digital.hero
+    - canvas.component.sdc.emerging_digital.trust-list
+    - canvas.component.sdc.olivero.teaser
+constraints:
+  read_only: true
+  migration_allowed: false
+  source_generation_allowed: false
+  config_entity_creation_allowed: false
+  config_entity_update_allowed: false
+  config_export_allowed: false
+  config_language_lock_activation_allowed: false
+  production_access_allowed: false
+  provider_secret_allowed: false
+  natural_language_heuristic_used: false

--- a/scripts/runner/configuration-language-canvas-runtime-source-api-766.php
+++ b/scripts/runner/configuration-language-canvas-runtime-source-api-766.php
@@ -1,0 +1,466 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Drupal\Core\Config\Entity\ConfigEntityTypeInterface;
+use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionType;
+use ReflectionUnionType;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/'
+  . 'configuration-language-canvas-runtime-source-api-cohort-766.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #766 runtime API baseline is incomplete.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #766 manifest must be a mapping.');
+}
+if (($manifest['issue'] ?? NULL) !== 766) {
+  throw new RuntimeException('Issue #766 manifest identity mismatch.');
+}
+if (($manifest['parent_issue'] ?? NULL) !== 609) {
+  throw new RuntimeException('Issue #766 parent identity mismatch.');
+}
+if (($manifest['cohort']['total'] ?? NULL) !== 30) {
+  throw new RuntimeException('Issue #766 cohort must contain 30 names.');
+}
+
+$manifestNames = $manifest['cohort']['names'] ?? NULL;
+if (!is_array($manifestNames) || count($manifestNames) !== 30) {
+  throw new RuntimeException('Issue #766 manifest names are incomplete.');
+}
+$manifestNames = array_values(array_map('strval', $manifestNames));
+sort($manifestNames, SORT_STRING);
+if (count(array_unique($manifestNames)) !== 30) {
+  throw new RuntimeException('Issue #766 manifest names must be unique.');
+}
+
+$manifestHash = hash(
+  'sha256',
+  implode("\n", $manifestNames) . "\n",
+);
+$expectedHash = $manifest['cohort']['names_sha256'] ?? NULL;
+if ($manifestHash !== $expectedHash) {
+  throw new RuntimeException('Issue #766 manifest names hash mismatch.');
+}
+
+$canvasVersion = InstalledVersions::getPrettyVersion('drupal/canvas');
+if ($canvasVersion !== '1.10.1') {
+  throw new RuntimeException(sprintf(
+    'Issue #766 requires the locked Canvas 1.10.1 runtime, got %s.',
+    $canvasVersion ?? 'unknown',
+  ));
+}
+
+$typeToString = NULL;
+$typeToString = static function (?ReflectionType $type) use (&$typeToString): ?string {
+  if ($type === NULL) {
+    return NULL;
+  }
+  if ($type instanceof ReflectionNamedType) {
+    return ($type->allowsNull() && $type->getName() !== 'mixed' ? '?' : '')
+      . $type->getName();
+  }
+  if ($type instanceof ReflectionUnionType) {
+    return implode('|', array_map(
+      $typeToString,
+      $type->getTypes(),
+    ));
+  }
+  if ($type instanceof ReflectionIntersectionType) {
+    return implode('&', array_map(
+      $typeToString,
+      $type->getTypes(),
+    ));
+  }
+  return (string) $type;
+};
+
+$parameterToArray = static function (
+  ReflectionParameter $parameter,
+) use ($typeToString): array {
+  $default = NULL;
+  $hasDefault = $parameter->isDefaultValueAvailable();
+  if ($hasDefault) {
+    try {
+      $default = $parameter->getDefaultValue();
+    }
+    catch (ReflectionException) {
+      $default = '__unavailable__';
+    }
+  }
+
+  return [
+    'name' => $parameter->getName(),
+    'type' => $typeToString($parameter->getType()),
+    'optional' => $parameter->isOptional(),
+    'variadic' => $parameter->isVariadic(),
+    'by_reference' => $parameter->isPassedByReference(),
+    'has_default' => $hasDefault,
+    'default' => $default,
+  ];
+};
+
+$reflectMethods = static function (
+  string|object $class,
+) use ($parameterToArray, $typeToString): array {
+  $reflection = new ReflectionClass($class);
+  $methods = [];
+  foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+    $name = $method->getName();
+    if (!preg_match(
+      '/source|component|config|discover|generate|create|update|definition|plugin|setting|version/i',
+      $name,
+    )) {
+      continue;
+    }
+    $methods[] = [
+      'name' => $name,
+      'declaring_class' => $method->getDeclaringClass()->getName(),
+      'static' => $method->isStatic(),
+      'parameters' => array_map(
+        $parameterToArray,
+        $method->getParameters(),
+      ),
+      'return_type' => $typeToString($method->getReturnType()),
+    ];
+  }
+  usort(
+    $methods,
+    static fn(array $left, array $right): int =>
+      [$left['name'], $left['declaring_class']]
+      <=> [$right['name'], $right['declaring_class']],
+  );
+  return $methods;
+};
+
+$entityTypeManager = \Drupal::entityTypeManager();
+$componentEntityTypeIds = [];
+foreach ($entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+  if (!$definition instanceof ConfigEntityTypeInterface) {
+    continue;
+  }
+  if ($definition->getConfigPrefix() === 'canvas.component') {
+    $componentEntityTypeIds[] = $entityTypeId;
+  }
+}
+sort($componentEntityTypeIds, SORT_STRING);
+if (count($componentEntityTypeIds) !== 1) {
+  throw new RuntimeException(sprintf(
+    'Expected exactly one Canvas component config entity type, found %d.',
+    count($componentEntityTypeIds),
+  ));
+}
+$componentEntityTypeId = $componentEntityTypeIds[0];
+$componentDefinition = $entityTypeManager->getDefinition($componentEntityTypeId);
+$componentStorage = $entityTypeManager->getStorage($componentEntityTypeId);
+
+$repositoryCanvasFrNames = [];
+foreach (glob($configDirectory . '/canvas.component.*.yml') ?: [] as $path) {
+  $data = Yaml::parseFile($path);
+  if (is_array($data) && ($data['langcode'] ?? NULL) === 'fr') {
+    $repositoryCanvasFrNames[] = basename($path, '.yml');
+  }
+}
+sort($repositoryCanvasFrNames, SORT_STRING);
+
+$baselineProblems = [];
+if ($repositoryCanvasFrNames !== $manifestNames) {
+  $baselineProblems[] = [
+    'reason' => 'canvas_fr_name_set_mismatch',
+    'missing' => array_values(array_diff($manifestNames, $repositoryCanvasFrNames)),
+    'unexpected' => array_values(array_diff(
+      $repositoryCanvasFrNames,
+      $manifestNames,
+    )),
+  ];
+}
+
+$sourceCounts = [
+  'block' => 0,
+  'sdc' => 0,
+];
+$items = [];
+$sourceClasses = [];
+foreach ($manifestNames as $configName) {
+  $path = $configDirectory . '/' . $configName . '.yml';
+  if (!is_file($path)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_missing',
+    ];
+    continue;
+  }
+  $repositoryData = Yaml::parseFile($path);
+  if (!is_array($repositoryData)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_invalid',
+    ];
+    continue;
+  }
+  if (($repositoryData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_langcode_not_fr',
+    ];
+    continue;
+  }
+  if (is_file($configDirectory . '/language/en/' . $configName . '.yml')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'unexpected_en_override',
+    ];
+    continue;
+  }
+
+  $entityId = $repositoryData['id'] ?? NULL;
+  $expectedSource = $repositoryData['source'] ?? NULL;
+  $expectedSourceLocalId = $repositoryData['source_local_id'] ?? NULL;
+  $expectedProvider = $repositoryData['provider'] ?? NULL;
+  if (
+    !is_string($entityId)
+    || $entityId === ''
+    || !is_string($expectedSource)
+    || !isset($sourceCounts[$expectedSource])
+    || !is_string($expectedSourceLocalId)
+    || $expectedSourceLocalId === ''
+    || !is_string($expectedProvider)
+    || $expectedProvider === ''
+  ) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_source_identity_invalid',
+    ];
+    continue;
+  }
+
+  $entity = $componentStorage->load($entityId);
+  if ($entity === NULL) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_component_entity_missing',
+    ];
+    continue;
+  }
+  if (!is_a($entity, 'Drupal\\canvas\\Entity\\Component')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_component_entity_class_unexpected',
+      'actual_class' => $entity::class,
+    ];
+    continue;
+  }
+  if (!method_exists($entity, 'getComponentSource')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'get_component_source_method_missing',
+    ];
+    continue;
+  }
+
+  $runtimeData = $entity->toArray();
+  foreach ([
+    'source' => $expectedSource,
+    'source_local_id' => $expectedSourceLocalId,
+    'provider' => $expectedProvider,
+  ] as $key => $expectedValue) {
+    if (($runtimeData[$key] ?? NULL) !== $expectedValue) {
+      $baselineProblems[] = [
+        'name' => $configName,
+        'reason' => 'runtime_source_identity_mismatch',
+        'key' => $key,
+        'expected' => $expectedValue,
+        'actual' => $runtimeData[$key] ?? NULL,
+      ];
+      continue 2;
+    }
+  }
+
+  $sourceObject = $entity->getComponentSource();
+  if (!is_object($sourceObject)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'component_source_object_missing',
+    ];
+    continue;
+  }
+
+  $sourceClass = $sourceObject::class;
+  if (!isset($sourceClasses[$sourceClass])) {
+    $sourceClasses[$sourceClass] = [
+      'class' => $sourceClass,
+      'methods' => $reflectMethods($sourceObject),
+      'component_count' => 0,
+      'source_kinds' => [],
+    ];
+  }
+  $sourceClasses[$sourceClass]['component_count']++;
+  $sourceClasses[$sourceClass]['source_kinds'][$expectedSource] = TRUE;
+
+  $pluginId = NULL;
+  if (method_exists($sourceObject, 'getPluginId')) {
+    $pluginIdMethod = new ReflectionMethod($sourceObject, 'getPluginId');
+    if ($pluginIdMethod->getNumberOfRequiredParameters() === 0) {
+      $pluginId = $sourceObject->getPluginId();
+    }
+  }
+
+  $sourceCounts[$expectedSource]++;
+  $items[] = [
+    'config_name' => $configName,
+    'entity_id' => $entityId,
+    'entity_type_id' => $componentEntityTypeId,
+    'entity_class' => $entity::class,
+    'source' => $expectedSource,
+    'source_local_id' => $expectedSourceLocalId,
+    'provider' => $expectedProvider,
+    'source_class' => $sourceClass,
+    'source_plugin_id' => is_scalar($pluginId) ? $pluginId : NULL,
+    'active_version' => $repositoryData['active_version'] ?? NULL,
+  ];
+}
+
+ksort($sourceClasses, SORT_STRING);
+foreach ($sourceClasses as &$sourceClass) {
+  $sourceKinds = array_keys($sourceClass['source_kinds']);
+  sort($sourceKinds, SORT_STRING);
+  $sourceClass['source_kinds'] = $sourceKinds;
+}
+unset($sourceClass);
+usort(
+  $items,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+
+$container = \Drupal::getContainer();
+$managerClass = 'Drupal\\canvas\\ComponentSource\\ComponentSourceManager';
+$managerClassAvailable = class_exists($managerClass);
+$managerServiceCandidates = [
+  $managerClass,
+  'canvas.component_source_manager',
+  'canvas.component_source.manager',
+  'plugin.manager.canvas.component_source',
+];
+$managerServicesPresent = [];
+foreach ($managerServiceCandidates as $serviceId) {
+  if ($container->has($serviceId)) {
+    $managerServicesPresent[] = $serviceId;
+  }
+}
+sort($managerServicesPresent, SORT_STRING);
+
+$blockManager = $container->get('plugin.manager.block');
+$sdcManager = $container->get('plugin.manager.sdc');
+$managerApi = [
+  'component_source_manager' => [
+    'class' => $managerClass,
+    'class_available' => $managerClassAvailable,
+    'service_ids_present' => $managerServicesPresent,
+    'methods' => $managerClassAvailable ? $reflectMethods($managerClass) : [],
+  ],
+  'block_plugin_manager' => [
+    'service_id' => 'plugin.manager.block',
+    'class' => $blockManager::class,
+    'methods' => $reflectMethods($blockManager),
+  ],
+  'sdc_plugin_manager' => [
+    'service_id' => 'plugin.manager.sdc',
+    'class' => $sdcManager::class,
+    'methods' => $reflectMethods($sdcManager),
+  ],
+];
+
+$entityApi = [
+  'entity_type_id' => $componentEntityTypeId,
+  'config_prefix' => $componentDefinition instanceof ConfigEntityTypeInterface
+    ? $componentDefinition->getConfigPrefix()
+    : NULL,
+  'entity_class' => $componentDefinition->getClass(),
+  'methods' => $reflectMethods($componentDefinition->getClass()),
+];
+
+$problems = $baselineProblems;
+if (count($items) !== 30) {
+  $problems[] = [
+    'reason' => 'runtime_component_count_mismatch',
+    'actual' => count($items),
+    'expected' => 30,
+  ];
+}
+if ($sourceCounts !== ['block' => 26, 'sdc' => 4]) {
+  $problems[] = [
+    'reason' => 'runtime_source_kind_count_mismatch',
+    'actual' => $sourceCounts,
+    'expected' => ['block' => 26, 'sdc' => 4],
+  ];
+}
+if (!$managerClassAvailable) {
+  $problems[] = [
+    'reason' => 'component_source_manager_class_missing',
+    'class' => $managerClass,
+  ];
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'CANVAS_RUNTIME_SOURCE_API_MAPPED'
+  : 'CANVAS_RUNTIME_SOURCE_API_MAPPING_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'runtime' => [
+    'canvas_version' => $canvasVersion,
+    'component_entity_api' => $entityApi,
+    'manager_api' => $managerApi,
+    'source_classes' => array_values($sourceClasses),
+  ],
+  'counts' => [
+    'candidate_total' => 30,
+    'mapped' => count($items),
+    'block' => $sourceCounts['block'],
+    'sdc' => $sourceCounts['sdc'],
+    'source_class_count' => count($sourceClasses),
+    'baseline_problem' => count($baselineProblems),
+    'problem_count' => count($problems),
+  ],
+  'manifest_names_sha256' => $manifestHash,
+  'items' => $items,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'source_generation_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'natural_language_heuristic_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasRuntimeSourceApi766Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasRuntimeSourceApi766Test.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #766 Canvas runtime source API proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasRuntimeSourceApi766Test extends TestCase {
+
+  /**
+   * The manifest fixes the exact 30 Canvas component cohort.
+   */
+  public function testManifestFixesExactCanvasRuntimeCohort(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/docs/evidence/'
+      . 'configuration-language-canvas-runtime-source-api-cohort-766.yml';
+    self::assertFileExists($path);
+
+    $manifest = DrupalYaml::decode((string) file_get_contents($path));
+    self::assertIsArray($manifest);
+    self::assertSame(766, $manifest['issue'] ?? NULL);
+    self::assertSame(609, $manifest['parent_issue'] ?? NULL);
+    self::assertSame('1.10.1', $manifest['baseline']['canvas_version'] ?? NULL);
+    self::assertSame(30, $manifest['cohort']['total'] ?? NULL);
+    self::assertSame(26, $manifest['cohort']['block'] ?? NULL);
+    self::assertSame(4, $manifest['cohort']['sdc'] ?? NULL);
+
+    $names = $manifest['cohort']['names'] ?? NULL;
+    self::assertIsArray($names);
+    self::assertCount(30, $names);
+    self::assertCount(30, array_unique($names));
+    sort($names, SORT_STRING);
+    self::assertSame(
+      'b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23',
+      hash('sha256', implode("\n", $names) . "\n"),
+    );
+    self::assertTrue($manifest['constraints']['read_only'] ?? FALSE);
+    self::assertFalse($manifest['constraints']['migration_allowed'] ?? TRUE);
+    self::assertFalse(
+      $manifest['constraints']['source_generation_allowed'] ?? TRUE,
+    );
+    self::assertFalse(
+      $manifest['constraints']['config_entity_creation_allowed'] ?? TRUE,
+    );
+    self::assertFalse(
+      $manifest['constraints']['config_entity_update_allowed'] ?? TRUE,
+    );
+  }
+
+  /**
+   * The probe maps native runtime APIs without executing mutation primitives.
+   */
+  public function testProbeUsesNativeReadOnlyRuntimeIntrospection(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-canvas-runtime-source-api-766.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      "InstalledVersions::getPrettyVersion('drupal/canvas')",
+      $script,
+    );
+    self::assertStringContainsString(
+      "getConfigPrefix() === 'canvas.component'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "method_exists(\$entity, 'getComponentSource')",
+      $script,
+    );
+    self::assertStringContainsString(
+      '$entity->getComponentSource()',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'plugin.manager.block'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'plugin.manager.sdc'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'Drupal\\\\canvas\\\\ComponentSource\\\\ComponentSourceManager'",
+      $script,
+    );
+    self::assertStringContainsString(
+      'CANVAS_RUNTIME_SOURCE_API_MAPPED',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'source_generation_executed' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'config_entity_creation_executed' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'config_entity_update_executed' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      '->generateComponents(',
+      '->createConfigEntity(',
+      '->updateConfigEntity(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route is owner-only, live-main-only and read-only.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-runtime-source-api-766.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 766',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-canvas-runtime-api map'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      "grep -Fq 'No differences'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'CANVAS_RUNTIME_SOURCE_API_MAPPED',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.mapped == 30',
+      $workflow,
+    );
+    self::assertStringContainsString('.counts.block == 26', $workflow);
+    self::assertStringContainsString('.counts.sdc == 4', $workflow);
+    self::assertStringContainsString(
+      '.constraints.source_generation_executed == false',
+      $workflow,
+    );
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Read-only tooling for #766. This PR maps the native Drupal Canvas 1.10.1 runtime APIs available to the exact 30 remaining FR `canvas.component.*` configs identified by #764.

It adds only:
- an exact 30-name manifest derived from trusted #764 evidence;
- a runtime introspection probe;
- an owner-only/live-main-only trusted fresh-DDEV route;
- contract tests.

## Fixed baseline

- base main: `b8f4314c291b32b7230191fa2a17ca932898bf05`;
- Canvas runtime required: `1.10.1`;
- exact cohort: 30 configs = 26 block + 4 SDC;
- exact-name SHA-256: `b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23`.

## Runtime contract

The probe discovers the Canvas Component config entity type via `config_prefix=canvas.component`, loads each real component entity, verifies repository/runtime `source`, `source_local_id` and `provider`, obtains `getComponentSource()` read-only, and records source classes plus relevant public API signatures by Reflection. It also maps the native ComponentSourceManager class and the Block/SDC plugin managers actually installed.

The proof explicitly does **not** invoke component generation, config entity create/update, save/write/delete, migration or export. It exists only to select the authoritative provenance primitive for the next tranche.

## Safety

No `config/sync` mutation, no `cex`, no Configuration Language Lock activation, no production access, no provider secret, no natural-language heuristic. The self-hosted job has only `contents: read` and uses `persist-credentials: false`; only the hosted report job can write the terminal #766 comment.

Refs #766 #609 #764 #760 #756 #526