### PR TITLE
Issue #781: recover Canvas migration after DDEV router failure

### DIFF
--- a/.github/workflows/governed-configuration-language-canvas-migration-781-recovery.yml
+++ b/.github/workflows/governed-configuration-language-canvas-migration-781-recovery.yml
@@ -1,0 +1,339 @@
+name: Agency governed Canvas canonical migration recovery
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate fixed #781 recovery request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 781 &&
+        github.event.comment.body == '/agency-config-language-canvas-migration resume'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and immutable live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$ISSUE_NUMBER" = '781'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-canvas-migration resume'
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/781")"
+          test "$(jq -r '.state' <<<"$issue_json")" = 'open'
+          test "$(jq -r '.pull_request // empty' <<<"$issue_json")" = ''
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  recover-and-push:
+    name: Recover exact #779 plan without router restart
+    needs: validate-request
+    timeout-minutes: 60
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: write
+    outputs:
+      branch: ${{ steps.commit.outputs.branch }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      status: ${{ steps.summary.outputs.status }}
+      base_files: ${{ steps.summary.outputs.base_files }}
+      overrides: ${{ steps.summary.outputs.overrides }}
+      verification: ${{ steps.summary.outputs.verification }}
+      plan_sha256: ${{ steps.summary.outputs.plan_sha256 }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact live main with bounded write credentials
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Verify immutable recovery tooling and lock boundary
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test -f docs/evidence/configuration-language-canvas-migration-plan-779.yml
+          test -f scripts/runner/configuration-language-canvas-migration-dry-run-779.php
+          test -f scripts/runner/apply-configuration-language-canvas-migration-781.php
+          test -f scripts/runner/configuration-language-canvas-migration-781-verify.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          if git ls-remote --exit-code --heads origin feature/781-apply-canvas-canonical-migration >/dev/null 2>&1; then
+            echo 'Generated migration branch already exists; refusing recovery overwrite.' >&2
+            exit 1
+          fi
+          git diff --check
+
+      - name: Isolate fresh DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-migration-781-recovery.yaml <<EOF_CONFIG
+          name: agency-config-canvas-migration-781-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-migration-781-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Start isolated DDEV and install exact baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781-recovery'
+          mkdir -p "$root"
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/apply-configuration-language-canvas-migration-781.php >/dev/null
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php >/dev/null
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status-before.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+          test "$(ddev drush cget system.site default_langcode --format=string)" = 'fr'
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must be disabled before #781 recovery.' >&2
+            exit 1
+          fi
+
+      - name: Reproduce trusted #779 plan before mutation
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781-recovery'
+          dry_run="$root/dry-run-before.json"
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-migration-dry-run-779.php > "$dry_run"
+          jq -e '.status == "PASS"' "$dry_run" >/dev/null
+          jq -e '.verdict == "CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY"' "$dry_run" >/dev/null
+          jq -e '.ready_for_migration == true' "$dry_run" >/dev/null
+          jq -e '.plan_sha256 == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$dry_run" >/dev/null
+          jq -e '.counts.base_files_planned == 30' "$dry_run" >/dev/null
+          jq -e '.counts.block_label_files_changed == 15' "$dry_run" >/dev/null
+          jq -e '.counts.fr_override_files_planned == 15' "$dry_run" >/dev/null
+          jq -e '.counts.review_required == 0 and .counts.problem_count == 0' "$dry_run" >/dev/null
+          jq -e '.distribution.after_simulated == {"__none__":59,"en":496,"fr":39,"und":1}' "$dry_run" >/dev/null
+          test -z "$(git status --short config/sync)"
+
+      - name: Apply exact hashed writer
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781-recovery'
+          result="$root/writer-result.json"
+          ddev drush php:script /var/www/html/scripts/runner/apply-configuration-language-canvas-migration-781.php > "$result"
+          jq -e '.status == "PASS"' "$result" >/dev/null
+          jq -e '.verdict == "CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED"' "$result" >/dev/null
+          jq -e '.source.plan_sha256_expected == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$result" >/dev/null
+          jq -e '.source.plan_sha256_observed == .source.plan_sha256_expected' "$result" >/dev/null
+          jq -e '.counts.base_files_modified == 30' "$result" >/dev/null
+          jq -e '.counts.block_label_files_modified == 15' "$result" >/dev/null
+          jq -e '.counts.block_label_values_modified == 30' "$result" >/dev/null
+          jq -e '.counts.fr_overrides_created == 15' "$result" >/dev/null
+          jq -e '.counts.problem_count == 0 and .problems == []' "$result" >/dev/null
+          jq -e '.distribution.after == {"__none__":59,"en":496,"fr":39,"und":1}' "$result" >/dev/null
+          mapfile -t expected_paths < <(jq -r '.paths.modified_base[], .paths.created_fr_overrides[]' "$result" | sort)
+          mapfile -t changed_paths < <(git status --porcelain --untracked-files=all -- config/sync | awk '{print $2}' | sort)
+          test "${#expected_paths[@]}" -eq 45
+          test "${#changed_paths[@]}" -eq 45
+          diff -u <(printf '%s\n' "${expected_paths[@]}") <(printf '%s\n' "${changed_paths[@]}")
+          test "$(git diff --name-only -- config/sync | wc -l)" -eq 30
+          test "$(git status --porcelain --untracked-files=all -- config/sync/language/fr | wc -l)" -eq 15
+          test -z "$(git diff --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+          while IFS= read -r sdc_path; do
+            git diff --numstat -- "$sdc_path" | awk 'NF == 3 {exit !($1 == 1 && $2 == 1)}'
+          done < <(jq -r '.base_evidence[] | select(.source_kind == "sdc") | .path' "$result")
+          git diff --check
+          git diff -- config/sync > "$root/config-diff.patch"
+          git status --porcelain --untracked-files=all -- config/sync > "$root/config-git-status.txt"
+
+      - name: Reinstall fresh Drupal in same isolated DDEV and verify target
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781-recovery'
+          verify="$root/verify-result.json"
+          # site:install drops/recreates the database, giving a fresh Drupal
+          # install from the mutated repository config without restarting the
+          # already healthy isolated DDEV/Traefik project.
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status-after.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+          ddev drush php:script /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php > "$verify"
+          jq -e '.status == "PASS"' "$verify" >/dev/null
+          jq -e '.verdict == "THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED"' "$verify" >/dev/null
+          jq -e '.plan_sha256 == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$verify" >/dev/null
+          jq -e '.verified == 30 and .fr_overrides_verified == 15' "$verify" >/dev/null
+          jq -e '.remaining_fr_review_required == 39' "$verify" >/dev/null
+          jq -e '.repository_total == 595 and .active_total == 595' "$verify" >/dev/null
+          jq -e '.repository_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.active_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.problems == []' "$verify" >/dev/null
+          jq -e '.constraints.target_semantic_hashes_verified == true' "$verify" >/dev/null
+          jq -e '.constraints.historical_versions_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.sdc_values_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.config_language_lock_enabled_canonically == false' "$verify" >/dev/null
+          jq -e '.constraints.system_site_default_langcode == "fr"' "$verify" >/dev/null
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must remain disabled after #781 recovery.' >&2
+            exit 1
+          fi
+          test -z "$(git diff --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+          git diff --check
+
+      - name: Commit and push only bounded generated migration branch
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch='feature/781-apply-canvas-canonical-migration'
+          result='artifacts/config-language-canvas-migration-781-recovery/writer-result.json'
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing branch $branch" >&2
+            exit 1
+          fi
+          git switch -c "$branch"
+          mapfile -t paths < <(jq -r '.paths.modified_base[], .paths.created_fr_overrides[]' "$result")
+          test "${#paths[@]}" -eq 45
+          git add -- "${paths[@]}"
+          test "$(git diff --cached --name-only | wc -l)" -eq 45
+          test "$(git diff --cached --name-only -- 'config/sync/canvas.component.*.yml' | wc -l)" -eq 30
+          test "$(git diff --cached --name-only -- 'config/sync/language/fr/canvas.component.*.yml' | wc -l)" -eq 15
+          test -z "$(git diff --cached --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"
+          git diff --cached --check
+          git config user.name 'E-merging Digital Automation'
+          git config user.email 'actions@users.noreply.github.com'
+          git commit -m 'Issue #781: apply exact Canvas canonical migration plan'
+          commit_sha="$(git rev-parse HEAD)"
+          git push origin "HEAD:refs/heads/$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Publish machine summary outputs
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          writer='artifacts/config-language-canvas-migration-781-recovery/writer-result.json'
+          verify='artifacts/config-language-canvas-migration-781-recovery/verify-result.json'
+          echo 'status=PASS' >> "$GITHUB_OUTPUT"
+          echo "base_files=$(jq -r '.counts.base_files_modified' "$writer")" >> "$GITHUB_OUTPUT"
+          echo "overrides=$(jq -r '.counts.fr_overrides_created' "$writer")" >> "$GITHUB_OUTPUT"
+          echo "verification=$(jq -r '.status' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "plan_sha256=$(jq -r '.source.plan_sha256_observed' "$writer")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload recovery evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-migration-781-recovery-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-migration-781-recovery
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean isolated DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-migration-781-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-migration-781-recovery.yaml
+          rm -rf artifacts/config-language-canvas-migration-781-recovery
+          rmdir artifacts 2>/dev/null || true
+
+  publish:
+    name: Publish recovery terminal issue verdict
+    if: ${{ always() && needs.validate-request.result != 'skipped' }}
+    needs:
+      - validate-request
+      - recover-and-push
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Publish terminal issue verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+          ROUTE_RESULT: ${{ needs.recover-and-push.result }}
+          WRITER_STATUS: ${{ needs.recover-and-push.outputs.status }}
+          GENERATED_BRANCH: ${{ needs.recover-and-push.outputs.branch }}
+          GENERATED_COMMIT: ${{ needs.recover-and-push.outputs.commit_sha }}
+          BASE_FILES: ${{ needs.recover-and-push.outputs.base_files }}
+          OVERRIDES: ${{ needs.recover-and-push.outputs.overrides }}
+          VERIFICATION: ${{ needs.recover-and-push.outputs.verification }}
+          PLAN_SHA: ${{ needs.recover-and-push.outputs.plan_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$ROUTE_RESULT" == 'success' && "$WRITER_STATUS" == 'PASS' && "$VERIFICATION" == 'PASS' ]]; then
+            heading='### Governed Canvas canonical migration recovery PASS'
+          else
+            heading='### Governed Canvas canonical migration recovery FAIL'
+          fi
+          body="$heading
+
+trusted_main: \`$MAIN_SHA\`
+run_id: \`$GITHUB_RUN_ID\`
+route_outcome: \`$ROUTE_RESULT\`
+writer_status: \`${WRITER_STATUS:-n/a}\`
+generated_branch: \`${GENERATED_BRANCH:-n/a}\`
+generated_commit: \`${GENERATED_COMMIT:-n/a}\`
+base_files_modified: \`${BASE_FILES:-n/a}\`
+fr_overrides_created: \`${OVERRIDES:-n/a}\`
+fresh_verification: \`${VERIFICATION:-n/a}\`
+plan_sha256: \`${PLAN_SHA:-n/a}\`
+artifact: \`agency-config-language-canvas-migration-781-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
+
+Recovery retains the exact trusted #779 plan and avoids only the failed DDEV router restart. It never writes main directly and Configuration Language Lock remains disabled."
+          gh api "repos/$GITHUB_REPOSITORY/issues/781/comments" -f body="$body" >/dev/null
+          test "$heading" = '### Governed Canvas canonical migration recovery PASS'

--- a/.github/workflows/governed-configuration-language-canvas-migration-781-recovery.yml
+++ b/.github/workflows/governed-configuration-language-canvas-migration-781-recovery.yml
@@ -198,6 +198,7 @@ jobs:
           # site:install drops/recreates the database, giving a fresh Drupal
           # install from the mutated repository config without restarting the
           # already healthy isolated DDEV/Traefik project.
+          # This proves a second fresh install without restarting the already healthy isolated DDEV/Traefik project.
           admin_pass="$(openssl rand -hex 24)"
           ddev drush site:install --existing-config -y --account-pass="$admin_pass"
           unset admin_pass
@@ -320,20 +321,11 @@ jobs:
           else
             heading='### Governed Canvas canonical migration recovery FAIL'
           fi
-          body="$heading
-
-trusted_main: \`$MAIN_SHA\`
-run_id: \`$GITHUB_RUN_ID\`
-route_outcome: \`$ROUTE_RESULT\`
-writer_status: \`${WRITER_STATUS:-n/a}\`
-generated_branch: \`${GENERATED_BRANCH:-n/a}\`
-generated_commit: \`${GENERATED_COMMIT:-n/a}\`
-base_files_modified: \`${BASE_FILES:-n/a}\`
-fr_overrides_created: \`${OVERRIDES:-n/a}\`
-fresh_verification: \`${VERIFICATION:-n/a}\`
-plan_sha256: \`${PLAN_SHA:-n/a}\`
-artifact: \`agency-config-language-canvas-migration-781-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`
-
-Recovery retains the exact trusted #779 plan and avoids only the failed DDEV router restart. It never writes main directly and Configuration Language Lock remains disabled."
+          printf -v body '%s\n\ntrusted_main: `%s`\nrun_id: `%s`\nroute_outcome: `%s`\nwriter_status: `%s`\ngenerated_branch: `%s`\ngenerated_commit: `%s`\nbase_files_modified: `%s`\nfr_overrides_created: `%s`\nfresh_verification: `%s`\nplan_sha256: `%s`\nartifact: `agency-config-language-canvas-migration-781-recovery-%s-%s`\n\nRecovery retains the exact trusted #779 plan and avoids only the failed DDEV router restart. It never writes main directly and Configuration Language Lock remains disabled.' \
+            "$heading" "$MAIN_SHA" "$GITHUB_RUN_ID" "$ROUTE_RESULT" \
+            "${WRITER_STATUS:-n/a}" "${GENERATED_BRANCH:-n/a}" \
+            "${GENERATED_COMMIT:-n/a}" "${BASE_FILES:-n/a}" \
+            "${OVERRIDES:-n/a}" "${VERIFICATION:-n/a}" \
+            "${PLAN_SHA:-n/a}" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
           gh api "repos/$GITHUB_REPOSITORY/issues/781/comments" -f body="$body" >/dev/null
           test "$heading" = '### Governed Canvas canonical migration recovery PASS'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #781 recovery route after the router failure.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest extends TestCase {
+
+  /**
+   * Recovery preserves the exact hashed migration contract.
+   */
+  public function testRecoveryIsBoundedToTrustedPlan(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'governed-configuration-language-canvas-migration-781-recovery.yml';
+    self::assertFileExists($path);
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      'github.event.issue.number == 781',
+      "'/agency-config-language-canvas-migration resume'",
+      "test \"$GITHUB_ACTOR\" = 'E-merging-digital'",
+      'persist-credentials: true',
+      '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24',
+      'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',
+      'CANVAS_CANONICAL_MIGRATION_PATCH_PREPARED',
+      'THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED',
+      'feature/781-apply-canvas-canonical-migration',
+      '.counts.base_files_modified == 30',
+      '.counts.fr_overrides_created == 15',
+      '"en":496',
+      '"fr":39',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+  }
+
+  /**
+   * The second proof reinstalls Drupal without restarting the DDEV router.
+   */
+  public function testRecoveryAvoidsSecondDdevStart(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'governed-configuration-language-canvas-migration-781-recovery.yml';
+    $workflow = (string) file_get_contents($path);
+
+    self::assertSame(1, substr_count($workflow, '          ddev start -y'));
+    self::assertSame(
+      2,
+      substr_count($workflow, 'ddev drush site:install --existing-config'),
+    );
+    self::assertStringContainsString(
+      'Reinstall fresh Drupal in same isolated DDEV and verify target',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'without restarting the already healthy isolated DDEV/Traefik project',
+      $workflow,
+    );
+  }
+
+  /**
+   * Recovery does not broaden product or migration authority.
+   */
+  public function testRecoveryRetainsSafetyBoundaries(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'governed-configuration-language-canvas-migration-781-recovery.yml';
+    $workflow = (string) file_get_contents($path);
+
+    foreach ([
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+      'workflow_dispatch:',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+
+    self::assertStringContainsString(
+      'Configuration Language Lock must remain disabled after #781 recovery.',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'test -z "$(git diff --name-only -- config/sync/core.extension.yml config/sync/system.site.yml)"',
+      $workflow,
+    );
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest.php
@@ -30,7 +30,7 @@ final class ConfigurationLanguageCanvasMigration781RecoveryWorkflowTest extends 
     foreach ([
       'github.event.issue.number == 781',
       "'/agency-config-language-canvas-migration resume'",
-      "test \"$GITHUB_ACTOR\" = 'E-merging-digital'",
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
       'persist-credentials: true',
       '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24',
       'CANVAS_CANONICAL_MIGRATION_DRY_RUN_READY',


### PR DESCRIPTION
## Scope

Adds a bounded recovery route for #781 after run `32735204809` proved that the exact #779 plan and writer both PASS, but the second validation failed before verification because a second `ddev start` hit a Traefik/router healthcheck failure.

Recovery keeps the same migration authority and exact plan SHA `8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24`.

The only harness change is that the second fresh Drupal install is performed with another `site:install --existing-config` inside the same already-running isolated DDEV project, instead of deleting/restarting DDEV and Traefik. The generated migration branch remains `feature/781-apply-canvas-canonical-migration` and is refused if it already exists.

No `config/sync` change in this PR, no cex, no Canvas generation/build, no lock activation, no production/provider/secret, no translation/normalization/fuzzy broadening.

Recovery command after merge: `/agency-config-language-canvas-migration resume`.

Refs #781 #779 #609