### PR TITLE
[P1][Ops] Implémenter le health check Drupal provider-neutral (#759)

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -3,6 +3,7 @@ _core:
 module:
   admin_toolbar: 0
   agency_ai_translation: 0
+  agency_health: 0
   ai: 0
   ai_automators: 0
   ai_ckeditor: 0

--- a/docs/operations/agency-health-endpoints.md
+++ b/docs/operations/agency-health-endpoints.md
@@ -1,0 +1,46 @@
+# Agency Drupal health endpoints
+
+Issue: #759
+
+Agency consumes the provider-neutral Drupal health contract v1 defined by `E-merging-digital/platform-ops/contracts/drupal-health.yaml`. The application implementation deliberately has no dependency on Better Stack or any other monitoring provider.
+
+## Public probes
+
+| Probe | Route | Required checks | Success | Unavailable | External timeout |
+| --- | --- | --- | --- | --- | --- |
+| Liveness | `GET /health/live` | application runtime + minimal Drupal bootstrap | `200 {"status":"ok"}` | `503 {"status":"unavailable"}` when Drupal can still build the response; otherwise any 5xx/timeout/network failure is unhealthy | 3 s |
+| Readiness | `GET /health/ready` | minimal Drupal bootstrap + required database connectivity | `200 {"status":"ok"}` | `503 {"status":"unavailable"}` | 5 s |
+
+Both responses use `Content-Type: application/json` and `Cache-Control: no-store`. Unsupported HTTP methods are rejected by Drupal routing.
+
+Liveness is allowed through Drupal maintenance mode so that the monitoring layer can distinguish a live runtime/bootstrap from traffic readiness. Readiness is not maintenance-access enabled and therefore must not claim the application is ready while normal Drupal traffic is intentionally unavailable.
+
+## Readiness dependency policy
+
+For Agency v1, the database is the only application-specific dependency that gates readiness. The probe executes a minimal `SELECT 1` through Drupal's existing database connection service. Any database exception or indeterminate result fails closed to the same public `503 {"status":"unavailable"}` response.
+
+Mail, AI providers, analytics, search indexing and other optional integrations do not gate readiness because Agency can still serve normal public traffic without them. They require separate operational signals if they later become critical.
+
+## Public security boundary
+
+The public payload is intentionally binary. It must never expose component versions, stack traces, database names, private hosts, connection strings, credentials, tokens, filesystem paths, infrastructure internals, customer data or detailed failure causes.
+
+Rich diagnostics remain separate from these public routes and must use an authenticated/operator surface where needed. The existing production diagnostic workflows are not part of the public health contract.
+
+## Monitoring integration handoff
+
+The current production monitoring in `E-merging-digital/platform-ops` already owns:
+
+- `agency-prod-http`: homepage HTTPS/content/TLS monitor;
+- `agency-prod-dns`: DNS monitor.
+
+Those monitors must remain in place. Health monitoring is additive, not a replacement for homepage/content or DNS coverage.
+
+After the endpoint implementation is merged and deployed, `platform-ops` should add provider-adapter monitors for:
+
+- `https://emergingdigital.be/health/live`, expecting HTTP 200 and the healthy payload, with an external timeout no greater than 3 seconds;
+- `https://emergingdigital.be/health/ready`, expecting HTTP 200 and the healthy payload, with an external timeout no greater than 5 seconds.
+
+The exact provider representation, alert routing and credentials remain owned by `platform-ops`. No Better Stack token or provider-specific configuration belongs in Agency Drupal.
+
+A future PREPROD may consume the same two routes after #758 creates a real environment. This document does not create, configure or promote PREPROD.

--- a/web/modules/custom/agency_health/agency_health.info.yml
+++ b/web/modules/custom/agency_health/agency_health.info.yml
@@ -1,0 +1,5 @@
+name: Agency Health
+type: module
+description: 'Provider-neutral public liveness and readiness probes for Agency Drupal.'
+package: Custom
+core_version_requirement: ^11

--- a/web/modules/custom/agency_health/agency_health.routing.yml
+++ b/web/modules/custom/agency_health/agency_health.routing.yml
@@ -1,0 +1,20 @@
+agency_health.liveness:
+  path: '/health/live'
+  defaults:
+    _controller: '\Drupal\agency_health\Controller\HealthController::liveness'
+  requirements:
+    _access: 'TRUE'
+  methods: [GET]
+  options:
+    _maintenance_access: TRUE
+    no_cache: TRUE
+
+agency_health.readiness:
+  path: '/health/ready'
+  defaults:
+    _controller: '\Drupal\agency_health\Controller\HealthController::readiness'
+  requirements:
+    _access: 'TRUE'
+  methods: [GET]
+  options:
+    no_cache: TRUE

--- a/web/modules/custom/agency_health/agency_health.routing.yml
+++ b/web/modules/custom/agency_health/agency_health.routing.yml
@@ -3,6 +3,7 @@ agency_health.liveness:
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::liveness'
   requirements:
+    # Public by contract; response is deliberately binary and non-sensitive.
     _access: 'TRUE'
   methods: [GET]
   options:
@@ -14,6 +15,7 @@ agency_health.readiness:
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::readiness'
   requirements:
+    # Public by contract; detailed diagnostics remain on operator surfaces.
     _access: 'TRUE'
   methods: [GET]
   options:

--- a/web/modules/custom/agency_health/agency_health.services.yml
+++ b/web/modules/custom/agency_health/agency_health.services.yml
@@ -1,0 +1,4 @@
+services:
+  agency_health.probe:
+    class: Drupal\agency_health\HealthProbe
+    arguments: ['@database']

--- a/web/modules/custom/agency_health/src/Controller/HealthController.php
+++ b/web/modules/custom/agency_health/src/Controller/HealthController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_health\Controller;
+
+use Drupal\agency_health\HealthProbeInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Exposes minimal provider-neutral liveness and readiness responses.
+ */
+final class HealthController extends ControllerBase {
+
+  /**
+   * Constructs the health controller.
+   */
+  public function __construct(
+    private readonly HealthProbeInterface $healthProbe,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('agency_health.probe'),
+    );
+  }
+
+  /**
+   * Returns the minimal liveness response.
+   */
+  public function liveness(): JsonResponse {
+    return $this->response($this->healthProbe->isLive());
+  }
+
+  /**
+   * Returns the minimal readiness response.
+   */
+  public function readiness(): JsonResponse {
+    return $this->response($this->healthProbe->isReady());
+  }
+
+  /**
+   * Builds the binary public response required by the shared contract.
+   */
+  private function response(bool $healthy): JsonResponse {
+    return new JsonResponse(
+      ['status' => $healthy ? 'ok' : 'unavailable'],
+      $healthy ? 200 : 503,
+      ['Cache-Control' => 'no-store'],
+    );
+  }
+
+}

