### PR TITLE
Issue #791: keep health routes canonical without language prefix

### DIFF
--- a/web/modules/custom/agency_health/agency_health.routing.yml
+++ b/web/modules/custom/agency_health/agency_health.routing.yml
@@ -2,6 +2,7 @@ agency_health.liveness:
   path: '/health/live'
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::liveness'
+    _disable_route_normalizer: TRUE
   requirements:
     # Public by contract; response is deliberately binary and non-sensitive.
     _access: 'TRUE'
@@ -14,6 +15,7 @@ agency_health.readiness:
   path: '/health/ready'
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::readiness'
+    _disable_route_normalizer: TRUE
   requirements:
     # Public by contract; detailed diagnostics remain on operator surfaces.
     _access: 'TRUE'

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Drupal\Tests\agency_project_tests\Functional;
 
 use Behat\Mink\Driver\BrowserKitDriver;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -21,6 +24,9 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
    */
   protected static $modules = [
     'agency_health',
+    'language',
+    'node',
+    'redirect',
   ];
 
   /**
@@ -29,17 +35,83 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
-   * Liveness and readiness return the exact minimal healthy contract.
+   * {@inheritdoc}
    */
-  public function testPublicHealthEndpointsAreHealthyAndMinimal(): void {
+  protected function setUp(): void {
+    parent::setUp();
+
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    $this->config('language.negotiation')
+      ->set('url.source', 'path_prefix')
+      ->set('url.prefixes', ['fr' => 'fr'])
+      ->set('url.domains', ['fr' => ''])
+      ->save();
+
+    $this->config('language.types')
+      ->set('all', [
+        'language_interface',
+        'language_content',
+        'language_url',
+      ])
+      ->set('configurable', [
+        'language_interface',
+        'language_content',
+      ])
+      ->set('negotiation.language_interface.enabled', [
+        'language-url' => -8,
+        'language-selected' => -6,
+      ])
+      ->set('negotiation.language_content.enabled', [
+        'language-url' => -8,
+        'language-selected' => 12,
+      ])
+      ->set('negotiation.language_url.enabled', [
+        'language-url' => -8,
+      ])
+      ->save();
+
+    $this->config('redirect.settings')
+      ->set('route_normalizer_enabled', TRUE)
+      ->save();
+
+    NodeType::create([
+      'type' => 'page',
+      'name' => 'Basic page',
+    ])->save();
+
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * Liveness and readiness bypass only Redirect's route normalizer.
+   */
+  public function testPublicHealthEndpointsAreCanonicalHealthyAndMinimal(): void {
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
+
     foreach (['/health/live', '/health/ready'] as $path) {
-      $this->getSession()->visit($this->baseUrl . $path);
+      $client->request('GET', $this->baseUrl . $path);
+      $response = $client->getResponse();
 
-      $this->assertSession()->statusCodeEquals(200);
-      $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
-      $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+      self::assertSame(200, $response->getStatusCode());
+      self::assertFalse($response->headers->has('Location'));
+      self::assertStringContainsString(
+        'application/json',
+        (string) $response->headers->get('Content-Type'),
+      );
+      self::assertStringContainsString(
+        'no-store',
+        (string) $response->headers->get('Cache-Control'),
+      );
 
-      $body = trim($this->getSession()->getPage()->getContent());
+      $body = trim((string) $response->getContent());
       self::assertSame('{"status":"ok"}', $body);
 
       foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -49,17 +121,47 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
   }
 
   /**
-   * Unsupported methods are rejected by the route contract.
+   * Unsupported methods remain rejected without a language redirect.
    */
   public function testHealthEndpointsRejectPost(): void {
     $driver = $this->getSession()->getDriver();
     self::assertInstanceOf(BrowserKitDriver::class, $driver);
     $client = $driver->getClient();
+    $client->followRedirects(FALSE);
 
     foreach (['/health/live', '/health/ready'] as $path) {
       $client->request('POST', $this->baseUrl . $path);
-      self::assertSame(405, $client->getResponse()->getStatusCode());
+      $response = $client->getResponse();
+      self::assertSame(405, $response->getStatusCode());
+      self::assertFalse($response->headers->has('Location'));
     }
+  }
+
+  /**
+   * Normal editorial routes still keep Redirect language normalization.
+   */
+  public function testEditorialRouteStillUsesLanguageCanonicalization(): void {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Canonical multilingual page',
+      'langcode' => 'fr',
+      'status' => Node::PUBLISHED,
+    ]);
+    $node->save();
+
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
+    $client->request('GET', $this->baseUrl . '/node/' . $node->id());
+
+    $response = $client->getResponse();
+    self::assertSame(301, $response->getStatusCode());
+    self::assertSame(
+      '/fr/node/' . $node->id(),
+      parse_url((string) $response->headers->get('Location'), PHP_URL_PATH),
+    );
+    self::assertSame('1', $response->headers->get('X-Drupal-Route-Normalizer'));
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
@@ -101,17 +101,17 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
       $response = $client->getResponse();
 
       self::assertSame(200, $response->getStatusCode());
-      self::assertFalse($response->headers->has('Location'));
+      self::assertNull($response->getHeader('Location'));
       self::assertStringContainsString(
         'application/json',
-        (string) $response->headers->get('Content-Type'),
+        (string) $response->getHeader('Content-Type'),
       );
       self::assertStringContainsString(
         'no-store',
-        (string) $response->headers->get('Cache-Control'),
+        (string) $response->getHeader('Cache-Control'),
       );
 
-      $body = trim((string) $response->getContent());
+      $body = trim($response->getContent());
       self::assertSame('{"status":"ok"}', $body);
 
       foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -133,7 +133,7 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
       $client->request('POST', $this->baseUrl . $path);
       $response = $client->getResponse();
       self::assertSame(405, $response->getStatusCode());
-      self::assertFalse($response->headers->has('Location'));
+      self::assertNull($response->getHeader('Location'));
     }
   }
 
