### PR TITLE
Issue #759 recovery: prove readiness failure over Drupal HTTP

### DIFF
--- a/docs/operations/agency-health-endpoints.md
+++ b/docs/operations/agency-health-endpoints.md
@@ -4,6 +4,17 @@ Issue: #759
 
 Agency consumes the provider-neutral Drupal health contract v1 defined by `E-merging-digital/platform-ops/contracts/drupal-health.yaml`. The application implementation deliberately has no dependency on Better Stack or any other monitoring provider.
 
+## Drupal / contrib audit
+
+Classification: **BUILD IN AGENCY**, after `USE DRUPAL` / contrib audit.
+
+- Drupal core provides the routing, controller, HTTP response and Database API primitives needed by the implementation, but no public liveness + readiness endpoint matching the Platform Ops v1 payload, status and DB fail-closed contract was identified.
+- `drupal/health_check` 3.2.0 is a stable, security-covered Drupal 11/12-compatible module and is appropriate for a simple bootstrap/load-balancer probe, but its public endpoint returns a timestamp and does not implement the required database readiness contract.
+- `drupal/health_check_url` 3.3 is stable, security-covered and Drupal 11-compatible, but is primarily a configurable response endpoint and likewise does not implement the required DB readiness semantics.
+- Adding either contrib and then replacing/augmenting its public response contract would increase dependencies and configuration surface without removing the small Agency-specific gap.
+
+The bounded custom module therefore composes Drupal core primitives only: a GET-only route/controller plus Drupal's existing `database` service and a single `SELECT 1` readiness check. It is not a monitoring framework and contains no provider adapter.
+
 ## Public probes
 
 | Probe | Route | Required checks | Success | Unavailable | External timeout |
@@ -11,7 +22,7 @@ Agency consumes the provider-neutral Drupal health contract v1 defined by `E-mer
 | Liveness | `GET /health/live` | application runtime + minimal Drupal bootstrap | `200 {"status":"ok"}` | `503 {"status":"unavailable"}` when Drupal can still build the response; otherwise any 5xx/timeout/network failure is unhealthy | 3 s |
 | Readiness | `GET /health/ready` | minimal Drupal bootstrap + required database connectivity | `200 {"status":"ok"}` | `503 {"status":"unavailable"}` | 5 s |
 
-Both responses use `Content-Type: application/json` and `Cache-Control: no-store`. Unsupported HTTP methods are rejected by Drupal routing.
+Both responses use `Content-Type: application/json` and include `Cache-Control: no-store`. Unsupported HTTP methods are rejected by Drupal routing with `405 Method Not Allowed`.
 
 Liveness is allowed through Drupal maintenance mode so that the monitoring layer can distinguish a live runtime/bootstrap from traffic readiness. Readiness is not maintenance-access enabled and therefore must not claim the application is ready while normal Drupal traffic is intentionally unavailable.
 
@@ -19,7 +30,13 @@ Liveness is allowed through Drupal maintenance mode so that the monitoring layer
 
 For Agency v1, the database is the only application-specific dependency that gates readiness. The probe executes a minimal `SELECT 1` through Drupal's existing database connection service. Any database exception or indeterminate result fails closed to the same public `503 {"status":"unavailable"}` response.
 
-Mail, AI providers, analytics, search indexing and other optional integrations do not gate readiness because Agency can still serve normal public traffic without them. They require separate operational signals if they later become critical.
+Mail, AI providers, analytics, link checking and other optional integrations do not gate readiness because Agency can still serve normal public traffic without them. They require separate operational signals if they later become critical.
+
+The automated proof is layered deliberately:
+
+- the probe unit test proves that a database exception maps to `FALSE` without leaking the exception;
+- the functional failure module injects a failed required-readiness result after a real Drupal bootstrap and proves that a real HTTP request returns `503 {"status":"unavailable"}` while `/health/live` remains healthy;
+- the normal BrowserTestBase proof executes both healthy endpoints against a real Drupal installation and verifies status, exact body, content type, no-store and GET-only routing.
 
 ## Public security boundary
 
@@ -36,11 +53,11 @@ The current production monitoring in `E-merging-digital/platform-ops` already ow
 
 Those monitors must remain in place. Health monitoring is additive, not a replacement for homepage/content or DNS coverage.
 
-After the endpoint implementation is merged and deployed, `platform-ops` should add provider-adapter monitors for:
+After the endpoint implementation is merged and deployed, `platform-ops` may add provider-adapter monitors for:
 
 - `https://emergingdigital.be/health/live`, expecting HTTP 200 and the healthy payload, with an external timeout no greater than 3 seconds;
 - `https://emergingdigital.be/health/ready`, expecting HTTP 200 and the healthy payload, with an external timeout no greater than 5 seconds.
 
 The exact provider representation, alert routing and credentials remain owned by `platform-ops`. No Better Stack token or provider-specific configuration belongs in Agency Drupal.
 
