### PR TITLE
Issue #779: add deterministic Canvas migration dry-run

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-migration-dry-run-779.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-migration-dry-run-779.yml
@@ -1,0 +1,312 @@
+name: Agency trusted Canvas canonical migration dry-run
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-target:
+    name: Validate fixed #779 live-main target
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 779 &&
+        github.event.comment.body == '/agency-config-language-canvas-migration dry-run'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue and immutable main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$ISSUE_NUMBER" = '779'
+          test "$TRIGGER_COMMENT" = \
+            '/agency-config-language-canvas-migration dry-run'
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/issues/779" --jq '.state')" = 'open'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  dry-run:
+    name: Dry-run exact 30 Canvas canonical promotions
+    needs: validate-target
+    timeout-minutes: 35
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      base_files: ${{ steps.dry_run.outputs.base_files }}
+      label_files: ${{ steps.dry_run.outputs.label_files }}
+      overrides: ${{ steps.dry_run.outputs.overrides }}
+      existing_overrides: ${{ steps.dry_run.outputs.existing_overrides }}
+      review_required: ${{ steps.dry_run.outputs.review_required }}
+      plan_sha256: ${{ steps.dry_run.outputs.plan_sha256 }}
+      verdict: ${{ steps.dry_run.outputs.verdict }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact trusted main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-target.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable #779 target and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f \
+            scripts/runner/configuration-language-canvas-migration-dry-run-779.php
+          test -f \
+            scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php
+          test -f \
+            scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php
+          test -f \
+            scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-dry-run-779.yaml <<EOF_CONFIG
+          name: agency-config-canvas-dry-run-779-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-dry-run-779-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact canonical main
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-dry-run-779'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-dry-run-779.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+      - name: Produce deterministic read-only Canvas migration plan
+        id: dry_run
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-dry-run-779'
+          result="$root/result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-dry-run-779.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e \
+            '.verdict == "CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY"' \
+            "$result" >/dev/null
+          jq -e '.ready_for_migration == true' "$result" >/dev/null
+          jq -e '.cohort.total == 30' "$result" >/dev/null
+          jq -e '.cohort.block == 26' "$result" >/dev/null
+          jq -e '.cohort.sdc == 4' "$result" >/dev/null
+          jq -e \
+            '.cohort.names_sha256 == "b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23"' \
+            "$result" >/dev/null
+          jq -e '.proofs.sdc.material_translatable_leaves == 36' \
+            "$result" >/dev/null
+          jq -e '.proofs.sdc.final_matched_leaves == 36' \
+            "$result" >/dev/null
+          jq -e '.proofs.block.definition_resolved == 26' \
+            "$result" >/dev/null
+          jq -e '.proofs.argumented_block.deterministic == 3' \
+            "$result" >/dev/null
+          jq -e '.counts.base_files_planned == 30' "$result" >/dev/null
+          jq -e '.counts.block_files_planned == 26' "$result" >/dev/null
+          jq -e '.counts.sdc_files_planned == 4' "$result" >/dev/null
+          jq -e '.counts.langcode_changes == 30' "$result" >/dev/null
+          jq -e '.counts.block_label_files_changed == 15' "$result" >/dev/null
+          jq -e '.counts.block_label_value_changes == 30' "$result" >/dev/null
+          jq -e '.counts.fr_override_files_planned == 15' "$result" >/dev/null
+          jq -e '.counts.review_required == 0' "$result" >/dev/null
+          jq -e '.counts.proof_problem == 0' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0' "$result" >/dev/null
+          jq -e \
+            '.distribution.before == {"__none__":59,"en":466,"fr":69,"und":1}' \
+            "$result" >/dev/null
+          jq -e \
+            '.distribution.after_simulated == {"__none__":59,"en":496,"fr":39,"und":1}' \
+            "$result" >/dev/null
+          jq -e '.distribution.total == 595' "$result" >/dev/null
+          jq -e '.plan.base_files | length == 30' "$result" >/dev/null
+          jq -e '.plan.fr_overrides | length == 15' "$result" >/dev/null
+          jq -e \
+            '[.plan.base_files[] | select(.source_kind == "sdc") | (.operations | length)] | all(. == 1)' \
+            "$result" >/dev/null
+          jq -e \
+            '[.plan.base_files[] | .historical_versions_modified] | all(. == false)' \
+            "$result" >/dev/null
+          jq -e '.plan_sha256 | test("^[0-9a-f]{64}$")' "$result" >/dev/null
+          jq -e '.constraints.read_only == true' "$result" >/dev/null
+          jq -e '.constraints.in_memory_simulation_only == true' "$result" >/dev/null
+          jq -e '.constraints.repository_config_mutated == false' "$result" >/dev/null
+          jq -e '.constraints.historical_versions_rewritten == false' "$result" >/dev/null
+          jq -e '.constraints.sdc_values_rewritten == false' "$result" >/dev/null
+          jq -e \
+            '.constraints.sdc_native_value_presence_used_as_preservation_guard_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.block_labels_from_native_provenance_only == true' \
+            "$result" >/dev/null
+          jq -e '.constraints.generic_normalization_used == false' "$result" >/dev/null
+          jq -e '.constraints.natural_language_heuristic_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.automatic_arbitrary_text_translation_used == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.fuzzy_matching_used == false' "$result" >/dev/null
+          jq -e '.constraints.source_generation_executed == false' "$result" >/dev/null
+          jq -e '.constraints.block_build_executed == false' "$result" >/dev/null
+          jq -e '.constraints.config_entity_creation_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_entity_update_executed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e '.constraints.config_language_lock_activation_allowed == false' \
+            "$result" >/dev/null
+          jq -e '.constraints.migration_allowed_by_this_dry_run == false' \
+            "$result" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+          echo "base_files=$(jq -r '.counts.base_files_planned' "$result")" >> "$GITHUB_OUTPUT"
+          echo "label_files=$(jq -r '.counts.block_label_files_changed' "$result")" >> "$GITHUB_OUTPUT"
+          echo "overrides=$(jq -r '.counts.fr_override_files_planned' "$result")" >> "$GITHUB_OUTPUT"
+          echo "existing_overrides=$(jq -r '.counts.existing_fr_override_files' "$result")" >> "$GITHUB_OUTPUT"
+          echo "review_required=$(jq -r '.counts.review_required' "$result")" >> "$GITHUB_OUTPUT"
+          echo "plan_sha256=$(jq -r '.plan_sha256' "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #779 Canvas dry-run evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-dry-run-779-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-dry-run-779
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-dry-run-779-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-dry-run-779.yaml
+          git restore --worktree -- web/robots.txt config/sync
+          git clean -fd -- config/sync
+          rm -rf artifacts/config-language-canvas-dry-run-779
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi
+
+  report-result:
+    name: Publish #779 Canvas dry-run verdict
+    if: ${{ always() && needs.validate-target.result == 'success' }}
+    needs:
+      - validate-target
+      - dry-run
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-target.outputs.main_sha }}
+          DRY_RUN_RESULT: ${{ needs.dry-run.result }}
+          BASE_FILES: ${{ needs.dry-run.outputs.base_files }}
+          LABEL_FILES: ${{ needs.dry-run.outputs.label_files }}
+          OVERRIDES: ${{ needs.dry-run.outputs.overrides }}
+          EXISTING_OVERRIDES: ${{ needs.dry-run.outputs.existing_overrides }}
+          REVIEW_REQUIRED: ${{ needs.dry-run.outputs.review_required }}
+          PLAN_SHA256: ${{ needs.dry-run.outputs.plan_sha256 }}
+          MACHINE_VERDICT: ${{ needs.dry-run.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$DRY_RUN_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 779 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Canvas canonical migration dry-run ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${DRY_RUN_RESULT}\`
+          verdict: \`${MACHINE_VERDICT:-n/a}\`
+          base_files_planned: \`${BASE_FILES:-n/a}\`
+          block_label_files_changed: \`${LABEL_FILES:-n/a}\`
+          fr_override_files_planned: \`${OVERRIDES:-n/a}\`
+          existing_fr_override_files: \`${EXISTING_OVERRIDES:-n/a}\`
+          review_required: \`${REVIEW_REQUIRED:-n/a}\`
+          plan_sha256: \`${PLAN_SHA256:-n/a}\`
+          simulated_distribution: \`__none__=59, en=496, fr=39, und=1\`
+          artifact: \`agency-config-language-canvas-dry-run-779-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          Strict read-only in-memory migration plan. No config/sync mutation, historical-version rewrite, SDC value rewrite, Canvas generation/build, config export, Configuration Language Lock activation, production access, provider secret, natural-language heuristic, arbitrary-text translation, generic normalization or fuzzy match is permitted. This dry-run does not itself authorize or apply the migration.
+          EOF_BODY
+          )"
+          test "$DRY_RUN_RESULT" = 'success'

--- a/scripts/runner/configuration-language-canvas-migration-dry-run-779.php
+++ b/scripts/runner/configuration-language-canvas-migration-dry-run-779.php
@@ -1,0 +1,573 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/configuration-language-canvas-runtime-source-api-cohort-766.yml';
+
+$runProbe = static function (string $path): array {
+  if (!is_file($path)) {
+    throw new RuntimeException(sprintf('Required provenance probe missing: %s', $path));
+  }
+
+  return (static function (string $isolatedPath): array {
+    ob_start();
+    try {
+      require $isolatedPath;
+      $raw = (string) ob_get_clean();
+    }
+    catch (Throwable $throwable) {
+      ob_end_clean();
+      throw $throwable;
+    }
+
+    $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+    if (!is_array($decoded)) {
+      throw new RuntimeException('Provenance probe did not return a mapping.');
+    }
+    return $decoded;
+  })($path);
+};
+
+$canonicalize = NULL;
+$canonicalize = static function (mixed $value) use (&$canonicalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($canonicalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $canonicalize($child);
+  }
+  return $value;
+};
+
+$setPath = static function (array &$target, array $segments, mixed $value): void {
+  $cursor = &$target;
+  foreach ($segments as $index => $segment) {
+    if ($index === count($segments) - 1) {
+      $cursor[$segment] = $value;
+      return;
+    }
+    if (!isset($cursor[$segment]) || !is_array($cursor[$segment])) {
+      $cursor[$segment] = [];
+    }
+    $cursor = &$cursor[$segment];
+  }
+};
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #779 repository baseline is unavailable.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (
+  !is_array($manifest)
+  || ($manifest['issue'] ?? NULL) !== 766
+  || ($manifest['parent_issue'] ?? NULL) !== 609
+  || ($manifest['cohort']['total'] ?? NULL) !== 30
+  || ($manifest['cohort']['block'] ?? NULL) !== 26
+  || ($manifest['cohort']['sdc'] ?? NULL) !== 4
+) {
+  throw new RuntimeException('Issue #779 requires the exact #766 Canvas cohort.');
+}
+
+$names = $manifest['cohort']['names'] ?? NULL;
+if (!is_array($names) || count($names) !== 30) {
+  throw new RuntimeException('Issue #766 Canvas cohort names are incomplete.');
+}
+$names = array_values(array_map('strval', $names));
+sort($names, SORT_STRING);
+$namesHash = hash('sha256', implode("\n", $names) . "\n");
+if (
+  $namesHash !== 'b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23'
+  || $namesHash !== ($manifest['cohort']['names_sha256'] ?? NULL)
+) {
+  throw new RuntimeException('Issue #779 Canvas cohort hash mismatch.');
+}
+
+$sdcProof = $runProbe(
+  $projectRoot . '/scripts/runner/configuration-language-sdc-native-metadata-provenance-772.php',
+);
+$blockProof = $runProbe(
+  $projectRoot . '/scripts/runner/configuration-language-canvas-block-native-label-provenance-774.php',
+);
+$argumentProof = $runProbe(
+  $projectRoot . '/scripts/runner/configuration-language-argumented-block-plain-text-provenance-776.php',
+);
+
+$proofProblems = [];
+if (
+  ($sdcProof['status'] ?? NULL) !== 'PASS'
+  || ($sdcProof['verdict'] ?? NULL) !== 'SDC_NATIVE_METADATA_PROVENANCE_ANALYZED'
+  || ($sdcProof['counts']['candidate_total'] ?? NULL) !== 4
+  || ($sdcProof['counts']['material_translatable_leaves'] ?? NULL) !== 36
+  || ($sdcProof['counts']['final_matched_leaves'] ?? NULL) !== 36
+  || ($sdcProof['counts']['final_unmatched_leaves'] ?? NULL) !== 0
+  || ($sdcProof['counts']['problem_count'] ?? NULL) !== 0
+) {
+  $proofProblems[] = ['reason' => 'sdc_provenance_contract_not_satisfied'];
+}
+if (
+  ($blockProof['status'] ?? NULL) !== 'PASS'
+  || ($blockProof['verdict'] ?? NULL) !== 'CANVAS_BLOCK_NATIVE_LABEL_PROVENANCE_ANALYZED'
+  || ($blockProof['counts']['candidate_total'] ?? NULL) !== 26
+  || ($blockProof['counts']['definition_resolved'] ?? NULL) !== 26
+  || ($blockProof['counts']['current_no_exact_native_label_match'] ?? NULL) !== 0
+  || ($blockProof['counts']['settings_differs_from_current'] ?? NULL) !== 0
+  || ($blockProof['counts']['problem_count'] ?? NULL) !== 0
+) {
+  $proofProblems[] = ['reason' => 'block_provenance_contract_not_satisfied'];
+}
+if (
+  ($argumentProof['status'] ?? NULL) !== 'PASS'
+  || ($argumentProof['verdict'] ?? NULL) !== 'ARGUMENTED_BLOCK_PLAIN_TEXT_PROVENANCE_ANALYZED'
+  || ($argumentProof['counts']['candidate_total'] ?? NULL) !== 3
+  || ($argumentProof['counts']['deterministic_native_argument_provenance'] ?? NULL) !== 3
+  || ($argumentProof['counts']['review_required'] ?? NULL) !== 0
+  || ($argumentProof['counts']['problem_count'] ?? NULL) !== 0
+) {
+  $proofProblems[] = ['reason' => 'argumented_block_provenance_contract_not_satisfied'];
+}
+
+$blockByName = [];
+foreach (($blockProof['items'] ?? []) as $item) {
+  if (is_array($item) && is_string($item['config_name'] ?? NULL)) {
+    $blockByName[$item['config_name']] = $item;
+  }
+}
+$argumentByName = [];
+foreach (($argumentProof['items'] ?? []) as $item) {
+  if (is_array($item) && is_string($item['config_name'] ?? NULL)) {
+    $argumentByName[$item['config_name']] = $item;
+  }
+}
+$sdcByName = [];
+foreach (($sdcProof['items'] ?? []) as $item) {
+  if (is_array($item) && is_string($item['config_name'] ?? NULL)) {
+    $sdcByName[$item['config_name']] = $item;
+  }
+}
+
+$currentDistribution = [];
+$totalConfig = 0;
+foreach (glob($configDirectory . '/*.yml') ?: [] as $path) {
+  $data = Yaml::parseFile($path);
+  if (!is_array($data)) {
+    continue;
+  }
+  $totalConfig++;
+  $langcode = isset($data['langcode']) && is_string($data['langcode'])
+    ? $data['langcode']
+    : '__none__';
+  $currentDistribution[$langcode] = ($currentDistribution[$langcode] ?? 0) + 1;
+}
+ksort($currentDistribution, SORT_STRING);
+$expectedCurrentDistribution = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+if ($totalConfig !== 595 || $currentDistribution !== $expectedCurrentDistribution) {
+  $proofProblems[] = [
+    'reason' => 'repository_distribution_drifted',
+    'total' => $totalConfig,
+    'actual' => $currentDistribution,
+    'expected' => $expectedCurrentDistribution,
+  ];
+}
+
+$basePlans = [];
+$overridePlans = [];
+$labelChangedFiles = 0;
+$blockFiles = 0;
+$sdcFiles = 0;
+$existingOverrideFiles = 0;
+$reviewRequired = [];
+
+foreach ($names as $configName) {
+  $basePath = $configDirectory . '/' . $configName . '.yml';
+  if (!is_file($basePath)) {
+    $reviewRequired[] = [
+      'config_name' => $configName,
+      'reason' => 'base_config_missing',
+    ];
+    continue;
+  }
+
+  $before = Yaml::parseFile($basePath);
+  if (!is_array($before) || ($before['langcode'] ?? NULL) !== 'fr') {
+    $reviewRequired[] = [
+      'config_name' => $configName,
+      'reason' => 'base_config_not_expected_fr_mapping',
+    ];
+    continue;
+  }
+
+  $after = $before;
+  $after['langcode'] = 'en';
+  $operations = [[
+    'path' => 'langcode',
+    'before' => 'fr',
+    'after' => 'en',
+    'provenance' => '#766 exact remaining-FR Canvas cohort',
+  ]];
+  $sourceKind = $before['source'] ?? NULL;
+
+  if ($sourceKind === 'block') {
+    $blockFiles++;
+    $proof = $blockByName[$configName] ?? NULL;
+    if (!is_array($proof)) {
+      $reviewRequired[] = [
+        'config_name' => $configName,
+        'reason' => 'block_provenance_item_missing',
+      ];
+      continue;
+    }
+
+    $currentLabel = $proof['canvas_labels']['label'] ?? NULL;
+    $settingsLabel = $proof['canvas_labels']['active_default_settings_label'] ?? NULL;
+    $kind = $proof['native_admin_label']['kind'] ?? NULL;
+    $arguments = $proof['native_admin_label']['arguments'] ?? NULL;
+    if (
+      !is_string($currentLabel)
+      || $settingsLabel !== $currentLabel
+      || !is_string($kind)
+      || !is_array($arguments)
+      || ($before['label'] ?? NULL) !== $currentLabel
+      || ($before['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL)
+        !== $currentLabel
+    ) {
+      $reviewRequired[] = [
+        'config_name' => $configName,
+        'reason' => 'block_current_label_contract_mismatch',
+      ];
+      continue;
+    }
+
+    $canonicalLabel = NULL;
+    $labelProvenance = NULL;
+    if ($kind === 'scalar_definition_literal') {
+      $scalar = $proof['native_admin_label']['scalar_definition'] ?? NULL;
+      if (is_string($scalar)) {
+        $canonicalLabel = $scalar;
+        $labelProvenance = '#774 plugin.manager.block scalar definition';
+      }
+    }
+    elseif ($kind === 'translatable_markup' && $arguments === []) {
+      $source = $proof['native_admin_label']['untranslated_source'] ?? NULL;
+      if (is_string($source) && $source !== '') {
+        $canonicalLabel = $source;
+        $labelProvenance = '#774 plugin.manager.block untranslated source';
+      }
+    }
+    elseif ($kind === 'translatable_markup' && $arguments !== []) {
+      $argumentItem = $argumentByName[$configName] ?? NULL;
+      $source = is_array($argumentItem)
+        ? ($argumentItem['future_base_label'] ?? NULL)
+        : NULL;
+      if (
+        is_string($source)
+        && $source !== ''
+        && ($argumentItem['decision'] ?? NULL)
+          === 'deterministic_native_argument_provenance'
+        && ($argumentItem['future_fr_override_label'] ?? NULL) === $currentLabel
+      ) {
+        $canonicalLabel = $source;
+        $labelProvenance = '#776 structured argument provenance + PlainTextOutput';
+      }
+    }
+
+    if (!is_string($canonicalLabel) || $canonicalLabel === '') {
+      $reviewRequired[] = [
+        'config_name' => $configName,
+        'reason' => 'canonical_block_label_unresolved',
+      ];
+      continue;
+    }
+
+    if ($canonicalLabel !== $currentLabel) {
+      $labelChangedFiles++;
+      $after['label'] = $canonicalLabel;
+      $setPath(
+        $after,
+        ['versioned_properties', 'active', 'settings', 'default_settings', 'label'],
+        $canonicalLabel,
+      );
+      $operations[] = [
+        'path' => 'label',
+        'before' => $currentLabel,
+        'after' => $canonicalLabel,
+        'provenance' => $labelProvenance,
+      ];
+      $operations[] = [
+        'path' => 'versioned_properties.active.settings.default_settings.label',
+        'before' => $settingsLabel,
+        'after' => $canonicalLabel,
+        'provenance' => $labelProvenance,
+      ];
+
+      $relativeOverride = 'language/fr/' . $configName . '.yml';
+      $overridePath = $configDirectory . '/' . $relativeOverride;
+      $overrideBefore = [];
+      if (is_file($overridePath)) {
+        $existingOverrideFiles++;
+        $parsed = Yaml::parseFile($overridePath);
+        if (!is_array($parsed)) {
+          $reviewRequired[] = [
+            'config_name' => $configName,
+            'reason' => 'existing_fr_override_invalid',
+          ];
+          continue;
+        }
+        $overrideBefore = $parsed;
+      }
+      $overrideAfter = $overrideBefore;
+      $overrideAfter['label'] = $currentLabel;
+      $setPath(
+        $overrideAfter,
+        ['versioned_properties', 'active', 'settings', 'default_settings', 'label'],
+        $currentLabel,
+      );
+      $overridePlans[] = [
+        'config_name' => $configName,
+        'path' => $relativeOverride,
+        'action' => $overrideBefore === [] ? 'create' : 'update',
+        'before' => $canonicalize($overrideBefore),
+        'after' => $canonicalize($overrideAfter),
+        'provenance' => 'preserve exact current FR Canvas labels after canonical base promotion',
+      ];
+    }
+  }
+  elseif ($sourceKind === 'sdc') {
+    $sdcFiles++;
+    $proof = $sdcByName[$configName] ?? NULL;
+    if (
+      !is_array($proof)
+      || ($proof['classification'] ?? NULL)
+        !== 'all_material_values_present_in_combined_native_sources'
+      || ($proof['final_unmatched_leaf_count'] ?? NULL) !== 0
+    ) {
+      $reviewRequired[] = [
+        'config_name' => $configName,
+        'reason' => 'sdc_native_value_coverage_incomplete',
+      ];
+      continue;
+    }
+    // #772 proves all 36 current translatable values are already present in
+    // admitted native source surfaces. #779 therefore changes no SDC value:
+    // source-value presence is a preservation guard, not a rewrite signal.
+  }
+  else {
+    $reviewRequired[] = [
+      'config_name' => $configName,
+      'reason' => 'unexpected_canvas_source_kind',
+      'source' => $sourceKind,
+    ];
+    continue;
+  }
+
+  $basePlans[] = [
+    'config_name' => $configName,
+    'path' => $configName . '.yml',
+    'source_kind' => $sourceKind,
+    'before_hash' => hash(
+      'sha256',
+      json_encode($canonicalize($before), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+    ),
+    'after_hash' => hash(
+      'sha256',
+      json_encode($canonicalize($after), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+    ),
+    'operations' => $operations,
+    'before' => $canonicalize($before),
+    'after' => $canonicalize($after),
+    'historical_versions_modified' => FALSE,
+  ];
+}
+
+usort(
+  $basePlans,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+usort(
+  $overridePlans,
+  static fn(array $left, array $right): int =>
+    $left['config_name'] <=> $right['config_name'],
+);
+usort(
+  $reviewRequired,
+  static fn(array $left, array $right): int =>
+    ($left['config_name'] ?? '') <=> ($right['config_name'] ?? ''),
+);
+
+$simulatedDistribution = $currentDistribution;
+$simulatedDistribution['fr'] -= count($basePlans);
+$simulatedDistribution['en'] += count($basePlans);
+ksort($simulatedDistribution, SORT_STRING);
+$expectedTargetDistribution = [
+  '__none__' => 59,
+  'en' => 496,
+  'fr' => 39,
+  'und' => 1,
+];
+
+if (count($basePlans) !== 30) {
+  $reviewRequired[] = [
+    'reason' => 'base_plan_count_mismatch',
+    'actual' => count($basePlans),
+    'expected' => 30,
+  ];
+}
+if ($blockFiles !== 26 || $sdcFiles !== 4) {
+  $reviewRequired[] = [
+    'reason' => 'source_kind_count_mismatch',
+    'block' => $blockFiles,
+    'sdc' => $sdcFiles,
+  ];
+}
+if ($labelChangedFiles !== 15) {
+  $reviewRequired[] = [
+    'reason' => 'block_label_change_count_mismatch',
+    'actual' => $labelChangedFiles,
+    'expected' => 15,
+  ];
+}
+if (count($overridePlans) !== 15) {
+  $reviewRequired[] = [
+    'reason' => 'fr_override_plan_count_mismatch',
+    'actual' => count($overridePlans),
+    'expected' => 15,
+  ];
+}
+if ($simulatedDistribution !== $expectedTargetDistribution) {
+  $reviewRequired[] = [
+    'reason' => 'simulated_distribution_mismatch',
+    'actual' => $simulatedDistribution,
+    'expected' => $expectedTargetDistribution,
+  ];
+}
+foreach ($basePlans as $plan) {
+  if (($plan['historical_versions_modified'] ?? TRUE) !== FALSE) {
+    $reviewRequired[] = [
+      'config_name' => $plan['config_name'] ?? NULL,
+      'reason' => 'historical_version_mutation_planned',
+    ];
+  }
+}
+
+$planPayload = [
+  'cohort_names_sha256' => $namesHash,
+  'base_files' => $basePlans,
+  'fr_overrides' => $overridePlans,
+  'simulated_distribution' => $simulatedDistribution,
+];
+$planCanonical = $canonicalize($planPayload);
+$planHash = hash(
+  'sha256',
+  json_encode(
+    $planCanonical,
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+  ),
+);
+
+$allProblems = [...$proofProblems, ...$reviewRequired];
+$status = $proofProblems === [] ? 'PASS' : 'FAIL';
+$ready = $status === 'PASS' && $reviewRequired === [];
+$verdict = $status !== 'PASS'
+  ? 'CANVAS_CANONICAL_MIGRATION_DRY_RUN_FAILED'
+  : ($ready
+    ? 'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY'
+    : 'CANVAS_CANONICAL_MIGRATION_DRY_RUN_REVIEW_REQUIRED');
+
+$result = [
+  'schema_version' => 1,
+  'status' => $status,
+  'verdict' => $verdict,
+  'ready_for_migration' => $ready,
+  'cohort' => [
+    'total' => 30,
+    'block' => 26,
+    'sdc' => 4,
+    'names_sha256' => $namesHash,
+  ],
+  'proofs' => [
+    'sdc' => [
+      'issue' => 772,
+      'verdict' => $sdcProof['verdict'] ?? NULL,
+      'material_translatable_leaves' => $sdcProof['counts']['material_translatable_leaves'] ?? NULL,
+      'final_matched_leaves' => $sdcProof['counts']['final_matched_leaves'] ?? NULL,
+    ],
+    'block' => [
+      'issue' => 774,
+      'verdict' => $blockProof['verdict'] ?? NULL,
+      'definition_resolved' => $blockProof['counts']['definition_resolved'] ?? NULL,
+    ],
+    'argumented_block' => [
+      'issue' => 776,
+      'verdict' => $argumentProof['verdict'] ?? NULL,
+      'deterministic' => $argumentProof['counts']['deterministic_native_argument_provenance'] ?? NULL,
+    ],
+  ],
+  'counts' => [
+    'base_files_planned' => count($basePlans),
+    'block_files_planned' => $blockFiles,
+    'sdc_files_planned' => $sdcFiles,
+    'langcode_changes' => count($basePlans),
+    'block_label_files_changed' => $labelChangedFiles,
+    'block_label_value_changes' => $labelChangedFiles * 2,
+    'fr_override_files_planned' => count($overridePlans),
+    'existing_fr_override_files' => $existingOverrideFiles,
+    'review_required' => count($reviewRequired),
+    'proof_problem' => count($proofProblems),
+    'problem_count' => count($allProblems),
+  ],
+  'distribution' => [
+    'before' => $currentDistribution,
+    'after_simulated' => $simulatedDistribution,
+    'total' => $totalConfig,
+  ],
+  'plan_sha256' => $planHash,
+  'plan' => $planCanonical,
+  'review_required' => $reviewRequired,
+  'problems' => $allProblems,
+  'constraints' => [
+    'read_only' => TRUE,
+    'in_memory_simulation_only' => TRUE,
+    'repository_config_mutated' => FALSE,
+    'historical_versions_rewritten' => FALSE,
+    'sdc_values_rewritten' => FALSE,
+    'sdc_native_value_presence_used_as_preservation_guard_only' => TRUE,
+    'block_labels_from_native_provenance_only' => TRUE,
+    'generic_normalization_used' => FALSE,
+    'natural_language_heuristic_used' => FALSE,
+    'automatic_arbitrary_text_translation_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'source_generation_executed' => FALSE,
+    'block_build_executed' => FALSE,
+    'config_entity_creation_executed' => FALSE,
+    'config_entity_update_executed' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'production_access_allowed' => FALSE,
+    'provider_secret_used' => FALSE,
+    'migration_allowed_by_this_dry_run' => FALSE,
+    'executed_mutating_methods' => [],
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT
+  | JSON_UNESCAPED_SLASHES
+  | JSON_UNESCAPED_UNICODE
+  | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigrationDryRun779Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigrationDryRun779Test.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #779 Canvas migration dry-run.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasMigrationDryRun779Test extends TestCase {
+
+  /**
+   * The dry-run is fixed to the exact #766 cohort and admitted proofs.
+   */
+  public function testDryRunReusesExactCohortAndProofs(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/configuration-language-canvas-migration-dry-run-779.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'configuration-language-canvas-runtime-source-api-cohort-766.yml',
+      'configuration-language-sdc-native-metadata-provenance-772.php',
+      'configuration-language-canvas-block-native-label-provenance-774.php',
+      'configuration-language-argumented-block-plain-text-provenance-776.php',
+      'b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23',
+      "'total' => 30",
+      "'block' => 26",
+      "'sdc' => 4",
+      "'block_label_files_changed' => \$labelChangedFiles",
+      "'fr_override_files_planned' => count(\$overridePlans)",
+      'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+  }
+
+  /**
+   * The plan remains in-memory and preserves unproven values/history.
+   */
+  public function testDryRunIsReadOnlyAndFailClosed(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/configuration-language-canvas-migration-dry-run-779.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      "'read_only' => TRUE",
+      "'in_memory_simulation_only' => TRUE",
+      "'repository_config_mutated' => FALSE",
+      "'historical_versions_rewritten' => FALSE",
+      "'sdc_values_rewritten' => FALSE",
+      "'sdc_native_value_presence_used_as_preservation_guard_only' => TRUE",
+      "'block_labels_from_native_provenance_only' => TRUE",
+      "'generic_normalization_used' => FALSE",
+      "'natural_language_heuristic_used' => FALSE",
+      "'automatic_arbitrary_text_translation_used' => FALSE",
+      "'fuzzy_matching_used' => FALSE",
+      "'migration_allowed_by_this_dry_run' => FALSE",
+      "'en' => 496",
+      "'fr' => 39",
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+
+    foreach ([
+      '->generateComponents(',
+      '->build(',
+      '->save(',
+      '->write(',
+      '->delete(',
+      'file_put_contents(',
+      'Yaml::dump(',
+      'drush cex',
+      'html_entity_decode(',
+      'str_replace(',
+      'preg_replace(',
+      'similar_text(',
+      'levenshtein(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * Trusted execution is fixed to #779 and requires READY evidence.
+   */
+  public function testTrustedWorkflowIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-migration-dry-run-779.yml';
+    self::assertFileExists($path);
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      'github.event.issue.number == 779',
+      "'/agency-config-language-canvas-migration dry-run'",
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      'persist-credentials: false',
+      'ddev drush site:install --existing-config',
+      'ddev drush cim -y',
+      "grep -Fq 'No differences'",
+      'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',
+      '.counts.base_files_planned == 30',
+      '.counts.block_label_files_changed == 15',
+      '.counts.fr_override_files_planned == 15',
+      '.counts.review_required == 0',
+      '"en":496',
+      '"fr":39',
+      '.constraints.repository_config_mutated == false',
+      '.constraints.migration_allowed_by_this_dry_run == false',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Implements the strictly read-only #779 migration dry-run for the exact 30 Canvas components from #766.

The dry-run reuses the already merged runtime proofs instead of recreating their decisions:
- #772 for 4 SDC / 36 native-covered translatable leaves;
- #774 for 26 Block native labels via `plugin.manager.block`;
- #776 for the 3 argument-bearing Block labels and plain-text projection.

Expected in-memory plan:
- 30 base files: `langcode: fr -> en`;
- 15 Block files: top-level + active default-settings labels promoted to native canonical source;
- 15 FR override files preserving those exact current labels;
- 4 SDC files: langcode-only, no SDC value rewrite;
- no historical-version rewrite;
- simulated distribution `__none__=59, en=496, fr=39, und=1`, total 595.

The plan is canonicalized and SHA-256 hashed. `ready_for_migration` is true only with zero proof problems and zero review-required items.

No `config/sync` mutation, no `drush cex`, Canvas generation/build, Configuration Language Lock activation, production/provider/secret, natural-language heuristic, arbitrary translation, generic normalization or fuzzy match.

Refs #779 #776 #774 #772 #766 #609