@@ -159,9 +159,9 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
     self::assertSame(301, $response->getStatusCode());
     self::assertSame(
       '/fr/node/' . $node->id(),
-      parse_url((string) $response->headers->get('Location'), PHP_URL_PATH),
+      parse_url((string) $response->getHeader('Location'), PHP_URL_PATH),
     );
-    self::assertSame('1', $response->headers->get('X-Drupal-Route-Normalizer'));
+    self::assertSame('1', $response->getHeader('X-Drupal-Route-Normalizer'));
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
@@ -93,17 +93,17 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
     $response = $client->getResponse();
 
     self::assertSame(503, $response->getStatusCode());
-    self::assertFalse($response->headers->has('Location'));
+    self::assertNull($response->getHeader('Location'));
     self::assertStringContainsString(
       'application/json',
-      (string) $response->headers->get('Content-Type'),
+      (string) $response->getHeader('Content-Type'),
     );
     self::assertStringContainsString(
       'no-store',
-      (string) $response->headers->get('Cache-Control'),
+      (string) $response->getHeader('Cache-Control'),
     );
 
-    $body = trim((string) $response->getContent());
+    $body = trim($response->getContent());
     self::assertSame('{"status":"unavailable"}', $body);
 
     foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -114,8 +114,8 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
     $client->request('GET', $this->baseUrl . '/health/live');
     $response = $client->getResponse();
     self::assertSame(200, $response->getStatusCode());
-    self::assertFalse($response->headers->has('Location'));
-    self::assertSame('{"status":"ok"}', trim((string) $response->getContent()));
+    self::assertNull($response->getHeader('Location'));
+    self::assertSame('{"status":"ok"}', trim($response->getContent()));
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Functional;
 