-A future PREPROD may consume the same two routes after #758 creates a real environment. This document does not create, configure or promote PREPROD.
+A future PREPROD reuses the exact same two application routes after #758 creates a real environment. This document does not create, configure or promote PREPROD.

--- a/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/agency_health_test_failure.info.yml
+++ b/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/agency_health_test_failure.info.yml
@@ -1,0 +1,7 @@
+name: 'Agency Health Failure Test'
+type: module
+description: 'Test-only fault injection for Agency readiness HTTP failure semantics.'
+package: Testing
+core_version_requirement: ^11
+dependencies:
+  - agency_health:agency_health

--- a/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/agency_health_test_failure.services.yml
+++ b/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/agency_health_test_failure.services.yml
@@ -1,0 +1,4 @@
+services:
+  agency_health_test_failure.probe:
+    class: Drupal\agency_health_test_failure\FailingHealthProbe
+    decorates: agency_health.probe

--- a/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/src/FailingHealthProbe.php
+++ b/web/modules/custom/agency_project_tests/tests/modules/agency_health_test_failure/src/FailingHealthProbe.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\agency_health_test_failure;
+
+use Drupal\agency_health\HealthProbeInterface;
+
+/**
+ * Simulates an unavailable required dependency for functional HTTP tests.
+ */
+final class FailingHealthProbe implements HealthProbeInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isLive(): bool {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isReady(): bool {
+    return FALSE;
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Covers fail-closed readiness over a real Drupal HTTP request.
+ *
+ * @group agency_project_tests
+ */
+#[RunTestsInSeparateProcesses]
+final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'agency_health',
+    'agency_health_test_failure',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A failed required dependency returns only the unavailable contract.
+   */
+  public function testReadinessRequiredDependencyFailureReturns503(): void {
+    $this->drupalGet('/health/ready');
+
+    $this->assertSession()->statusCodeEquals(503);
+    $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+
+    $body = trim($this->getSession()->getPage()->getContent());
+    self::assertSame('{"status":"unavailable"}', $body);
+
+    foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, strtolower($body));
+    }
+
+    // The fault is readiness-only: Drupal/runtime liveness must remain healthy.
+    $this->drupalGet('/health/live');
+    $this->assertSession()->statusCodeEquals(200);
+    self::assertSame(
+      '{"status":"ok"}',
+      trim($this->getSession()->getPage()->getContent()),
+    );
+  }
+
+}


### PR DESCRIPTION
## Recovery bornée #759

PR #787 a été fusionnée sur son HEAD exact `2d2a3158a7803724d13599d65576888cdc4b922f` pendant que la revue finale renforçait l'exigence de preuve `READINESS_DB_FAILURE = 503` sur une vraie requête Drupal.

Cette PR ne modifie **aucun code runtime de production** déjà fusionné. Elle matérialise uniquement la preuve manquante et l'audit `CONTRIBUTED MODULES FIRST` :

- module de fault injection exclusivement sous `agency_project_tests/tests/modules` ;
- BrowserTestBase réel : readiness indisponible -> `503 {"status":"unavailable"}` + `application/json` + `no-store` + aucune fuite ;
- la même installation prouve que liveness reste `200 {"status":"ok"}` ;
- la preuve se combine avec `AgencyHealthProbeTest`, qui atteste qu'une exception DB réelle est convertie en résultat readiness `FALSE` ;
- documentation de l'audit Drupal core / `health_check` / `health_check_url` et classification `BUILD IN AGENCY`.

Diff attendu contre `main`: tests + documentation uniquement. Aucun #758/PREPROD, aucun secret, aucun provider monitoring, aucun workflow de déploiement.

Refs #759.