--- a/web/modules/custom/agency_health/src/HealthProbe.php
+++ b/web/modules/custom/agency_health/src/HealthProbe.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_health;
+
+use Drupal\Core\Database\Connection;
+
+/**
+ * Implements the minimal Platform Ops health contract for Drupal.
+ */
+final class HealthProbe implements HealthProbeInterface {
+
+  /**
+   * Constructs the health probe.
+   */
+  public function __construct(
+    private readonly Connection $database,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isLive(): bool {
+    // Reaching this service proves that Drupal completed the request bootstrap.
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isReady(): bool {
+    try {
+      return (string) $this->database->query('SELECT 1')->fetchField() === '1';
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+}

--- a/web/modules/custom/agency_health/src/HealthProbeInterface.php
+++ b/web/modules/custom/agency_health/src/HealthProbeInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_health;
+
+/**
+ * Provides provider-neutral application health checks.
+ */
+interface HealthProbeInterface {
+
+  /**
+   * Returns whether the minimal Drupal request bootstrap is live.
+   */
+  public function isLive(): bool;
+
+  /**
+   * Returns whether required application dependencies are ready.
+   */
+  public function isReady(): bool;
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Functional;
 
+use Behat\Mink\Driver\BrowserKitDriver;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -51,8 +52,11 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
    * Unsupported methods are rejected by the route contract.
    */
   public function testHealthEndpointsRejectPost(): void {
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+
     foreach (['/health/live', '/health/ready'] as $path) {
-      $client = $this->getSession()->getDriver()->getClient();
       $client->request('POST', $this->baseUrl . $path);
       self::assertSame(405, $client->getResponse()->getStatusCode());
     }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Covers the public Agency health endpoints through a real Drupal request.
+ *
+ * @group agency_project_tests
+ */
+#[RunTestsInSeparateProcesses]
+final class AgencyHealthEndpointTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'agency_health',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Liveness and readiness return the exact minimal healthy contract.
+   */
+  public function testPublicHealthEndpointsAreHealthyAndMinimal(): void {
+    foreach (['/health/live', '/health/ready'] as $path) {
+      $this->getSession()->visit($this->baseUrl . $path);
+
+      $this->assertSession()->statusCodeEquals(200);
+      $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
+      $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+
+      $body = trim($this->getSession()->getPage()->getContent());
+      self::assertSame('{"status":"ok"}', $body);
+
+      foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
+        self::assertStringNotContainsString($forbidden, strtolower($body));
+      }
+    }
+  }
+
+  /**
+   * Unsupported methods are rejected by the route contract.
+   */
+  public function testHealthEndpointsRejectPost(): void {
+    foreach (['/health/live', '/health/ready'] as $path) {
+      $client = $this->getSession()->getDriver()->getClient();
+      $client->request('POST', $this->baseUrl . $path);
+      self::assertSame(405, $client->getResponse()->getStatusCode());
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthControllerTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthControllerTest.php
@@ -49,7 +49,10 @@ final class AgencyHealthControllerTest extends TestCase {
     self::assertSame(200, $response->getStatusCode());
     self::assertSame('{"status":"ok"}', $response->getContent());
     self::assertSame('application/json', $response->headers->get('Content-Type'));
-    self::assertSame('no-store', $response->headers->get('Cache-Control'));
+    self::assertStringContainsString(
+      'no-store',
+      (string) $response->headers->get('Cache-Control'),
+    );
   }
 
   /**
@@ -59,7 +62,10 @@ final class AgencyHealthControllerTest extends TestCase {
     self::assertSame(503, $response->getStatusCode());
     self::assertSame('{"status":"unavailable"}', $response->getContent());
     self::assertSame('application/json', $response->headers->get('Content-Type'));
-    self::assertSame('no-store', $response->headers->get('Cache-Control'));
+    self::assertStringContainsString(
+      'no-store',
+      (string) $response->headers->get('Cache-Control'),
+    );
 
     $body = (string) $response->getContent();
     foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthControllerTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\agency_health\Controller\HealthController;
+use Drupal\agency_health\HealthProbeInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Covers the public health response contract.
+ *
+ * @group agency_project_tests
+ */
+final class AgencyHealthControllerTest extends TestCase {
+
+  /**
+   * Healthy probes expose only the minimal success payload.
+   */
+  public function testHealthyResponsesAreMinimal(): void {
+    $probe = $this->createMock(HealthProbeInterface::class);
+    $probe->method('isLive')->willReturn(TRUE);
+    $probe->method('isReady')->willReturn(TRUE);
+    $controller = new HealthController($probe);
+
+    $this->assertHealthyResponse($controller->liveness());
+    $this->assertHealthyResponse($controller->readiness());
+  }
+
+  /**
+   * Failed required checks expose only the binary unavailable payload.
+   */
+  public function testFailedResponsesAreMinimalAndFailClosed(): void {
+    $probe = $this->createMock(HealthProbeInterface::class);
+    $probe->method('isLive')->willReturn(FALSE);
+    $probe->method('isReady')->willReturn(FALSE);
+    $controller = new HealthController($probe);
+
+    $this->assertUnavailableResponse($controller->liveness());
+    $this->assertUnavailableResponse($controller->readiness());
+  }
+
+  /**
+   * Asserts the exact public healthy response.
+   */
+  private function assertHealthyResponse(JsonResponse $response): void {
+    self::assertSame(200, $response->getStatusCode());
+    self::assertSame('{"status":"ok"}', $response->getContent());
+    self::assertSame('application/json', $response->headers->get('Content-Type'));
+    self::assertSame('no-store', $response->headers->get('Cache-Control'));
+  }
+
+  /**
+   * Asserts the exact public unavailable response and no detail leakage.
+   */
+  private function assertUnavailableResponse(JsonResponse $response): void {
+    self::assertSame(503, $response->getStatusCode());
+    self::assertSame('{"status":"unavailable"}', $response->getContent());
+    self::assertSame('application/json', $response->headers->get('Content-Type'));
+    self::assertSame('no-store', $response->headers->get('Cache-Control'));
+
+    $body = (string) $response->getContent();
+    foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, strtolower($body));
+    }
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProbeTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProbeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\agency_health\HealthProbe;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\StatementInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the provider-neutral Agency health probe.
+ *
+ * @group agency_project_tests
+ */
+final class AgencyHealthProbeTest extends TestCase {
+
+  /**
+   * Reaching the probe proves the minimal Drupal bootstrap completed.
+   */
+  public function testLivenessSucceedsAfterBootstrap(): void {
+    $database = $this->createMock(Connection::class);
+    $probe = new HealthProbe($database);
+
+    self::assertTrue($probe->isLive());
+  }
+
+  /**
+   * Readiness succeeds only when the required database responds.
+   */
+  public function testReadinessSucceedsWhenDatabaseResponds(): void {
+    $statement = $this->createMock(StatementInterface::class);
+    $statement->expects(self::once())
+      ->method('fetchField')
+      ->willReturn(1);
+
+    $database = $this->createMock(Connection::class);
+    $database->expects(self::once())
+      ->method('query')
+      ->with('SELECT 1')
+      ->willReturn($statement);
+
+    $probe = new HealthProbe($database);
+
+    self::assertTrue($probe->isReady());
+  }
+
+  /**
+   * Readiness fails closed without leaking a database exception.
+   */
+  public function testReadinessFailsClosedWhenDatabaseThrows(): void {
+    $database = $this->createMock(Connection::class);
+    $database->expects(self::once())
+      ->method('query')
+      ->with('SELECT 1')
+      ->willThrowException(new \RuntimeException('sensitive-internal-db-detail'));
+
+    $probe = new HealthProbe($database);
+
+    self::assertFalse($probe->isReady());
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the public Agency health routing contract.
+ *
+ * @group agency_project_tests
+ */
+final class AgencyHealthRoutingTest extends TestCase {
+
+  /**
+   * Health routes remain public, GET-only and explicitly uncacheable.
+   */
+  public function testHealthRoutesMatchSharedContract(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/web/modules/custom/agency_health/agency_health.routing.yml';
+    self::assertFileExists($path);
+
+    $routing = DrupalYaml::decode((string) file_get_contents($path));
+    self::assertIsArray($routing);
+
+    self::assertSame('/health/live', $routing['agency_health.liveness']['path']);
+    self::assertSame('/health/ready', $routing['agency_health.readiness']['path']);
+
+    foreach (['agency_health.liveness', 'agency_health.readiness'] as $route) {
+      self::assertSame('TRUE', $routing[$route]['requirements']['_access']);
+      self::assertSame(['GET'], $routing[$route]['methods']);
+      self::assertTrue($routing[$route]['options']['no_cache']);
+    }
+
+    self::assertTrue($routing['agency_health.liveness']['options']['_maintenance_access']);
+    self::assertArrayNotHasKey(
+      '_maintenance_access',
+      $routing['agency_health.readiness']['options'],
+    );
+  }
+
+}


### PR DESCRIPTION
## Scope

Implémente uniquement #759 après audit read-only de l’existant et consommation du contrat live `E-merging-digital/platform-ops#4` / `contracts/drupal-health.yaml` v1.

### Audit
- aucun endpoint applicatif public liveness/readiness conforme n’existait ;
- les routes custom existantes sont des surfaces admin/domain-specific ;
- le workflow historique `trusted-production-health-diagnostic.yml` est un diagnostic opérateur SSH, pas un probe public ;
- le monitoring PROD courant reste `agency-prod-http` + `agency-prod-dns` dans `platform-ops`.

### Implémentation
- nouveau module custom borné `agency_health` ;
- `GET /health/live` : runtime + bootstrap Drupal minimal ;
- `GET /health/ready` : bootstrap Drupal + `SELECT 1` via le service DB Drupal ;
- payload public exact et binaire : `{"status":"ok"}` / `{"status":"unavailable"}` ;
- codes `200` / `503`, `Cache-Control: no-store`, routes GET-only ;
- readiness fail-closed sur toute erreur DB sans détail public ;
- aucune dépendance Better Stack/provider dans le domaine Agency.

### Tests
- unit : liveness, readiness DB success/failure, réponses 200/503, absence de fuite ;
- unit routing : paths, accès public, GET-only, no-cache, maintenance semantics ;
- BrowserTestBase : vrai bootstrap Drupal + requêtes HTTP liveness/readiness + payload/headers minimaux.

### Monitoring handoff
Après merge + déploiement, `platform-ops` pourra ajouter deux monitors provider-adapter vers `/health/live` et `/health/ready`. Ils doivent compléter, et non remplacer, `agency-prod-http` et `agency-prod-dns`. Aucun token Better Stack n'est utilisé ici.

Aucun travail #758/PREPROD, Canvas, Configuration Language, migration serveur ou refactoring non lié.

Refs #759 `E-merging-digital/platform-ops#4`.