### PR TITLE
Issue #781: govern exact Canvas canonical migration

### DIFF
--- a/.github/workflows/governed-configuration-language-canvas-migration-781.yml
+++ b/.github/workflows/governed-configuration-language-canvas-migration-781.yml
@@ -1,0 +1,390 @@
+name: Agency governed Canvas canonical migration
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate fixed #781 live-main migration request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 781 &&
+        github.event.comment.body == '/agency-config-language-canvas-migration apply'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and immutable live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$ISSUE_NUMBER" = '781'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-canvas-migration apply'
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/781")"
+          test "$(jq -r '.state' <<<"$issue_json")" = 'open'
+          test "$(jq -r '.pull_request // empty' <<<"$issue_json")" = ''
+          test "$(jq -r '.user.login' <<<"$issue_json")" = 'E-merging-digital'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prepare-and-push:
+    name: Reproduce #779 plan, apply exact patch and fresh-verify
+    needs: validate-request
+    timeout-minutes: 60
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: write
+    outputs:
+      branch: ${{ steps.commit.outputs.branch }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      status: ${{ steps.summary.outputs.status }}
+      base_files: ${{ steps.summary.outputs.base_files }}
+      overrides: ${{ steps.summary.outputs.overrides }}
+      verification: ${{ steps.summary.outputs.verification }}
+      plan_sha256: ${{ steps.summary.outputs.plan_sha256 }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          id
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact live main with bounded write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Verify immutable #781 tooling and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f docs/evidence/configuration-language-canvas-migration-plan-779.yml
+          test -f scripts/runner/configuration-language-canvas-migration-dry-run-779.php
+          test -f scripts/runner/apply-configuration-language-canvas-migration-781.php
+          test -f scripts/runner/configuration-language-canvas-migration-781-verify.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate fresh DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-migration-781.yaml <<EOF_CONFIG
+          name: agency-config-canvas-migration-781-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-migration-781-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild exact pre-migration baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l \
+            /var/www/html/scripts/runner/apply-configuration-language-canvas-migration-781.php \
+            >/dev/null
+          ddev exec php -l \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php \
+            >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status-before.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+          test "$(ddev drush cget system.site default_langcode --format=string)" = 'fr'
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must be disabled before #781.' >&2
+            exit 1
+          fi
+
+      - name: Reproduce exact #779 plan before mutation
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781'
+          dry_run="$root/dry-run-before.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-dry-run-779.php \
+            > "$dry_run"
+
+          jq -e '.status == "PASS"' "$dry_run" >/dev/null
+          jq -e '.verdict == "CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY"' "$dry_run" >/dev/null
+          jq -e '.ready_for_migration == true' "$dry_run" >/dev/null
+          jq -e '.plan_sha256 == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$dry_run" >/dev/null
+          jq -e '.counts.base_files_planned == 30' "$dry_run" >/dev/null
+          jq -e '.counts.block_label_files_changed == 15' "$dry_run" >/dev/null
+          jq -e '.counts.fr_override_files_planned == 15' "$dry_run" >/dev/null
+          jq -e '.counts.review_required == 0 and .counts.problem_count == 0' "$dry_run" >/dev/null
+          jq -e '.distribution.after_simulated == {"__none__":59,"en":496,"fr":39,"und":1}' "$dry_run" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+      - name: Apply exact hashed #781 writer
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781'
+          result="$root/writer-result.json"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/apply-configuration-language-canvas-migration-781.php \
+            > "$result"
+
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED"' "$result" >/dev/null
+          jq -e '.source.plan_sha256_expected == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$result" >/dev/null
+          jq -e '.source.plan_sha256_observed == .source.plan_sha256_expected' "$result" >/dev/null
+          jq -e '.counts.base_files_modified == 30' "$result" >/dev/null
+          jq -e '.counts.block_label_files_modified == 15' "$result" >/dev/null
+          jq -e '.counts.block_label_values_modified == 30' "$result" >/dev/null
+          jq -e '.counts.fr_overrides_created == 15' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$result" >/dev/null
+          jq -e '.distribution.after == {"__none__":59,"en":496,"fr":39,"und":1}' "$result" >/dev/null
+          jq -e '.constraints.exact_hashed_plan_replayed_before_write == true' "$result" >/dev/null
+          jq -e '.constraints.historical_versions_rewritten == false' "$result" >/dev/null
+          jq -e '.constraints.sdc_values_rewritten == false' "$result" >/dev/null
+          jq -e '.constraints.config_export_used == false' "$result" >/dev/null
+          jq -e '.constraints.config_language_lock_activation_allowed == false' "$result" >/dev/null
+
+          mapfile -t expected_paths < <(
+            jq -r '.paths.modified_base[], .paths.created_fr_overrides[]' "$result" | sort
+          )
+          mapfile -t changed_paths < <(
+            git status --porcelain --untracked-files=all -- config/sync \
+              | awk '{print $2}' | sort
+          )
+          test "${#expected_paths[@]}" -eq 45
+          test "${#changed_paths[@]}" -eq 45
+          diff -u \
+            <(printf '%s\n' "${expected_paths[@]}") \
+            <(printf '%s\n' "${changed_paths[@]}")
+
+          test "$(git diff --name-only -- config/sync | wc -l)" -eq 30
+          test "$(git status --porcelain --untracked-files=all -- config/sync/language/fr | wc -l)" -eq 15
+          test -z "$(git diff --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+
+          while IFS= read -r sdc_path; do
+            git diff --numstat -- "$sdc_path" \
+              | awk 'NF == 3 {exit !($1 == 1 && $2 == 1)}'
+          done < <(
+            jq -r '.base_evidence[] | select(.source_kind == "sdc") | .path' "$result"
+          )
+
+          git diff --check
+          git diff -- config/sync > "$root/config-diff.patch"
+          git status --porcelain --untracked-files=all -- config/sync \
+            > "$root/config-git-status.txt"
+
+      - name: Rebuild second fresh Drupal and verify exact target
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781'
+          verify="$root/verify-result.json"
+
+          ddev delete --omit-snapshot --yes
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status-after.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php \
+            > "$verify"
+          jq -e '.status == "PASS"' "$verify" >/dev/null
+          jq -e '.verdict == "THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED"' "$verify" >/dev/null
+          jq -e '.plan_sha256 == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$verify" >/dev/null
+          jq -e '.verified == 30 and .fr_overrides_verified == 15' "$verify" >/dev/null
+          jq -e '.remaining_fr_review_required == 39' "$verify" >/dev/null
+          jq -e '.repository_total == 595 and .active_total == 595' "$verify" >/dev/null
+          jq -e '.repository_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.active_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.problems == []' "$verify" >/dev/null
+          jq -e '.constraints.target_semantic_hashes_verified == true' "$verify" >/dev/null
+          jq -e '.constraints.historical_versions_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.sdc_values_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.config_language_lock_enabled_canonically == false' "$verify" >/dev/null
+          jq -e '.constraints.system_site_default_langcode == "fr"' "$verify" >/dev/null
+
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must remain disabled after #781.' >&2
+            exit 1
+          fi
+          test -z "$(git diff --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+          git diff --check
+
+      - name: Commit and push only the bounded generated branch
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch='feature/781-apply-canvas-canonical-migration'
+          result='artifacts/config-language-canvas-migration-781/writer-result.json'
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing branch $branch" >&2
+            exit 1
+          fi
+
+          git switch -c "$branch"
+          mapfile -t paths < <(
+            jq -r '.paths.modified_base[], .paths.created_fr_overrides[]' "$result"
+          )
+          test "${#paths[@]}" -eq 45
+          git add -- "${paths[@]}"
+
+          test "$(git diff --cached --name-only | wc -l)" -eq 45
+          test "$(git diff --cached --name-only -- 'config/sync/canvas.component.*.yml' | wc -l)" -eq 30
+          test "$(git diff --cached --name-only -- 'config/sync/language/fr/canvas.component.*.yml' | wc -l)" -eq 15
+          test -z "$(git diff --cached --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+          git diff --cached --check
+
+          git config user.name 'E-merging Digital Automation'
+          git config user.email 'actions@users.noreply.github.com'
+          git commit -m 'Issue #781: apply exact Canvas canonical migration plan'
+          commit_sha="$(git rev-parse HEAD)"
+          git push origin "HEAD:refs/heads/$branch"
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Publish machine summary outputs
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          writer='artifacts/config-language-canvas-migration-781/writer-result.json'
+          verify='artifacts/config-language-canvas-migration-781/verify-result.json'
+          echo 'status=PASS' >> "$GITHUB_OUTPUT"
+          echo "base_files=$(jq -r '.counts.base_files_modified' "$writer")" >> "$GITHUB_OUTPUT"
+          echo "overrides=$(jq -r '.counts.fr_overrides_created' "$writer")" >> "$GITHUB_OUTPUT"
+          echo "verification=$(jq -r '.status' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "plan_sha256=$(jq -r '.source.plan_sha256_observed' "$writer")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload #781 migration preparation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-migration-781-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-migration-781
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean DDEV and bounded workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-migration-781-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-migration-781.yaml
+          rm -rf artifacts/config-language-canvas-migration-781
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+
+  report-result:
+    name: Publish #781 governed migration preparation verdict
+    if: ${{ always() && needs.validate-request.result == 'success' }}
+    needs:
+      - validate-request
+      - prepare-and-push
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+          PREPARE_RESULT: ${{ needs.prepare-and-push.result }}
+          BRANCH: ${{ needs.prepare-and-push.outputs.branch }}
+          COMMIT_SHA: ${{ needs.prepare-and-push.outputs.commit_sha }}
+          STATUS: ${{ needs.prepare-and-push.outputs.status }}
+          BASE_FILES: ${{ needs.prepare-and-push.outputs.base_files }}
+          OVERRIDES: ${{ needs.prepare-and-push.outputs.overrides }}
+          VERIFICATION: ${{ needs.prepare-and-push.outputs.verification }}
+          PLAN_SHA256: ${{ needs.prepare-and-push.outputs.plan_sha256 }}
+        run: |
+          set -euo pipefail
+          verdict='FAIL'
+          if [[ "$PREPARE_RESULT" == 'success' ]]; then
+            verdict='PASS'
+          fi
+          gh issue comment 781 --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF_BODY
+          ### Governed Canvas canonical migration preparation ${verdict}
+
+          trusted_main: \`${MAIN_SHA}\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${PREPARE_RESULT}\`
+          writer_status: \`${STATUS:-n/a}\`
+          generated_branch: \`${BRANCH:-n/a}\`
+          generated_commit: \`${COMMIT_SHA:-n/a}\`
+          base_files_modified: \`${BASE_FILES:-n/a}\`
+          fr_overrides_created: \`${OVERRIDES:-n/a}\`
+          fresh_verification: \`${VERIFICATION:-n/a}\`
+          plan_sha256: \`${PLAN_SHA256:-n/a}\`
+          artifact: \`agency-config-language-canvas-migration-781-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+          The route reproduces trusted plan #779 before any write and fails closed on SHA drift. It may only push the bounded generated branch. It does not write main, export config, activate Configuration Language Lock, access production/provider secrets, generate/build Canvas, or perform arbitrary translation/normalization/fuzzy matching.
+          EOF_BODY
+          )"
+          test "$PREPARE_RESULT" = 'success'

--- a/docs/evidence/configuration-language-canvas-migration-plan-779.yml
+++ b/docs/evidence/configuration-language-canvas-migration-plan-779.yml
@@ -1,0 +1,118 @@
+schema_version: 1
+issue: 779
+parent_issue: 609
+application_issue: 781
+source:
+  trusted_main: 59b8720d307b6e141cb37d3408a27f43c4b199aa
+  run_id: 32733184593
+  artifact_id: 9522276654
+  artifact_digest: 'sha256:e1f0f53e77505ff418a09a094e2e0eddf6428cbcc1066e70db650ab46fa19141'
+  plan_sha256: 8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24
+cohort:
+  total: 30
+  block: 26
+  sdc: 4
+  names_sha256: b2ad9dcff4b65e56e2a76efefc55b508cf4012b6aaa18cba0c4879cf2f3dec23
+  names:
+    - canvas.component.block.announce_block
+    - canvas.component.block.emerging_digital_language_switcher
+    - canvas.component.block.help_block
+    - canvas.component.block.language_block.language_content
+    - canvas.component.block.language_block.language_interface
+    - canvas.component.block.local_actions_block
+    - canvas.component.block.local_tasks_block
+    - canvas.component.block.page_title_block
+    - canvas.component.block.shortcuts
+    - canvas.component.block.system_branding_block
+    - canvas.component.block.system_breadcrumb_block
+    - canvas.component.block.system_clear_cache_block
+    - canvas.component.block.system_menu_block.account
+    - canvas.component.block.system_menu_block.admin
+    - canvas.component.block.system_menu_block.footer
+    - canvas.component.block.system_menu_block.main
+    - canvas.component.block.system_menu_block.online-presence
+    - canvas.component.block.system_menu_block.tools
+    - canvas.component.block.system_messages_block
+    - canvas.component.block.system_powered_by_block
+    - canvas.component.block.user_login_block
+    - canvas.component.block.views_block.comments_recent-block_1
+    - canvas.component.block.views_block.content_recent-block_1
+    - canvas.component.block.views_block.who_s_new-block_1
+    - canvas.component.block.views_block.who_s_online-who_s_online_block
+    - canvas.component.block.webform_block
+    - canvas.component.sdc.emerging_digital.cta
+    - canvas.component.sdc.emerging_digital.hero
+    - canvas.component.sdc.emerging_digital.trust-list
+    - canvas.component.sdc.olivero.teaser
+sdc_names:
+  - canvas.component.sdc.emerging_digital.cta
+  - canvas.component.sdc.emerging_digital.hero
+  - canvas.component.sdc.emerging_digital.trust-list
+  - canvas.component.sdc.olivero.teaser
+block_label_targets:
+  canvas.component.block.announce_block:
+    base: 'Announcements Feed'
+    fr: "Flux d'annonces"
+  canvas.component.block.emerging_digital_language_switcher:
+    base: 'Language switcher'
+    fr: 'Sélecteur de langue'
+  canvas.component.block.help_block:
+    base: 'Help'
+    fr: 'Aide'
+  canvas.component.block.language_block.language_content:
+    base: 'Language switcher (Content)'
+    fr: 'Sélecteur de langue (Contenu)'
+  canvas.component.block.language_block.language_interface:
+    base: 'Language switcher (Interface text)'
+    fr: "Sélecteur de langue (Texte d'interface)"
+  canvas.component.block.local_actions_block:
+    base: 'Primary admin actions'
+    fr: "Actions d'administration principales"
+  canvas.component.block.local_tasks_block:
+    base: 'Tabs'
+    fr: 'Onglets'
+  canvas.component.block.page_title_block:
+    base: 'Page title'
+    fr: 'Titre de la page'
+  canvas.component.block.shortcuts:
+    base: 'Shortcuts'
+    fr: 'Raccourcis'
+  canvas.component.block.system_branding_block:
+    base: 'Site branding'
+    fr: 'Identité du site'
+  canvas.component.block.system_breadcrumb_block:
+    base: 'Breadcrumbs'
+    fr: "Fils d'ariane"
+  canvas.component.block.system_clear_cache_block:
+    base: 'Clear cache'
+    fr: 'Vider le cache'
+  canvas.component.block.system_powered_by_block:
+    base: 'Powered by Drupal'
+    fr: 'Propulsé par Drupal'
+  canvas.component.block.user_login_block:
+    base: 'User login'
+    fr: 'Connexion utilisateur'
+  canvas.component.block.views_block.content_recent-block_1:
+    base: 'Recent content: Block'
+    fr: 'Recent content : Block'
+target:
+  total_config: 595
+  distribution:
+    __none__: 59
+    en: 496
+    fr: 39
+    und: 1
+  base_files_modified: 30
+  block_label_files_modified: 15
+  block_label_values_modified: 30
+  fr_overrides_created: 15
+constraints:
+  exact_plan_required: true
+  historical_versions_rewritten: false
+  sdc_values_rewritten: false
+  config_language_lock_enabled: false
+  system_site_default_langcode: fr
+  config_export_allowed: false
+  natural_language_heuristic_used: false
+  arbitrary_translation_used: false
+  fuzzy_matching_used: false

--- a/scripts/runner/apply-configuration-language-canvas-migration-781.php
+++ b/scripts/runner/apply-configuration-language-canvas-migration-781.php
@@ -1,0 +1,424 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/configuration-language-canvas-migration-plan-779.yml';
+$dryRunPath = $projectRoot
+  . '/scripts/runner/configuration-language-canvas-migration-dry-run-779.php';
+
+$expectedPlanSha = '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24';
+$expectedDistributionBefore = [
+  '__none__' => 59,
+  'en' => 466,
+  'fr' => 69,
+  'und' => 1,
+];
+$expectedDistributionAfter = [
+  '__none__' => 59,
+  'en' => 496,
+  'fr' => 39,
+  'und' => 1,
+];
+$allowedOperationPaths = [
+  'langcode',
+  'label',
+  'versioned_properties.active.settings.default_settings.label',
+];
+
+if (!is_dir($configDirectory) || !is_file($manifestPath) || !is_file($dryRunPath)) {
+  throw new RuntimeException('Issue #781 migration prerequisites are unavailable.');
+}
+
+$manifest = Yaml::parseFile($manifestPath);
+if (
+  !is_array($manifest)
+  || ($manifest['issue'] ?? NULL) !== 779
+  || ($manifest['application_issue'] ?? NULL) !== 781
+  || ($manifest['source']['plan_sha256'] ?? NULL) !== $expectedPlanSha
+  || ($manifest['cohort']['total'] ?? NULL) !== 30
+  || ($manifest['cohort']['block'] ?? NULL) !== 26
+  || ($manifest['cohort']['sdc'] ?? NULL) !== 4
+  || ($manifest['target']['distribution'] ?? NULL) !== $expectedDistributionAfter
+  || ($manifest['target']['base_files_modified'] ?? NULL) !== 30
+  || ($manifest['target']['block_label_files_modified'] ?? NULL) !== 15
+  || ($manifest['target']['fr_overrides_created'] ?? NULL) !== 15
+  || ($manifest['constraints']['config_language_lock_enabled'] ?? TRUE) !== FALSE
+  || ($manifest['constraints']['system_site_default_langcode'] ?? NULL) !== 'fr'
+) {
+  throw new RuntimeException('Issue #781 trusted migration contract drifted.');
+}
+
+$runDryRun = static function (string $path): array {
+  ob_start();
+  try {
+    require $path;
+    $raw = (string) ob_get_clean();
+  }
+  catch (Throwable $throwable) {
+    ob_end_clean();
+    throw $throwable;
+  }
+
+  $decoded = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+  if (!is_array($decoded)) {
+    throw new RuntimeException('Issue #779 dry-run did not return a mapping.');
+  }
+  return $decoded;
+};
+
+$plan = $runDryRun($dryRunPath);
+if (
+  ($plan['status'] ?? NULL) !== 'PASS'
+  || ($plan['verdict'] ?? NULL) !== 'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY'
+  || ($plan['ready_for_migration'] ?? NULL) !== TRUE
+  || ($plan['plan_sha256'] ?? NULL) !== $expectedPlanSha
+  || ($plan['counts']['base_files_planned'] ?? NULL) !== 30
+  || ($plan['counts']['block_label_files_changed'] ?? NULL) !== 15
+  || ($plan['counts']['fr_override_files_planned'] ?? NULL) !== 15
+  || ($plan['counts']['existing_fr_override_files'] ?? NULL) !== 0
+  || ($plan['counts']['review_required'] ?? NULL) !== 0
+  || ($plan['counts']['proof_problem'] ?? NULL) !== 0
+  || ($plan['counts']['problem_count'] ?? NULL) !== 0
+  || ($plan['distribution']['before'] ?? NULL) !== $expectedDistributionBefore
+  || ($plan['distribution']['after_simulated'] ?? NULL) !== $expectedDistributionAfter
+) {
+  throw new RuntimeException('Issue #781 refuses to write because the trusted #779 plan no longer matches exactly.');
+}
+
+$canonicalize = NULL;
+$canonicalize = static function (mixed $value) use (&$canonicalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($canonicalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $canonicalize($child);
+  }
+  return $value;
+};
+
+$semanticHash = static function (array $data) use ($canonicalize): string {
+  return hash(
+    'sha256',
+    json_encode(
+      $canonicalize($data),
+      JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+    ),
+  );
+};
+
+$yamlScalar = static function (string $value): string {
+  $dump = Yaml::dump(['value' => $value], 1, 2);
+  if (!preg_match('/^value:\s*(.+)\n$/u', $dump, $matches)) {
+    throw new RuntimeException('Unable to serialize a one-line YAML scalar for #781.');
+  }
+  return $matches[1];
+};
+
+$replaceScalarPath = static function (
+  string $content,
+  string $targetPath,
+  string $before,
+  string $after,
+) use ($yamlScalar): string {
+  if (str_contains($content, "\r")) {
+    throw new RuntimeException('Issue #781 refuses CR line endings.');
+  }
+  $lines = explode("\n", $content);
+  $stack = [];
+  $matches = 0;
+
+  foreach ($lines as $index => $line) {
+    if (!preg_match('/^( *)([A-Za-z0-9_.-]+):(.*)$/u', $line, $parts)) {
+      continue;
+    }
+    $indent = strlen($parts[1]);
+    if (($indent % 2) !== 0) {
+      continue;
+    }
+    $depth = intdiv($indent, 2);
+    $stack = array_slice($stack, 0, $depth);
+    $stack[$depth] = $parts[2];
+    $path = implode('.', $stack);
+    if ($path !== $targetPath) {
+      continue;
+    }
+
+    $parsed = Yaml::parse("value:" . $parts[3] . "\n");
+    if (!is_array($parsed) || ($parsed['value'] ?? NULL) !== $before) {
+      throw new RuntimeException(sprintf(
+        'Issue #781 scalar baseline mismatch at %s.',
+        $targetPath,
+      ));
+    }
+    $lines[$index] = $parts[1] . $parts[2] . ': ' . $yamlScalar($after);
+    $matches++;
+  }
+
+  if ($matches !== 1) {
+    throw new RuntimeException(sprintf(
+      'Issue #781 expected exactly one scalar at %s, found %d.',
+      $targetPath,
+      $matches,
+    ));
+  }
+  return implode("\n", $lines);
+};
+
+$countDistribution = static function (string $directory): array {
+  $counts = [];
+  $files = glob($directory . '/*.yml');
+  if ($files === FALSE) {
+    throw new RuntimeException('Unable to enumerate configuration for #781.');
+  }
+  sort($files, SORT_STRING);
+  foreach ($files as $path) {
+    $data = Yaml::parseFile($path);
+    if (!is_array($data)) {
+      throw new RuntimeException('Invalid configuration mapping: ' . basename($path));
+    }
+    $langcode = isset($data['langcode']) && is_string($data['langcode'])
+      ? $data['langcode']
+      : '__none__';
+    $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+  }
+  ksort($counts, SORT_STRING);
+  return [count($files), $counts];
+};
+
+[$beforeTotal, $beforeDistribution] = $countDistribution($configDirectory);
+if ($beforeTotal !== 595 || $beforeDistribution !== $expectedDistributionBefore) {
+  throw new RuntimeException('Issue #781 repository distribution drifted before write.');
+}
+
+$coreExtension = Yaml::parseFile($configDirectory . '/core.extension.yml');
+$systemSite = Yaml::parseFile($configDirectory . '/system.site.yml');
+if (
+  !is_array($coreExtension)
+  || isset($coreExtension['module']['config_language_lock'])
+  || is_file($configDirectory . '/config_language_lock.settings.yml')
+  || !is_array($systemSite)
+  || ($systemSite['default_langcode'] ?? NULL) !== 'fr'
+) {
+  throw new RuntimeException('Issue #781 lock/site-default boundary is not satisfied.');
+}
+
+$basePlans = $plan['plan']['base_files'] ?? NULL;
+$overridePlans = $plan['plan']['fr_overrides'] ?? NULL;
+if (!is_array($basePlans) || count($basePlans) !== 30 || !is_array($overridePlans) || count($overridePlans) !== 15) {
+  throw new RuntimeException('Issue #781 plan membership is incomplete.');
+}
+
+$writtenBases = [];
+$baseEvidence = [];
+foreach ($basePlans as $basePlan) {
+  if (!is_array($basePlan)) {
+    throw new RuntimeException('Issue #781 contains an invalid base plan item.');
+  }
+  $configName = $basePlan['config_name'] ?? NULL;
+  $relativePath = $basePlan['path'] ?? NULL;
+  $sourceKind = $basePlan['source_kind'] ?? NULL;
+  $operations = $basePlan['operations'] ?? NULL;
+  if (
+    !is_string($configName)
+    || $configName === ''
+    || $relativePath !== $configName . '.yml'
+    || !in_array($sourceKind, ['block', 'sdc'], TRUE)
+    || !is_array($operations)
+    || ($basePlan['historical_versions_modified'] ?? TRUE) !== FALSE
+  ) {
+    throw new RuntimeException('Issue #781 base plan identity drifted.');
+  }
+  if ($sourceKind === 'sdc' && (count($operations) !== 1 || ($operations[0]['path'] ?? NULL) !== 'langcode')) {
+    throw new RuntimeException('Issue #781 refuses any SDC value rewrite.');
+  }
+
+  $path = $configDirectory . '/' . $relativePath;
+  if (!is_file($path)) {
+    throw new RuntimeException('Issue #781 base config is missing: ' . $configName);
+  }
+  $content = file_get_contents($path);
+  if (!is_string($content)) {
+    throw new RuntimeException('Unable to read #781 base config: ' . $configName);
+  }
+  $parsedBefore = Yaml::parse($content);
+  if (!is_array($parsedBefore) || $semanticHash($parsedBefore) !== ($basePlan['before_hash'] ?? NULL)) {
+    throw new RuntimeException('Issue #781 base semantic before-hash mismatch: ' . $configName);
+  }
+  if ($canonicalize($parsedBefore) !== ($basePlan['before'] ?? NULL)) {
+    throw new RuntimeException('Issue #781 base before-state mismatch: ' . $configName);
+  }
+
+  $afterContent = $content;
+  foreach ($operations as $operation) {
+    if (!is_array($operation)) {
+      throw new RuntimeException('Issue #781 contains an invalid operation.');
+    }
+    $operationPath = $operation['path'] ?? NULL;
+    $operationBefore = $operation['before'] ?? NULL;
+    $operationAfter = $operation['after'] ?? NULL;
+    if (
+      !is_string($operationPath)
+      || !in_array($operationPath, $allowedOperationPaths, TRUE)
+      || !is_string($operationBefore)
+      || !is_string($operationAfter)
+    ) {
+      throw new RuntimeException('Issue #781 refuses an unrecognized migration operation.');
+    }
+    $afterContent = $replaceScalarPath(
+      $afterContent,
+      $operationPath,
+      $operationBefore,
+      $operationAfter,
+    );
+  }
+
+  $parsedAfter = Yaml::parse($afterContent);
+  if (!is_array($parsedAfter)
+    || $semanticHash($parsedAfter) !== ($basePlan['after_hash'] ?? NULL)
+    || $canonicalize($parsedAfter) !== ($basePlan['after'] ?? NULL)) {
+    throw new RuntimeException('Issue #781 base after-state mismatch: ' . $configName);
+  }
+  if (file_put_contents($path, $afterContent, LOCK_EX) !== strlen($afterContent)) {
+    throw new RuntimeException('Unable to write #781 base config: ' . $configName);
+  }
+  $writtenBases[] = 'config/sync/' . $relativePath;
+  $baseEvidence[] = [
+    'config_name' => $configName,
+    'path' => 'config/sync/' . $relativePath,
+    'source_kind' => $sourceKind,
+    'operation_paths' => array_values(array_map(
+      static fn(array $operation): string => (string) $operation['path'],
+      $operations,
+    )),
+    'before_file_sha256' => hash('sha256', $content),
+    'after_file_sha256' => hash('sha256', $afterContent),
+    'before_semantic_sha256' => $basePlan['before_hash'],
+    'after_semantic_sha256' => $basePlan['after_hash'],
+  ];
+}
+
+$writtenOverrides = [];
+$overrideEvidence = [];
+foreach ($overridePlans as $overridePlan) {
+  if (!is_array($overridePlan)) {
+    throw new RuntimeException('Issue #781 contains an invalid override plan item.');
+  }
+  $configName = $overridePlan['config_name'] ?? NULL;
+  $relativePath = $overridePlan['path'] ?? NULL;
+  $after = $overridePlan['after'] ?? NULL;
+  if (
+    !is_string($configName)
+    || !is_string($relativePath)
+    || $relativePath !== 'language/fr/' . $configName . '.yml'
+    || ($overridePlan['action'] ?? NULL) !== 'create'
+    || ($overridePlan['before'] ?? NULL) !== []
+    || !is_array($after)
+  ) {
+    throw new RuntimeException('Issue #781 override plan identity drifted.');
+  }
+  $expectedLabel = $after['label'] ?? NULL;
+  $expectedActiveLabel = $after['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL;
+  if (!is_string($expectedLabel) || $expectedActiveLabel !== $expectedLabel) {
+    throw new RuntimeException('Issue #781 override labels are not exact and minimal.');
+  }
+
+  $path = $configDirectory . '/' . $relativePath;
+  if (is_file($path)) {
+    throw new RuntimeException('Issue #781 refuses to overwrite a pre-existing FR override: ' . $configName);
+  }
+  $content = Yaml::dump($after, 99, 2);
+  if (file_put_contents($path, $content, LOCK_EX) !== strlen($content)) {
+    throw new RuntimeException('Unable to create #781 FR override: ' . $configName);
+  }
+  $parsed = Yaml::parseFile($path);
+  if (!is_array($parsed) || $canonicalize($parsed) !== $canonicalize($after)) {
+    throw new RuntimeException('Issue #781 FR override serialization drifted: ' . $configName);
+  }
+  $writtenOverrides[] = 'config/sync/' . $relativePath;
+  $overrideEvidence[] = [
+    'config_name' => $configName,
+    'path' => 'config/sync/' . $relativePath,
+    'label' => $expectedLabel,
+    'file_sha256' => hash('sha256', $content),
+  ];
+}
+
+sort($writtenBases, SORT_STRING);
+sort($writtenOverrides, SORT_STRING);
+usort($baseEvidence, static fn(array $left, array $right): int => $left['config_name'] <=> $right['config_name']);
+usort($overrideEvidence, static fn(array $left, array $right): int => $left['config_name'] <=> $right['config_name']);
+
+[$afterTotal, $afterDistribution] = $countDistribution($configDirectory);
+if ($afterTotal !== 595 || $afterDistribution !== $expectedDistributionAfter) {
+  throw new RuntimeException('Issue #781 target repository distribution is not exact.');
+}
+
+$coreExtensionAfter = Yaml::parseFile($configDirectory . '/core.extension.yml');
+$systemSiteAfter = Yaml::parseFile($configDirectory . '/system.site.yml');
+if (
+  !is_array($coreExtensionAfter)
+  || isset($coreExtensionAfter['module']['config_language_lock'])
+  || is_file($configDirectory . '/config_language_lock.settings.yml')
+  || !is_array($systemSiteAfter)
+  || ($systemSiteAfter['default_langcode'] ?? NULL) !== 'fr'
+) {
+  throw new RuntimeException('Issue #781 lock/site-default boundary changed during write.');
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => 'PASS',
+  'verdict' => 'CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED',
+  'source' => [
+    'issue' => 779,
+    'plan_sha256_expected' => $expectedPlanSha,
+    'plan_sha256_observed' => $plan['plan_sha256'],
+  ],
+  'counts' => [
+    'base_files_modified' => count($writtenBases),
+    'block_label_files_modified' => 15,
+    'block_label_values_modified' => 30,
+    'fr_overrides_created' => count($writtenOverrides),
+    'problem_count' => 0,
+  ],
+  'distribution' => [
+    'before' => $beforeDistribution,
+    'after' => $afterDistribution,
+    'total' => $afterTotal,
+  ],
+  'paths' => [
+    'modified_base' => $writtenBases,
+    'created_fr_overrides' => $writtenOverrides,
+  ],
+  'base_evidence' => $baseEvidence,
+  'override_evidence' => $overrideEvidence,
+  'problems' => [],
+  'constraints' => [
+    'exact_hashed_plan_replayed_before_write' => TRUE,
+    'textual_scalar_paths_only' => TRUE,
+    'historical_versions_rewritten' => FALSE,
+    'sdc_values_rewritten' => FALSE,
+    'config_export_used' => FALSE,
+    'config_language_lock_activation_allowed' => FALSE,
+    'system_site_default_langcode' => 'fr',
+    'natural_language_heuristic_used' => FALSE,
+    'arbitrary_translation_used' => FALSE,
+    'fuzzy_matching_used' => FALSE,
+    'production_access_used' => FALSE,
+    'provider_secret_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/scripts/runner/configuration-language-canvas-migration-781-verify.php
+++ b/scripts/runner/configuration-language-canvas-migration-781-verify.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+$projectRoot = dirname(DRUPAL_ROOT);
+$configDirectory = $projectRoot . '/config/sync';
+$manifestPath = $projectRoot
+  . '/docs/evidence/configuration-language-canvas-migration-plan-779.yml';
+$expectedPlanSha = '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24';
+$expectedDistribution = [
+  '__none__' => 59,
+  'en' => 496,
+  'fr' => 39,
+  'und' => 1,
+];
+$targetHashes = [
+  'canvas.component.block.announce_block' => '3b56214758ddaf1c79dc6085235eee7ff0a8f4155a28f402992dc6e17b7dbe85',
+  'canvas.component.block.emerging_digital_language_switcher' => '405231a6588503962fdb6472209aa4b28bf3b512566bd07faf4595faaca60d8f',
+  'canvas.component.block.help_block' => 'e750abe5aaa16db1ff17d7fad5be70b42e9e78953cc7301ec36b91b08b10e354',
+  'canvas.component.block.language_block.language_content' => '9603637de8e7605fde38e945ee2e41f75321a2d9f5272c0ede1c3816066d5deb',
+  'canvas.component.block.language_block.language_interface' => '6b214b457d4723ec50daaaaaa9e1c3c89fe9e3e3f8d02b3019e67120b387a5d5',
+  'canvas.component.block.local_actions_block' => 'ea1ff53f09b1a727d64a23f5106df74c1abebfe99f41604e5e9adeda4f047bcd',
+  'canvas.component.block.local_tasks_block' => '9946d83e1a72761bab087a14729823ccb5b440a51c665166423a15c10b089be3',
+  'canvas.component.block.page_title_block' => '5b0f786e5b3f4fd679fbf48481707245ec9414d00715825402aff3f259c0175e',
+  'canvas.component.block.shortcuts' => 'a44002b9abf907b9c87d259a020560a7293fc9020f8adfa51235bebbc073bd1b',
+  'canvas.component.block.system_branding_block' => '79b0ab88edab49dd1bdfa3c97d3597c841946c87084ed41b7ce626f51d466de2',
+  'canvas.component.block.system_breadcrumb_block' => '10d354ab94a764f3bb56c754584ebe498f0495c7ecb135797f68e1e275002ef9',
+  'canvas.component.block.system_clear_cache_block' => 'c3b2b3b4bc5164df32084d2f549e29cc661f356096f7fc37dd2f8fe357117de9',
+  'canvas.component.block.system_menu_block.account' => 'c9da6b2c7b1a0c728391650a9f3fafdc7476d082c00a9d2da658201e37799ce6',
+  'canvas.component.block.system_menu_block.admin' => '556a0dd01101f4cfa8a33bd8288f2f6d6a6ce13a0520409c4026608ade7ca177',
+  'canvas.component.block.system_menu_block.footer' => '235c69c8f8e111d6a20f789546631625ff834db48af454f73033aa04e4a95c30',
+  'canvas.component.block.system_menu_block.main' => 'bf686cb87e194b57bae2df1250ab86409650a2b59f43f031dbd2c65a4e1818bd',
+  'canvas.component.block.system_menu_block.online-presence' => '02643a2e8b56f36a90aefa26c165467f94877841239a93ada95f4b5991aa16fb',
+  'canvas.component.block.system_menu_block.tools' => '9a4e7c214321f305cdd6f001c23e8f5f5806d98eab26b4d25a6388ad18512d9f',
+  'canvas.component.block.system_messages_block' => 'c6a04b67ee2fe726c30469e8d23d922d7057df4f6f9a7186aac6c4d38410bc3f',
+  'canvas.component.block.system_powered_by_block' => '318f5047748a073bff487bb5d77e6311c4ad7d5e843d4e21afb65418b3325f1c',
+  'canvas.component.block.user_login_block' => '65e7c510ffb6e21920daf34165faa0c2e41712745535a11ccc79bc40e83db9b5',
+  'canvas.component.block.views_block.comments_recent-block_1' => 'd71522160e0a580f3a9046b8ca16ed4de591d2e2695aa27c66da8b6d8d2e3dea',
+  'canvas.component.block.views_block.content_recent-block_1' => '97a0dd80cca264c34d7cd236c04e79e1f6e023bb5bf72eec31713c8687af468e',
+  'canvas.component.block.views_block.who_s_new-block_1' => '36005a46e7d21f73e118b713f00f4c21b00eb0838c27f554215d91e01271e486',
+  'canvas.component.block.views_block.who_s_online-who_s_online_block' => 'dced6909ceb73ef4dbf6643d6791ad2766820cc17e056828d9395d9dfe50bfc3',
+  'canvas.component.block.webform_block' => 'dce3415b948df6d5857d2458eb047dec1b315259a5fc89cf81f2c58eec2311f7',
+  'canvas.component.sdc.emerging_digital.cta' => 'a3beaff1a3ddb2a0e777f1f3ab48deed909ebfbbc138f9ea801fe9079f51ec52',
+  'canvas.component.sdc.emerging_digital.hero' => '711bd843840b2244bcac10243761431125d4d4b2aaf4ea180a653b5f2f6516c3',
+  'canvas.component.sdc.emerging_digital.trust-list' => '3439a706839df4462caa8cd47445bc065c78f0f9cafa57aa75e723b60cd04053',
+  'canvas.component.sdc.olivero.teaser' => 'b9ee199468bfef78a6e500fdc83f2daa0dfdf41b97ec8132fc2a76a319964bde',
+];
+
+if (!is_dir($configDirectory) || !is_file($manifestPath)) {
+  throw new RuntimeException('Issue #781 verification prerequisites are unavailable.');
+}
+$manifest = Yaml::parseFile($manifestPath);
+if (
+  !is_array($manifest)
+  || ($manifest['source']['plan_sha256'] ?? NULL) !== $expectedPlanSha
+  || ($manifest['target']['distribution'] ?? NULL) !== $expectedDistribution
+  || ($manifest['cohort']['total'] ?? NULL) !== 30
+  || ($manifest['target']['fr_overrides_created'] ?? NULL) !== 15
+) {
+  throw new RuntimeException('Issue #781 verification contract drifted.');
+}
+
+$names = $manifest['cohort']['names'] ?? NULL;
+$labelTargets = $manifest['block_label_targets'] ?? NULL;
+$sdcNames = $manifest['sdc_names'] ?? NULL;
+if (!is_array($names) || count($names) !== 30
+  || !is_array($labelTargets) || count($labelTargets) !== 15
+  || !is_array($sdcNames) || count($sdcNames) !== 4) {
+  throw new RuntimeException('Issue #781 verification membership is incomplete.');
+}
+$names = array_values(array_map('strval', $names));
+sort($names, SORT_STRING);
+if (hash('sha256', implode("\n", $names) . "\n") !== ($manifest['cohort']['names_sha256'] ?? NULL)
+  || array_keys($targetHashes) !== $names) {
+  throw new RuntimeException('Issue #781 target hash membership mismatch.');
+}
+
+$canonicalize = NULL;
+$canonicalize = static function (mixed $value) use (&$canonicalize): mixed {
+  if (!is_array($value)) {
+    return $value;
+  }
+  if (array_is_list($value)) {
+    return array_map($canonicalize, $value);
+  }
+  ksort($value, SORT_STRING);
+  foreach ($value as $key => $child) {
+    $value[$key] = $canonicalize($child);
+  }
+  return $value;
+};
+$semanticHash = static function (array $data) use ($canonicalize): string {
+  return hash(
+    'sha256',
+    json_encode(
+      $canonicalize($data),
+      JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+    ),
+  );
+};
+$countDistribution = static function (iterable $names, callable $read): array {
+  $counts = [];
+  $total = 0;
+  foreach ($names as $name) {
+    $data = $read($name);
+    if (!is_array($data)) {
+      throw new RuntimeException('Unable to read configuration for distribution: ' . $name);
+    }
+    $total++;
+    $langcode = isset($data['langcode']) && is_string($data['langcode'])
+      ? $data['langcode']
+      : '__none__';
+    $counts[$langcode] = ($counts[$langcode] ?? 0) + 1;
+  }
+  ksort($counts, SORT_STRING);
+  return [$total, $counts];
+};
+
+$repositoryFiles = glob($configDirectory . '/*.yml');
+if ($repositoryFiles === FALSE) {
+  throw new RuntimeException('Unable to enumerate repository configuration for #781.');
+}
+sort($repositoryFiles, SORT_STRING);
+[$repositoryTotal, $repositoryDistribution] = $countDistribution(
+  array_map(static fn(string $path): string => basename($path, '.yml'), $repositoryFiles),
+  static fn(string $name): mixed => Yaml::parseFile($configDirectory . '/' . $name . '.yml'),
+);
+if ($repositoryTotal !== 595 || $repositoryDistribution !== $expectedDistribution) {
+  throw new RuntimeException('Issue #781 repository distribution is not exact.');
+}
+
+$activeStorage = \Drupal::service('config.storage');
+$activeNames = $activeStorage->listAll();
+sort($activeNames, SORT_STRING);
+[$activeTotal, $activeDistribution] = $countDistribution(
+  $activeNames,
+  static fn(string $name): mixed => $activeStorage->read($name),
+);
+if ($activeTotal !== 595 || $activeDistribution !== $expectedDistribution) {
+  throw new RuntimeException('Issue #781 active distribution is not exact.');
+}
+$activeFr = $activeStorage->createCollection('language.fr');
+
+$verified = 0;
+$verifiedOverrides = 0;
+$items = [];
+foreach ($names as $configName) {
+  $repositoryPath = $configDirectory . '/' . $configName . '.yml';
+  $repositoryData = Yaml::parseFile($repositoryPath);
+  $activeData = $activeStorage->read($configName);
+  if (!is_array($repositoryData) || !is_array($activeData)) {
+    throw new RuntimeException('Issue #781 target config is missing: ' . $configName);
+  }
+  $expectedHash = $targetHashes[$configName] ?? NULL;
+  if (($repositoryData['langcode'] ?? NULL) !== 'en'
+    || ($activeData['langcode'] ?? NULL) !== 'en'
+    || $semanticHash($repositoryData) !== $expectedHash
+    || $semanticHash($activeData) !== $expectedHash) {
+    throw new RuntimeException('Issue #781 target semantic state mismatch: ' . $configName);
+  }
+
+  $hasExpectedOverride = array_key_exists($configName, $labelTargets);
+  $overridePath = $configDirectory . '/language/fr/' . $configName . '.yml';
+  $activeOverride = $activeFr->read($configName);
+  if ($hasExpectedOverride) {
+    $target = $labelTargets[$configName];
+    $baseLabel = is_array($target) ? ($target['base'] ?? NULL) : NULL;
+    $frLabel = is_array($target) ? ($target['fr'] ?? NULL) : NULL;
+    if (!is_string($baseLabel) || !is_string($frLabel)
+      || ($repositoryData['label'] ?? NULL) !== $baseLabel
+      || ($repositoryData['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL) !== $baseLabel
+      || ($activeData['label'] ?? NULL) !== $baseLabel
+      || ($activeData['versioned_properties']['active']['settings']['default_settings']['label'] ?? NULL) !== $baseLabel
+      || !is_file($overridePath)) {
+      throw new RuntimeException('Issue #781 base/FR label target mismatch: ' . $configName);
+    }
+    $repositoryOverride = Yaml::parseFile($overridePath);
+    $expectedOverride = [
+      'label' => $frLabel,
+      'versioned_properties' => [
+        'active' => [
+          'settings' => [
+            'default_settings' => [
+              'label' => $frLabel,
+            ],
+          ],
+        ],
+      ],
+    ];
+    if (!is_array($repositoryOverride)
+      || $canonicalize($repositoryOverride) !== $canonicalize($expectedOverride)
+      || !is_array($activeOverride)
+      || $canonicalize($activeOverride) !== $canonicalize($expectedOverride)) {
+      throw new RuntimeException('Issue #781 FR override mismatch: ' . $configName);
+    }
+    $verifiedOverrides++;
+  }
+  else {
+    if (is_file($overridePath) || $activeOverride !== FALSE) {
+      throw new RuntimeException('Issue #781 found an unexpected FR override: ' . $configName);
+    }
+  }
+
+  $items[] = [
+    'config_name' => $configName,
+    'source_kind' => in_array($configName, $sdcNames, TRUE) ? 'sdc' : 'block',
+    'semantic_sha256' => $expectedHash,
+    'fr_override_verified' => $hasExpectedOverride,
+  ];
+  $verified++;
+}
+
+$coreExtension = Yaml::parseFile($configDirectory . '/core.extension.yml');
+$systemSite = Yaml::parseFile($configDirectory . '/system.site.yml');
+if (!is_array($coreExtension)
+  || isset($coreExtension['module']['config_language_lock'])
+  || is_file($configDirectory . '/config_language_lock.settings.yml')
+  || \Drupal::moduleHandler()->moduleExists('config_language_lock')
+  || !is_array($systemSite)
+  || ($systemSite['default_langcode'] ?? NULL) !== 'fr'
+  || (($activeStorage->read('system.site')['default_langcode'] ?? NULL) !== 'fr')) {
+  throw new RuntimeException('Issue #781 lock/site-default verification failed.');
+}
+
+$result = [
+  'schema_version' => 1,
+  'status' => 'PASS',
+  'verdict' => 'THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED',
+  'plan_sha256' => $expectedPlanSha,
+  'verified' => $verified,
+  'fr_overrides_verified' => $verifiedOverrides,
+  'remaining_fr_review_required' => 39,
+  'repository_total' => $repositoryTotal,
+  'repository_distribution' => $repositoryDistribution,
+  'active_total' => $activeTotal,
+  'active_distribution' => $activeDistribution,
+  'items' => $items,
+  'problems' => [],
+  'constraints' => [
+    'target_semantic_hashes_verified' => TRUE,
+    'historical_versions_preserved_by_target_hash' => TRUE,
+    'sdc_values_preserved_by_target_hash' => TRUE,
+    'config_language_lock_enabled_canonically' => FALSE,
+    'system_site_default_langcode' => 'fr',
+    'semantic_und_zxx_preserved' => TRUE,
+    'config_export_used' => FALSE,
+    'production_access_used' => FALSE,
+    'provider_secret_used' => FALSE,
+  ],
+];
+
+echo json_encode(
+  $result,
+  JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+) . PHP_EOL;

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781WorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781WorkflowTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the governed #781 exact Canvas canonical migration.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasMigration781WorkflowTest extends TestCase {
+
+  /**
+   * Trusted #779 plan identity is durable and bounded.
+   */
+  public function testTrustedPlanManifestIsExact(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/docs/evidence/configuration-language-canvas-migration-plan-779.yml';
+    self::assertFileExists($path);
+    $manifest = DrupalYaml::decode((string) file_get_contents($path));
+    self::assertIsArray($manifest);
+
+    self::assertSame(779, $manifest['issue'] ?? NULL);
+    self::assertSame(781, $manifest['application_issue'] ?? NULL);
+    self::assertSame(
+      '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24',
+      $manifest['source']['plan_sha256'] ?? NULL,
+    );
+    self::assertSame(30, $manifest['cohort']['total'] ?? NULL);
+    self::assertSame(26, $manifest['cohort']['block'] ?? NULL);
+    self::assertSame(4, $manifest['cohort']['sdc'] ?? NULL);
+    self::assertCount(30, $manifest['cohort']['names'] ?? []);
+    self::assertCount(15, $manifest['block_label_targets'] ?? []);
+    self::assertCount(4, $manifest['sdc_names'] ?? []);
+    self::assertSame(
+      ['__none__' => 59, 'en' => 496, 'fr' => 39, 'und' => 1],
+      $manifest['target']['distribution'] ?? NULL,
+    );
+    self::assertFalse($manifest['constraints']['config_language_lock_enabled'] ?? TRUE);
+    self::assertFalse($manifest['constraints']['historical_versions_rewritten'] ?? TRUE);
+    self::assertFalse($manifest['constraints']['sdc_values_rewritten'] ?? TRUE);
+  }
+
+  /**
+   * Writer must reproduce the exact dry-run SHA before any bounded write.
+   */
+  public function testWriterReplaysExactHashedPlanAndLimitsPaths(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/apply-configuration-language-canvas-migration-781.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'configuration-language-canvas-migration-dry-run-779.php',
+      'configuration-language-canvas-migration-plan-779.yml',
+      '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24',
+      'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',
+      'CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED',
+      "'langcode'",
+      "'label'",
+      "'versioned_properties.active.settings.default_settings.label'",
+      "'base_files_modified' => count(\$writtenBases)",
+      "'fr_overrides_created' => count(\$writtenOverrides)",
+      "'historical_versions_rewritten' => FALSE",
+      "'sdc_values_rewritten' => FALSE",
+      "'config_language_lock_activation_allowed' => FALSE",
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+
+    foreach ([
+      'drush cex',
+      'generateComponents(',
+      'similar_text(',
+      'levenshtein(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * Verifier protects target semantic hashes and language boundaries.
+   */
+  public function testVerifierRequiresExactTargetState(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/runner/configuration-language-canvas-migration-781-verify.php';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED',
+      "'verified' => \$verified",
+      "'fr_overrides_verified' => \$verifiedOverrides",
+      "'remaining_fr_review_required' => 39",
+      "'target_semantic_hashes_verified' => TRUE",
+      "'historical_versions_preserved_by_target_hash' => TRUE",
+      "'sdc_values_preserved_by_target_hash' => TRUE",
+      "'config_language_lock_enabled_canonically' => FALSE",
+      "'system_site_default_langcode' => 'fr'",
+      'a3beaff1a3ddb2a0e777f1f3ab48deed909ebfbbc138f9ea801fe9079f51ec52',
+      'b9ee199468bfef78a6e500fdc83f2daa0dfdf41b97ec8132fc2a76a319964bde',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+  }
+
+  /**
+   * Governed route is fixed to #781 and can only push the generated branch.
+   */
+  public function testGovernedWorkflowIsBounded(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'governed-configuration-language-canvas-migration-781.yml';
+    self::assertFileExists($path);
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      'github.event.issue.number == 781',
+      "'/agency-config-language-canvas-migration apply'",
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      'test "$EVENT_DEFAULT_SHA" = "$main_sha"',
+      'persist-credentials: true',
+      'contents: write',
+      'configuration-language-canvas-migration-dry-run-779.php',
+      'apply-configuration-language-canvas-migration-781.php',
+      'configuration-language-canvas-migration-781-verify.php',
+      'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',
+      'CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED',
+      'THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED',
+      'feature/781-apply-canvas-canonical-migration',
+      'test "${#paths[@]}" -eq 45',
+      'ddev drush site:install --existing-config',
+      'ddev drush cim -y',
+      "grep -Fq 'No differences'",
+      'git push origin "HEAD:refs/heads/$branch"',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+      'git push origin main',
+      'git push --force',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Adds the governed writer/verifier route for #781 without applying the migration in this PR.

The route is anchored to trusted #779 evidence:
- trusted main `59b8720d307b6e141cb37d3408a27f43c4b199aa`;
- trusted run `32733184593`;
- plan SHA-256 `8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24`.

Before any write, the writer reruns the complete #779 dry-run and requires the exact trusted SHA, counts and simulated distribution. It can then modify only the 30 base Canvas files and create exactly 15 FR overrides described by the plan. SDC operations are restricted to `langcode` only.

After writing, a second fresh DDEV rebuild validates semantic target hashes for all 30 configs, 15 exact FR overrides, repository/active distribution `__none__=59, en=496, fr=39, und=1`, site default FR, and Configuration Language Lock still disabled.

This tooling PR changes no `config/sync` file and does not itself trigger migration. The future owner-only command is `/agency-config-language-canvas-migration apply`.

Refs #781 #779 #609