+use Behat\Mink\Driver\BrowserKitDriver;
+use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -21,6 +23,8 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
   protected static $modules = [
     'agency_health',
     'agency_health_test_failure',
+    'language',
+    'redirect',
   ];
 
   /**
@@ -29,16 +33,77 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    $this->config('language.negotiation')
+      ->set('url.source', 'path_prefix')
+      ->set('url.prefixes', ['fr' => 'fr'])
+      ->set('url.domains', ['fr' => ''])
+      ->save();
+
+    $this->config('language.types')
+      ->set('all', [
+        'language_interface',
+        'language_content',
+        'language_url',
+      ])
+      ->set('configurable', [
+        'language_interface',
+        'language_content',
+      ])
+      ->set('negotiation.language_interface.enabled', [
+        'language-url' => -8,
+        'language-selected' => -6,
+      ])
+      ->set('negotiation.language_content.enabled', [
+        'language-url' => -8,
+        'language-selected' => 12,
+      ])
+      ->set('negotiation.language_url.enabled', [
+        'language-url' => -8,
+      ])
+      ->save();
+
+    $this->config('redirect.settings')
+      ->set('route_normalizer_enabled', TRUE)
+      ->save();
+
+    drupal_flush_all_caches();
+  }
+
+  /**
    * A failed required dependency returns only the unavailable contract.
    */
   public function testReadinessRequiredDependencyFailureReturns503(): void {
-    $this->drupalGet('/health/ready');
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
 
-    $this->assertSession()->statusCodeEquals(503);
-    $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
-    $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+    $client->request('GET', $this->baseUrl . '/health/ready');
+    $response = $client->getResponse();
 
-    $body = trim($this->getSession()->getPage()->getContent());
+    self::assertSame(503, $response->getStatusCode());
+    self::assertFalse($response->headers->has('Location'));
+    self::assertStringContainsString(
+      'application/json',
+      (string) $response->headers->get('Content-Type'),
+    );
+    self::assertStringContainsString(
+      'no-store',
+      (string) $response->headers->get('Cache-Control'),
+    );
+
+    $body = trim((string) $response->getContent());
     self::assertSame('{"status":"unavailable"}', $body);
 
     foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -46,12 +111,11 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
     }
 
     // The fault is readiness-only: Drupal/runtime liveness must remain healthy.
-    $this->drupalGet('/health/live');
-    $this->assertSession()->statusCodeEquals(200);
-    self::assertSame(
-      '{"status":"ok"}',
-      trim($this->getSession()->getPage()->getContent()),
-    );
+    $client->request('GET', $this->baseUrl . '/health/live');
+    $response = $client->getResponse();
+    self::assertSame(200, $response->getStatusCode());
+    self::assertFalse($response->headers->has('Location'));
+    self::assertSame('{"status":"ok"}', trim((string) $response->getContent()));
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
@@ -32,6 +32,7 @@ final class AgencyHealthRoutingTest extends TestCase {
       self::assertSame('TRUE', $routing[$route]['requirements']['_access']);
       self::assertSame(['GET'], $routing[$route]['methods']);
       self::assertTrue($routing[$route]['options']['no_cache']);
+      self::assertTrue($routing[$route]['defaults']['_disable_route_normalizer']);
     }
 
     self::assertTrue($routing['agency_health.liveness']['options']['_maintenance_access']);


### PR DESCRIPTION
## Scope #791 uniquement

Corrige le défaut externe prouvé par Platform Ops #14 / PR #15 : `/health/live` et `/health/ready` étaient normalisés en 301 vers `/fr/health/...` lorsque Redirect route normalizer + négociation `path_prefix` étaient actifs.

### Audit
- Agency verrouille `drupal/redirect` 1.13.0 ;
- `redirect.settings: route_normalizer_enabled = true` reste inchangé ;
- Redirect supporte l'attribut `_disable_route_normalizer` ;
- le correctif le plus étroit est un default de route sur les deux routes health uniquement.

### Runtime diff
- `agency_health.liveness.defaults._disable_route_normalizer = TRUE`
- `agency_health.readiness.defaults._disable_route_normalizer = TRUE`

Aucun changement global de langue, aucun changement Redirect global, aucun Nginx workaround, aucun changement Better Stack.

### Preuves ajoutées
Les tests fonctionnels reproduisent désormais :
- langue par défaut FR ;
- négociation URL `path_prefix` ;
- Redirect route normalizer activé ;
- GET `/health/live` = 200 direct, sans `Location`, JSON minimal + `no-store` ;
- GET `/health/ready` = même contrat ;
- POST = 405 sans redirection ;
- readiness failure = 503 `{"status":"unavailable"}` sans redirection ;
- route éditoriale `/node/{id}` reste 301-normalisée vers `/fr/node/{id}` avec `X-Drupal-Route-Normalizer: 1`, prouvant que le normalizer global reste actif.

#759 reste fermé. Aucun travail #758 dans cette PR.

Refs #791 #759.