### PR TITLE
Issue #772: prove native SDC metadata provenance

### DIFF
--- a/.github/workflows/trusted-configuration-language-sdc-native-metadata-772.yml
+++ b/.github/workflows/trusted-configuration-language-sdc-native-metadata-772.yml
@@ -1,0 +1,286 @@
+name: Agency trusted SDC native metadata provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #772 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 772 &&
+        github.event.comment.body == '/agency-config-language-sdc-metadata correlate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '772'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-sdc-metadata correlate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/772" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  correlate:
+    name: Correlate exact 4 SDCs to native metadata
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      all_present: ${{ steps.correlate.outputs.all_present }}
+      partial: ${{ steps.correlate.outputs.partial }}
+      none: ${{ steps.correlate.outputs.none }}
+      unresolved: ${{ steps.correlate.outputs.unresolved }}
+      material_leaves: ${{ steps.correlate.outputs.material_leaves }}
+      component_source_matched: ${{ steps.correlate.outputs.component_source_matched }}
+      pre_sdc_gap: ${{ steps.correlate.outputs.pre_sdc_gap }}
+      sdc_metadata_matched: ${{ steps.correlate.outputs.sdc_metadata_matched }}
+      newly_explained: ${{ steps.correlate.outputs.newly_explained }}
+      final_matched: ${{ steps.correlate.outputs.final_matched }}
+      final_unmatched: ${{ steps.correlate.outputs.final_unmatched }}
+      verdict: ${{ steps.correlate.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #772 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-sdc-metadata-772.yaml <<EOF_CONFIG
+          name: agency-config-sdc-metadata-772-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-sdc-metadata-772-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-sdc-metadata-772'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Correlate bounded SDC metadata provenance
+        id: correlate
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-sdc-metadata-772'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "SDC_NATIVE_METADATA_PROVENANCE_ANALYZED"' \
+            "$result" >/dev/null
+          jq -e '.counts.candidate_total == 4' "$result" >/dev/null
+          jq -e '.counts.analyzed == 4' "$result" >/dev/null
+          jq -e '.counts.sdc == 4' "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e '.counts.source_payload_unresolved == 0' "$result" >/dev/null
+          jq -e '.counts.material_translatable_leaves == 36' "$result" >/dev/null
+          jq -e '.counts.component_source_matched_leaves == 8' "$result" >/dev/null
+          jq -e '.counts.pre_sdc_gap_leaves == 28' "$result" >/dev/null
+          jq -e \
+            '(.counts.all_material_values_present_in_combined_native_sources + .counts.partial_material_values_present_in_combined_native_sources + .counts.no_material_values_present_in_combined_native_sources) == 4' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.strict_type_and_value_equality_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_specific_ids_from_runtime_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_creation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.value_presence_authorizes_migration == false' \
+            "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "all_present=$(jq -r '.counts.all_material_values_present_in_combined_native_sources' "$result")" >> "$GITHUB_OUTPUT"
+          echo "partial=$(jq -r '.counts.partial_material_values_present_in_combined_native_sources' "$result")" >> "$GITHUB_OUTPUT"
+          echo "none=$(jq -r '.counts.no_material_values_present_in_combined_native_sources' "$result")" >> "$GITHUB_OUTPUT"
+          echo "unresolved=$(jq -r '.counts.source_payload_unresolved' "$result")" >> "$GITHUB_OUTPUT"
+          echo "material_leaves=$(jq -r '.counts.material_translatable_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "component_source_matched=$(jq -r '.counts.component_source_matched_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "pre_sdc_gap=$(jq -r '.counts.pre_sdc_gap_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "sdc_metadata_matched=$(jq -r '.counts.sdc_metadata_matched_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "newly_explained=$(jq -r '.counts.newly_explained_by_sdc_metadata_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "final_matched=$(jq -r '.counts.final_matched_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "final_unmatched=$(jq -r '.counts.final_unmatched_leaves' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #772 SDC metadata evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-sdc-metadata-772-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-sdc-metadata-772
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-sdc-metadata-772-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-sdc-metadata-772.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-sdc-metadata-772
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #772 SDC metadata verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - correlate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CORRELATE_RESULT: ${{ needs.correlate.result }}
+          ALL_PRESENT: ${{ needs.correlate.outputs.all_present }}
+          PARTIAL: ${{ needs.correlate.outputs.partial }}
+          NONE: ${{ needs.correlate.outputs.none }}
+          UNRESOLVED: ${{ needs.correlate.outputs.unresolved }}
+          MATERIAL_LEAVES: ${{ needs.correlate.outputs.material_leaves }}
+          COMPONENT_SOURCE_MATCHED: ${{ needs.correlate.outputs.component_source_matched }}
+          PRE_SDC_GAP: ${{ needs.correlate.outputs.pre_sdc_gap }}
+          SDC_METADATA_MATCHED: ${{ needs.correlate.outputs.sdc_metadata_matched }}
+          NEWLY_EXPLAINED: ${{ needs.correlate.outputs.newly_explained }}
+          FINAL_MATCHED: ${{ needs.correlate.outputs.final_matched }}
+          FINAL_UNMATCHED: ${{ needs.correlate.outputs.final_unmatched }}
+          MACHINE_VERDICT: ${{ needs.correlate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CORRELATE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 772 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### SDC native metadata provenance ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CORRELATE_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`4\`
+          all_material_values_present: \`${ALL_PRESENT:-n/a}\`
+          partial_material_values_present: \`${PARTIAL:-n/a}\`
+          no_material_values_present: \`${NONE:-n/a}\`
+          source_payload_unresolved: \`${UNRESOLVED:-n/a}\`
+          material_leaves: \`${MATERIAL_LEAVES:-n/a}\`
+          component_source_matched: \`${COMPONENT_SOURCE_MATCHED:-n/a}\`
+          pre_sdc_gap: \`${PRE_SDC_GAP:-n/a}\`
+          sdc_metadata_matched: \`${SDC_METADATA_MATCHED:-n/a}\`
+          newly_explained_by_sdc_metadata: \`${NEWLY_EXPLAINED:-n/a}\`
+          final_matched: \`${FINAL_MATCHED:-n/a}\`
+          final_unmatched: \`${FINAL_UNMATCHED:-n/a}\`
+          artifact: \`agency-config-language-sdc-metadata-772-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Strict read-only correlation through runtime source IDs and Drupal's native plugin.manager.sdc. Value presence does not authorize migration. No Canvas generation, config mutation/export, Configuration Language Lock activation, production access, provider secret, language heuristic or fuzzy match is permitted.
+          EOF_BODY
+          )"
+          test "$CORRELATE_RESULT" = 'success'

--- a/scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php
+++ b/scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php
@@ -1,0 +1,621 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+
+$expectedNames = [
+  'canvas.component.sdc.emerging_digital.cta',
+  'canvas.component.sdc.emerging_digital.hero',
+  'canvas.component.sdc.emerging_digital.trust-list',
+  'canvas.component.sdc.olivero.teaser',
+];
+sort($expectedNames, SORT_STRING);
+$expectedNamesHash = 'b1babac65a7a0d0e6e22f776fc26cb486dea0882b2d27d98daed2a8f2f5cbe71';
+if (hash('sha256', implode("\n", $expectedNames) . "\n") !== $expectedNamesHash) {
+  throw new RuntimeException('Issue #772 fixed SDC cohort hash mismatch.');
+}
+
+if (!is_dir($configDirectory)) {
+  throw new RuntimeException('Issue #772 config directory is unavailable.');
+}
+
+$displayPath = static function (array $segments): string {
+  return implode('.', array_map(
+    static fn(string|int $segment): string => (string) $segment,
+    $segments,
+  ));
+};
+
+$isMaterial = static function (mixed $value): bool {
+  if ($value === NULL || $value === []) {
+    return FALSE;
+  }
+  if (is_string($value)) {
+    return trim($value) !== '';
+  }
+  return is_scalar($value);
+};
+
+$collectTranslatableLeaves = NULL;
+$collectTranslatableLeaves = static function (
+  TypedDataInterface $element,
+  array $segments = [],
+) use (&$collectTranslatableLeaves, $displayPath): array {
+  if ($element instanceof TraversableTypedDataInterface) {
+    $leaves = [];
+    foreach ($element as $key => $child) {
+      if (!$child instanceof TypedDataInterface) {
+        continue;
+      }
+      foreach (
+        $collectTranslatableLeaves($child, [...$segments, $key])
+        as $leaf
+      ) {
+        $leaves[] = $leaf;
+      }
+    }
+    return $leaves;
+  }
+
+  $definition = $element->getDataDefinition();
+  if (empty($definition['translatable'])) {
+    return [];
+  }
+
+  return [[
+    'segments' => $segments,
+    'path' => $displayPath($segments),
+    'value' => $element->getValue(),
+  ]];
+};
+
+$normalizeForEvidence = NULL;
+$normalizeForEvidence = static function (
+  mixed $value,
+  array $segments = [],
+) use (&$normalizeForEvidence, $displayPath): mixed {
+  if ($value instanceof TranslatableMarkup) {
+    return [
+      '__kind' => 'translatable_markup',
+      '__class' => $value::class,
+      'untranslated' => $value->getUntranslatedString(),
+    ];
+  }
+
+  if (is_array($value)) {
+    $normalized = [];
+    $keys = array_keys($value);
+    $isList = $keys === range(0, count($keys) - 1);
+    if (!$isList) {
+      sort($keys, SORT_STRING);
+    }
+    foreach ($keys as $key) {
+      $normalized[$key] = $normalizeForEvidence(
+        $value[$key],
+        [...$segments, $key],
+      );
+    }
+    return $normalized;
+  }
+
+  if ($value instanceof BackedEnum) {
+    return [
+      '__kind' => 'backed_enum',
+      '__class' => $value::class,
+      'name' => $value->name,
+      'value' => $value->value,
+    ];
+  }
+
+  if ($value instanceof UnitEnum) {
+    return [
+      '__kind' => 'unit_enum',
+      '__class' => $value::class,
+      'name' => $value->name,
+    ];
+  }
+
+  if (is_object($value)) {
+    return [
+      '__kind' => 'object',
+      '__class' => $value::class,
+      '__path' => $displayPath($segments),
+    ];
+  }
+
+  if (is_scalar($value) || $value === NULL) {
+    return $value;
+  }
+
+  return [
+    '__kind' => 'unsupported',
+    '__type' => get_debug_type($value),
+    '__path' => $displayPath($segments),
+  ];
+};
+
+$collectComparableScalars = NULL;
+$collectComparableScalars = static function (
+  mixed $value,
+  string $payload,
+  array $segments = [],
+) use (&$collectComparableScalars, $displayPath): array {
+  if ($value instanceof TranslatableMarkup) {
+    return [[
+      'payload' => $payload,
+      'path' => $displayPath([...$segments, 'untranslated']),
+      'kind' => 'translatable_markup_untranslated',
+      'value_type' => 'string',
+      'value' => $value->getUntranslatedString(),
+    ]];
+  }
+
+  if (is_array($value)) {
+    $scalars = [];
+    foreach ($value as $key => $child) {
+      foreach (
+        $collectComparableScalars($child, $payload, [...$segments, $key])
+        as $scalar
+      ) {
+        $scalars[] = $scalar;
+      }
+    }
+    return $scalars;
+  }
+
+  if (is_scalar($value)) {
+    return [[
+      'payload' => $payload,
+      'path' => $displayPath($segments),
+      'kind' => 'native_scalar',
+      'value_type' => get_debug_type($value),
+      'value' => $value,
+    ]];
+  }
+
+  return [];
+};
+
+$typedConfigManager = \Drupal::service('config.typed');
+$entityTypeManager = \Drupal::entityTypeManager();
+$container = \Drupal::getContainer();
+if (!$container->has('plugin.manager.sdc')) {
+  throw new RuntimeException('Issue #772 requires plugin.manager.sdc.');
+}
+$sdcManager = $container->get('plugin.manager.sdc');
+
+$componentEntityTypeIds = [];
+foreach ($entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+  if (
+    $definition instanceof \Drupal\Core\Config\Entity\ConfigEntityTypeInterface
+    && $definition->getConfigPrefix() === 'canvas.component'
+  ) {
+    $componentEntityTypeIds[] = $entityTypeId;
+  }
+}
+sort($componentEntityTypeIds, SORT_STRING);
+if (count($componentEntityTypeIds) !== 1) {
+  throw new RuntimeException(sprintf(
+    'Expected exactly one Canvas component config entity type, found %d.',
+    count($componentEntityTypeIds),
+  ));
+}
+$componentEntityTypeId = $componentEntityTypeIds[0];
+$componentStorage = $entityTypeManager->getStorage($componentEntityTypeId);
+
+$baselineProblems = [];
+$items = [];
+$totalMaterialLeaves = 0;
+$totalComponentSourceMatched = 0;
+$totalSdcMetadataMatched = 0;
+$totalNewlyExplainedBySdc = 0;
+$totalFinalMatched = 0;
+$totalFinalUnmatched = 0;
+$allPresent = 0;
+$partial = 0;
+$none = 0;
+$unresolved = 0;
+
+foreach ($expectedNames as $configName) {
+  $path = $configDirectory . '/' . $configName . '.yml';
+  if (!is_file($path)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_missing',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $repositoryData = Yaml::parseFile($path);
+  if (!is_array($repositoryData)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_invalid',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  if (($repositoryData['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_langcode_not_fr',
+      'actual' => $repositoryData['langcode'] ?? NULL,
+    ];
+    $unresolved++;
+    continue;
+  }
+  if (($repositoryData['source'] ?? NULL) !== 'sdc') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_source_not_sdc',
+      'actual' => $repositoryData['source'] ?? NULL,
+    ];
+    $unresolved++;
+    continue;
+  }
+  if (is_file($configDirectory . '/language/en/' . $configName . '.yml')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'unexpected_en_override',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $entityId = $repositoryData['id'] ?? NULL;
+  $repositorySourceLocalId = $repositoryData['source_local_id'] ?? NULL;
+  if (
+    !is_string($entityId)
+    || $entityId === ''
+    || !is_string($repositorySourceLocalId)
+    || $repositorySourceLocalId === ''
+  ) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_source_identity_invalid',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $entity = $componentStorage->load($entityId);
+  if ($entity === NULL || !method_exists($entity, 'getComponentSource')) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_component_source_unavailable',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $runtimeData = $entity->toArray();
+  foreach ([
+    'source' => 'sdc',
+    'source_local_id' => $repositorySourceLocalId,
+    'provider' => $repositoryData['provider'] ?? NULL,
+  ] as $key => $expectedValue) {
+    if (($runtimeData[$key] ?? NULL) !== $expectedValue) {
+      $baselineProblems[] = [
+        'name' => $configName,
+        'reason' => 'runtime_source_identity_mismatch',
+        'key' => $key,
+        'expected' => $expectedValue,
+        'actual' => $runtimeData[$key] ?? NULL,
+      ];
+      $unresolved++;
+      continue 2;
+    }
+  }
+
+  $sourceObject = $entity->getComponentSource();
+  if (
+    !is_object($sourceObject)
+    || !method_exists($sourceObject, 'getSourceSpecificComponentId')
+    || !method_exists($sourceObject, 'getConfiguration')
+  ) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_sdc_source_api_incomplete',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $sourceSpecificId = $sourceObject->getSourceSpecificComponentId();
+  if (
+    !is_string($sourceSpecificId)
+    || $sourceSpecificId === ''
+    || $sourceSpecificId !== $repositorySourceLocalId
+  ) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'source_specific_component_id_mismatch',
+      'expected' => $repositorySourceLocalId,
+      'actual' => $sourceSpecificId,
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  if (!$sdcManager->hasDefinition($sourceSpecificId)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'sdc_definition_missing',
+      'source_specific_component_id' => $sourceSpecificId,
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $sdcDefinition = $sdcManager->getDefinition($sourceSpecificId, FALSE);
+  if (!is_array($sdcDefinition)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'sdc_definition_not_array',
+      'source_specific_component_id' => $sourceSpecificId,
+      'actual_type' => get_debug_type($sdcDefinition),
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  if (($sdcDefinition['id'] ?? NULL) !== $sourceSpecificId) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'sdc_definition_id_mismatch',
+      'expected' => $sourceSpecificId,
+      'actual' => $sdcDefinition['id'] ?? NULL,
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $typed = $typedConfigManager->get($configName);
+  if (!$typed instanceof TypedDataInterface) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'typed_config_unavailable',
+    ];
+    $unresolved++;
+    continue;
+  }
+
+  $allTranslatableLeaves = $collectTranslatableLeaves($typed);
+  $materialLeaves = array_values(array_filter(
+    $allTranslatableLeaves,
+    static fn(array $leaf): bool => $isMaterial($leaf['value'] ?? NULL),
+  ));
+
+  $componentSourceConfiguration = $sourceObject->getConfiguration();
+  $componentSourceScalars = $collectComparableScalars(
+    $componentSourceConfiguration,
+    'component_source_configuration',
+    ['component_source_configuration'],
+  );
+  $sdcDefinitionScalars = $collectComparableScalars(
+    $sdcDefinition,
+    'sdc_definition',
+    ['sdc_definition'],
+  );
+  $allNativeScalars = [
+    ...$componentSourceScalars,
+    ...$sdcDefinitionScalars,
+  ];
+
+  $componentSourceMatchedLeafCount = 0;
+  $sdcMetadataMatchedLeafCount = 0;
+  $newlyExplainedBySdcCount = 0;
+  $finalMatchedLeafCount = 0;
+  $evidenceLeaves = [];
+
+  foreach ($materialLeaves as $leaf) {
+    $value = $leaf['value'];
+    $valueType = get_debug_type($value);
+    $matches = [];
+    foreach ($allNativeScalars as $scalar) {
+      if (
+        $scalar['value_type'] === $valueType
+        && $scalar['value'] === $value
+      ) {
+        $matches[] = [
+          'payload' => $scalar['payload'],
+          'path' => $scalar['path'],
+          'kind' => $scalar['kind'],
+        ];
+      }
+    }
+
+    $componentSourceMatches = array_values(array_filter(
+      $matches,
+      static fn(array $match): bool =>
+        $match['payload'] === 'component_source_configuration',
+    ));
+    $sdcMetadataMatches = array_values(array_filter(
+      $matches,
+      static fn(array $match): bool => $match['payload'] === 'sdc_definition',
+    ));
+
+    if ($componentSourceMatches !== []) {
+      $componentSourceMatchedLeafCount++;
+    }
+    if ($sdcMetadataMatches !== []) {
+      $sdcMetadataMatchedLeafCount++;
+    }
+    if ($componentSourceMatches === [] && $sdcMetadataMatches !== []) {
+      $newlyExplainedBySdcCount++;
+    }
+    if ($matches !== []) {
+      $finalMatchedLeafCount++;
+    }
+
+    $evidenceLeaves[] = [
+      'path' => $leaf['path'],
+      'value' => $value,
+      'value_type' => $valueType,
+      'component_source_matches' => $componentSourceMatches,
+      'sdc_metadata_matches' => $sdcMetadataMatches,
+      'final_matched' => $matches !== [],
+      'newly_explained_by_sdc_metadata' =>
+        $componentSourceMatches === [] && $sdcMetadataMatches !== [],
+    ];
+  }
+
+  $materialLeafCount = count($materialLeaves);
+  $finalUnmatchedLeafCount = $materialLeafCount - $finalMatchedLeafCount;
+  if ($materialLeafCount === 0) {
+    $classification = 'no_material_translatable_leaves';
+  }
+  elseif ($finalMatchedLeafCount === $materialLeafCount) {
+    $classification = 'all_material_values_present_in_combined_native_sources';
+    $allPresent++;
+  }
+  elseif ($finalMatchedLeafCount > 0) {
+    $classification = 'partial_material_values_present_in_combined_native_sources';
+    $partial++;
+  }
+  else {
+    $classification = 'no_material_values_present_in_combined_native_sources';
+    $none++;
+  }
+
+  $totalMaterialLeaves += $materialLeafCount;
+  $totalComponentSourceMatched += $componentSourceMatchedLeafCount;
+  $totalSdcMetadataMatched += $sdcMetadataMatchedLeafCount;
+  $totalNewlyExplainedBySdc += $newlyExplainedBySdcCount;
+  $totalFinalMatched += $finalMatchedLeafCount;
+  $totalFinalUnmatched += $finalUnmatchedLeafCount;
+
+  $items[] = [
+    'config_name' => $configName,
+    'entity_id' => $entityId,
+    'source' => 'sdc',
+    'source_specific_component_id' => $sourceSpecificId,
+    'source_class' => $sourceObject::class,
+    'sdc_manager_class' => $sdcManager::class,
+    'sdc_definition_provider' => $sdcDefinition['provider'] ?? NULL,
+    'classification' => $classification,
+    'material_translatable_leaf_count' => $materialLeafCount,
+    'component_source_matched_leaf_count' => $componentSourceMatchedLeafCount,
+    'sdc_metadata_matched_leaf_count' => $sdcMetadataMatchedLeafCount,
+    'newly_explained_by_sdc_metadata_count' => $newlyExplainedBySdcCount,
+    'final_matched_leaf_count' => $finalMatchedLeafCount,
+    'final_unmatched_leaf_count' => $finalUnmatchedLeafCount,
+    'material_translatable_leaves' => $evidenceLeaves,
+    'native_source' => [
+      'component_source_configuration' => $normalizeForEvidence(
+        $componentSourceConfiguration,
+        ['component_source_configuration'],
+      ),
+      'sdc_definition' => $normalizeForEvidence(
+        $sdcDefinition,
+        ['sdc_definition'],
+      ),
+    ],
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+
+if (count($items) !== 4) {
+  $baselineProblems[] = [
+    'reason' => 'analyzed_component_count_mismatch',
+    'actual' => count($items),
+    'expected' => 4,
+  ];
+}
+if ($totalMaterialLeaves !== 36) {
+  $baselineProblems[] = [
+    'reason' => 'material_translatable_leaf_baseline_mismatch',
+    'actual' => $totalMaterialLeaves,
+    'expected' => 36,
+  ];
+}
+if ($totalComponentSourceMatched !== 8) {
+  $baselineProblems[] = [
+    'reason' => 'component_source_match_baseline_mismatch',
+    'actual' => $totalComponentSourceMatched,
+    'expected' => 8,
+  ];
+}
+if (($totalMaterialLeaves - $totalComponentSourceMatched) !== 28) {
+  $baselineProblems[] = [
+    'reason' => 'pre_sdc_gap_baseline_mismatch',
+    'actual' => $totalMaterialLeaves - $totalComponentSourceMatched,
+    'expected' => 28,
+  ];
+}
+
+$problems = $baselineProblems;
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'SDC_NATIVE_METADATA_PROVENANCE_ANALYZED'
+  : 'SDC_NATIVE_METADATA_PROVENANCE_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'cohort_names_sha256' => $expectedNamesHash,
+  'runtime' => [
+    'component_entity_type_id' => $componentEntityTypeId,
+    'sdc_manager_service_id' => 'plugin.manager.sdc',
+    'sdc_manager_class' => $sdcManager::class,
+  ],
+  'counts' => [
+    'candidate_total' => 4,
+    'analyzed' => count($items),
+    'sdc' => count($items),
+    'baseline_problem' => count($baselineProblems),
+    'problem_count' => count($problems),
+    'source_payload_unresolved' => $unresolved,
+    'material_translatable_leaves' => $totalMaterialLeaves,
+    'component_source_matched_leaves' => $totalComponentSourceMatched,
+    'pre_sdc_gap_leaves' => $totalMaterialLeaves - $totalComponentSourceMatched,
+    'sdc_metadata_matched_leaves' => $totalSdcMetadataMatched,
+    'newly_explained_by_sdc_metadata_leaves' => $totalNewlyExplainedBySdc,
+    'final_matched_leaves' => $totalFinalMatched,
+    'final_unmatched_leaves' => $totalFinalUnmatched,
+    'all_material_values_present_in_combined_native_sources' => $allPresent,
+    'partial_material_values_present_in_combined_native_sources' => $partial,
+    'no_material_values_present_in_combined_native_sources' => $none,
+  ],
+  'items' => $items,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'strict_type_and_value_equality_only' => TRUE,
+    'source_specific_ids_from_runtime_only' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'value_presence_authorizes_migration' => FALSE,
+    'source_generation_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSdcNativeMetadata772Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSdcNativeMetadata772Test.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #772 SDC native metadata provenance proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageSdcNativeMetadata772Test extends TestCase {
+
+  /**
+   * The probe is fixed to the four SDC gaps established by #770.
+   */
+  public function testProbeFixesExactSdcGapCohort(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-sdc-native-metadata-provenance-772.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    foreach ([
+      'canvas.component.sdc.emerging_digital.cta',
+      'canvas.component.sdc.emerging_digital.hero',
+      'canvas.component.sdc.emerging_digital.trust-list',
+      'canvas.component.sdc.olivero.teaser',
+    ] as $name) {
+      self::assertStringContainsString("'$name'", $script);
+    }
+    self::assertStringContainsString(
+      'b1babac65a7a0d0e6e22f776fc26cb486dea0882b2d27d98daed2a8f2f5cbe71',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'material_translatable_leaves' => \$totalMaterialLeaves",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'component_source_matched_leaves' => \$totalComponentSourceMatched",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'pre_sdc_gap_leaves' => \$totalMaterialLeaves - \$totalComponentSourceMatched",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'expected' => 36",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'expected' => 8",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'expected' => 28",
+      $script,
+    );
+  }
+
+  /**
+   * Native SDC resolution is read-only and uses runtime source IDs.
+   */
+  public function testProbeUsesNativeSdcManagerWithoutGeneration(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-sdc-native-metadata-provenance-772.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("'plugin.manager.sdc'", $script);
+    self::assertStringContainsString(
+      '$sourceObject->getSourceSpecificComponentId()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$sdcManager->hasDefinition($sourceSpecificId)',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$sdcManager->getDefinition($sourceSpecificId, FALSE)',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$sourceObject->getConfiguration()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$value->getUntranslatedString()',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'strict_type_and_value_equality_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'source_specific_ids_from_runtime_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'value_presence_authorizes_migration' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'source_generation_executed' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      'SDC_NATIVE_METADATA_PROVENANCE_ANALYZED',
+      $script,
+    );
+
+    foreach ([
+      '->generateComponents(',
+      '->save(',
+      '->write(',
+      '->delete(',
+      '->createConfigEntity(',
+      '->updateConfigEntity(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route is fixed, live-main-only and read-only.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-sdc-native-metadata-772.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 772',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-sdc-metadata correlate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      "grep -Fq 'No differences'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'SDC_NATIVE_METADATA_PROVENANCE_ANALYZED',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.candidate_total == 4',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.material_translatable_leaves == 36',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.component_source_matched_leaves == 8',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.pre_sdc_gap_leaves == 28',
+      $workflow,
+    );
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Implements the bounded read-only #772 proof for the exact four SDC gaps left by #770.

This PR adds only:
- a probe that combines already-proven `ComponentSource::getConfiguration()` values with exact `plugin.manager.sdc->getDefinition($source_specific_component_id)` metadata;
- an owner-only/live-main-only fresh-DDEV trusted route;
- a contract test.

Baseline locked from #770:
- 4 SDC components;
- 36 material translatable leaves;
- 8 already explained by ComponentSource configuration;
- 28 pre-SDC metadata gaps.

The trusted result will measure how many of those 28 gaps are newly explained by native SDC metadata. It does **not** require a preferred outcome and does not authorize migration by value equality.

No `config/sync` change, no Canvas generation, no save/create/update/delete, no `drush cex`, no Configuration Language Lock activation, no production/provider/secret, no language heuristic or fuzzy matching.

Refs #772 #770 #766 #609