### PR TITLE
Issue #781: apply exact Canvas canonical migration plan

### DIFF
--- a/config/sync/canvas.component.block.announce_block.yml
+++ b/config/sync/canvas.component.block.announce_block.yml
@@ -1,5 +1,5 @@
 uuid: b33a2a35-9f38-4e18-b7bc-18af59429be2
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: announce_block
-        label: "Flux d'annonces"
+        label: 'Announcements Feed'
         label_display: '0'
         provider: announcements_feed
     fallback_metadata:
       slot_definitions: null
-label: "Flux d'annonces"
+label: 'Announcements Feed'
 id: block.announce_block
 provider: announcements_feed
 source: block

--- a/config/sync/canvas.component.block.emerging_digital_language_switcher.yml
+++ b/config/sync/canvas.component.block.emerging_digital_language_switcher.yml
@@ -1,5 +1,5 @@
 uuid: 9eac8c98-5a3c-42ec-ae8c-bbbbe9c7c37d
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: emerging_digital_language_switcher
-        label: 'Sélecteur de langue'
+        label: 'Language switcher'
         label_display: '0'
         provider: emerging_digital_content
     fallback_metadata:
       slot_definitions: null
-label: 'Sélecteur de langue'
+label: 'Language switcher'
 id: block.emerging_digital_language_switcher
 provider: emerging_digital_content
 source: block

--- a/config/sync/canvas.component.block.help_block.yml
+++ b/config/sync/canvas.component.block.help_block.yml
@@ -1,5 +1,5 @@
 uuid: 7d1cd17f-699e-42fa-a423-e8ba36ed28d3
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,7 +10,7 @@ versioned_properties:
     settings:
       default_settings:
         id: help_block
-        label: Aide
+        label: Help
         label_display: '0'
         provider: help
     fallback_metadata:
@@ -24,7 +24,7 @@ versioned_properties:
         provider: help
     fallback_metadata:
       slot_definitions: null
-label: Aide
+label: Help
 id: block.help_block
 provider: help
 source: block

--- a/config/sync/canvas.component.block.language_block.language_content.yml
+++ b/config/sync/canvas.component.block.language_block.language_content.yml
@@ -1,5 +1,5 @@
 uuid: 45f5e201-ffb4-4323-bd02-c027a4878302
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,7 +10,7 @@ versioned_properties:
     settings:
       default_settings:
         id: 'language_block:language_content'
-        label: 'Sélecteur de langue (Contenu)'
+        label: 'Language switcher (Content)'
         label_display: '0'
         provider: language
     fallback_metadata:
@@ -24,7 +24,7 @@ versioned_properties:
         provider: language
     fallback_metadata:
       slot_definitions: null
-label: 'Sélecteur de langue (Contenu)'
+label: 'Language switcher (Content)'
 id: block.language_block.language_content
 provider: language
 source: block

--- a/config/sync/canvas.component.block.language_block.language_interface.yml
+++ b/config/sync/canvas.component.block.language_block.language_interface.yml
@@ -1,5 +1,5 @@
 uuid: ee0b945f-81b9-4f88-ac66-43ca79f3a9f5
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: 'language_block:language_interface'
-        label: "Sélecteur de langue (Texte d'interface)"
+        label: 'Language switcher (Interface text)'
         label_display: '0'
         provider: language
     fallback_metadata:
       slot_definitions: null
-label: "Sélecteur de langue (Texte d'interface)"
+label: 'Language switcher (Interface text)'
 id: block.language_block.language_interface
 provider: language
 source: block

--- a/config/sync/canvas.component.block.local_actions_block.yml
+++ b/config/sync/canvas.component.block.local_actions_block.yml
@@ -1,5 +1,5 @@
 uuid: d9781dcd-5500-4476-a9a0-95e042822e04
-langcode: fr
+langcode: en
 status: false
 dependencies: {  }
 active_version: b82a1a15d11b93c8
@@ -8,7 +8,7 @@ versioned_properties:
     settings:
       default_settings:
         id: local_actions_block
-        label: "Actions d'administration principales"
+        label: 'Primary admin actions'
         label_display: '0'
         provider: core
     fallback_metadata:
@@ -22,7 +22,7 @@ versioned_properties:
         provider: core
     fallback_metadata:
       slot_definitions: null
-label: "Actions d'administration principales"
+label: 'Primary admin actions'
 id: block.local_actions_block
 provider: core
 source: block

--- a/config/sync/canvas.component.block.local_tasks_block.yml
+++ b/config/sync/canvas.component.block.local_tasks_block.yml
@@ -1,5 +1,5 @@
 uuid: a9d5741c-7526-4dd0-b1c4-7172f33429dc
-langcode: fr
+langcode: en
 status: false
 dependencies: {  }
 active_version: 067c47f16b04d8d4
@@ -8,14 +8,14 @@ versioned_properties:
     settings:
       default_settings:
         id: local_tasks_block
-        label: Onglets
+        label: Tabs
         label_display: '0'
         provider: core
         primary: true
         secondary: true
     fallback_metadata:
       slot_definitions: null
-label: Onglets
+label: Tabs
 id: block.local_tasks_block
 provider: core
 source: block

--- a/config/sync/canvas.component.block.page_title_block.yml
+++ b/config/sync/canvas.component.block.page_title_block.yml
@@ -1,5 +1,5 @@
 uuid: 6ffbd635-bb1f-44e1-ad59-145b1465a50a
-langcode: fr
+langcode: en
 status: false
 dependencies: {  }
 active_version: 6da973c196fbbf54
@@ -8,7 +8,7 @@ versioned_properties:
     settings:
       default_settings:
         id: page_title_block
-        label: 'Titre de la page'
+        label: 'Page title'
         label_display: '0'
         provider: core
     fallback_metadata:
@@ -22,7 +22,7 @@ versioned_properties:
         provider: core
     fallback_metadata:
       slot_definitions: null
-label: 'Titre de la page'
+label: 'Page title'
 id: block.page_title_block
 provider: core
 source: block

--- a/config/sync/canvas.component.block.shortcuts.yml
+++ b/config/sync/canvas.component.block.shortcuts.yml
@@ -1,5 +1,5 @@
 uuid: 58d43de5-a2ed-444d-91e9-644fa5d76ffb
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: shortcuts
-        label: Raccourcis
+        label: Shortcuts
         label_display: '0'
         provider: shortcut
     fallback_metadata:
       slot_definitions: null
-label: Raccourcis
+label: Shortcuts
 id: block.shortcuts
 provider: shortcut
 source: block

--- a/config/sync/canvas.component.block.system_branding_block.yml
+++ b/config/sync/canvas.component.block.system_branding_block.yml
@@ -1,5 +1,5 @@
 uuid: b8ea9ddf-9b1f-4cc3-8a16-ec686d4d1f43
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,7 +10,7 @@ versioned_properties:
     settings:
       default_settings:
         id: system_branding_block
-        label: 'Identité du site'
+        label: 'Site branding'
         label_display: '0'
         provider: system
         use_site_logo: true
@@ -30,7 +30,7 @@ versioned_properties:
         use_site_slogan: true
     fallback_metadata:
       slot_definitions: null
-label: 'Identité du site'
+label: 'Site branding'
 id: block.system_branding_block
 provider: system
 source: block

--- a/config/sync/canvas.component.block.system_breadcrumb_block.yml
+++ b/config/sync/canvas.component.block.system_breadcrumb_block.yml
@@ -1,5 +1,5 @@
 uuid: 7166095b-7095-4a44-ab3c-04e63d197608
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,7 +10,7 @@ versioned_properties:
     settings:
       default_settings:
         id: system_breadcrumb_block
-        label: "Fils d'ariane"
+        label: Breadcrumbs
         label_display: '0'
         provider: system
     fallback_metadata:
@@ -24,7 +24,7 @@ versioned_properties:
         provider: system
     fallback_metadata:
       slot_definitions: null
-label: "Fils d'ariane"
+label: Breadcrumbs
 id: block.system_breadcrumb_block
 provider: system
 source: block

