### PR TITLE
Issue #774: prove Canvas Block native label provenance

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-block-native-label-774.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-block-native-label-774.yml
@@ -1,0 +1,282 @@
+name: Agency trusted Canvas Block native label provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #774 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 774 &&
+        github.event.comment.body == '/agency-config-language-block-labels correlate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '774'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-block-labels correlate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/774" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  correlate:
+    name: Correlate exact 26 Canvas Blocks to native labels
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      translatable: ${{ steps.correlate.outputs.translatable }}
+      scalar: ${{ steps.correlate.outputs.scalar }}
+      source_match: ${{ steps.correlate.outputs.source_match }}
+      fr_match: ${{ steps.correlate.outputs.fr_match }}
+      en_match: ${{ steps.correlate.outputs.en_match }}
+      scalar_match: ${{ steps.correlate.outputs.scalar_match }}
+      no_match: ${{ steps.correlate.outputs.no_match }}
+      differs_source: ${{ steps.correlate.outputs.differs_source }}
+      with_arguments: ${{ steps.correlate.outputs.with_arguments }}
+      verdict: ${{ steps.correlate.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #774 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-block-label-774.yaml <<EOF_CONFIG
+          name: agency-config-block-label-774-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-block-label-774-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-label-774'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Correlate bounded Block native label provenance
+        id: correlate
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-label-774'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e \
+            '.verdict == "CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_ANALYZED"' \
+            "$result" >/dev/null
+          jq -e '.counts.candidate_total == 26' "$result" >/dev/null
+          jq -e '.counts.analyzed == 26' "$result" >/dev/null
+          jq -e '.counts.definition_resolved == 26' "$result" >/dev/null
+          jq -e \
+            '(.counts.translatable_admin_label + .counts.scalar_admin_label) == 26' \
+            "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e \
+            '.cohort_names_sha256 == "e388542385fb7cd490c79ef0783dd1ace930ab1b1db1a0762fd50df783db247c"' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.source_local_ids_from_runtime_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.block_definition_surface == "plugin.manager.block"' \
+            "$result" >/dev/null
+          jq -e '.constraints.strict_equality_only == true' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.automatic_translation_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_proof == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.block_build_executed == false' "$result" >/dev/null
+          jq -e '.constraints.config_entity_creation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "translatable=$(jq -r '.counts.translatable_admin_label' "$result")" >> "$GITHUB_OUTPUT"
+          echo "scalar=$(jq -r '.counts.scalar_admin_label' "$result")" >> "$GITHUB_OUTPUT"
+          echo "source_match=$(jq -r '.counts.current_matches_untranslated_source' "$result")" >> "$GITHUB_OUTPUT"
+          echo "fr_match=$(jq -r '.counts.current_matches_rendered_fr' "$result")" >> "$GITHUB_OUTPUT"
+          echo "en_match=$(jq -r '.counts.current_matches_rendered_en' "$result")" >> "$GITHUB_OUTPUT"
+          echo "scalar_match=$(jq -r '.counts.current_matches_scalar_definition' "$result")" >> "$GITHUB_OUTPUT"
+          echo "no_match=$(jq -r '.counts.current_no_exact_native_label_match' "$result")" >> "$GITHUB_OUTPUT"
+          echo "differs_source=$(jq -r '.counts.current_differs_from_native_source' "$result")" >> "$GITHUB_OUTPUT"
+          echo "with_arguments=$(jq -r '.counts.admin_labels_with_arguments' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #774 Block label evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-block-label-774-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-block-label-774
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-block-label-774-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-block-label-774.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-block-label-774
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #774 Block label verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - correlate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CORRELATE_RESULT: ${{ needs.correlate.result }}
+          TRANSLATABLE: ${{ needs.correlate.outputs.translatable }}
+          SCALAR: ${{ needs.correlate.outputs.scalar }}
+          SOURCE_MATCH: ${{ needs.correlate.outputs.source_match }}
+          FR_MATCH: ${{ needs.correlate.outputs.fr_match }}
+          EN_MATCH: ${{ needs.correlate.outputs.en_match }}
+          SCALAR_MATCH: ${{ needs.correlate.outputs.scalar_match }}
+          NO_MATCH: ${{ needs.correlate.outputs.no_match }}
+          DIFFERS_SOURCE: ${{ needs.correlate.outputs.differs_source }}
+          WITH_ARGUMENTS: ${{ needs.correlate.outputs.with_arguments }}
+          MACHINE_VERDICT: ${{ needs.correlate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CORRELATE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 774 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Canvas Block native label provenance ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CORRELATE_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`26\`
+          translatable_admin_label: \`${TRANSLATABLE:-n/a}\`
+          scalar_admin_label: \`${SCALAR:-n/a}\`
+          current_matches_untranslated_source: \`${SOURCE_MATCH:-n/a}\`
+          current_matches_rendered_fr: \`${FR_MATCH:-n/a}\`
+          current_matches_rendered_en: \`${EN_MATCH:-n/a}\`
+          current_matches_scalar_definition: \`${SCALAR_MATCH:-n/a}\`
+          current_no_exact_native_label_match: \`${NO_MATCH:-n/a}\`
+          current_differs_from_native_source: \`${DIFFERS_SOURCE:-n/a}\`
+          admin_labels_with_arguments: \`${WITH_ARGUMENTS:-n/a}\`
+          artifact: \`agency-config-language-block-label-774-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Strict read-only provenance through runtime source IDs and Drupal's native plugin.manager.block. No label value or language classification authorizes migration by itself. No Canvas generation/build, config mutation/export, Configuration Language Lock activation, production access, provider secret, language heuristic or fuzzy match is permitted.
+          EOF_BODY
+          )"
+          test "$CORRELATE_RESULT" = 'success'

--- a/scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php
+++ b/scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php
@@ -1,0 +1,547 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Drupal\Core\Config\Entity\ConfigEntityTypeInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/'
+  . 'configuration-language-canvas-runtime-source-api-cohort-766.yml';
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #774 source baseline is incomplete.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (!is_array($manifest)) {
+  throw new RuntimeException('Issue #766 manifest must be a mapping.');
+}
+if (($manifest['issue'] ?? NULL) !== 766 || ($manifest['parent_issue'] ?? NULL) !== 609) {
+  throw new RuntimeException('Issue #774 must reuse the exact #766 cohort.');
+}
+
+$manifestNames = $manifest['cohort']['names'] ?? NULL;
+if (!is_array($manifestNames) || count($manifestNames) !== 30) {
+  throw new RuntimeException('Issue #766 manifest names are incomplete.');
+}
+$blockNames = array_values(array_filter(
+  array_map('strval', $manifestNames),
+  static fn(string $name): bool => str_starts_with(
+    $name,
+    'canvas.component.block.',
+  ),
+));
+sort($blockNames, SORT_STRING);
+if (count($blockNames) !== 26 || count(array_unique($blockNames)) !== 26) {
+  throw new RuntimeException('Issue #774 requires exactly 26 unique Block names.');
+}
+$blockNamesHash = hash('sha256', implode("\n", $blockNames) . "\n");
+if (
+  $blockNamesHash
+  !== 'e388542385fb7cd490c79ef0783dd1ace930ab1b1db1a0762fd50df783db247c'
+) {
+  throw new RuntimeException('Issue #774 Block cohort hash mismatch.');
+}
+
+$canvasVersion = InstalledVersions::getPrettyVersion('drupal/canvas');
+if ($canvasVersion !== '1.10.1') {
+  throw new RuntimeException(sprintf(
+    'Issue #774 requires Canvas 1.10.1, got %s.',
+    $canvasVersion ?? 'unknown',
+  ));
+}
+
+$entityTypeManager = \Drupal::entityTypeManager();
+$activeStorage = \Drupal::service('config.storage');
+$blockManager = \Drupal::service('plugin.manager.block');
+$stringTranslation = \Drupal::translation();
+
+$componentEntityTypeIds = [];
+foreach ($entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+  if (
+    $definition instanceof ConfigEntityTypeInterface
+    && $definition->getConfigPrefix() === 'canvas.component'
+  ) {
+    $componentEntityTypeIds[] = $entityTypeId;
+  }
+}
+sort($componentEntityTypeIds, SORT_STRING);
+if (count($componentEntityTypeIds) !== 1) {
+  throw new RuntimeException('Expected exactly one Canvas Component config entity type.');
+}
+$componentEntityTypeId = $componentEntityTypeIds[0];
+$componentStorage = $entityTypeManager->getStorage($componentEntityTypeId);
+
+$baselineProblems = [];
+$repositoryDataByName = [];
+foreach ($blockNames as $configName) {
+  $path = $configDirectory . '/' . $configName . '.yml';
+  if (!is_file($path)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_missing',
+    ];
+    continue;
+  }
+  $data = Yaml::parseFile($path);
+  if (!is_array($data)) {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_invalid',
+    ];
+    continue;
+  }
+  $repositoryDataByName[$configName] = $data;
+  if (($data['langcode'] ?? NULL) !== 'fr') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_langcode_not_fr',
+      'actual' => $data['langcode'] ?? NULL,
+    ];
+  }
+  if (($data['source'] ?? NULL) !== 'block') {
+    $baselineProblems[] = [
+      'name' => $configName,
+      'reason' => 'repository_source_not_block',
+      'actual' => $data['source'] ?? NULL,
+    ];
+  }
+}
+
+$activeDistribution = [
+  '__none__' => 0,
+  'en' => 0,
+  'fr' => 0,
+  'und' => 0,
+];
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_config_unreadable',
+    ];
+    continue;
+  }
+  $langcode = $data['langcode'] ?? NULL;
+  $key = is_string($langcode) ? $langcode : '__none__';
+  if (!array_key_exists($key, $activeDistribution)) {
+    $activeDistribution[$key] = 0;
+  }
+  $activeDistribution[$key]++;
+}
+ksort($activeDistribution, SORT_STRING);
+$expectedDistribution = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+ksort($expectedDistribution, SORT_STRING);
+if (count($activeNames) !== 595) {
+  $baselineProblems[] = [
+    'reason' => 'active_total_mismatch',
+    'actual' => count($activeNames),
+    'expected' => 595,
+  ];
+}
+if ($activeDistribution !== $expectedDistribution) {
+  $baselineProblems[] = [
+    'reason' => 'active_distribution_mismatch',
+    'actual' => $activeDistribution,
+    'expected' => $expectedDistribution,
+  ];
+}
+
+$renderTranslation = static function (
+  TranslatableMarkup $label,
+  string $langcode,
+) use ($stringTranslation): string {
+  $options = $label->getOptions();
+  $options['langcode'] = $langcode;
+  return (string) $stringTranslation->translate(
+    $label->getUntranslatedString(),
+    $label->getArguments(),
+    $options,
+  );
+};
+
+$items = [];
+$problems = $baselineProblems;
+$definitionResolved = 0;
+$translatableLabelCount = 0;
+$scalarLabelCount = 0;
+$currentMatchesUntranslated = 0;
+$currentMatchesRuntimeRender = 0;
+$currentMatchesFrRender = 0;
+$currentMatchesEnRender = 0;
+$currentMatchesScalar = 0;
+$currentNoExactNativeMatch = 0;
+$currentDiffersFromNativeSource = [];
+$settingsDiffersFromCurrent = [];
+$labelsWithArguments = 0;
+
+foreach ($blockNames as $configName) {
+  $repositoryData = $repositoryDataByName[$configName] ?? NULL;
+  if (!is_array($repositoryData)) {
+    continue;
+  }
+
+  $activeData = $activeStorage->read($configName);
+  if (!is_array($activeData)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'active_component_config_missing',
+    ];
+    continue;
+  }
+  foreach (['source', 'source_local_id', 'provider', 'label', 'id'] as $key) {
+    if (($activeData[$key] ?? NULL) !== ($repositoryData[$key] ?? NULL)) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'active_repository_identity_mismatch',
+        'key' => $key,
+        'repository' => $repositoryData[$key] ?? NULL,
+        'active' => $activeData[$key] ?? NULL,
+      ];
+      continue 2;
+    }
+  }
+
+  $entityId = $activeData['id'] ?? NULL;
+  $sourceLocalId = $activeData['source_local_id'] ?? NULL;
+  $provider = $activeData['provider'] ?? NULL;
+  $currentLabel = $activeData['label'] ?? NULL;
+  $settingsLabel = $activeData['versioned_properties']['active']['settings']
+    ['default_settings']['label'] ?? NULL;
+  if (
+    !is_string($entityId)
+    || $entityId === ''
+    || !is_string($sourceLocalId)
+    || $sourceLocalId === ''
+    || !is_string($provider)
+    || $provider === ''
+    || !is_string($currentLabel)
+    || !is_string($settingsLabel)
+  ) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'component_identity_or_label_invalid',
+    ];
+    continue;
+  }
+
+  $entity = $componentStorage->load($entityId);
+  if ($entity === NULL || !method_exists($entity, 'getComponentSource')) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_component_entity_unavailable',
+    ];
+    continue;
+  }
+  $runtimeData = $entity->toArray();
+  if (
+    ($runtimeData['source'] ?? NULL) !== 'block'
+    || ($runtimeData['source_local_id'] ?? NULL) !== $sourceLocalId
+  ) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'runtime_component_source_identity_mismatch',
+    ];
+    continue;
+  }
+  $sourceObject = $entity->getComponentSource();
+  if (!is_object($sourceObject)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'component_source_object_missing',
+    ];
+    continue;
+  }
+
+  if (!$blockManager->hasDefinition($sourceLocalId)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'block_definition_missing',
+      'source_local_id' => $sourceLocalId,
+    ];
+    continue;
+  }
+  $definition = $blockManager->getDefinition($sourceLocalId, FALSE);
+  if (!is_array($definition)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'block_definition_invalid',
+      'source_local_id' => $sourceLocalId,
+    ];
+    continue;
+  }
+  $definitionResolved++;
+
+  $instanceIdentity = [
+    'plugin_id' => NULL,
+    'base_plugin_id' => NULL,
+    'derivative_id' => NULL,
+  ];
+  try {
+    $instance = $blockManager->createInstance($sourceLocalId, []);
+    if (method_exists($instance, 'getPluginId')) {
+      $instanceIdentity['plugin_id'] = $instance->getPluginId();
+    }
+    if (method_exists($instance, 'getBaseId')) {
+      $instanceIdentity['base_plugin_id'] = $instance->getBaseId();
+    }
+    if (method_exists($instance, 'getDerivativeId')) {
+      $instanceIdentity['derivative_id'] = $instance->getDerivativeId();
+    }
+  }
+  catch (Throwable $exception) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'block_instance_identity_unavailable',
+      'source_local_id' => $sourceLocalId,
+      'exception_class' => $exception::class,
+      'message' => $exception->getMessage(),
+    ];
+    continue;
+  }
+
+  $adminLabel = $definition['admin_label'] ?? NULL;
+  $labelEvidence = [
+    'kind' => NULL,
+    'untranslated_source' => NULL,
+    'arguments' => [],
+    'options' => [],
+    'rendered_runtime' => NULL,
+    'rendered_fr' => NULL,
+    'rendered_en' => NULL,
+    'scalar_definition' => NULL,
+  ];
+  $matches = [
+    'current_equals_untranslated_source' => FALSE,
+    'current_equals_rendered_runtime' => FALSE,
+    'current_equals_rendered_fr' => FALSE,
+    'current_equals_rendered_en' => FALSE,
+    'current_equals_scalar_definition' => FALSE,
+    'settings_equals_untranslated_source' => FALSE,
+    'settings_equals_rendered_runtime' => FALSE,
+    'settings_equals_rendered_fr' => FALSE,
+    'settings_equals_rendered_en' => FALSE,
+    'settings_equals_scalar_definition' => FALSE,
+  ];
+
+  if ($adminLabel instanceof TranslatableMarkup) {
+    $translatableLabelCount++;
+    $untranslated = $adminLabel->getUntranslatedString();
+    $arguments = $adminLabel->getArguments();
+    $options = $adminLabel->getOptions();
+    if ($arguments !== []) {
+      $labelsWithArguments++;
+    }
+    $renderedRuntime = (string) $adminLabel;
+    $renderedFr = $renderTranslation($adminLabel, 'fr');
+    $renderedEn = $renderTranslation($adminLabel, 'en');
+    $labelEvidence = [
+      'kind' => 'translatable_markup',
+      'untranslated_source' => $untranslated,
+      'arguments' => $arguments,
+      'options' => $options,
+      'rendered_runtime' => $renderedRuntime,
+      'rendered_fr' => $renderedFr,
+      'rendered_en' => $renderedEn,
+      'scalar_definition' => NULL,
+    ];
+    $matches = [
+      'current_equals_untranslated_source' => $currentLabel === $untranslated,
+      'current_equals_rendered_runtime' => $currentLabel === $renderedRuntime,
+      'current_equals_rendered_fr' => $currentLabel === $renderedFr,
+      'current_equals_rendered_en' => $currentLabel === $renderedEn,
+      'current_equals_scalar_definition' => FALSE,
+      'settings_equals_untranslated_source' => $settingsLabel === $untranslated,
+      'settings_equals_rendered_runtime' => $settingsLabel === $renderedRuntime,
+      'settings_equals_rendered_fr' => $settingsLabel === $renderedFr,
+      'settings_equals_rendered_en' => $settingsLabel === $renderedEn,
+      'settings_equals_scalar_definition' => FALSE,
+    ];
+    $currentMatchesUntranslated += (int) $matches['current_equals_untranslated_source'];
+    $currentMatchesRuntimeRender += (int) $matches['current_equals_rendered_runtime'];
+    $currentMatchesFrRender += (int) $matches['current_equals_rendered_fr'];
+    $currentMatchesEnRender += (int) $matches['current_equals_rendered_en'];
+    if (!$matches['current_equals_untranslated_source']) {
+      $currentDiffersFromNativeSource[] = $configName;
+    }
+  }
+  elseif (is_scalar($adminLabel)) {
+    $scalarLabelCount++;
+    $scalar = (string) $adminLabel;
+    $labelEvidence = [
+      'kind' => 'scalar_definition_literal',
+      'untranslated_source' => NULL,
+      'arguments' => [],
+      'options' => [],
+      'rendered_runtime' => NULL,
+      'rendered_fr' => NULL,
+      'rendered_en' => NULL,
+      'scalar_definition' => $scalar,
+    ];
+    $matches['current_equals_scalar_definition'] = $currentLabel === $scalar;
+    $matches['settings_equals_scalar_definition'] = $settingsLabel === $scalar;
+    $currentMatchesScalar += (int) $matches['current_equals_scalar_definition'];
+    if (!$matches['current_equals_scalar_definition']) {
+      $currentDiffersFromNativeSource[] = $configName;
+    }
+  }
+  else {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'admin_label_type_unsupported',
+      'actual_type' => get_debug_type($adminLabel),
+    ];
+    continue;
+  }
+
+  $anyCurrentMatch = in_array(TRUE, [
+    $matches['current_equals_untranslated_source'],
+    $matches['current_equals_rendered_runtime'],
+    $matches['current_equals_rendered_fr'],
+    $matches['current_equals_rendered_en'],
+    $matches['current_equals_scalar_definition'],
+  ], TRUE);
+  if (!$anyCurrentMatch) {
+    $currentNoExactNativeMatch++;
+  }
+  if ($currentLabel !== $settingsLabel) {
+    $settingsDiffersFromCurrent[] = $configName;
+  }
+
+  $items[] = [
+    'config_name' => $configName,
+    'entity_id' => $entityId,
+    'provider' => $provider,
+    'source_local_id' => $sourceLocalId,
+    'component_source_class' => $sourceObject::class,
+    'block_definition' => [
+      'definition_id' => $definition['id'] ?? NULL,
+      'provider' => $definition['provider'] ?? NULL,
+      'class' => $definition['class'] ?? NULL,
+      'deriver' => $definition['deriver'] ?? NULL,
+      'category_type' => isset($definition['category'])
+        ? get_debug_type($definition['category'])
+        : NULL,
+    ],
+    'instance_identity' => $instanceIdentity,
+    'canvas_labels' => [
+      'label' => $currentLabel,
+      'active_default_settings_label' => $settingsLabel,
+      'labels_equal' => $currentLabel === $settingsLabel,
+    ],
+    'native_admin_label' => $labelEvidence,
+    'strict_matches' => $matches,
+    'current_has_any_exact_native_label_match' => $anyCurrentMatch,
+  ];
+}
+
+sort($currentDiffersFromNativeSource, SORT_STRING);
+sort($settingsDiffersFromCurrent, SORT_STRING);
+usort(
+  $items,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+
+if (count($items) !== 26) {
+  $problems[] = [
+    'reason' => 'analyzed_component_count_mismatch',
+    'actual' => count($items),
+    'expected' => 26,
+  ];
+}
+if ($definitionResolved !== 26) {
+  $problems[] = [
+    'reason' => 'resolved_definition_count_mismatch',
+    'actual' => $definitionResolved,
+    'expected' => 26,
+  ];
+}
+if (($translatableLabelCount + $scalarLabelCount) !== 26) {
+  $problems[] = [
+    'reason' => 'native_label_kind_count_mismatch',
+    'translatable' => $translatableLabelCount,
+    'scalar' => $scalarLabelCount,
+  ];
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_ANALYZED'
+  : 'CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'runtime' => [
+    'canvas_version' => $canvasVersion,
+    'component_entity_type_id' => $componentEntityTypeId,
+    'block_manager_class' => $blockManager::class,
+    'active_total' => count($activeNames),
+    'active_distribution' => $activeDistribution,
+  ],
+  'counts' => [
+    'candidate_total' => 26,
+    'analyzed' => count($items),
+    'definition_resolved' => $definitionResolved,
+    'translatable_admin_label' => $translatableLabelCount,
+    'scalar_admin_label' => $scalarLabelCount,
+    'admin_labels_with_arguments' => $labelsWithArguments,
+    'current_matches_untranslated_source' => $currentMatchesUntranslated,
+    'current_matches_rendered_runtime' => $currentMatchesRuntimeRender,
+    'current_matches_rendered_fr' => $currentMatchesFrRender,
+    'current_matches_rendered_en' => $currentMatchesEnRender,
+    'current_matches_scalar_definition' => $currentMatchesScalar,
+    'current_no_exact_native_label_match' => $currentNoExactNativeMatch,
+    'current_differs_from_native_source' => count($currentDiffersFromNativeSource),
+    'settings_differs_from_current' => count($settingsDiffersFromCurrent),
+    'baseline_problem' => count($baselineProblems),
+    'problem_count' => count($problems),
+  ],
+  'cohort_names_sha256' => $blockNamesHash,
+  'current_differs_from_native_source_names' => $currentDiffersFromNativeSource,
+  'settings_differs_from_current_names' => $settingsDiffersFromCurrent,
+  'items' => $items,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'source_local_ids_from_runtime_only' => TRUE,
+    'block_definition_surface' => 'plugin.manager.block',
+    'strict_equality_only' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'automatic_translation_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'source_generation_executed' => FALSE,
+    'block_build_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasBlockNativeLabel774Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasBlockNativeLabel774Test.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #774 Canvas Block native label provenance proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasBlockNativeLabel774Test extends TestCase {
+
+  /**
+   * The probe reuses the exact 26 Block subset from the #766 cohort.
+   */
+  public function testProbeFixesExactBlockCohort(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-canvas-block-native-label-provenance-774.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'configuration-language-canvas-runtime-source-api-cohort-766.yml',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'canvas.component.block.'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "count(\$blockNames) !== 26",
+      $script,
+    );
+    self::assertStringContainsString(
+      'e388542385fb7cd490c79ef0783dd1ace930ab1b1db1a0762fd50df783db247c',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'candidate_total' => 26",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'definition_resolved' => \$definitionResolved",
+      $script,
+    );
+  }
+
+  /**
+   * Native Block labels remain source/render/literal evidence, not heuristics.
+   */
+  public function testProbeUsesNativeBlockManagerAndStrictLabelEvidence(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-canvas-block-native-label-provenance-774.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString("'plugin.manager.block'", $script);
+    self::assertStringContainsString(
+      '$blockManager->hasDefinition($sourceLocalId)',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$blockManager->getDefinition($sourceLocalId, FALSE)',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$blockManager->createInstance($sourceLocalId, [])',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$adminLabel->getUntranslatedString()',
+      $script,
+    );
+    self::assertStringContainsString(
+      '$adminLabel->getArguments()',
+      $script,
+    );
+    self::assertStringContainsString(
+      "$renderTranslation(\$adminLabel, 'fr')",
+      $script,
+    );
+    self::assertStringContainsString(
+      "$renderTranslation(\$adminLabel, 'en')",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'strict_equality_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'source_local_ids_from_runtime_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'automatic_translation_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'migration_allowed_by_this_proof' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      'CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_ANALYZED',
+      $script,
+    );
+
+    foreach ([
+      '->generateComponents(',
+      '->build(',
+      '->save(',
+      '->write(',
+      '->delete(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route is fixed to #774, live main and read-only execution.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-block-native-label-774.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    self::assertStringContainsString(
+      'github.event.issue.number == 774',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "'/agency-config-language-block-labels correlate'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'persist-credentials: false',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ddev drush site:install --existing-config',
+      $workflow,
+    );
+    self::assertStringContainsString('ddev drush cim -y', $workflow);
+    self::assertStringContainsString(
+      "grep -Fq 'No differences'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_ANALYZED',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.candidate_total == 26',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.counts.definition_resolved == 26',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      '.constraints.block_definition_surface == "plugin.manager.block"',
+      $workflow,
+    );
+    self::assertStringContainsString('contents: read', $workflow);
+    self::assertStringContainsString('issues: write', $workflow);
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasBlockNativeLabel774Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasBlockNativeLabel774Test.php
@@ -85,11 +85,11 @@ final class ConfigurationLanguageCanvasBlockNativeLabel774Test extends TestCase 
       $script,
     );
     self::assertStringContainsString(
-      "$renderTranslation(\$adminLabel, 'fr')",
+      "\$renderTranslation(\$adminLabel, 'fr')",
       $script,
     );
     self::assertStringContainsString(
-      "$renderTranslation(\$adminLabel, 'en')",
+      "\$renderTranslation(\$adminLabel, 'en')",
       $script,
     );
     self::assertStringContainsString(


### PR DESCRIPTION
## Scope

Implements the bounded read-only #774 proof for the exact 26 Canvas Block components.

This PR adds only:
- a probe that resolves runtime `source_local_id` through `plugin.manager.block`, captures native `admin_label` provenance, and separates untranslated source / runtime rendering / FR rendering / EN rendering / scalar derivative literals;
- an owner-only/live-main-only fresh-DDEV trusted route;
- a contract test.

Cohort: 26 exact Block components, hash `e388542385fb7cd490c79ef0783dd1ace930ab1b1db1a0762fd50df783db247c`.

The proof uses strict equality only. It does not infer language from text and does not authorize migration from any match.

No `config/sync` change, no Canvas generation/build, no save/create/update/delete, no `drush cex`, no Configuration Language Lock activation, no production/provider/secret, no natural-language heuristic or fuzzy matching.

Refs #774 #772 #770 #609