### PR TITLE
Issue #759: add bounded production health proof

### DIFF
--- a/.github/workflows/trusted-agency-health-production-proof.yml
+++ b/.github/workflows/trusted-agency-health-production-proof.yml
@@ -1,0 +1,259 @@
+name: Agency trusted health production proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-health-proof:
+    name: Prove provider-neutral health endpoints in production
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.actor == 'E-merging-digital' &&
+        github.event.comment.user.login == 'E-merging-digital' &&
+        github.event.comment.body == '/agency-health production-prove'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      group: agency-health-production-proof-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate owner request and live main
+        id: request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_ACTOR" = 'E-merging-digital'
+          test "$COMMENT_AUTHOR" = "$GITHUB_ACTOR"
+          test "$TRIGGER_COMMENT" = '/agency-health production-prove'
+          test "$ISSUE_NUMBER" = '759'
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+          test "$(jq -r '.state' <<<"$issue_json")" = 'open'
+          test "$(jq -r '.pull_request // empty' <<<"$issue_json")" = ''
+          test "$(jq -r '.user.login' <<<"$issue_json")" = 'E-merging-digital'
+
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$main_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$EVENT_DEFAULT_SHA" = "$main_sha"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact trusted main
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.request.outputs.main_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable health runtime authority
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.request.outputs.main_sha }}
+          RUNTIME_MERGE_SHA: d7bf3abfa7b8df7014d27bb2402b61555bf569a0
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          git cat-file -e "${RUNTIME_MERGE_SHA}^{commit}"
+          git merge-base --is-ancestor "$RUNTIME_MERGE_SHA" "$EXPECTED_MAIN_SHA"
+          test -z "$(git diff --name-only "$RUNTIME_MERGE_SHA" "$EXPECTED_MAIN_SHA" -- config/sync/core.extension.yml web/modules/custom/agency_health)"
+          test -f web/modules/custom/agency_health/agency_health.routing.yml
+          test -f web/modules/custom/agency_health/src/HealthProbe.php
+          git diff --check
+
+      - name: Configure existing production SSH channel
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Verify exact production runtime SHA
+        id: runtime
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          RUNTIME_MERGE_SHA: d7bf3abfa7b8df7014d27bb2402b61555bf569a0
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          production_sha="$(ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" "git -C /var/www/agency/current rev-parse HEAD")"
+          [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$production_sha" = "$RUNTIME_MERGE_SHA"
+          echo "production_sha=$production_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Probe public liveness and readiness
+        id: probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/agency-health-production
+
+          probe() {
+            local name="$1"
+            local path="$2"
+            local timeout="$3"
+            local nominal="$4"
+            local body="artifacts/agency-health-production/${name}.body"
+            local headers="artifacts/agency-health-production/${name}.headers"
+            local metrics="artifacts/agency-health-production/${name}.metrics"
+            local status time_total content_type cache_control compact_body nominal_met
+
+            curl --fail-with-body -sS \
+              --connect-timeout 3 \
+              --max-time "$timeout" \
+              -D "$headers" \
+              -o "$body" \
+              -w 'status=%{http_code}\ntime_total=%{time_total}\ncontent_type=%{content_type}\n' \
+              "https://emergingdigital.be${path}" > "$metrics"
+
+            status="$(sed -n 's/^status=//p' "$metrics")"
+            time_total="$(sed -n 's/^time_total=//p' "$metrics")"
+            content_type="$(sed -n 's/^content_type=//p' "$metrics")"
+            cache_control="$(sed -n 's/^cache-control:[[:space:]]*//Ip' "$headers" | tr -d '\r' | tail -n 1)"
+            compact_body="$(tr -d '\r\n' < "$body")"
+            nominal_met="$(awk -v actual="$time_total" -v target="$nominal" 'BEGIN { print (actual <= target) ? "true" : "false" }')"
+
+            test "$status" = '200'
+            test "$compact_body" = '{"status":"ok"}'
+            [[ "$content_type" == application/json* ]]
+            [[ "${cache_control,,}" == *no-store* ]]
+
+            jq -n \
+              --arg path "$path" \
+              --arg status "$status" \
+              --arg body "$compact_body" \
+              --arg content_type "$content_type" \
+              --arg cache_control "$cache_control" \
+              --arg time_total "$time_total" \
+              --argjson nominal_target_met "$nominal_met" \
+              '{path:$path,status:($status|tonumber),body:$body,content_type:$content_type,cache_control:$cache_control,time_seconds:($time_total|tonumber),nominal_target_met:$nominal_target_met}' \
+              > "artifacts/agency-health-production/${name}.json"
+          }
+
+          probe live '/health/live' 3 1
+          probe ready '/health/ready' 5 2
+
+          jq -s '{schema_version:1,status:"PASS",probes:.}' \
+            artifacts/agency-health-production/live.json \
+            artifacts/agency-health-production/ready.json \
+            > artifacts/agency-health-production/result.json
+
+      - name: Upload production health evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-health-production-759-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/agency-health-production
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish bounded proof result
+        if: ${{ always() && steps.request.outcome == 'success' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN: ${{ steps.request.outputs.main_sha }}
+          PRODUCTION_SHA: ${{ steps.runtime.outputs.production_sha }}
+          PROBE_OUTCOME: ${{ steps.probe.outcome }}
+        run: |
+          set -euo pipefail
+          result='artifacts/agency-health-production/result.json'
+          status='FAIL'
+          live_status='n/a'
+          live_body='n/a'
+          live_content_type='n/a'
+          live_cache='n/a'
+          live_time='n/a'
+          live_nominal='n/a'
+          ready_status='n/a'
+          ready_body='n/a'
+          ready_content_type='n/a'
+          ready_cache='n/a'
+          ready_time='n/a'
+          ready_nominal='n/a'
+
+          if [[ "$PROBE_OUTCOME" == 'success' ]] && [[ -s "$result" ]] && jq -e '.status == "PASS" and (.probes | length) == 2' "$result" >/dev/null 2>&1; then
+            status='PASS'
+            live_status="$(jq -r '.probes[] | select(.path == "/health/live") | .status' "$result")"
+            live_body="$(jq -r '.probes[] | select(.path == "/health/live") | .body' "$result")"
+            live_content_type="$(jq -r '.probes[] | select(.path == "/health/live") | .content_type' "$result")"
+            live_cache="$(jq -r '.probes[] | select(.path == "/health/live") | .cache_control' "$result")"
+            live_time="$(jq -r '.probes[] | select(.path == "/health/live") | .time_seconds' "$result")"
+            live_nominal="$(jq -r '.probes[] | select(.path == "/health/live") | .nominal_target_met' "$result")"
+            ready_status="$(jq -r '.probes[] | select(.path == "/health/ready") | .status' "$result")"
+            ready_body="$(jq -r '.probes[] | select(.path == "/health/ready") | .body' "$result")"
+            ready_content_type="$(jq -r '.probes[] | select(.path == "/health/ready") | .content_type' "$result")"
+            ready_cache="$(jq -r '.probes[] | select(.path == "/health/ready") | .cache_control' "$result")"
+            ready_time="$(jq -r '.probes[] | select(.path == "/health/ready") | .time_seconds' "$result")"
+            ready_nominal="$(jq -r '.probes[] | select(.path == "/health/ready") | .nominal_target_met' "$result")"
+          fi
+
+          artifact="agency-health-production-759-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          body="$(cat <<EOF_BODY
+          ### Agency health production proof ${status}
+
+          trusted_main: \`${TRUSTED_MAIN:-n/a}\`
+          production_runtime_sha: \`${PRODUCTION_SHA:-n/a}\`
+          runtime_authority: \`d7bf3abfa7b8df7014d27bb2402b61555bf569a0\`
+          run_id: \`${GITHUB_RUN_ID}\`
+          route_outcome: \`${PROBE_OUTCOME:-unknown}\`
+
+          liveness_status: \`${live_status}\`
+          liveness_body: \`${live_body}\`
+          liveness_content_type: \`${live_content_type}\`
+          liveness_cache_control: \`${live_cache}\`
+          liveness_time_seconds: \`${live_time}\`
+          liveness_nominal_le_1s: \`${live_nominal}\`
+
+          readiness_status: \`${ready_status}\`
+          readiness_body: \`${ready_body}\`
+          readiness_content_type: \`${ready_content_type}\`
+          readiness_cache_control: \`${ready_cache}\`
+          readiness_time_seconds: \`${ready_time}\`
+          readiness_nominal_le_2s: \`${ready_nominal}\`
+
+          artifact: \`${artifact}\`
+
+          Read-only proof only. This route accepts no URL, shell command or diagnostic input and performs no deployment, Drupal mutation, service restart or monitoring-provider mutation.
+          EOF_BODY
+          )"
+          gh issue comment 759 --repo "$GITHUB_REPOSITORY" --body "$body"
+
+      - name: Cleanup SSH material and verify workspace
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set +e
+          rm -rf ~/.ssh artifacts/agency-health-production
+          rmdir artifacts 2>/dev/null || true
+          git diff --check
+          status="$(git status --porcelain)"
+          if [[ -n "$status" ]]; then
+            printf '%s\n' "$status" >&2
+            exit 1
+          fi

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProductionProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProductionProofWorkflowTest.php
@@ -27,7 +27,7 @@ final class AgencyHealthProductionProofWorkflowTest extends TestCase {
 
     foreach ([
       "github.event.comment.body == '/agency-health production-prove'",
-      "test \"$ISSUE_NUMBER\" = '759'",
+      'test "$ISSUE_NUMBER" = \'759\'',
       'd7bf3abfa7b8df7014d27bb2402b61555bf569a0',
       'git merge-base --is-ancestor',
       'config/sync/core.extension.yml web/modules/custom/agency_health',

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProductionProofWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthProductionProofWorkflowTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the bounded #759 production health proof route.
+ *
+ * @group agency_project_tests
+ */
+final class AgencyHealthProductionProofWorkflowTest extends TestCase {
+
+  /**
+   * The proof is fixed to #759, production and the merged runtime authority.
+   */
+  public function testProductionProofIsBoundedAndReadOnly(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/trusted-agency-health-production-proof.yml';
+    self::assertFileExists($path);
+
+    $workflow = (string) file_get_contents($path);
+    self::assertIsArray(DrupalYaml::decode($workflow));
+
+    foreach ([
+      "github.event.comment.body == '/agency-health production-prove'",
+      "test \"$ISSUE_NUMBER\" = '759'",
+      'd7bf3abfa7b8df7014d27bb2402b61555bf569a0',
+      'git merge-base --is-ancestor',
+      'config/sync/core.extension.yml web/modules/custom/agency_health',
+      'persist-credentials: false',
+      'git -C /var/www/agency/current rev-parse HEAD',
+      'https://emergingdigital.be${path}',
+      "probe live '/health/live' 3 1",
+      "probe ready '/health/ready' 5 2",
+      'test "$compact_body" = \'{"status":"ok"}\'',
+      'application/json',
+      'no-store',
+      'nominal_target_met',
+      'agency-health-production-759-',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $workflow);
+    }
+
+    foreach ([
+      'workflow_dispatch:',
+      'contents: write',
+      'persist-credentials: true',
+      'deploy-production.sh',
+      'drush state:set',
+      'drush cim',
+      'drush updb',
+      'systemctl restart',
+      'systemctl reload',
+      'BETTERUPTIME_API_TOKEN',
+      'OPENAI_API_KEY',
+      '${{ inputs.',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+}


### PR DESCRIPTION
## Preuve terminale bornée #759

Cette PR n'altère pas le runtime Drupal déjà fusionné via #787. Elle ajoute uniquement une route de preuve production read-only dédiée à #759 et son test de garde-fous.

Contrat de la route :
- commande exacte owner-only sur l'issue #759 : `/agency-health production-prove` ;
- exécution depuis le live `main` uniquement ;
- autorité runtime immuable `d7bf3abfa7b8df7014d27bb2402b61555bf569a0` ;
- preuve de zéro dérive depuis cette autorité dans `config/sync/core.extension.yml` et `web/modules/custom/agency_health` ;
- canal SSH existant utilisé uniquement pour lire le SHA de `/var/www/agency/current` ;
- GET publics fixes `/health/live` et `/health/ready` ;
- assertions 200, payload exact `{"status":"ok"}`, `application/json`, `Cache-Control: no-store` ;
- timeouts externes 3s/5s et mesure des cibles nominales 1s/2s ;
- artifact non sensible + commentaire borné dans #759.

Interdits conservés : aucun déploiement, aucune mutation Drupal/PROD, aucun restart/reload service, aucun input URL/shell, aucun secret exposé, aucune dépendance Better Stack, aucune implémentation #758.

Refs #759.