--- a/config/sync/canvas.component.block.system_clear_cache_block.yml
+++ b/config/sync/canvas.component.block.system_clear_cache_block.yml
@@ -1,5 +1,5 @@
 uuid: 188f9428-3bbd-417c-96fc-71e63ef92c80
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: system_clear_cache_block
-        label: 'Vider le cache'
+        label: 'Clear cache'
         label_display: '0'
         provider: system
     fallback_metadata:
       slot_definitions: null
-label: 'Vider le cache'
+label: 'Clear cache'
 id: block.system_clear_cache_block
 provider: system
 source: block

--- a/config/sync/canvas.component.block.system_menu_block.account.yml
+++ b/config/sync/canvas.component.block.system_menu_block.account.yml
@@ -1,5 +1,5 @@
 uuid: 3ee089df-42cf-4095-bbdc-75f22e639c0f
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_menu_block.admin.yml
+++ b/config/sync/canvas.component.block.system_menu_block.admin.yml
@@ -1,5 +1,5 @@
 uuid: 71025e65-17b9-472e-970f-482eda9de5e3
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_menu_block.footer.yml
+++ b/config/sync/canvas.component.block.system_menu_block.footer.yml
@@ -1,5 +1,5 @@
 uuid: 9f000a15-e42c-4450-a210-7e80dc5ac560
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_menu_block.main.yml
+++ b/config/sync/canvas.component.block.system_menu_block.main.yml
@@ -1,5 +1,5 @@
 uuid: 8491de6c-6a13-4acc-a391-cf4e1e46fbc1
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_menu_block.online-presence.yml
+++ b/config/sync/canvas.component.block.system_menu_block.online-presence.yml
@@ -1,5 +1,5 @@
 uuid: 92f1d97c-a511-46f1-92da-b45681fc431f
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_menu_block.tools.yml
+++ b/config/sync/canvas.component.block.system_menu_block.tools.yml
@@ -1,5 +1,5 @@
 uuid: 221e6ced-5860-478b-a01a-095ac20af0e2
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.system_messages_block.yml
+++ b/config/sync/canvas.component.block.system_messages_block.yml
@@ -1,5 +1,5 @@
 uuid: 0538fad9-3980-4304-bbd2-e9fcd9b4662a
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:

--- a/config/sync/canvas.component.block.system_powered_by_block.yml
+++ b/config/sync/canvas.component.block.system_powered_by_block.yml
@@ -1,5 +1,5 @@
 uuid: fbb74cc9-41cd-4a27-981e-c6cf3c09cc7a
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,7 +10,7 @@ versioned_properties:
     settings:
       default_settings:
         id: system_powered_by_block
-        label: 'Propulsé par Drupal'
+        label: 'Powered by Drupal'
         label_display: '0'
         provider: system
     fallback_metadata:
@@ -24,7 +24,7 @@ versioned_properties:
         provider: system
     fallback_metadata:
       slot_definitions: null
-label: 'Propulsé par Drupal'
+label: 'Powered by Drupal'
 id: block.system_powered_by_block
 provider: system
 source: block

--- a/config/sync/canvas.component.block.user_login_block.yml
+++ b/config/sync/canvas.component.block.user_login_block.yml
@@ -1,5 +1,5 @@
 uuid: 15fa5cac-6bd3-4873-b7b6-2bc5a849b6e8
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:
@@ -10,12 +10,12 @@ versioned_properties:
     settings:
       default_settings:
         id: user_login_block
-        label: 'Connexion utilisateur'
+        label: 'User login'
         label_display: '0'
         provider: user
     fallback_metadata:
       slot_definitions: null
-label: 'Connexion utilisateur'
+label: 'User login'
 id: block.user_login_block
 provider: user
 source: block

--- a/config/sync/canvas.component.block.views_block.comments_recent-block_1.yml
+++ b/config/sync/canvas.component.block.views_block.comments_recent-block_1.yml
@@ -1,5 +1,5 @@
 uuid: 0980fdc0-313b-468d-a086-f42a93709a90
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.views_block.content_recent-block_1.yml
+++ b/config/sync/canvas.component.block.views_block.content_recent-block_1.yml
@@ -1,5 +1,5 @@
 uuid: d9e1401b-352e-4d7b-abae-54dbef04a511
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:
@@ -12,7 +12,7 @@ versioned_properties:
     settings:
       default_settings:
         id: 'views_block:content_recent-block_1'
