### PR TITLE
Issue #791: keep health routes canonical without language prefix

### DIFF
--- a/web/modules/custom/agency_health/agency_health.routing.yml
+++ b/web/modules/custom/agency_health/agency_health.routing.yml
@@ -2,6 +2,7 @@ agency_health.liveness:
   path: '/health/live'
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::liveness'
+    _disable_route_normalizer: TRUE
   requirements:
     # Public by contract; response is deliberately binary and non-sensitive.
     _access: 'TRUE'
@@ -14,6 +15,7 @@ agency_health.readiness:
   path: '/health/ready'
   defaults:
     _controller: '\Drupal\agency_health\Controller\HealthController::readiness'
+    _disable_route_normalizer: TRUE
   requirements:
     # Public by contract; detailed diagnostics remain on operator surfaces.
     _access: 'TRUE'

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthEndpointTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Drupal\Tests\agency_project_tests\Functional;
 
 use Behat\Mink\Driver\BrowserKitDriver;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -21,6 +24,9 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
    */
   protected static $modules = [
     'agency_health',
+    'language',
+    'node',
+    'redirect',
   ];
 
   /**
@@ -29,17 +35,91 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
-   * Liveness and readiness return the exact minimal healthy contract.
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    if (!ConfigurableLanguage::load('fr')) {
+      ConfigurableLanguage::createFromLangcode('fr')->save();
+    }
+    if (!ConfigurableLanguage::load('en')) {
+      ConfigurableLanguage::createFromLangcode('en')->save();
+    }
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    $this->config('language.negotiation')
+      ->set('url.source', 'path_prefix')
+      ->set('url.prefixes', ['fr' => 'fr', 'en' => 'en'])
+      ->set('url.domains', ['fr' => '', 'en' => ''])
+      ->save();
+
+    $this->config('language.types')
+      ->set('all', [
+        'language_interface',
+        'language_content',
+        'language_url',
+      ])
+      ->set('configurable', [
+        'language_interface',
+        'language_content',
+      ])
+      ->set('negotiation.language_interface.enabled', [
+        'language-url' => -8,
+        'language-selected' => -6,
+      ])
+      ->set('negotiation.language_content.enabled', [
+        'language-url' => -8,
+        'language-selected' => 12,
+      ])
+      ->set('negotiation.language_url.enabled', [
+        'language-url' => -8,
+      ])
+      ->save();
+
+    $this->config('redirect.settings')
+      ->set('route_normalizer_enabled', TRUE)
+      ->set('default_status_code', 301)
+      ->save();
+
+    if (!NodeType::load('page')) {
+      NodeType::create([
+        'type' => 'page',
+        'name' => 'Basic page',
+      ])->save();
+    }
+
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * Liveness and readiness stay direct under multilingual normalization.
    */
   public function testPublicHealthEndpointsAreHealthyAndMinimal(): void {
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
+
     foreach (['/health/live', '/health/ready'] as $path) {
-      $this->getSession()->visit($this->baseUrl . $path);
+      $client->request('GET', $this->baseUrl . $path);
+      $response = $client->getResponse();
 
-      $this->assertSession()->statusCodeEquals(200);
-      $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
-      $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+      self::assertSame(200, $response->getStatusCode());
+      self::assertFalse($response->headers->has('Location'));
+      self::assertStringStartsWith(
+        'application/json',
+        (string) $response->headers->get('Content-Type'),
+      );
+      self::assertStringContainsString(
+        'no-store',
+        strtolower((string) $response->headers->get('Cache-Control')),
+      );
 
-      $body = trim($this->getSession()->getPage()->getContent());
+      $body = trim((string) $response->getContent());
       self::assertSame('{"status":"ok"}', $body);
 
       foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -55,11 +135,42 @@ final class AgencyHealthEndpointTest extends BrowserTestBase {
     $driver = $this->getSession()->getDriver();
     self::assertInstanceOf(BrowserKitDriver::class, $driver);
     $client = $driver->getClient();
+    $client->followRedirects(FALSE);
 
     foreach (['/health/live', '/health/ready'] as $path) {
       $client->request('POST', $this->baseUrl . $path);
       self::assertSame(405, $client->getResponse()->getStatusCode());
     }
+  }
+
+  /**
+   * A normal editorial route remains subject to language normalization.
+   */
+  public function testEditorialRouteStillUsesLanguageRouteNormalizer(): void {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Normalizer control page',
+      'langcode' => 'fr',
+      'status' => Node::PUBLISHED,
+    ]);
+    $node->save();
+
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
+    $client->request('GET', $this->baseUrl . '/node/' . $node->id());
+
+    $response = $client->getResponse();
+    self::assertSame(301, $response->getStatusCode());
+    self::assertSame('1', $response->headers->get('X-Drupal-Route-Normalizer'));
+
+    $location = $response->headers->get('Location');
+    self::assertNotNull($location);
+    self::assertSame(
+      '/fr/node/' . $node->id(),
+      parse_url($location, PHP_URL_PATH),
+    );
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/AgencyHealthReadinessFailureTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Functional;
 
+use Behat\Mink\Driver\BrowserKitDriver;
+use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -21,6 +23,8 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
   protected static $modules = [
     'agency_health',
     'agency_health_test_failure',
+    'language',
+    'redirect',
   ];
 
   /**
@@ -29,16 +33,83 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
   protected $defaultTheme = 'stark';
 
   /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    if (!ConfigurableLanguage::load('fr')) {
+      ConfigurableLanguage::createFromLangcode('fr')->save();
+    }
+    if (!ConfigurableLanguage::load('en')) {
+      ConfigurableLanguage::createFromLangcode('en')->save();
+    }
+
+    $this->config('system.site')
+      ->set('default_langcode', 'fr')
+      ->save();
+
+    $this->config('language.negotiation')
+      ->set('url.source', 'path_prefix')
+      ->set('url.prefixes', ['fr' => 'fr', 'en' => 'en'])
+      ->set('url.domains', ['fr' => '', 'en' => ''])
+      ->save();
+
+    $this->config('language.types')
+      ->set('all', [
+        'language_interface',
+        'language_content',
+        'language_url',
+      ])
+      ->set('configurable', [
+        'language_interface',
+        'language_content',
+      ])
+      ->set('negotiation.language_interface.enabled', [
+        'language-url' => -8,
+        'language-selected' => -6,
+      ])
+      ->set('negotiation.language_content.enabled', [
+        'language-url' => -8,
+        'language-selected' => 12,
+      ])
+      ->set('negotiation.language_url.enabled', [
+        'language-url' => -8,
+      ])
+      ->save();
+
+    $this->config('redirect.settings')
+      ->set('route_normalizer_enabled', TRUE)
+      ->set('default_status_code', 301)
+      ->save();
+
+    drupal_flush_all_caches();
+  }
+
+  /**
    * A failed required dependency returns only the unavailable contract.
    */
   public function testReadinessRequiredDependencyFailureReturns503(): void {
-    $this->drupalGet('/health/ready');
+    $driver = $this->getSession()->getDriver();
+    self::assertInstanceOf(BrowserKitDriver::class, $driver);
+    $client = $driver->getClient();
+    $client->followRedirects(FALSE);
 
-    $this->assertSession()->statusCodeEquals(503);
-    $this->assertSession()->responseHeaderContains('Content-Type', 'application/json');
-    $this->assertSession()->responseHeaderContains('Cache-Control', 'no-store');
+    $client->request('GET', $this->baseUrl . '/health/ready');
+    $response = $client->getResponse();
 
-    $body = trim($this->getSession()->getPage()->getContent());
+    self::assertSame(503, $response->getStatusCode());
+    self::assertFalse($response->headers->has('Location'));
+    self::assertStringStartsWith(
+      'application/json',
+      (string) $response->headers->get('Content-Type'),
+    );
+    self::assertStringContainsString(
+      'no-store',
+      strtolower((string) $response->headers->get('Cache-Control')),
+    );
+
+    $body = trim((string) $response->getContent());
     self::assertSame('{"status":"unavailable"}', $body);
 
     foreach (['version', 'database', 'host', 'trace', 'exception', 'token', 'password'] as $forbidden) {
@@ -46,11 +117,13 @@ final class AgencyHealthReadinessFailureTest extends BrowserTestBase {
     }
 
     // The fault is readiness-only: Drupal/runtime liveness must remain healthy.
-    $this->drupalGet('/health/live');
-    $this->assertSession()->statusCodeEquals(200);
+    $client->request('GET', $this->baseUrl . '/health/live');
+    $liveness = $client->getResponse();
+    self::assertSame(200, $liveness->getStatusCode());
+    self::assertFalse($liveness->headers->has('Location'));
     self::assertSame(
       '{"status":"ok"}',
-      trim($this->getSession()->getPage()->getContent()),
+      trim((string) $liveness->getContent()),
     );
   }
 

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/AgencyHealthRoutingTest.php
@@ -32,6 +32,7 @@ final class AgencyHealthRoutingTest extends TestCase {
       self::assertSame('TRUE', $routing[$route]['requirements']['_access']);
       self::assertSame(['GET'], $routing[$route]['methods']);
       self::assertTrue($routing[$route]['options']['no_cache']);
+      self::assertTrue($routing[$route]['defaults']['_disable_route_normalizer']);
     }
 
     self::assertTrue($routing['agency_health.liveness']['options']['_maintenance_access']);


### PR DESCRIPTION
## Fermée sans merge — doublon concurrent de #793

Pendant l’implémentation, `main` a avancé via PR #793, qui a déjà fusionné exactement le correctif #791 attendu avec le même runtime diff et les mêmes preuves multilingues.

#793 est maintenant l’autorité : CI exacte verte, merge `2b72172a82e77fc3a7260cd819cdcfa7c007719a`, deploy PROD réussi et Platform Ops PR #15 rerun PASS.

Cette PR #796 est donc fermée sans merge afin de ne pas dupliquer ni écraser le travail déjà terminalisé.

Refs #791 #793.