### PR TITLE
Issue #785: add bounded Canvas post-merge proof route

### DIFF
--- a/.github/workflows/trusted-configuration-language-canvas-migration-781-post-merge-proof.yml
+++ b/.github/workflows/trusted-configuration-language-canvas-migration-781-post-merge-proof.yml
@@ -1,0 +1,245 @@
+name: Agency trusted Canvas canonical migration #781 post-merge proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate fixed #781 post-merge proof request
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 781 &&
+        github.event.comment.body == '/agency-config-language-canvas-migration post-merge-prove'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      main_sha: ${{ steps.validate.outputs.main_sha }}
+    steps:
+      - name: Validate actor, issue, command and immutable live main
+        id: validate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$ISSUE_NUMBER" = '781'
+          test "$TRIGGER_COMMENT" = '/agency-config-language-canvas-migration post-merge-prove'
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/781")"
+          test "$(jq -r '.state' <<<"$issue_json")" = 'open'
+          test "$(jq -r '.pull_request // empty' <<<"$issue_json")" = ''
+          test "$(jq -r '.user.login' <<<"$issue_json")" = 'E-merging-digital'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+  prove:
+    name: Prove merged #781 target on fresh DDEV
+    needs: validate-request
+    timeout-minutes: 55
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+      - ddev
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summary.outputs.status }}
+      verdict: ${{ steps.summary.outputs.verdict }}
+      repository_distribution: ${{ steps.summary.outputs.repository_distribution }}
+      active_distribution: ${{ steps.summary.outputs.active_distribution }}
+      verified: ${{ steps.summary.outputs.verified }}
+      fr_overrides_verified: ${{ steps.summary.outputs.fr_overrides_verified }}
+      remaining_fr: ${{ steps.summary.outputs.remaining_fr }}
+      problems: ${{ steps.summary.outputs.problems }}
+    steps:
+      - name: Verify runner identity and toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          git --version
+          docker --version
+          ddev version
+          jq --version
+
+      - name: Checkout exact live main read-only
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-request.outputs.main_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable migration authority and proof inputs
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+          MIGRATION_MERGE_SHA: 53d049f50bc8c3e29d040cb97bb2fd4b896e5769
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          git merge-base --is-ancestor "$MIGRATION_MERGE_SHA" "$EXPECTED_MAIN_SHA"
+          test -z "$(git diff --name-only "$MIGRATION_MERGE_SHA" "$EXPECTED_MAIN_SHA" -- config/sync)"
+          test -f docs/evidence/configuration-language-canvas-migration-plan-779.yml
+          test -f scripts/runner/configuration-language-canvas-migration-781-verify.php
+          test "$(grep -c '^  config_language_lock:' config/sync/core.extension.yml || true)" = '0'
+          test ! -f config/sync/config_language_lock.settings.yml
+          git diff --check
+
+      - name: Isolate fresh DDEV project
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .ddev/config.gate-config-language-canvas-migration-781-post-merge.yaml <<EOF_CONFIG
+          name: agency-config-canvas-781-post-merge-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          EOF_CONFIG
+          ddev utility configyaml \
+            | grep -F "agency-config-canvas-781-post-merge-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Rebuild fresh Drupal and prove exact merged target
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/config-language-canvas-migration-781-post-merge'
+          verify="$root/verify-result.json"
+          mkdir -p "$root"
+
+          ddev start -y
+          ddev composer install --no-interaction --no-progress --prefer-dist
+          ddev exec php -l /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php >/dev/null
+
+          admin_pass="$(openssl rand -hex 24)"
+          ddev drush site:install --existing-config -y --account-pass="$admin_pass"
+          unset admin_pass
+          ddev drush cim -y
+          ddev drush cr
+
+          config_status="$(ddev drush config:status 2>&1)"
+          printf '%s\n' "$config_status" > "$root/config-status.txt"
+          grep -Fq 'No differences' <<<"$config_status"
+
+          ddev drush php:script \
+            /var/www/html/scripts/runner/configuration-language-canvas-migration-781-verify.php \
+            > "$verify"
+
+          jq -e '.status == "PASS"' "$verify" >/dev/null
+          jq -e '.verdict == "THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED"' "$verify" >/dev/null
+          jq -e '.plan_sha256 == "8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24"' "$verify" >/dev/null
+          jq -e '.verified == 30 and .fr_overrides_verified == 15' "$verify" >/dev/null
+          jq -e '.remaining_fr_review_required == 39' "$verify" >/dev/null
+          jq -e '.repository_total == 595 and .active_total == 595' "$verify" >/dev/null
+          jq -e '.repository_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.active_distribution == {"__none__":59,"en":496,"fr":39,"und":1}' "$verify" >/dev/null
+          jq -e '.problems == [] and (.problems | length) == 0' "$verify" >/dev/null
+          jq -e '.constraints.target_semantic_hashes_verified == true' "$verify" >/dev/null
+          jq -e '.constraints.historical_versions_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.sdc_values_preserved_by_target_hash == true' "$verify" >/dev/null
+          jq -e '.constraints.config_language_lock_enabled_canonically == false' "$verify" >/dev/null
+          jq -e '.constraints.system_site_default_langcode == "fr"' "$verify" >/dev/null
+
+          test "$(ddev drush cget system.site default_langcode --format=string)" = 'fr'
+          if ddev drush pm:list --status=enabled --type=module --field=name | grep -Fxq 'config_language_lock'; then
+            echo 'Configuration Language Lock must remain disabled after #781.' >&2
+            exit 1
+          fi
+          test -z "$(git status --porcelain --untracked-files=all -- config/sync)"
+          git diff --check
+
+      - name: Publish machine summary outputs
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify='artifacts/config-language-canvas-migration-781-post-merge/verify-result.json'
+          echo 'status=PASS' >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "repository_distribution=$(jq -c '.repository_distribution' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "active_distribution=$(jq -c '.active_distribution' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "verified=$(jq -r '.verified' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "fr_overrides_verified=$(jq -r '.fr_overrides_verified' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "remaining_fr=$(jq -r '.remaining_fr_review_required' "$verify")" >> "$GITHUB_OUTPUT"
+          echo "problems=$(jq -r '.problems | length' "$verify")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload post-merge proof evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-config-language-canvas-migration-781-post-merge-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/config-language-canvas-migration-781-post-merge
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Clean isolated DDEV and workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          isolated_name="agency-config-canvas-781-post-merge-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ddev delete --omit-snapshot --yes "$isolated_name" || \
+            ddev stop --unlist --omit-snapshot "$isolated_name" || true
+          rm -f .ddev/config.gate-config-language-canvas-migration-781-post-merge.yaml
+          rm -rf artifacts/config-language-canvas-migration-781-post-merge
+          rmdir artifacts 2>/dev/null || true
+
+  publish:
+    name: Publish #781 post-merge terminal proof verdict
+    if: ${{ always() && needs.validate-request.result != 'skipped' }}
+    needs:
+      - validate-request
+      - prove
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Publish terminal issue verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ needs.validate-request.outputs.main_sha }}
+          PROVE_RESULT: ${{ needs.prove.result }}
+          STATUS: ${{ needs.prove.outputs.status }}
+          VERDICT: ${{ needs.prove.outputs.verdict }}
+          REPOSITORY_DISTRIBUTION: ${{ needs.prove.outputs.repository_distribution }}
+          ACTIVE_DISTRIBUTION: ${{ needs.prove.outputs.active_distribution }}
+          VERIFIED: ${{ needs.prove.outputs.verified }}
+          FR_OVERRIDES_VERIFIED: ${{ needs.prove.outputs.fr_overrides_verified }}
+          REMAINING_FR: ${{ needs.prove.outputs.remaining_fr }}
+          PROBLEMS: ${{ needs.prove.outputs.problems }}
+        run: |
+          set -euo pipefail
+          heading='### Trusted Canvas canonical migration post-merge proof FAIL'
+          if [[ "$PROVE_RESULT" == 'success' && "$STATUS" == 'PASS' ]]; then
+            heading='### Trusted Canvas canonical migration post-merge proof PASS'
+          fi
+
+          printf -v body '%s\n\nmain_exact: `%s`\nmigration_merge_sha: `53d049f50bc8c3e29d040cb97bb2fd4b896e5769`\nrun_id: `%s`\nroute_outcome: `%s`\nstatus: `%s`\nverdict: `%s`\nrepository_distribution: `%s`\nactive_distribution: `%s`\ncanvas_base_configs_en: `%s/30`\nfr_overrides_exact: `%s/15`\nremaining_fr_review_required: `%s`\nproblem_count: `%s`\nartifact: `agency-config-language-canvas-migration-781-post-merge-%s-%s`\n\nThe proof is read-only, requires zero config/sync drift since PR #784, rebuilds a fresh DDEV site from existing config, and keeps Configuration Language Lock disabled.' \
+            "$heading" "$MAIN_SHA" "$GITHUB_RUN_ID" "$PROVE_RESULT" \
+            "${STATUS:-n/a}" "${VERDICT:-n/a}" \
+            "${REPOSITORY_DISTRIBUTION:-n/a}" "${ACTIVE_DISTRIBUTION:-n/a}" \
+            "${VERIFIED:-n/a}" "${FR_OVERRIDES_VERIFIED:-n/a}" \
+            "${REMAINING_FR:-n/a}" "${PROBLEMS:-n/a}" \
+            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
+
+          gh api "repos/$GITHUB_REPOSITORY/issues/781/comments" -f body="$body" >/dev/null
+          test "$heading" = '### Trusted Canvas canonical migration post-merge proof PASS'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781PostMergeWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageCanvasMigration781PostMergeWorkflowTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #781 post-merge proof route.
+ *
+ * @group agency_project_tests
+ * @group configuration_language
+ */
+final class ConfigurationLanguageCanvasMigration781PostMergeWorkflowTest extends TestCase {
+
+  /**
+   * Post-merge proof is fixed to #781 and the exact #784 config authority.
+   */
+  public function testPostMergeProofIsBoundedToMergedMigrationAuthority(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-migration-781-post-merge-proof.yml';
+    self::assertFileExists($path);
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      'github.event.issue.number == 781',
+      "'/agency-config-language-canvas-migration post-merge-prove'",
+      'test "$GITHUB_ACTOR" = \'E-merging-digital\'',
+      '53d049f50bc8c3e29d040cb97bb2fd4b896e5769',
+      'git merge-base --is-ancestor',
+      'git diff --name-only "$MIGRATION_MERGE_SHA" "$EXPECTED_MAIN_SHA" -- config/sync',
+      'configuration-language-canvas-migration-781-verify.php',
+      'THIRTY_CANVAS_CANONICAL_PROMOTIONS_VERIFIED',
+      '8627ce9ec73a45f5501a410e15c4e56fcbc45239ee2c1c166e5d5445337e1a24',
+      '.verified == 30 and .fr_overrides_verified == 15',
+      '.remaining_fr_review_required == 39',
+      '"en":496',
+      '"fr":39',
+      'persist-credentials: false',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+  }
+
+  /**
+   * Proof validates target semantics and remains repository read-only.
+   */
+  public function testPostMergeProofRetainsReadOnlySafetyBoundaries(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/.github/workflows/'
+      . 'trusted-configuration-language-canvas-migration-781-post-merge-proof.yml';
+    $workflow = (string) file_get_contents($path);
+
+    foreach ([
+      '.constraints.target_semantic_hashes_verified == true',
+      '.constraints.historical_versions_preserved_by_target_hash == true',
+      '.constraints.sdc_values_preserved_by_target_hash == true',
+      '.constraints.config_language_lock_enabled_canonically == false',
+      '.constraints.system_site_default_langcode == "fr"',
+      'No differences',
+      'test -z "$(git status --porcelain --untracked-files=all -- config/sync)"',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'drush cex',
+      'generateComponents(',
+      'OPENAI_API_KEY',
+      'SSH_PRIVATE_KEY',
+      'PRODUCTION_SSH',
+      'persist-credentials: true',
+      'contents: write',
+      'workflow_dispatch:',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Scope

Adds only the missing read-only terminal proof route required to close #781 after PR #784.

The workflow:
- is owner-only and fixed to issue #781 + `/agency-config-language-canvas-migration post-merge-prove`;
- binds execution to live main;
- requires PR #784 merge SHA `53d049f50bc8c3e29d040cb97bb2fd4b896e5769` to be an ancestor;
- fails closed if `config/sync` changed since that migration merge;
- checks out with `persist-credentials: false`;
- builds one isolated fresh DDEV site from existing config;
- runs the existing #781 verifier and requires exact `59/496/39/1`, total 595, 30/30 base EN, 15/15 exact FR overrides, target semantic hashes, historical/SDC preservation, default language FR, lock disabled and zero problems;
- uploads evidence and reports PASS/FAIL back to #781.

No `config/sync` change, no cex, no production/provider/secret, no Canvas generation/build, no lock activation.

Refs #785 #781 #784 #779 #609