-        label: 'Recent content : Block'
+        label: 'Recent content: Block'
         label_display: '0'
         provider: views
         views_label: ''
@@ -30,7 +30,7 @@ versioned_properties:
         items_per_page: null
     fallback_metadata:
       slot_definitions: null
-label: 'Recent content : Block'
+label: 'Recent content: Block'
 id: block.views_block.content_recent-block_1
 provider: views
 source: block

--- a/config/sync/canvas.component.block.views_block.who_s_new-block_1.yml
+++ b/config/sync/canvas.component.block.views_block.who_s_new-block_1.yml
@@ -1,5 +1,5 @@
 uuid: 0fa39633-210d-4c2b-8c7c-37f71f8f962c
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.views_block.who_s_online-who_s_online_block.yml
+++ b/config/sync/canvas.component.block.views_block.who_s_online-who_s_online_block.yml
@@ -1,5 +1,5 @@
 uuid: a5d32a16-70e5-4e36-89fc-92abc2e7c4c7
-langcode: fr
+langcode: en
 status: false
 dependencies:
   config:

--- a/config/sync/canvas.component.block.webform_block.yml
+++ b/config/sync/canvas.component.block.webform_block.yml
@@ -1,5 +1,5 @@
 uuid: 92d15b3f-b4ac-47b7-be51-a930a1c4878a
-langcode: fr
+langcode: en
 status: false
 dependencies:
   module:

--- a/config/sync/canvas.component.sdc.emerging_digital.cta.yml
+++ b/config/sync/canvas.component.sdc.emerging_digital.cta.yml
@@ -1,5 +1,5 @@
 uuid: e9671299-54b4-463c-9378-42cbd1557a67
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/canvas.component.sdc.emerging_digital.hero.yml
+++ b/config/sync/canvas.component.sdc.emerging_digital.hero.yml
@@ -1,5 +1,5 @@
 uuid: 6480184b-d40e-409e-8383-94e695caae9d
-langcode: fr
+langcode: en
 status: true
 dependencies:
   module:

--- a/config/sync/canvas.component.sdc.emerging_digital.trust-list.yml
+++ b/config/sync/canvas.component.sdc.emerging_digital.trust-list.yml
@@ -1,5 +1,5 @@
 uuid: a24a89f2-2284-40cf-b3ac-c340fe51fdd3
-langcode: fr
+langcode: en
 status: true
 dependencies:
   theme:

--- a/config/sync/canvas.component.sdc.olivero.teaser.yml
+++ b/config/sync/canvas.component.sdc.olivero.teaser.yml
@@ -1,5 +1,5 @@
 uuid: ef327590-e835-4ea7-bfe1-0381ed556caa
-langcode: fr
+langcode: en
 status: false
 dependencies:
   theme:

--- a/config/sync/language/fr/canvas.component.block.announce_block.yml
+++ b/config/sync/language/fr/canvas.component.block.announce_block.yml
@@ -1,0 +1,6 @@
+label: "Flux d'annonces"
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: "Flux d'annonces"

--- a/config/sync/language/fr/canvas.component.block.emerging_digital_language_switcher.yml
+++ b/config/sync/language/fr/canvas.component.block.emerging_digital_language_switcher.yml
@@ -1,0 +1,6 @@
+label: 'Sélecteur de langue'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Sélecteur de langue'

--- a/config/sync/language/fr/canvas.component.block.help_block.yml
+++ b/config/sync/language/fr/canvas.component.block.help_block.yml
@@ -1,0 +1,6 @@
+label: Aide
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: Aide

--- a/config/sync/language/fr/canvas.component.block.language_block.language_content.yml
+++ b/config/sync/language/fr/canvas.component.block.language_block.language_content.yml
@@ -1,0 +1,6 @@
+label: 'Sélecteur de langue (Contenu)'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Sélecteur de langue (Contenu)'

--- a/config/sync/language/fr/canvas.component.block.language_block.language_interface.yml
+++ b/config/sync/language/fr/canvas.component.block.language_block.language_interface.yml
@@ -1,0 +1,6 @@
+label: "Sélecteur de langue (Texte d'interface)"
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: "Sélecteur de langue (Texte d'interface)"

