### PR TITLE
Issue #770: correlate Canvas native source payloads

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-native-source-payload-770.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-native-source-payload-770.yml
@@ -1,0 +1,270 @@
+name: Agency trusted Canvas native source payload correlation
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #770 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 770 &&
+        github.event.comment.body == '/agency-config-language-canvas-source correlate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '770'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-canvas-source correlate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/770" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  correlate:
+    name: Correlate exact 30 Canvas components to native source payloads
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      all_present: ${{ steps.correlate.outputs.all_present }}
+      partial: ${{ steps.correlate.outputs.partial }}
+      none: ${{ steps.correlate.outputs.none }}
+      unresolved: ${{ steps.correlate.outputs.unresolved }}
+      material_leaves: ${{ steps.correlate.outputs.material_leaves }}
+      matched_leaves: ${{ steps.correlate.outputs.matched_leaves }}
+      unmatched_leaves: ${{ steps.correlate.outputs.unmatched_leaves }}
+      verdict: ${{ steps.correlate.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #770 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            docs/evidence/configuration-language-canvas-runtime-source-api-cohort-766.yml
+          test -f \
+            scripts/runner/configuration-language-canvas-native-source-payload-770.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-source-770.yaml <<EOF_CONFIG
+          name: agency-config-canvas-source-770-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-source-770-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-source-770'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-canvas-native-source-payload-770.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Correlate bounded native source payloads
+        id: correlate
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-source-770'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-native-source-payload-770.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "CANVAS_NATIVE_SOURCE_PAYLOADS_CORRELATED"' \
+            "$result" >/dev/null
+          jq -e '.counts.candidate_total == 30' "$result" >/dev/null
+          jq -e '.counts.analyzed == 30' "$result" >/dev/null
+          jq -e '.counts.block == 26' "$result" >/dev/null
+          jq -e '.counts.sdc == 4' "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e '.counts.source_payload_unresolved == 0' "$result" >/dev/null
+          jq -e '.counts.material_translatable_leaves > 0' "$result" >/dev/null
+          jq -e \
+            '(.counts.all_material_values_present_in_native_source_payload + .counts.partial_material_values_present_in_native_source_payload + .counts.no_material_values_present_in_native_source_payload) == 30' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.strict_type_and_value_equality_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.value_presence_authorizes_migration == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_creation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "all_present=$(jq -r '.counts.all_material_values_present_in_native_source_payload' "$result")" >> "$GITHUB_OUTPUT"
+          echo "partial=$(jq -r '.counts.partial_material_values_present_in_native_source_payload' "$result")" >> "$GITHUB_OUTPUT"
+          echo "none=$(jq -r '.counts.no_material_values_present_in_native_source_payload' "$result")" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$(jq -r '.counts.source_payload_unresolved' "$result")" >> "$GITHUB_OUTPUT"
+          echo "material_leaves=$(jq -r '.counts.material_translatable_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "matched_leaves=$(jq -r '.counts.matched_material_translatable_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "unmatched_leaves=$(jq -r '.counts.unmatched_material_translatable_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #770 source correlation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-source-770-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-source-770
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-source-770-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-source-770.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-canvas-source-770
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #770 source correlation verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - correlate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CORRELATE_RESULT: ${{ needs.correlate.result }}
+          ALL_PRESENT: ${{ needs.correlate.outputs.all_present }}
+          PARTIAL: ${{ needs.correlate.outputs.partial }}
+          NONE: ${{ needs.correlate.outputs.none }}
+          UNRESOLVED: ${{ needs.correlate.outputs.unresolved }}
+          MATERIAL_LEAVES: ${{ needs.correlate.outputs.material_leaves }}
+          MATCHED_LEAVES: ${{ needs.correlate.outputs.matched_leaves }}
+          UNMATCHED_LEAVES: ${{ needs.correlate.outputs.unmatched_leaves }}
+          MACHINE_VERDICT: ${{ needs.correlate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CORRELATE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 770 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Canvas native source payload correlation ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CORRELATE_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`30\`
+          source_kinds: \`block=26, sdc=4\`
+          all_material_values_present: \`${ALL_PRESENT:-n/a}\`
+          partial_material_values_present: \`${PARTIAL:-n/a}\`
+          no_material_values_present: \`${NONE:-n/a}\`
+          source_payload_unresolved: \`${UNRESOLVED:-n/a}\`
+          material_leaves: \`${MATERIAL_LEAVES:-n/a}\`
+          matched_leaves: \`${MATCHED_LEAVES:-n/a}\`
+          unmatched_leaves: \`${UNMATCHED_LEAVES:-n/a}\`
+          artifact: \`agency-config-language-canvas-source-770-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Strict read-only type-and-value correlation only. Value presence does not authorize migration. No generation, config mutation/export, Configuration Language Lock activation, production access, provider secret, language heuristic or fuzzy match is permitted.
+          EOF_BODY
+          )"
+          test "$CORRELATE_RESULT" = 'success'

--- a/scripts/runner/configuration-language-canvas-native-source-payload-770.php
+++ b/scripts/runner/configuration-language-canvas-native-source-payload-770.php
@@ -1,0 +1,647 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Drupal\Core\Config\Entity\ConfigEntityTypeInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/'
+  . 'configuration-language-canvas-runtime-source-api-cohort-766.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #770 source baseline is incomplete.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #766 manifest must be a mapping.');
+}
+if (($manifest['issue'] ?? NULL) !== 766 || ($manifest['parent_issue'] ?? NULL) !== 609) {
+  throw new RuntimeException('Issue #770 must reuse the exact #766 cohort.');
+}
+if (($manifest['cohort']['total'] ?? NULL) !== 30) {
+  throw new RuntimeException('Issue #770 requires exactly 30 Canvas components.');
+}
+
+$manifestNames = $manifest['cohort']['names'] ?? NULL;
+if (!is_array($manifestNames) || count($manifestNames) !== 30) {
+  throw new RuntimeException('Issue #766 manifest names are incomplete.');
+}
+$manifestNames = array_values(array_map('strval', $manifestNames));
+sort($manifestNames, SORT_STRING);
+if (count(array_unique($manifestNames)) !== 30) {
+  throw new RuntimeException('Issue #766 manifest names must be unique.');
+}
+$manifestHash = hash('sha256', implode("\n", $manifestNames) . "\n");
+if (
+  $manifestHash
+  !== 'b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23'
+  || $manifestHash !== ($manifest['cohort']['names_sha256'] ?? NULL)
+) {
+  throw new RuntimeException('Issue #766 manifest names hash mismatch.');
+}
+
+$canvasVersion = InstalledVersions::getPrettyVersion('drupal/canvas');
+if ($canvasVersion !== '1.10.1') {
+  throw new RuntimeException(sprintf(
+    'Issue #770 requires Canvas 1.10.1, got %s.',
+    $canvasVersion ?? 'unknown',
+  ));
+}
+
+$typedConfigManager = \Drupal::service('config.typed');
+$activeStorage = \Drupal::service('config.storage');
+$entityTypeManager = \Drupal::entityTypeManager();
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach ($collectTranslatableLeaves($child, [...$segments, $key]) as $leaf) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (empty($definition['translatable'])) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$serializationNotes = [];
+$normalizePayload = NULL;
+$normalizePayload = static function (
+  mixed $value,
+  string $path,
+) use (&$normalizePayload, &$serializationNotes): mixed {
+  if ($value === NULL || is_scalar($value)) {
+    return $value;
+  }
+  if ($value instanceof TranslatableMarkup) {
+    return [
+      '__kind' => 'translatable_markup',
+      '__class' => $value::class,
+      'untranslated' => $value->getUntranslatedString(),
+    ];
+  }
+  if ($value instanceof BackedEnum) {
+    return [
+      '__kind' => 'backed_enum',
+      '__class' => $value::class,
+      'name' => $value->name,
+      'value' => $value->value,
+    ];
+  }
+  if ($value instanceof UnitEnum) {
+    return [
+      '__kind' => 'unit_enum',
+      '__class' => $value::class,
+      'name' => $value->name,
+    ];
+  }
+  if (is_array($value)) {
+    $normalized = [];
+    foreach ($value as $key => $child) {
+      $normalized[$key] = $normalizePayload(
+        $child,
+        $path . '.' . (string) $key,
+      );
+    }
+    if (!array_is_list($normalized)) {
+      ksort($normalized, SORT_STRING);
+    }
+    return $normalized;
+  }
+  if (is_object($value)) {
+    $public = get_object_vars($value);
+    $serializationNotes[] = [
+      'path' => $path,
+      'representation' => 'object_class_and_public_properties_only',
+      'class' => $value::class,
+    ];
+    return [
+      '__kind' => 'object',
+      '__class' => $value::class,
+      'public' => $normalizePayload($public, $path . '.public'),
+    ];
+  }
+  if (is_resource($value)) {
+    throw new RuntimeException(sprintf(
+      'Unsupported resource in native source payload at %s.',
+      $path,
+    ));
+  }
+
+  throw new RuntimeException(sprintf(
+    'Unsupported native source payload value at %s.',
+    $path,
+  ));
+};
+
+$collectEvidenceScalars = NULL;
+$collectEvidenceScalars = static function (
+  mixed $value,
+  string $path,
+  string $payload,
+) use (&$collectEvidenceScalars): array {
+  if ($value === NULL) {
+    return [];
+  }
+  if (is_scalar($value)) {
+    return [[
+      'payload' => $payload,
+      'path' => $path,
+      'kind' => 'native_scalar',
+      'value' => $value,
+    ]];
+  }
+  if ($value instanceof TranslatableMarkup) {
+    return [[
+      'payload' => $payload,
+      'path' => $path . '.__untranslated',
+      'kind' => 'translatable_markup_untranslated_source',
+      'value' => $value->getUntranslatedString(),
+    ]];
+  }
+  if ($value instanceof BackedEnum) {
+    return [[
+      'payload' => $payload,
+      'path' => $path . '.__enum_value',
+      'kind' => 'backed_enum_value',
+      'value' => $value->value,
+    ]];
+  }
+  if (is_array($value)) {
+    $points = [];
+    foreach ($value as $key => $child) {
+      foreach (
+        $collectEvidenceScalars(
+          $child,
+          $path . '.' . (string) $key,
+          $payload,
+        ) as $point
+      ) {
+        $points[] = $point;
+      }
+    }
+    return $points;
+  }
+
+  return [];
+};
+
+$componentEntityTypeIds = [];
+foreach ($entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+  if (
+    $definition instanceof ConfigEntityTypeInterface
+    && $definition->getConfigPrefix() === 'canvas.component'
+  ) {
+    $componentEntityTypeIds[] = $entityTypeId;
+  }
+}
+sort($componentEntityTypeIds, SORT_STRING);
+if (count($componentEntityTypeIds) !== 1) {
+  throw new RuntimeException('Expected exactly one Canvas Component config entity type.');
+}
+$componentEntityTypeId = $componentEntityTypeIds[0];
+$componentStorage = $entityTypeManager->getStorage($componentEntityTypeId);
+
+$repositoryCanvasFrNames = [];
+foreach (glob($configDirectory . '/canvas.component.*.yml') ?: [] as $path) {
+  $data = Yaml::parseFile($path);
+  if (is_array($data) && ($data['langcode'] ?? NULL) === 'fr') {
+    $repositoryCanvasFrNames[] = basename($path, '.yml');
+  }
+}
+sort($repositoryCanvasFrNames, SORT_STRING);
+
+$baselineProblems = [];
+if ($repositoryCanvasFrNames !== $manifestNames) {
+  $baselineProblems[] = [
+    'reason' => 'canvas_fr_name_set_mismatch',
+    'missing' => array_values(array_diff($manifestNames, $repositoryCanvasFrNames)),
+    'unexpected' => array_values(array_diff($repositoryCanvasFrNames, $manifestNames)),
+  ];
+}
+
+$sourceCounts = ['block' => 0, 'sdc' => 0];
+$classifications = [
+  'all_material_values_present_in_native_source_payload' => 0,
+  'partial_material_values_present_in_native_source_payload' => 0,
+  'no_material_values_present_in_native_source_payload' => 0,
+  'source_payload_unresolved' => 0,
+];
+$items = [];
+$unmatchedLeaves = [];
+$totalMaterialLeaves = 0;
+$totalMatchedLeaves = 0;
+
+foreach ($manifestNames as $configName) {
+  $repositoryPath = $configDirectory . '/' . $configName . '.yml';
+  $repositoryData = Yaml::parseFile($repositoryPath);
+  if (!is_array($repositoryData)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_invalid',
+    ];
+    continue;
+  }
+  if (($repositoryData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_langcode_not_fr',
+    ];
+    continue;
+  }
+  if (is_file($configDirectory . '/language/en/' . $configName . '.yml')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'unexpected_en_override',
+    ];
+    continue;
+  }
+
+  $activeData = $activeStorage->read($configName);
+  if (!is_array($activeData) || $activeData !== $repositoryData) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'active_repository_mismatch',
+    ];
+    continue;
+  }
+  if (!$typedConfigManager->hasConfigSchema($configName)) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'config_schema_missing',
+    ];
+    continue;
+  }
+
+  try {
+    $typed = $typedConfigManager->createFromNameAndData($configName, $activeData);
+    $allLeaves = $collectTranslatableLeaves($typed);
+  }
+  catch (Throwable $exception) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'typed_config_traversal_failed',
+      'error_class' => $exception::class,
+    ];
+    continue;
+  }
+
+  $materialLeaves = [];
+  foreach ($allLeaves as $leaf) {
+    if (!$isMaterial($leaf['value'])) {
+      continue;
+    }
+    if (!is_scalar($leaf['value'])) {
+      $classifications['source_payload_unresolved']++;
+      $items[] = [
+        'config_name' => $configName,
+        'classification' => 'source_payload_unresolved',
+        'reason' => 'material_leaf_not_scalar',
+        'leaf_path' => $leaf['path'],
+        'leaf_type' => get_debug_type($leaf['value']),
+      ];
+      continue 2;
+    }
+    $materialLeaves[] = [
+      'path' => $leaf['path'],
+      'value' => $leaf['value'],
+      'value_type' => get_debug_type($leaf['value']),
+    ];
+  }
+  usort(
+    $materialLeaves,
+    static fn(array $left, array $right): int => $left['path'] <=> $right['path'],
+  );
+
+  $entityId = $repositoryData['id'] ?? NULL;
+  $sourceKind = $repositoryData['source'] ?? NULL;
+  $sourceLocalId = $repositoryData['source_local_id'] ?? NULL;
+  $provider = $repositoryData['provider'] ?? NULL;
+  if (
+    !is_string($entityId)
+    || !is_string($sourceKind)
+    || !isset($sourceCounts[$sourceKind])
+    || !is_string($sourceLocalId)
+    || !is_string($provider)
+  ) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'source_identity_invalid',
+    ];
+    continue;
+  }
+
+  $entity = $componentStorage->load($entityId);
+  if ($entity === NULL || !method_exists($entity, 'getComponentSource')) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'runtime_component_or_source_missing',
+    ];
+    continue;
+  }
+
+  $runtimeData = $entity->toArray();
+  if (
+    ($runtimeData['source'] ?? NULL) !== $sourceKind
+    || ($runtimeData['source_local_id'] ?? NULL) !== $sourceLocalId
+    || ($runtimeData['provider'] ?? NULL) !== $provider
+  ) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'runtime_source_identity_mismatch',
+    ];
+    continue;
+  }
+
+  try {
+    $source = $entity->getComponentSource();
+    $configuration = $source->getConfiguration();
+    $pluginDefinition = $source->getPluginDefinition();
+    $runtimeSourceLocalId = $source->getSourceSpecificComponentId();
+    $versionHash = $source->generateVersionHash();
+  }
+  catch (Throwable $exception) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'native_source_payload_read_failed',
+      'error_class' => $exception::class,
+    ];
+    continue;
+  }
+
+  if (
+    !is_array($configuration)
+    || !is_array($pluginDefinition)
+    || !is_string($runtimeSourceLocalId)
+    || $runtimeSourceLocalId !== $sourceLocalId
+    || !is_string($versionHash)
+    || $versionHash === ''
+  ) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'native_source_payload_shape_invalid',
+      'configuration_type' => get_debug_type($configuration),
+      'definition_type' => get_debug_type($pluginDefinition),
+      'runtime_source_local_id' => $runtimeSourceLocalId,
+      'version_hash_type' => get_debug_type($versionHash),
+    ];
+    continue;
+  }
+
+  try {
+    $normalizedConfiguration = $normalizePayload(
+      $configuration,
+      'configuration',
+    );
+    $normalizedDefinition = $normalizePayload(
+      $pluginDefinition,
+      'plugin_definition',
+    );
+  }
+  catch (Throwable $exception) {
+    $classifications['source_payload_unresolved']++;
+    $items[] = [
+      'config_name' => $configName,
+      'classification' => 'source_payload_unresolved',
+      'reason' => 'native_source_payload_serialization_failed',
+      'error_class' => $exception::class,
+    ];
+    continue;
+  }
+
+  $evidencePoints = array_merge(
+    $collectEvidenceScalars($configuration, 'configuration', 'configuration'),
+    $collectEvidenceScalars(
+      $pluginDefinition,
+      'plugin_definition',
+      'plugin_definition',
+    ),
+  );
+
+  $leafEvidence = [];
+  $matchedLeafCount = 0;
+  foreach ($materialLeaves as $leaf) {
+    $matches = [];
+    foreach ($evidencePoints as $point) {
+      if ($point['value'] === $leaf['value']) {
+        $matches[] = [
+          'payload' => $point['payload'],
+          'path' => $point['path'],
+          'kind' => $point['kind'],
+        ];
+      }
+    }
+    usort(
+      $matches,
+      static fn(array $left, array $right): int =>
+        [$left['payload'], $left['path'], $left['kind']]
+        <=> [$right['payload'], $right['path'], $right['kind']],
+    );
+    if ($matches !== []) {
+      $matchedLeafCount++;
+    }
+    else {
+      $unmatchedLeaves[] = [
+        'config_name' => $configName,
+        'source' => $sourceKind,
+        'leaf_path' => $leaf['path'],
+        'value' => $leaf['value'],
+        'value_type' => $leaf['value_type'],
+      ];
+    }
+    $leafEvidence[] = [
+      ...$leaf,
+      'strict_native_matches' => $matches,
+      'matched' => $matches !== [],
+    ];
+  }
+
+  $materialLeafCount = count($materialLeaves);
+  if ($materialLeafCount > 0 && $matchedLeafCount === $materialLeafCount) {
+    $classification = 'all_material_values_present_in_native_source_payload';
+  }
+  elseif ($matchedLeafCount > 0) {
+    $classification = 'partial_material_values_present_in_native_source_payload';
+  }
+  else {
+    $classification = 'no_material_values_present_in_native_source_payload';
+  }
+  $classifications[$classification]++;
+  $sourceCounts[$sourceKind]++;
+  $totalMaterialLeaves += $materialLeafCount;
+  $totalMatchedLeaves += $matchedLeafCount;
+
+  $items[] = [
+    'config_name' => $configName,
+    'entity_id' => $entityId,
+    'source' => $sourceKind,
+    'source_local_id' => $sourceLocalId,
+    'provider' => $provider,
+    'source_class' => $source::class,
+    'classification' => $classification,
+    'material_translatable_leaf_count' => $materialLeafCount,
+    'matched_material_leaf_count' => $matchedLeafCount,
+    'unmatched_material_leaf_count' => $materialLeafCount - $matchedLeafCount,
+    'material_translatable_leaves' => $leafEvidence,
+    'native_source' => [
+      'configuration' => $normalizedConfiguration,
+      'plugin_definition' => $normalizedDefinition,
+      'source_specific_component_id' => $runtimeSourceLocalId,
+      'version_hash' => $versionHash,
+    ],
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+usort(
+  $unmatchedLeaves,
+  static fn(array $left, array $right): int =>
+    [$left['config_name'], $left['leaf_path']]
+    <=> [$right['config_name'], $right['leaf_path']],
+);
+usort(
+  $serializationNotes,
+  static fn(array $left, array $right): int =>
+    [$left['path'], $left['class']] <=> [$right['path'], $right['class']],
+);
+
+$analyzed = array_sum($classifications);
+$problems = $baselineProblems;
+if ($analyzed !== 30) {
+  $problems[] = [
+    'reason' => 'analyzed_component_count_mismatch',
+    'actual' => $analyzed,
+    'expected' => 30,
+  ];
+}
+if ($sourceCounts !== ['block' => 26, 'sdc' => 4]) {
+  $problems[] = [
+    'reason' => 'source_kind_count_mismatch',
+    'actual' => $sourceCounts,
+    'expected' => ['block' => 26, 'sdc' => 4],
+  ];
+}
+if ($classifications['source_payload_unresolved'] !== 0) {
+  $problems[] = [
+    'reason' => 'source_payload_unresolved_present',
+    'count' => $classifications['source_payload_unresolved'],
+  ];
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'CANVAS_NATIVE_SOURCE_PAYLOADS_CORRELATED'
+  : 'CANVAS_NATIVE_SOURCE_PAYLOAD_CORRELATION_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'baseline' => [
+    'canvas_version' => $canvasVersion,
+    'manifest_issue' => 766,
+    'manifest_names_sha256' => $manifestHash,
+    'expected_candidate_count' => 30,
+    'expected_source_counts' => ['block' => 26, 'sdc' => 4],
+  ],
+  'counts' => [
+    'candidate_total' => 30,
+    'analyzed' => $analyzed,
+    'block' => $sourceCounts['block'],
+    'sdc' => $sourceCounts['sdc'],
+    'baseline_problem' => count($baselineProblems),
+    'problem_count' => count($problems),
+    'material_translatable_leaves' => $totalMaterialLeaves,
+    'matched_material_translatable_leaves' => $totalMatchedLeaves,
+    'unmatched_material_translatable_leaves' => count($unmatchedLeaves),
+    ...$classifications,
+  ],
+  'items' => $items,
+  'unmatched_material_translatable_leaves' => $unmatchedLeaves,
+  'serialization_notes' => $serializationNotes,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'strict_type_and_value_equality_only' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'value_presence_authorizes_migration' => FALSE,
+    'source_generation_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasNativeSourcePayload770Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasNativeSourcePayload770Test.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #770 Canvas native source correlation proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasNativeSourcePayload770Test extends TestCase {
+
+  /**
+   * The analyzer reuses the exact #766 cohort and native read-only APIs.
+   */
+  public function testAnalyzerIsStrictAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-canvas-native-source-payload-770.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'configuration-language-canvas-runtime-source-api-cohort-766.yml',
+      $script,
+    );
+    self::assertStringContainsString(
+      'b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23',
+      $script,
+    );
+    self::assertStringContainsString(
+      "InstalledVersions::getPrettyVersion('drupal/canvas')",
+      $script,
+    );
+    self::assertStringContainsString(
+      '$entity->getComponentSource()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$source->getConfiguration()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$source->getPluginDefinition()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$source->getSourceSpecificComponentId()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$source->generateVersionHash()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$value->getUntranslatedString()',
+      $script,
+    );
+    self::assertStringContainsString(
+      "if (\$point['value'] === \$leaf['value'])",
+      $script,
+    );
+    self::assertStringContainsString(
+      'CANVAS_NATIVE_SOURCE_PAYLOADS_CORRELATED',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'value_presence_authorizes_migration' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'strict_type_and_value_equality_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'fuzzy_matching_used' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      '->save(',
+      '->write(',
+      '->delete(',
+      '->generateComponents(',
+      '->createConfigEntity(',
+      '->updateConfigEntity(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route stays owner-only, live-main-only and read-only.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-native-source-payload-770.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 770',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-canvas-source correlate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      "grep -Fq 'No differences'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'CANVAS_NATIVE_SOURCE_PAYLOADS_CORRELATED',
+      $workflow,
+    );
+    self::assertStringContainsString('.counts.analyzed == 30', $workflow);
+    self::assertStringContainsString('.counts.block == 26', $workflow);
+    self::assertStringContainsString('.counts.sdc == 4', $workflow);
+    self::assertStringContainsString(
+      '.counts.source_payload_unresolved == 0',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.constraints.value_presence_authorizes_migration == false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.constraints.source_generation_executed == false',
+      $workflow,
+    );
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Implémente la preuve read-only #770 pour corréler les 30 `canvas.component.*` FR aux payloads natifs de leurs `ComponentSource` Canvas 1.10.1.

Cette PR ajoute uniquement :
- l’analyseur borné aux 30 noms du manifeste #766 ;
- une route trusted owner-only/live-main-only en fresh DDEV ;
- un test de contrat.

Aucune modification `config/sync`, aucune migration, aucun `generateComponents`, aucun save/create/update/delete, aucun `drush cex`, aucune activation Configuration Language Lock, aucune production/provider/secret.

La corrélation est stricte (`===`) et machine-readable ; un match de valeur n’est explicitement **pas** une autorisation de migration. Les `TranslatableMarkup` exposent uniquement leur chaîne source non traduite comme valeur comparable. Les objets inconnus ne deviennent pas des preuves via `__toString()`.

Refs #770 #766 #764 #609