### PR TITLE
Issue #776: prove argumented Block label provenance

### DIFF
--- a/.github/workflows/trusted-configuration-language-argumented-block-label-776.yml
+++ b/.github/workflows/trusted-configuration-language-argumented-block-label-776.yml
@@ -1,0 +1,243 @@
+name: Agency trusted argumented Block label provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #776 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 776 &&
+        github.event.comment.body == '/agency-config-language-block-arguments correlate'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '776'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-block-arguments correlate'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/776" --jq '.state')" = 'open'
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  correlate:
+    name: Correlate exact 3 argumented Block labels
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      deterministic: ${{ steps.correlate.outputs.deterministic }}
+      review_required: ${{ steps.correlate.outputs.review_required }}
+      verdict: ${{ steps.correlate.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #776 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            scripts/runner/configuration-language-argumented-block-label-provenance-776.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-block-arguments-776.yaml <<EOF_CONFIG
+          name: agency-config-block-arguments-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-block-arguments-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-arguments-776'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-argumented-block-label-provenance-776.php \
+            >/dev/null
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Correlate bounded argument provenance
+        id: correlate
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-arguments-776'
+          result="$root/result.json"
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-argumented-block-label-provenance-776.php \
+            > "$result"
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "ARGUMENTED_BLOCK_LABEL_PROVENANCE_ANALYZED"' \
+            "$result" >/dev/null
+          jq -e '.counts.candidate_total == 3' "$result" >/dev/null
+          jq -e '.counts.analyzed == 3' "$result" >/dev/null
+          jq -e \
+            '(.counts.deterministic_native_argument_provenance + .counts.review_required) == 3' \
+            "$result" >/dev/null
+          jq -e '.counts.baseline_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e \
+            '.cohort_names_sha256 == "ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14"' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.strict_equality_only == true' "$result" >/dev/null
+          jq -e \
+            '.constraints.language_rendering_only_via_drupal_translation_api == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.automatic_arbitrary_text_translation_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_proof == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.block_build_executed == false' "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+          echo "deterministic=$(jq -r '.counts.deterministic_native_argument_provenance' "$result")" >> "$GITHUB_OUTPUT"
+          echo "review_required=$(jq -r '.counts.review_required' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #776 argument provenance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-block-arguments-776-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-block-arguments-776
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-block-arguments-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-block-arguments-776.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-block-arguments-776
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #776 argument provenance verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - correlate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CORRELATE_RESULT: ${{ needs.correlate.result }}
+          DETERMINISTIC: ${{ needs.correlate.outputs.deterministic }}
+          REVIEW_REQUIRED: ${{ needs.correlate.outputs.review_required }}
+          MACHINE_VERDICT: ${{ needs.correlate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CORRELATE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 776 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Argumented Block label provenance ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CORRELATE_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`3\`
+          deterministic_native_argument_provenance: \`${DETERMINISTIC:-n/a}\`
+          review_required: \`${REVIEW_REQUIRED:-n/a}\`
+          artifact: \`agency-config-language-block-arguments-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Strict read-only argument provenance. No result authorizes migration by itself. No Canvas generation/build, config mutation/export, Configuration Language Lock activation, production access, provider secret, natural-language heuristic, arbitrary-text auto-translation or fuzzy match is permitted.
+          EOF_BODY
+          )"
+          test "$CORRELATE_RESULT" = 'success'

--- a/scripts/runner/configuration-language-argumented-block-label-provenance-776.php
+++ b/scripts/runner/configuration-language-argumented-block-label-provenance-776.php
@@ -1,0 +1,522 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+
+$names = [
+  'canvas.component.block.language_block.language_content',
+  'canvas.component.block.language_block.language_interface',
+  'canvas.component.block.views_block.content_recent-block_1',
+];
+sort($names, SORT_STRING);
+$namesHash = hash('sha256', implode("\n", $names) . "\n");
+if (
+  $namesHash
+  !== 'ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14'
+) {
+  throw new RuntimeException('Issue #776 cohort hash mismatch.');
+}
+
+$canvasVersion = InstalledVersions::getPrettyVersion('drupal/canvas');
+if ($canvasVersion !== '1.10.1') {
+  throw new RuntimeException(sprintf(
+    'Issue #776 requires Canvas 1.10.1, got %s.',
+    $canvasVersion ?? 'unknown',
+  ));
+}
+
+$activeStorage = \Drupal::service('config.storage');
+$blockManager = \Drupal::service('plugin.manager.block');
+$languageManager = \Drupal::languageManager();
+$stringTranslation = \Drupal::translation();
+$entityTypeManager = \Drupal::entityTypeManager();
+$viewStorage = $entityTypeManager->getStorage('view');
+
+$renderTranslation = static function (
+  string $source,
+  array $arguments,
+  string $langcode,
+) use ($stringTranslation): string {
+  return (string) $stringTranslation->translate(
+    $source,
+    $arguments,
+    ['langcode' => $langcode],
+  );
+};
+
+$renderMarkup = static function (
+  TranslatableMarkup $markup,
+  string $langcode,
+) use ($stringTranslation): string {
+  $options = $markup->getOptions();
+  $options['langcode'] = $langcode;
+  return (string) $stringTranslation->translate(
+    $markup->getUntranslatedString(),
+    $markup->getArguments(),
+    $options,
+  );
+};
+
+$argumentEvidence = static function (mixed $value) use ($renderMarkup): array {
+  if ($value instanceof TranslatableMarkup) {
+    return [
+      'kind' => 'translatable_markup',
+      'source' => $value->getUntranslatedString(),
+      'fr' => $renderMarkup($value, 'fr'),
+      'en' => $renderMarkup($value, 'en'),
+      'arguments' => $value->getArguments(),
+      'options' => $value->getOptions(),
+    ];
+  }
+  if (is_scalar($value)) {
+    $literal = (string) $value;
+    return [
+      'kind' => 'scalar_literal',
+      'source' => $literal,
+      'fr' => $literal,
+      'en' => $literal,
+      'arguments' => [],
+      'options' => [],
+    ];
+  }
+  throw new RuntimeException(sprintf(
+    'Unsupported argument provenance type: %s.',
+    get_debug_type($value),
+  ));
+};
+
+$baselineProblems = [];
+$activeDistribution = [
+  '__none__' => 0,
+  'en' => 0,
+  'fr' => 0,
+  'und' => 0,
+];
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+foreach ($activeNames as $name) {
+  $data = $activeStorage->read($name);
+  if (!is_array($data)) {
+    $baselineProblems[] = [
+      'name' => $name,
+      'reason' => 'active_config_unreadable',
+    ];
+    continue;
+  }
+  $langcode = $data['langcode'] ?? NULL;
+  $key = is_string($langcode) ? $langcode : '__none__';
+  if (!array_key_exists($key, $activeDistribution)) {
+    $activeDistribution[$key] = 0;
+  }
+  $activeDistribution[$key]++;
+}
+ksort($activeDistribution, SORT_STRING);
+$expectedDistribution = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+ksort($expectedDistribution, SORT_STRING);
+if (count($activeNames) !== 595) {
+  $baselineProblems[] = [
+    'reason' => 'active_total_mismatch',
+    'actual' => count($activeNames),
+    'expected' => 595,
+  ];
+}
+if ($activeDistribution !== $expectedDistribution) {
+  $baselineProblems[] = [
+    'reason' => 'active_distribution_mismatch',
+    'actual' => $activeDistribution,
+    'expected' => $expectedDistribution,
+  ];
+}
+
+$items = [];
+$problems = $baselineProblems;
+$deterministic = 0;
+$reviewRequired = 0;
+
+foreach ($names as $configName) {
+  $path = $configDirectory . '/' . $configName . '.yml';
+  if (!is_file($path)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'repository_config_missing',
+    ];
+    continue;
+  }
+  $repositoryData = Yaml::parseFile($path);
+  $activeData = $activeStorage->read($configName);
+  if (!is_array($repositoryData) || !is_array($activeData)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'component_config_unreadable',
+    ];
+    continue;
+  }
+  if ($repositoryData !== $activeData) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'active_repository_component_mismatch',
+    ];
+    continue;
+  }
+  if (($activeData['langcode'] ?? NULL) !== 'fr') {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'component_langcode_not_fr',
+    ];
+    continue;
+  }
+
+  $sourceLocalId = $activeData['source_local_id'] ?? NULL;
+  $currentLabel = $activeData['label'] ?? NULL;
+  $settingsLabel = $activeData['versioned_properties']['active']['settings']
+    ['default_settings']['label'] ?? NULL;
+  if (
+    !is_string($sourceLocalId)
+    || $sourceLocalId === ''
+    || !is_string($currentLabel)
+    || !is_string($settingsLabel)
+  ) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'component_identity_or_label_invalid',
+    ];
+    continue;
+  }
+  if ($currentLabel !== $settingsLabel) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'canvas_label_settings_label_mismatch',
+    ];
+    continue;
+  }
+  if (!$blockManager->hasDefinition($sourceLocalId)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'block_definition_missing',
+      'source_local_id' => $sourceLocalId,
+    ];
+    continue;
+  }
+
+  $definition = $blockManager->getDefinition($sourceLocalId, FALSE);
+  if (!is_array($definition)) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'block_definition_invalid',
+    ];
+    continue;
+  }
+  $adminLabel = $definition['admin_label'] ?? NULL;
+  if (!$adminLabel instanceof TranslatableMarkup) {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'argumented_admin_label_not_translatable_markup',
+      'actual_type' => get_debug_type($adminLabel),
+    ];
+    continue;
+  }
+
+  $adminSource = $adminLabel->getUntranslatedString();
+  $adminArguments = $adminLabel->getArguments();
+  $adminFr = $renderMarkup($adminLabel, 'fr');
+  $adminEnWithRuntimeArguments = $renderMarkup($adminLabel, 'en');
+
+  $argumentSources = [];
+  $provenance = NULL;
+
+  if (str_starts_with($sourceLocalId, 'language_block:')) {
+    $derivativeId = substr($sourceLocalId, strlen('language_block:'));
+    if (!in_array($derivativeId, ['language_content', 'language_interface'], TRUE)) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'unexpected_language_block_derivative',
+        'derivative_id' => $derivativeId,
+      ];
+      continue;
+    }
+    $definedInfo = $languageManager->getDefinedLanguageTypesInfo();
+    $typeInfo = $definedInfo[$derivativeId] ?? NULL;
+    $typeName = is_array($typeInfo) ? ($typeInfo['name'] ?? NULL) : NULL;
+    if (!$typeName instanceof TranslatableMarkup) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'language_type_name_provenance_missing',
+        'derivative_id' => $derivativeId,
+        'actual_type' => get_debug_type($typeName),
+      ];
+      continue;
+    }
+    $typeEvidence = $argumentEvidence($typeName);
+    $argumentSources['@type'] = $typeEvidence;
+    $provenance = [
+      'kind' => 'language_type_info',
+      'derivative_id' => $derivativeId,
+      'service' => 'language_manager',
+      'source_method' => 'getDefinedLanguageTypesInfo',
+    ];
+  }
+  elseif ($sourceLocalId === 'views_block:content_recent-block_1') {
+    $dependencies = $definition['config_dependencies']['config'] ?? NULL;
+    if (!is_array($dependencies)) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'views_config_dependency_missing',
+      ];
+      continue;
+    }
+    $viewDependencies = array_values(array_filter(
+      array_map('strval', $dependencies),
+      static fn(string $dependency): bool => str_starts_with(
+        $dependency,
+        'views.view.',
+      ),
+    ));
+    if (count($viewDependencies) !== 1) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'views_config_dependency_not_unique',
+        'dependencies' => $viewDependencies,
+      ];
+      continue;
+    }
+    $viewId = substr($viewDependencies[0], strlen('views.view.'));
+    $view = $viewStorage->load($viewId);
+    if ($view === NULL) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'view_entity_missing',
+        'view_id' => $viewId,
+      ];
+      continue;
+    }
+    $derivativeId = substr($sourceLocalId, strlen('views_block:'));
+    $displayData = $view->get('display');
+    if (!is_array($displayData)) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'view_display_data_invalid',
+      ];
+      continue;
+    }
+    $matchingDisplayIds = [];
+    foreach (array_keys($displayData) as $displayId) {
+      if ($viewId . '-' . $displayId === $derivativeId) {
+        $matchingDisplayIds[] = (string) $displayId;
+      }
+    }
+    if (count($matchingDisplayIds) !== 1) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'view_display_identity_not_unique',
+        'view_id' => $viewId,
+        'derivative_id' => $derivativeId,
+        'matches' => $matchingDisplayIds,
+      ];
+      continue;
+    }
+    $displayId = $matchingDisplayIds[0];
+    $displayTitle = $displayData[$displayId]['display_title'] ?? NULL;
+    $viewLabel = $view->label();
+    try {
+      $viewEvidence = $argumentEvidence($viewLabel);
+      $displayEvidence = $argumentEvidence($displayTitle);
+    }
+    catch (RuntimeException $exception) {
+      $problems[] = [
+        'name' => $configName,
+        'reason' => 'view_argument_provenance_unsupported',
+        'message' => $exception->getMessage(),
+      ];
+      continue;
+    }
+    $argumentSources['@view'] = $viewEvidence;
+    $argumentSources['@display'] = $displayEvidence;
+    $provenance = [
+      'kind' => 'views_config_entity',
+      'view_id' => $viewId,
+      'display_id' => $displayId,
+      'config_dependency' => $viewDependencies[0],
+      'source_method' => 'view label + display.display_title',
+    ];
+  }
+  else {
+    $problems[] = [
+      'name' => $configName,
+      'reason' => 'unexpected_argumented_source_local_id',
+      'source_local_id' => $sourceLocalId,
+    ];
+    continue;
+  }
+
+  $sourceArguments = [];
+  $frArguments = [];
+  $enArguments = [];
+  foreach ($argumentSources as $placeholder => $evidence) {
+    $sourceArguments[$placeholder] = $evidence['source'];
+    $frArguments[$placeholder] = $evidence['fr'];
+    $enArguments[$placeholder] = $evidence['en'];
+  }
+
+  $sourceFormatted = (string) new FormattableMarkup(
+    $adminSource,
+    $sourceArguments,
+  );
+  $frReconstructed = $renderTranslation($adminSource, $frArguments, 'fr');
+  $enReconstructed = $renderTranslation($adminSource, $enArguments, 'en');
+
+  $runtimeArgumentMatch = TRUE;
+  foreach ($adminArguments as $placeholder => $runtimeArgument) {
+    if (!array_key_exists($placeholder, $argumentSources)) {
+      $runtimeArgumentMatch = FALSE;
+      break;
+    }
+    $runtimeString = $runtimeArgument instanceof TranslatableMarkup
+      ? (string) $runtimeArgument
+      : (is_scalar($runtimeArgument) ? (string) $runtimeArgument : NULL);
+    if ($runtimeString !== $argumentSources[$placeholder]['fr']) {
+      $runtimeArgumentMatch = FALSE;
+      break;
+    }
+  }
+  if (count($adminArguments) !== count($argumentSources)) {
+    $runtimeArgumentMatch = FALSE;
+  }
+
+  $isDeterministic = $runtimeArgumentMatch
+    && $currentLabel === $frReconstructed
+    && $sourceFormatted !== ''
+    && $enReconstructed !== '';
+  if ($isDeterministic) {
+    $deterministic++;
+  }
+  else {
+    $reviewRequired++;
+  }
+
+  $items[] = [
+    'config_name' => $configName,
+    'source_local_id' => $sourceLocalId,
+    'current_canvas_label' => $currentLabel,
+    'native_admin_label' => [
+      'source_format' => $adminSource,
+      'runtime_arguments' => array_map(
+        static fn(mixed $value): mixed => is_scalar($value)
+          ? $value
+          : (is_object($value) ? ['class' => $value::class, 'string' => (string) $value] : get_debug_type($value)),
+        $adminArguments,
+      ),
+      'rendered_fr_with_runtime_arguments' => $adminFr,
+      'rendered_en_with_runtime_arguments' => $adminEnWithRuntimeArguments,
+    ],
+    'argument_provenance' => $provenance,
+    'arguments' => $argumentSources,
+    'reconstructed' => [
+      'source_formatted' => $sourceFormatted,
+      'fr' => $frReconstructed,
+      'en' => $enReconstructed,
+    ],
+    'strict_matches' => [
+      'runtime_arguments_equal_provenance_fr' => $runtimeArgumentMatch,
+      'current_equals_reconstructed_fr' => $currentLabel === $frReconstructed,
+      'current_equals_reconstructed_source' => $currentLabel === $sourceFormatted,
+      'current_equals_reconstructed_en' => $currentLabel === $enReconstructed,
+      'native_runtime_fr_equals_reconstructed_fr' => $adminFr === $frReconstructed,
+      'native_runtime_en_equals_reconstructed_en' =>
+        $adminEnWithRuntimeArguments === $enReconstructed,
+    ],
+    'future_base_label' => $isDeterministic ? $sourceFormatted : NULL,
+    'future_fr_override_label' => $isDeterministic ? $frReconstructed : NULL,
+    'future_en_rendered_label' => $isDeterministic ? $enReconstructed : NULL,
+    'decision' => $isDeterministic
+      ? 'deterministic_native_argument_provenance'
+      : 'review_required',
+  ];
+}
+
+usort(
+  $items,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+
+if (count($items) !== 3) {
+  $problems[] = [
+    'reason' => 'analyzed_count_mismatch',
+    'actual' => count($items),
+    'expected' => 3,
+  ];
+}
+if (($deterministic + $reviewRequired) !== 3) {
+  $problems[] = [
+    'reason' => 'decision_count_mismatch',
+    'deterministic' => $deterministic,
+    'review_required' => $reviewRequired,
+  ];
+}
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'ARGUMENTED_BLOCK_LABEL_PROVENANCE_ANALYZED'
+  : 'ARGUMENTED_BLOCK_LABEL_PROVENANCE_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'runtime' => [
+    'canvas_version' => $canvasVersion,
+    'block_manager_class' => $blockManager::class,
+    'language_manager_class' => $languageManager::class,
+    'active_total' => count($activeNames),
+    'active_distribution' => $activeDistribution,
+  ],
+  'counts' => [
+    'candidate_total' => 3,
+    'analyzed' => count($items),
+    'deterministic_native_argument_provenance' => $deterministic,
+    'review_required' => $reviewRequired,
+    'baseline_problem' => count($baselineProblems),
+    'problem_count' => count($problems),
+  ],
+  'cohort_names_sha256' => $namesHash,
+  'items' => $items,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'strict_equality_only' => TRUE,
+    'language_rendering_only_via_drupal_translation_api' => TRUE,
+    'natural_language_heuristic_used' => FALSE,
+    'automatic_arbitrary_text_translation_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'source_generation_executed' => FALSE,
+    'block_build_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockLabel776Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockLabel776Test.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #776 argumented Block label provenance proof.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageArgumentedBlockLabel776Test extends TestCase {
+
+  /**
+   * The probe is fixed to exactly three argument-bearing Block labels.
+   */
+  public function testProbeIsFixedToExactThreeComponents(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-argumented-block-label-provenance-776.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'canvas.component.block.language_block.language_content',
+      'canvas.component.block.language_block.language_interface',
+      'canvas.component.block.views_block.content_recent-block_1',
+      'ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+    self::assertStringContainsString("'candidate_total' => 3", $script);
+    self::assertStringContainsString(
+      'ARGUMENTED_BLOCK_LABEL_PROVENANCE_ANALYZED',
+      $script,
+    );
+  }
+
+  /**
+   * Argument provenance uses structured Drupal sources only.
+   */
+  public function testProbeUsesStructuredArgumentSourcesOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-argumented-block-label-provenance-776.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    self::assertStringContainsString(
+      '$languageManager->getDefinedLanguageTypesInfo()',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'views.view.'",
+      $script,
+    );
+    self::assertStringContainsString(
+      "$viewStorage->load($viewId)",
+      $script,
+    );
+    self::assertStringContainsString(
+      'new FormattableMarkup(',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'language_rendering_only_via_drupal_translation_api' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'natural_language_heuristic_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'automatic_arbitrary_text_translation_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'migration_allowed_by_this_proof' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      '->generateComponents(',
+      '->build(',
+      '->save(',
+      '->write(',
+      '->delete(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The trusted route is fixed to #776 and live main.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-argumented-block-label-776.yml';
+    self::assertFileExists($path);
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      'github.event.issue.number == 776',
+      "'/agency-config-language-block-arguments correlate'",
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      'persist-credentials: false',
+      'ddev drush site:install --existing-config',
+      'ddev drush cim -y',
+      "grep -Fq 'No differences'",
+      'ARGUMENTED_BLOCK_LABEL_PROVENANCE_ANALYZED',
+      '.counts.candidate_total == 3',
+      '.counts.problem_count == 0',
+      '.constraints.read_only == true',
+      '.constraints.migration_allowed_by_this_proof == false',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockLabel776Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockLabel776Test.php
@@ -61,7 +61,7 @@ final class ConfigurationLanguageArgumentedBlockLabel776Test extends TestCase {
       $script,
     );
     self::assertStringContainsString(
-      "$viewStorage->load($viewId)",
+      '$viewStorage->load($viewId)',
       $script,
     );
     self::assertStringContainsString(


### PR DESCRIPTION
## Scope

Implements the bounded read-only #776 proof for the final three argument-bearing Canvas Block labels left by #774.

Exact cohort:
- `language_block:language_content`
- `language_block:language_interface`
- `views_block:content_recent-block_1`

The probe derives argument provenance only from structured Drupal APIs:
- `language_manager->getDefinedLanguageTypesInfo()` for language type names;
- exact View config dependency + View label/display title for the Views derivative.

It records source-formatted labels without translation and FR/EN renderings only through Drupal's translation API. Strict equality decides deterministic vs review-required; no preferred outcome is required.

No `config/sync` change, Canvas generation/build, config write/export, Configuration Language Lock activation, production/provider/secret, natural-language heuristic, arbitrary-text translation or fuzzy matching.

Refs #776 #774 #609