--- a/config/sync/language/fr/canvas.component.block.local_actions_block.yml
+++ b/config/sync/language/fr/canvas.component.block.local_actions_block.yml
@@ -1,0 +1,6 @@
+label: "Actions d'administration principales"
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: "Actions d'administration principales"

--- a/config/sync/language/fr/canvas.component.block.local_tasks_block.yml
+++ b/config/sync/language/fr/canvas.component.block.local_tasks_block.yml
@@ -1,0 +1,6 @@
+label: Onglets
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: Onglets

--- a/config/sync/language/fr/canvas.component.block.page_title_block.yml
+++ b/config/sync/language/fr/canvas.component.block.page_title_block.yml
@@ -1,0 +1,6 @@
+label: 'Titre de la page'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Titre de la page'

--- a/config/sync/language/fr/canvas.component.block.shortcuts.yml
+++ b/config/sync/language/fr/canvas.component.block.shortcuts.yml
@@ -1,0 +1,6 @@
+label: Raccourcis
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: Raccourcis

--- a/config/sync/language/fr/canvas.component.block.system_branding_block.yml
+++ b/config/sync/language/fr/canvas.component.block.system_branding_block.yml
@@ -1,0 +1,6 @@
+label: 'Identité du site'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Identité du site'

--- a/config/sync/language/fr/canvas.component.block.system_breadcrumb_block.yml
+++ b/config/sync/language/fr/canvas.component.block.system_breadcrumb_block.yml
@@ -1,0 +1,6 @@
+label: "Fils d'ariane"
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: "Fils d'ariane"

--- a/config/sync/language/fr/canvas.component.block.system_clear_cache_block.yml
+++ b/config/sync/language/fr/canvas.component.block.system_clear_cache_block.yml
@@ -1,0 +1,6 @@
+label: 'Vider le cache'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Vider le cache'

--- a/config/sync/language/fr/canvas.component.block.system_powered_by_block.yml
+++ b/config/sync/language/fr/canvas.component.block.system_powered_by_block.yml
@@ -1,0 +1,6 @@
+label: 'Propulsé par Drupal'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Propulsé par Drupal'

--- a/config/sync/language/fr/canvas.component.block.user_login_block.yml
+++ b/config/sync/language/fr/canvas.component.block.user_login_block.yml
@@ -1,0 +1,6 @@
+label: 'Connexion utilisateur'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Connexion utilisateur'

--- a/config/sync/language/fr/canvas.component.block.views_block.content_recent-block_1.yml
+++ b/config/sync/language/fr/canvas.component.block.views_block.content_recent-block_1.yml
@@ -1,0 +1,6 @@
+label: 'Recent content : Block'
+versioned_properties:
+  active:
+    settings:
+      default_settings:
+        label: 'Recent content : Block'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
@@ -99,8 +99,8 @@ final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
 
     self::assertSame([
       '__none__' => 59,
-      'en' => 466,
-      'fr' => 69,
+      'en' => 496,
+      'fr' => 39,
       'und' => 1,
     ], $counts);
 


### PR DESCRIPTION
## Migration generated by governed #781 recovery

Exact generated commit: `ecca33c353e39610e43ce187c533a98a9e286832`.

Authority:
- trusted #779 plan SHA-256 `8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24`;
- recovery run `32740006838` PASS;
- writer PASS + second fresh Drupal verification PASS;
- recovery artifact id `9524931806`, digest `sha256:401a81af0ac38dd0386576019c765b51098fd295e8daa96e253b5a35f28d9357`.

Exact diff:
- 30 Canvas base files promoted `langcode: fr -> en`;
- 15 Block base files also promote the two active labels to their proven native canonical source;
- exactly 15 FR overrides preserve the localized current labels;
- 4 SDC are langcode-only;
- no historical-version rewrite, no file outside the cohort.

Expected repository/active distribution after migration: `__none__=59, en=496, fr=39, und=1`, total 595.

Configuration Language Lock remains disabled and `system.site.default_langcode=fr` remains unchanged. No cex, production/provider/secret, Canvas generation/build, arbitrary translation/normalization/fuzzy matching.

Refs #781 #779 #609