### PR TITLE
Issue #776: resolve plain-text Block label rendering gap

### DIFF
--- a/.github/workflows/trusted-configuration-language-argumented-block-plain-text-776.yml
+++ b/.github/workflows/trusted-configuration-language-argumented-block-plain-text-776.yml
@@ -1,0 +1,260 @@
+name: Agency trusted argumented Block plain-text provenance
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #776 plain-text target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 776 &&
+        github.event.comment.body == '/agency-config-language-block-arguments correlate-plain-text'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '776'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-block-arguments correlate-plain-text'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/776" --jq '.state')" = 'open'
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  correlate:
+    name: Resolve #776 safe-markup to plain-text boundary
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      deterministic: ${{ steps.correlate.outputs.deterministic }}
+      review_required: ${{ steps.correlate.outputs.review_required }}
+      interface_base: ${{ steps.correlate.outputs.interface_base }}
+      interface_fr: ${{ steps.correlate.outputs.interface_fr }}
+      verdict: ${{ steps.correlate.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #776 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            scripts/runner/configuration-language-argumented-block-label-provenance-776.php
+          test -f \
+            scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-block-plain-text-776.yaml <<EOF_CONFIG
+          name: agency-config-block-plain-text-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-block-plain-text-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-plain-text-776'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php \
+            >/dev/null
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Correlate bounded plain-text provenance
+        id: correlate
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-block-plain-text-776'
+          result="$root/result.json"
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e \
+            '.verdict == "ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_ANALYZED"' \
+            "$result" >/dev/null
+          jq -e '.counts.candidate_total == 3' "$result" >/dev/null
+          jq -e '.counts.analyzed == 3' "$result" >/dev/null
+          jq -e '.counts.deterministic_native_argument_provenance == 3' \
+            "$result" >/dev/null
+          jq -e '.counts.review_required == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e \
+            '.cohort_names_sha256 == "ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14"' \
+            "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e \
+            '.constraints.plain_text_projection_via_drupal_output_strategy == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.generic_normalization_used == false' "$result" >/dev/null
+          jq -e '.constraints.strict_equality_only == true' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.automatic_arbitrary_text_translation_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_proof == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e \
+            '.items[] | select(.config_name == "canvas.component.block.language_block.language_interface") | .future_base_label == "Language switcher (Interface text)"' \
+            "$result" >/dev/null
+          jq -e \
+            '.items[] | select(.config_name == "canvas.component.block.language_block.language_interface") | .future_fr_override_label == "Sélecteur de langue (Texte d\u0027interface)"' \
+            "$result" >/dev/null
+          jq -e \
+            '.items[] | select(.config_name == "canvas.component.block.language_block.language_interface") | .strict_matches.current_equals_plain_text_reconstructed_fr == true' \
+            "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "deterministic=$(jq -r '.counts.deterministic_native_argument_provenance' "$result")" >> "$GITHUB_OUTPUT"
+          echo "review_required=$(jq -r '.counts.review_required' "$result")" >> "$GITHUB_OUTPUT"
+          echo "interface_base=$(jq -r '.items[] | select(.config_name == "canvas.component.block.language_block.language_interface") | .future_base_label' "$result")" >> "$GITHUB_OUTPUT"
+          echo "interface_fr=$(jq -r '.items[] | select(.config_name == "canvas.component.block.language_block.language_interface") | .future_fr_override_label' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #776 plain-text evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-block-plain-text-776-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-block-plain-text-776
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-block-plain-text-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-block-plain-text-776.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-block-plain-text-776
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #776 plain-text provenance verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - correlate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          CORRELATE_RESULT: ${{ needs.correlate.result }}
+          DETERMINISTIC: ${{ needs.correlate.outputs.deterministic }}
+          REVIEW_REQUIRED: ${{ needs.correlate.outputs.review_required }}
+          INTERFACE_BASE: ${{ needs.correlate.outputs.interface_base }}
+          INTERFACE_FR: ${{ needs.correlate.outputs.interface_fr }}
+          MACHINE_VERDICT: ${{ needs.correlate.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$CORRELATE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 776 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Argumented Block plain-text provenance ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${CORRELATE_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          candidate_total: \`3\`
+          deterministic_native_argument_provenance: \`${DETERMINISTIC:-n/a}\`
+          review_required: \`${REVIEW_REQUIRED:-n/a}\`
+          language_interface_future_base_label: \`${INTERFACE_BASE:-n/a}\`
+          language_interface_future_fr_override_label: \`${INTERFACE_FR:-n/a}\`
+          artifact: \`agency-config-language-block-plain-text-776-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Plain-text projection uses Drupal's native PlainTextOutput output strategy to convert safe markup into label/configuration text. Strict equality remains required. No generic normalization, fuzzy matching, arbitrary-text translation, Canvas generation/build, config mutation/export, Configuration Language Lock activation, production access or provider secret is permitted.
+          EOF_BODY
+          )"
+          test "$CORRELATE_RESULT" = 'success'

--- a/scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php
+++ b/scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Component\Render\PlainTextOutput;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$sourceProbe = $projectRoot
+  . '/scripts/runner/'
+  . 'configuration-language-argumented-block-label-provenance-776.php';
+
+if (!is_file($sourceProbe)) {
+  throw new RuntimeException('Issue #776 source provenance probe is missing.');
+}
+
+ob_start();
+try {
+  require $sourceProbe;
+  $rawSource = (string) ob_get_clean();
+}
+catch (Throwable $throwable) {
+  ob_end_clean();
+  throw $throwable;
+}
+
+$source = json_decode($rawSource, TRUE, 512, JSON_THROW_ON_ERROR);
+if (!is_array($source)) {
+  throw new RuntimeException('Issue #776 source provenance payload is invalid.');
+}
+if (
+  ($source['status'] ?? NULL) !== 'PASS'
+  || ($source['verdict'] ?? NULL) !== 'ARGUMENTED_BLOCK_LABEL_PROVENANCE_ANALYZED'
+  || ($source['counts']['candidate_total'] ?? NULL) !== 3
+  || ($source['counts']['analyzed'] ?? NULL) !== 3
+  || ($source['counts']['baseline_problem'] ?? NULL) !== 0
+  || ($source['counts']['problem_count'] ?? NULL) !== 0
+  || ($source['cohort_names_sha256'] ?? NULL)
+    !== 'ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14'
+) {
+  throw new RuntimeException('Issue #776 source provenance payload is not trusted.');
+}
+
+$items = $source['items'] ?? NULL;
+if (!is_array($items) || count($items) !== 3) {
+  throw new RuntimeException('Issue #776 source provenance items are incomplete.');
+}
+
+$expectedNames = [
+  'canvas.component.block.language_block.language_content',
+  'canvas.component.block.language_block.language_interface',
+  'canvas.component.block.views_block.content_recent-block_1',
+];
+sort($expectedNames, SORT_STRING);
+
+$actualNames = [];
+$projectedItems = [];
+$deterministic = 0;
+$reviewRequired = 0;
+$problems = [];
+
+foreach ($items as $item) {
+  if (!is_array($item)) {
+    $problems[] = ['reason' => 'source_item_not_mapping'];
+    continue;
+  }
+
+  $configName = $item['config_name'] ?? NULL;
+  $currentLabel = $item['current_canvas_label'] ?? NULL;
+  $sourceFormatted = $item['reconstructed']['source_formatted'] ?? NULL;
+  $frSafeMarkup = $item['reconstructed']['fr'] ?? NULL;
+  $enSafeMarkup = $item['reconstructed']['en'] ?? NULL;
+  $nativeFrSafeMarkup = $item['native_admin_label']['rendered_fr_with_runtime_arguments'] ?? NULL;
+  $nativeEnSafeMarkup = $item['native_admin_label']['rendered_en_with_runtime_arguments'] ?? NULL;
+  $runtimeArgumentMatch = $item['strict_matches']['runtime_arguments_equal_provenance_fr'] ?? NULL;
+
+  if (
+    !is_string($configName)
+    || !is_string($currentLabel)
+    || !is_string($sourceFormatted)
+    || !is_string($frSafeMarkup)
+    || !is_string($enSafeMarkup)
+    || !is_string($nativeFrSafeMarkup)
+    || !is_string($nativeEnSafeMarkup)
+    || !is_bool($runtimeArgumentMatch)
+  ) {
+    $problems[] = [
+      'name' => is_string($configName) ? $configName : NULL,
+      'reason' => 'source_item_shape_invalid',
+    ];
+    continue;
+  }
+
+  $actualNames[] = $configName;
+  $frPlainText = PlainTextOutput::renderFromHtml($frSafeMarkup);
+  $enPlainText = PlainTextOutput::renderFromHtml($enSafeMarkup);
+  $nativeFrPlainText = PlainTextOutput::renderFromHtml($nativeFrSafeMarkup);
+  $nativeEnPlainText = PlainTextOutput::renderFromHtml($nativeEnSafeMarkup);
+
+  $isDeterministic = $runtimeArgumentMatch
+    && $currentLabel === $frPlainText
+    && $sourceFormatted !== ''
+    && $enPlainText !== '';
+
+  if ($isDeterministic) {
+    $deterministic++;
+  }
+  else {
+    $reviewRequired++;
+  }
+
+  $projectedItems[] = [
+    'config_name' => $configName,
+    'source_local_id' => $item['source_local_id'] ?? NULL,
+    'current_canvas_label' => $currentLabel,
+    'source_formatted' => $sourceFormatted,
+    'safe_markup_rendering' => [
+      'reconstructed_fr' => $frSafeMarkup,
+      'reconstructed_en' => $enSafeMarkup,
+      'native_runtime_fr' => $nativeFrSafeMarkup,
+      'native_runtime_en' => $nativeEnSafeMarkup,
+    ],
+    'plain_text_configuration_rendering' => [
+      'reconstructed_fr' => $frPlainText,
+      'reconstructed_en' => $enPlainText,
+      'native_runtime_fr' => $nativeFrPlainText,
+      'native_runtime_en' => $nativeEnPlainText,
+    ],
+    'strict_matches' => [
+      'runtime_arguments_equal_provenance_fr' => $runtimeArgumentMatch,
+      'current_equals_plain_text_reconstructed_fr' => $currentLabel === $frPlainText,
+      'current_equals_safe_markup_reconstructed_fr' => $currentLabel === $frSafeMarkup,
+      'plain_text_native_fr_equals_plain_text_reconstructed_fr' => $nativeFrPlainText === $frPlainText,
+      'plain_text_native_en_equals_plain_text_reconstructed_en' => $nativeEnPlainText === $enPlainText,
+    ],
+    'future_base_label' => $isDeterministic ? $sourceFormatted : NULL,
+    'future_fr_override_label' => $isDeterministic ? $currentLabel : NULL,
+    'future_en_rendered_label' => $isDeterministic ? $enPlainText : NULL,
+    'decision' => $isDeterministic
+      ? 'deterministic_native_argument_provenance'
+      : 'review_required',
+  ];
+}
+
+sort($actualNames, SORT_STRING);
+if ($actualNames !== $expectedNames) {
+  $problems[] = [
+    'reason' => 'cohort_name_set_mismatch',
+    'actual' => $actualNames,
+    'expected' => $expectedNames,
+  ];
+}
+
+usort(
+  $projectedItems,
+  static fn(array $left, array $right): int =>
+    ($left['config_name'] ?? '') <=> ($right['config_name'] ?? ''),
+);
+
+$status = $problems === [] ? 'PASS' : 'FAIL';
+$verdict = $status === 'PASS'
+  ? 'ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_ANALYZED'
+  : 'ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_FAILED';
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'source_verdict' => $source['verdict'],
+  'counts' => [
+    'candidate_total' => 3,
+    'analyzed' => count($projectedItems),
+    'deterministic_native_argument_provenance' => $deterministic,
+    'review_required' => $reviewRequired,
+    'problem_count' => count($problems),
+  ],
+  'cohort_names_sha256' => $source['cohort_names_sha256'],
+  'items' => $projectedItems,
+  'problems' => $problems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'plain_text_projection_surface' => PlainTextOutput::class,
+    'plain_text_projection_via_drupal_output_strategy' => TRUE,
+    'strict_equality_only' => TRUE,
+    'generic_normalization_used' => FALSE,
+    'natural_language_heuristic_used' => FALSE,
+    'automatic_arbitrary_text_translation_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'migration_allowed_by_this_proof' => FALSE,
+    'source_generation_executed' => FALSE,
+    'block_build_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the #776 safe-markup to plain-text provenance recovery.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageArgumentedBlockPlainText776Test extends TestCase {
+
+  /**
+   * The recovery reuses the exact three-item #776 source proof.
+   */
+  public function testRecoveryReusesExactSourceProvenance(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-argumented-block-plain-text-provenance-776.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    foreach ([
+      'configuration-language-argumented-block-label-provenance-776.php',
+      'ad40d7521d300bd8b77978997d3a290440e4aaa775179ec4009491e328a78f14',
+      "'candidate_total' => 3",
+      'ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_ANALYZED',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+  }
+
+  /**
+   * Safe markup is projected to config text through Drupal only.
+   */
+  public function testRecoveryUsesDrupalPlainTextOutputWithoutHeuristics(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/'
+      . 'configuration-language-argumented-block-plain-text-provenance-776.php';
+    self::assertFileExists($path);
+
+    $script = (string) file_get_contents($path);
+    self::assertStringContainsString(
+      'Drupal\\Component\\Render\\PlainTextOutput',
+      $script,
+    );
+    self::assertStringContainsString(
+      'PlainTextOutput::renderFromHtml($frSafeMarkup)',
+      $script,
+    );
+    self::assertStringContainsString(
+      "'plain_text_projection_via_drupal_output_strategy' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'generic_normalization_used' => FALSE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'strict_equality_only' => TRUE",
+      $script,
+    );
+    self::assertStringContainsString(
+      "'migration_allowed_by_this_proof' => FALSE",
+      $script,
+    );
+
+    foreach ([
+      'html_entity_decode(',
+      'str_replace(',
+      'preg_replace(',
+      'similar_text(',
+      'levenshtein(',
+      '->generateComponents(',
+      '->build(',
+      '->save(',
+      '->write(',
+      '->delete(',
+      'drush cex',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * Trusted recovery requires all three cases to become deterministic.
+   */
+  public function testTrustedRecoveryIsBoundedAndFailClosed(): void {
+    $root = dirname(DRUP_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-argumented-block-plain-text-776.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+    foreach ([
+      'github.event.issue.number == 776',
+      "'/agency-config-language-block-arguments correlate-plain-text'",
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      'persist-credentials: false',
+      'ddev drush site:install --existing-config',
+      'ddev drush cim -y',
+      "grep -Fq 'No differences'",
+      'ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_ANALYZED',
+      '.counts.deterministic_native_argument_provenance == 3',
+      '.counts.review_required == 0',
+      'Language switcher (Interface text)',
+      "Sélecteur de langue (Texte d'interface)",
+      '.constraints.generic_normalization_used == false',
+      '.constraints.migration_allowed_by_this_proof == false',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
@@ -116,7 +116,7 @@ final class ConfigurationLanguageArgumentedBlockPlainText776Test extends TestCas
       '.counts.deterministic_native_argument_provenance == 3',
       '.counts.review_required == 0',
       'Language switcher (Interface text)',
-      "Sélecteur de langue (Texte d'interface)",
+      'Sélecteur de langue (Texte d\\u0027interface)',
       '.constraints.generic_normalization_used == false',
       '.constraints.migration_allowed_by_this_proof == false',
     ] as $expected) {

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageArgumentedBlockPlainText776Test.php
@@ -96,7 +96,7 @@ final class ConfigurationLanguageArgumentedBlockPlainText776Test extends TestCas
    * Trusted recovery requires all three cases to become deterministic.
    */
   public function testTrustedRecoveryIsBoundedAndFailClosed(): void {
-    $root = dirname(DRUP_ROOT);
+    $root = dirname(DRUPAL_ROOT);
     $path = $root
       . '/.github/workflows/'
       . 'trusted-configuration-language-argumented-block-plain-text-776.yml';


### PR DESCRIPTION
## Scope

Recovery for the single `review_required` case left by the first #776 trusted proof.

The first proof established full structured provenance for all three argumented Block labels but `language_block:language_interface` differed only because Drupal's safe-markup `@type` placeholder rendered the apostrophe as `&#039;`, while Canvas config stores plain text.

This PR adds a bounded read-only projection through `Drupal\Component\Render\PlainTextOutput::renderFromHtml()`, the Drupal output strategy intended to convert safe HTML/markup into plain text suitable for labels/configuration. It reuses the original #776 proof payload and keeps strict equality.

Trusted recovery requires 3/3 deterministic and 0 review-required. It uses a distinct one-shot command: `/agency-config-language-block-arguments correlate-plain-text`.

No generic normalization, fuzzy matching, natural-language heuristic, arbitrary-text translation, Canvas generation/build, config mutation/export, Configuration Language Lock activation, production/provider/secret.

Refs #776 #774 #609