### PR TITLE
Issue #797: provision real PREPROD deployment path

### DIFF
--- a/.github/workflows/bootstrap-preproduction.yml
+++ b/.github/workflows/bootstrap-preproduction.yml
@@ -1,0 +1,116 @@
+name: Bootstrap Agency PREPROD host
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agency-preprod-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    name: Bootstrap isolated PREPROD runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: preproduction
+    steps:
+      - name: Checkout exact bootstrap source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Require main authority and PREPROD-only secrets
+        env:
+          PREPROD_BOOTSTRAP_HOST: ${{ secrets.PREPROD_BOOTSTRAP_HOST }}
+          PREPROD_BOOTSTRAP_USER: ${{ secrets.PREPROD_BOOTSTRAP_USER }}
+          PREPROD_BOOTSTRAP_SSH_PRIVATE_KEY: ${{ secrets.PREPROD_BOOTSTRAP_SSH_PRIVATE_KEY }}
+          PREPROD_DEPLOY_PUBLIC_KEY: ${{ secrets.PREPROD_DEPLOY_PUBLIC_KEY }}
+          PREPROD_HTTP_PASSWORD: ${{ secrets.PREPROD_HTTP_PASSWORD }}
+          PREPROD_TLS_EMAIL: ${{ secrets.PREPROD_TLS_EMAIL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF_NAME" == "main" ]]
+          test -n "$PREPROD_BOOTSTRAP_HOST"
+          test -n "$PREPROD_BOOTSTRAP_USER"
+          test -n "$PREPROD_BOOTSTRAP_SSH_PRIVATE_KEY"
+          [[ "$PREPROD_DEPLOY_PUBLIC_KEY" == ssh-* ]]
+          test -n "$PREPROD_HTTP_PASSWORD"
+          test -n "$PREPROD_TLS_EMAIL"
+
+      - name: Configure bootstrap SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.PREPROD_BOOTSTRAP_SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.PREPROD_BOOTSTRAP_HOST }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Stage bootstrap inputs
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_BOOTSTRAP_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_BOOTSTRAP_USER }}
+          DEPLOY_PUBLIC_KEY: ${{ secrets.PREPROD_DEPLOY_PUBLIC_KEY }}
+          ACCESS_PASSWORD: ${{ secrets.PREPROD_HTTP_PASSWORD }}
+          TLS_EMAIL: ${{ secrets.PREPROD_TLS_EMAIL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_PUBLIC_KEY" > "$RUNNER_TEMP/deploy-key.pub"
+          printf '%s\n' "$ACCESS_PASSWORD" > "$RUNNER_TEMP/access-password"
+          printf '%s\n' "$TLS_EMAIL" > "$RUNNER_TEMP/tls-email"
+          scp scripts/preproduction/bootstrap-host.sh "$RUNNER_TEMP/deploy-key.pub" "$RUNNER_TEMP/access-password" "$RUNNER_TEMP/tls-email" \
+            "$SERVER_USER@$SERVER_HOST:/tmp/"
+
+      - name: Bootstrap and enable TLS
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_BOOTSTRAP_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_BOOTSTRAP_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" <<'EOF_REMOTE'
+          set -euo pipefail
+          deploy_key="$(cat /tmp/deploy-key.pub)"
+          access_password="$(cat /tmp/access-password)"
+          tls_email="$(cat /tmp/tls-email)"
+          sudo env \
+            PREPROD_FQDN='preprod.emergingdigital.be' \
+            DEPLOY_PUBLIC_KEY="$deploy_key" \
+            ACCESS_PASSWORD="$access_password" \
+            TLS_EMAIL="$tls_email" \
+            ENABLE_TLS=1 \
+            bash /tmp/bootstrap-host.sh
+          rm -f /tmp/bootstrap-host.sh /tmp/deploy-key.pub /tmp/access-password /tmp/tls-email
+          EOF_REMOTE
+
+      - name: Verify external protected surface
+        env:
+          HTTP_PASSWORD: ${{ secrets.PREPROD_HTTP_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          unauthenticated="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://preprod.emergingdigital.be/)"
+          [[ "$unauthenticated" == "401" ]]
+          headers="$RUNNER_TEMP/preprod-headers.txt"
+          status="$(curl -sS -u "preprod:$HTTP_PASSWORD" -D "$headers" -o /dev/null -w '%{http_code}' --max-time 10 https://preprod.emergingdigital.be/)"
+          [[ "$status" =~ ^(200|404|503)$ ]]
+          grep -qi '^x-robots-tag:.*noindex' "$headers"
+          echo "PREPROD_PROTECTED_SURFACE=PASS"
+
+      - name: Remove local credentials
+        if: always()
+        shell: bash
+        run: |
+          rm -f ~/.ssh/id_ed25519 "$RUNNER_TEMP/deploy-key.pub" "$RUNNER_TEMP/access-password" "$RUNNER_TEMP/tls-email"

--- a/.github/workflows/deploy-preproduction.yml
+++ b/.github/workflows/deploy-preproduction.yml
@@ -91,7 +91,7 @@ jobs:
           [[ "$composer_lock_sha256" =~ ^[0-9a-f]{64}$ ]]
           [[ "$(sha256sum "$payload" | awk '{print $1}')" == "$artifact_sha256" ]]
           [[ "$(sha256sum composer.lock | awk '{print $1}')" == "$composer_lock_sha256" ]]
-          sha256sum -c "$checksum"
+          (cd "$root" && sha256sum -c agency-release-candidate.tar.gz.sha256)
           echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
           echo "composer_lock_sha256=$composer_lock_sha256" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-preproduction.yml
+++ b/.github/workflows/deploy-preproduction.yml
@@ -1,0 +1,300 @@
+name: Deploy Agency PREPROD candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact 40-character SHA already built from release/*
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: agency-preprod-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-and-validate:
+    name: Deploy exact candidate and validate real PREPROD
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: preproduction
+    env:
+      PREPROD_URL: https://preprod.emergingdigital.be
+    steps:
+      - name: Validate immutable candidate authority
+        id: candidate_run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          run_json="$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/build-release-candidate.yml/runs?event=push&head_sha=$CANDIDATE_SHA&status=completed&per_page=20" \
+            --jq '[.workflow_runs[] | select(.conclusion == "success" and (.head_branch | startswith("release/")))] | sort_by(.run_number) | last')"
+          [[ -n "$run_json" && "$run_json" != "null" ]]
+          run_id="$(jq -r '.id' <<<"$run_json")"
+          run_sha="$(jq -r '.head_sha' <<<"$run_json")"
+          run_branch="$(jq -r '.head_branch' <<<"$run_json")"
+          [[ "$run_sha" == "$CANDIDATE_SHA" ]]
+          [[ "$run_branch" == release/* ]]
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$run_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact candidate source for deploy scripts and validation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact immutable candidate artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate_run.outputs.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/preproduction-candidate
+          gh run download "$CANDIDATE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "agency-release-candidate-$CANDIDATE_SHA" \
+            --dir artifacts/preproduction-candidate
+
+      - name: Verify candidate SHA and digests before transport
+        id: identity
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          RELEASE_BRANCH: ${{ steps.candidate_run.outputs.release_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          root='artifacts/preproduction-candidate'
+          payload="$root/agency-release-candidate.tar.gz"
+          metadata="$root/candidate.json"
+          checksum="$root/agency-release-candidate.tar.gz.sha256"
+          test -f "$payload" -a -f "$metadata" -a -f "$checksum"
+          metadata_sha="$(jq -r '.candidate_sha' "$metadata")"
+          metadata_branch="$(jq -r '.source_branch' "$metadata")"
+          artifact_sha256="$(jq -r '.artifact_sha256' "$metadata")"
+          composer_lock_sha256="$(jq -r '.composer_lock_sha256' "$metadata")"
+          [[ "$metadata_sha" == "$CANDIDATE_SHA" ]]
+          [[ "$metadata_branch" == "$RELEASE_BRANCH" ]]
+          [[ "$metadata_branch" == release/* ]]
+          [[ "$artifact_sha256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$composer_lock_sha256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$(sha256sum "$payload" | awk '{print $1}')" == "$artifact_sha256" ]]
+          [[ "$(sha256sum composer.lock | awk '{print $1}')" == "$composer_lock_sha256" ]]
+          sha256sum -c "$checksum"
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+          echo "composer_lock_sha256=$composer_lock_sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Configure dedicated PREPROD SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.PREPROD_DEPLOY_SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Stage exact detached PREPROD request
+        id: request
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          request_id="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${CANDIDATE_SHA}"
+          remote_dir="/var/www/agency-preprod/shared/deploy-jobs/$request_id"
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
+          ssh "$SERVER_USER@$SERVER_HOST" "umask 077; mkdir -p '$remote_dir'; test ! -L '$remote_dir'; test ! -e '$remote_dir/result.env'"
+          scp \
+            scripts/preproduction/deploy-artifact.sh \
+            scripts/preproduction/launch-deploy.sh \
+            scripts/preproduction/inspect-deploy.sh \
+            artifacts/preproduction-candidate/agency-release-candidate.tar.gz \
+            artifacts/preproduction-candidate/candidate.json \
+            "$SERVER_USER@$SERVER_HOST:$remote_dir/"
+          ssh "$SERVER_USER@$SERVER_HOST" "chmod 700 '$remote_dir/deploy-artifact.sh' '$remote_dir/launch-deploy.sh' '$remote_dir/inspect-deploy.sh'"
+
+      - name: Launch detached PREPROD deployment
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          ARTIFACT_SHA256: ${{ steps.identity.outputs.artifact_sha256 }}
+          COMPOSER_LOCK_SHA256: ${{ steps.identity.outputs.composer_lock_sha256 }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          output="$(ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" \
+            "'$REMOTE_DIR/launch-deploy.sh' '$REQUEST_ID' '$CANDIDATE_SHA' '$ARTIFACT_SHA256' '$COMPOSER_LOCK_SHA256'" 2>&1)"
+          transport_exit="$?"
+          set -e
+          printf '%s\n' "$output"
+          echo "Launch transport exit=$transport_exit; detached polling is authoritative."
+
+      - name: Poll detached PREPROD result and collect non-sensitive evidence
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          ARTIFACT_SHA256: ${{ steps.identity.outputs.artifact_sha256 }}
+          COMPOSER_LOCK_SHA256: ${{ steps.identity.outputs.composer_lock_sha256 }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+          REQUEST_ID: ${{ steps.request.outputs.request_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence='artifacts/preproduction-deploy'
+          mkdir -p "$evidence"
+          terminal=''
+          poll=''
+          for attempt in $(seq 1 180); do
+            set +e
+            poll="$(ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" \
+              "'$REMOTE_DIR/inspect-deploy.sh' '$REQUEST_ID' '$CANDIDATE_SHA'" 2>&1)"
+            rc="$?"
+            set -e
+            if [[ "$rc" -ne 0 ]]; then sleep 5; continue; fi
+            outcome="$(sed -n 's/^outcome=//p' <<<"$poll" | head -n1)"
+            case "$outcome" in
+              SUCCESS|FAILURE|LOCKED|LOST|INVALID) terminal="$outcome"; break ;;
+              RUNNING|STARTING|NOT_STARTED) sleep 5 ;;
+              *) terminal='INVALID'; break ;;
+            esac
+          done
+          [[ -n "$terminal" ]] || terminal='TIMEOUT'
+          printf '%s\n' "$poll" | tee "$evidence/result.env"
+          for file in output.log bootstrap.log; do
+            ssh "$SERVER_USER@$SERVER_HOST" "cat '$REMOTE_DIR/$file' 2>/dev/null || true" > "$evidence/$file" 2>&1 || true
+          done
+          [[ "$terminal" == 'SUCCESS' ]]
+          grep -qx "candidate_sha=$CANDIDATE_SHA" "$evidence/result.env"
+          grep -qx "artifact_sha256=$ARTIFACT_SHA256" "$evidence/result.env"
+          grep -qx "composer_lock_sha256=$COMPOSER_LOCK_SHA256" "$evidence/result.env"
+          grep -qx 'exit_code=0' "$evidence/result.env"
+
+      - name: Verify active PREPROD identity
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          ARTIFACT_SHA256: ${{ steps.identity.outputs.artifact_sha256 }}
+          COMPOSER_LOCK_SHA256: ${{ steps.identity.outputs.composer_lock_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          remote_metadata="$(ssh "$SERVER_USER@$SERVER_HOST" 'cat /var/www/agency-preprod/current/.agency-candidate.json')"
+          [[ "$(jq -r '.candidate_sha' <<<"$remote_metadata")" == "$CANDIDATE_SHA" ]]
+          [[ "$(jq -r '.artifact_sha256' <<<"$remote_metadata")" == "$ARTIFACT_SHA256" ]]
+          [[ "$(jq -r '.composer_lock_sha256' <<<"$remote_metadata")" == "$COMPOSER_LOCK_SHA256" ]]
+          jq '{candidate_sha,artifact_sha256,composer_lock_sha256,source_branch}' <<<"$remote_metadata" \
+            > artifacts/preproduction-deploy/active-candidate.json
+
+      - name: Validate protected health and smoke
+        env:
+          HTTP_PASSWORD: ${{ secrets.PREPROD_HTTP_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence='artifacts/preproduction-deploy'
+          unauth="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$PREPROD_URL/fr/blog")"
+          [[ "$unauth" == '401' ]]
+          probe() {
+            name="$1" path="$2" max_time="$3"
+            status="$(curl -sS -u "preprod:$HTTP_PASSWORD" --max-time "$max_time" \
+              -D "$evidence/$name.headers" -o "$evidence/$name.body" -w '%{http_code}' "$PREPROD_URL$path")"
+            [[ "$status" == '200' ]]
+            [[ "$(cat "$evidence/$name.body")" == '{"status":"ok"}' ]]
+            grep -qi '^content-type: application/json' "$evidence/$name.headers"
+            grep -qi '^cache-control:.*no-store' "$evidence/$name.headers"
+            ! grep -qi '^location:' "$evidence/$name.headers"
+          }
+          probe live '/health/live' 3
+          probe ready '/health/ready' 5
+          smoke_status="$(curl -sS -u "preprod:$HTTP_PASSWORD" --max-time 10 \
+            -D "$evidence/smoke.headers" -o /dev/null -w '%{http_code}' "$PREPROD_URL/fr/blog")"
+          [[ "$smoke_status" == '200' ]]
+          grep -qi '^x-robots-tag:.*noindex' "$evidence/smoke.headers"
+          printf 'HEALTH_LIVE=PASS\nHEALTH_READY=PASS\nSMOKE=PASS\nACCESS_PROTECTION=PASS\n' > "$evidence/http.env"
+
+      - name: Install browser validation dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run protected Playwright desktop and mobile
+        env:
+          BROWSER_VALIDATION_BASE_URL: https://preprod.emergingdigital.be
+          PLAYWRIGHT_HTTP_USERNAME: preprod
+          PLAYWRIGHT_HTTP_PASSWORD: ${{ secrets.PREPROD_HTTP_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run browser:validate
+          jq -e '.result == "PASS" and .visual_desktop == "PASS" and .visual_mobile == "PASS"' \
+            artifacts/browser-validation/result.json >/dev/null
+
+      - name: Persist release-candidate terminal evidence
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          RELEASE_BRANCH: ${{ steps.candidate_run.outputs.release_branch }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate_run.outputs.run_id }}
+          ARTIFACT_SHA256: ${{ steps.identity.outputs.artifact_sha256 }}
+          COMPOSER_LOCK_SHA256: ${{ steps.identity.outputs.composer_lock_sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg candidate_sha "$CANDIDATE_SHA" \
+            --arg release_branch "$RELEASE_BRANCH" \
+            --arg candidate_run_id "$CANDIDATE_RUN_ID" \
+            --arg artifact_sha256 "$ARTIFACT_SHA256" \
+            --arg composer_lock_sha256 "$COMPOSER_LOCK_SHA256" \
+            '{schema_version:1,environment:"preproduction",url:"https://preprod.emergingdigital.be",candidate_sha:$candidate_sha,release_branch:$release_branch,candidate_run_id:$candidate_run_id,artifact_sha256:$artifact_sha256,composer_lock_sha256:$composer_lock_sha256,health:"PASS",smoke:"PASS",playwright_desktop:"PASS",playwright_mobile:"PASS",release_state:"READY_FOR_PROD",prod_promotion:"WAITING_FOR_HUMAN_GO"}' \
+            > artifacts/preproduction-deploy/release-candidate-evidence.json
+
+      - name: Upload non-sensitive PREPROD evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-preproduction-deploy-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/preproduction-deploy
+            artifacts/browser-validation/result.json
+            artifacts/browser-validation/evidence
+            artifacts/browser-validation/screenshots
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Cleanup credentials
+        if: always()
+        shell: bash
+        run: |
+          rm -f ~/.ssh/id_ed25519

--- a/config/splits/preproduction/system.mail.yml
+++ b/config/splits/preproduction/system.mail.yml
@@ -1,0 +1,14 @@
+_core:
+  default_config_hash: 5PvD9swkqWUeHkabdvbJ2SQqdhrzjkCT21wtD4BLfk4
+interface:
+  default: symfony_mailer
+mailer_dsn:
+  scheme: smtp
+  host: 127.0.0.1
+  user: null
+  password: null
+  port: 1025
+  options:
+    auto_tls: false
+    require_tls: false
+    verify_peer: false

--- a/config/sync/config_split.config_split.preproduction.yml
+++ b/config/sync/config_split.config_split.preproduction.yml
@@ -1,0 +1,17 @@
+uuid: 2ddcd900-f78e-4abe-90c0-3cf4ee201797
+langcode: en
+status: false
+dependencies: {  }
+id: preproduction
+label: Preproduction
+description: 'PREPROD-only safety overrides; production services and credentials are excluded.'
+weight: 0
+stackable: false
+no_patching: false
+storage: ../config/splits/preproduction
+folder: ../config/splits/preproduction
+module: {  }
+theme: {  }
+complete_list:
+  - system.mail
+partial_list: {  }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,10 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL;
+const httpUsername = process.env.PLAYWRIGHT_HTTP_USERNAME;
+const httpPassword = process.env.PLAYWRIGHT_HTTP_PASSWORD;
+const protectedTarget = Boolean(httpUsername || httpPassword);
 
 if (!baseURL) {
   throw new Error(
     'PLAYWRIGHT_BASE_URL is required. Use `npm run browser:validate` to detect DDEV automatically.',
+  );
+}
+
+if ((httpUsername && !httpPassword) || (!httpUsername && httpPassword)) {
+  throw new Error(
+    'PLAYWRIGHT_HTTP_USERNAME and PLAYWRIGHT_HTTP_PASSWORD must be supplied together.',
   );
 }
 
@@ -22,8 +31,16 @@ export default defineConfig({
   use: {
     baseURL,
     ignoreHTTPSErrors: true,
+    httpCredentials: protectedTarget
+      ? {
+          username: httpUsername,
+          password: httpPassword,
+        }
+      : undefined,
     screenshot: 'only-on-failure',
-    trace: 'retain-on-failure',
+    // A Playwright trace can contain request headers. Never retain one for a
+    // Basic-Auth-protected target because Authorization is sensitive.
+    trace: protectedTarget ? 'off' : 'retain-on-failure',
     video: 'off',
   },
   projects: [

--- a/scripts/preproduction/bootstrap-host.sh
+++ b/scripts/preproduction/bootstrap-host.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Idempotent Ubuntu 24.04 bootstrap for the Agency PREPROD host.
+# Secrets are generated on-host. The only caller-supplied credential material is
+# the public half of the dedicated PREPROD deploy key.
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run this bootstrap as root." >&2
+  exit 2
+fi
+
+source /etc/os-release
+if [[ "${ID:-}" != "ubuntu" || "${VERSION_CODENAME:-}" != "noble" ]]; then
+  echo "Ubuntu 24.04 LTS (noble) is required." >&2
+  exit 2
+fi
+
+PREPROD_FQDN="${PREPROD_FQDN:-preprod.emergingdigital.be}"
+DEPLOY_USER="${DEPLOY_USER:-agency-preprod}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/agency-preprod}"
+DEPLOY_PUBLIC_KEY="${DEPLOY_PUBLIC_KEY:-}"
+ENABLE_TLS="${ENABLE_TLS:-0}"
+TLS_EMAIL="${TLS_EMAIL:-}"
+DB_NAME="${DB_NAME:-agency_preprod}"
+DB_USER="${DB_USER:-agency_preprod}"
+CREDENTIAL_FILE="/root/agency-preprod-bootstrap-credentials.txt"
+
+[[ "$PREPROD_FQDN" =~ ^[A-Za-z0-9.-]+$ ]] || { echo "Invalid PREPROD_FQDN." >&2; exit 2; }
+[[ "$DEPLOY_USER" =~ ^[a-z_][a-z0-9_-]*$ ]] || { echo "Invalid DEPLOY_USER." >&2; exit 2; }
+[[ "$DB_NAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "Invalid DB_NAME." >&2; exit 2; }
+[[ "$DB_USER" =~ ^[A-Za-z0-9_]+$ ]] || { echo "Invalid DB_USER." >&2; exit 2; }
+if [[ -z "$DEPLOY_PUBLIC_KEY" ]]; then
+  echo "DEPLOY_PUBLIC_KEY is required and must be the dedicated PREPROD public SSH key." >&2
+  exit 2
+fi
+if [[ "$ENABLE_TLS" == "1" && -z "$TLS_EMAIL" ]]; then
+  echo "TLS_EMAIL is required when ENABLE_TLS=1." >&2
+  exit 2
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+  ca-certificates curl gnupg lsb-release software-properties-common \
+  nginx ufw apache2-utils openssl rsync jq unzip certbot python3-certbot-nginx \
+  postfix
+
+# Ubuntu 24.04 ships PHP 8.3. Use the same widely-used maintained package
+# source as the current PHP 8.4 server line, then pin the runtime explicitly.
+if ! grep -Rqs '^deb .*ondrej/php' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+  add-apt-repository -y ppa:ondrej/php
+fi
+apt-get update
+apt-get install -y \
+  php8.4-cli php8.4-fpm php8.4-common php8.4-opcache \
+  php8.4-mysql php8.4-xml php8.4-curl php8.4-mbstring php8.4-gd \
+  php8.4-zip php8.4-intl php8.4-bcmath
+
+# MariaDB's official repository setup supports the 11.8 series on noble.
+if ! grep -Rqs 'mariadb.*11.8' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+  curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
+    | bash -s -- --mariadb-server-version="mariadb-11.8"
+fi
+apt-get update
+apt-get install -y mariadb-server mariadb-client mariadb-backup
+
+systemctl enable --now nginx php8.4-fpm mariadb
+
+if ! id "$DEPLOY_USER" >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash "$DEPLOY_USER"
+fi
+usermod -a -G www-data "$DEPLOY_USER"
+install -d -m 0700 -o "$DEPLOY_USER" -g "$DEPLOY_USER" "/home/$DEPLOY_USER/.ssh"
+printf '%s\n' "$DEPLOY_PUBLIC_KEY" > "/home/$DEPLOY_USER/.ssh/authorized_keys"
+chown "$DEPLOY_USER:$DEPLOY_USER" "/home/$DEPLOY_USER/.ssh/authorized_keys"
+chmod 0600 "/home/$DEPLOY_USER/.ssh/authorized_keys"
+
+for path in \
+  "$PROJECT_ROOT/releases" \
+  "$PROJECT_ROOT/shared/files" \
+  "$PROJECT_ROOT/shared/private" \
+  "$PROJECT_ROOT/shared/settings" \
+  "$PROJECT_ROOT/shared/backups" \
+  "$PROJECT_ROOT/shared/deploy-jobs"; do
+  install -d -m 0750 -o "$DEPLOY_USER" -g www-data "$path"
+done
+touch "$PROJECT_ROOT/shared/deploy.lock" "$PROJECT_ROOT/shared/deployments.log"
+chown "$DEPLOY_USER:www-data" "$PROJECT_ROOT/shared/deploy.lock" "$PROJECT_ROOT/shared/deployments.log"
+chmod 0640 "$PROJECT_ROOT/shared/deploy.lock" "$PROJECT_ROOT/shared/deployments.log"
+chmod 2770 "$PROJECT_ROOT/shared/files" "$PROJECT_ROOT/shared/private"
+
+cat > /etc/mysql/mariadb.conf.d/99-agency-preprod.cnf <<'EOF_MARIADB'
+[mariadb]
+bind-address = 127.0.0.1
+max_allowed_packet = 64M
+EOF_MARIADB
+systemctl restart mariadb
+
+DB_PASSWORD=''
+HASH_SALT=''
+ACCESS_PASSWORD=''
+if [[ -f "$CREDENTIAL_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$CREDENTIAL_FILE"
+fi
+DB_PASSWORD="${DB_PASSWORD:-$(openssl rand -hex 24)}"
+HASH_SALT="${HASH_SALT:-$(openssl rand -hex 32)}"
+ACCESS_PASSWORD="${ACCESS_PASSWORD:-$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)}"
+
+umask 077
+cat > "$CREDENTIAL_FILE" <<EOF_CREDS
+DB_PASSWORD='$DB_PASSWORD'
+HASH_SALT='$HASH_SALT'
+ACCESS_USERNAME='preprod'
+ACCESS_PASSWORD='$ACCESS_PASSWORD'
+EOF_CREDS
+chmod 0600 "$CREDENTIAL_FILE"
+
+mariadb --protocol=socket <<EOF_SQL
+CREATE DATABASE IF NOT EXISTS \`$DB_NAME\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+ALTER USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON \`$DB_NAME\`.* TO '$DB_USER'@'localhost';
+FLUSH PRIVILEGES;
+EOF_SQL
+
+cat > "$PROJECT_ROOT/shared/settings/settings.php" <<EOF_SETTINGS
+<?php
+
+declare(strict_types=1);
+
+\$databases['default']['default'] = [
+  'database' => '$DB_NAME',
+  'username' => '$DB_USER',
+  'password' => '$DB_PASSWORD',
+  'host' => '127.0.0.1',
+  'port' => '3306',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
+\$settings['hash_salt'] = '$HASH_SALT';
+\$settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config/sync';
+\$settings['file_private_path'] = '$PROJECT_ROOT/shared/private';
+\$settings['trusted_host_patterns'] = ['^' . preg_quote('$PREPROD_FQDN', '/') . '$'];
+\$config['config_split.config_split.production']['status'] = FALSE;
+\$config['config_split.config_split.preproduction']['status'] = TRUE;
+// PREPROD is intentionally isolated from production AI credentials.
+putenv('OPENAI_API_KEY');
+unset(\$_ENV['OPENAI_API_KEY'], \$_SERVER['OPENAI_API_KEY']);
+EOF_SETTINGS
+chown "$DEPLOY_USER:www-data" "$PROJECT_ROOT/shared/settings/settings.php"
+chmod 0640 "$PROJECT_ROOT/shared/settings/settings.php"
+
+# Local SMTP sink: messages are accepted on loopback and discarded. There is no
+# relay and therefore no path to production recipients.
+cat > /etc/systemd/system/agency-preprod-smtp-sink.service <<'EOF_SINK'
+[Unit]
+Description=Agency PREPROD local SMTP sink
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/smtp-sink -h agency-preprod 127.0.0.1:1025 100
+Restart=on-failure
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+EOF_SINK
+systemctl daemon-reload
+systemctl enable --now agency-preprod-smtp-sink.service
+
+htpasswd -bc /etc/nginx/agency-preprod.htpasswd preprod "$ACCESS_PASSWORD" >/dev/null
+chown root:www-data /etc/nginx/agency-preprod.htpasswd
+chmod 0640 /etc/nginx/agency-preprod.htpasswd
+
+cat > /etc/nginx/sites-available/agency-preprod.conf <<EOF_NGINX
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $PREPROD_FQDN;
+    root $PROJECT_ROOT/current/web;
+    index index.php;
+
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
+    auth_basic "Agency PREPROD";
+    auth_basic_user_file /etc/nginx/agency-preprod.htpasswd;
+
+    location / {
+        try_files \$uri /index.php?\$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files \$uri =404;
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+    }
+
+    location ~ /\. {
+        deny all;
+    }
+}
+EOF_NGINX
+ln -sfn /etc/nginx/sites-available/agency-preprod.conf /etc/nginx/sites-enabled/agency-preprod.conf
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl reload nginx
+
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+
+if [[ "$ENABLE_TLS" == "1" ]]; then
+  certbot --nginx --non-interactive --agree-tos --redirect \
+    --email "$TLS_EMAIL" -d "$PREPROD_FQDN"
+fi
+
+# No Drupal cron/queue systemd unit is installed here. External side effects
+# remain disabled until the real PREPROD validation explicitly enables them.
+
+php -v | head -n 1
+mariadb --version
+nginx -v
+systemctl is-active php8.4-fpm mariadb nginx agency-preprod-smtp-sink.service
+mariadb --protocol=socket -Nse 'SELECT @@max_allowed_packet' | grep -qx '67108864'
+
+cat <<EOF_DONE
+PREPROD_BOOTSTRAP=PASS
+PREPROD_FQDN=$PREPROD_FQDN
+PROJECT_ROOT=$PROJECT_ROOT
+DEPLOY_USER=$DEPLOY_USER
+CREDENTIAL_FILE=$CREDENTIAL_FILE
+TLS_ENABLED=$ENABLE_TLS
+EOF_DONE

--- a/scripts/preproduction/bootstrap-host.sh
+++ b/scripts/preproduction/bootstrap-host.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 # Idempotent Ubuntu 24.04 bootstrap for the Agency PREPROD host.
-# Secrets are generated on-host. The only caller-supplied credential material is
-# the public half of the dedicated PREPROD deploy key.
+# Secrets are generated on-host unless an isolated PREPROD access password is
+# supplied by the governed bootstrap workflow. No production secret is used.
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "Run this bootstrap as root." >&2
@@ -24,6 +24,7 @@ ENABLE_TLS="${ENABLE_TLS:-0}"
 TLS_EMAIL="${TLS_EMAIL:-}"
 DB_NAME="${DB_NAME:-agency_preprod}"
 DB_USER="${DB_USER:-agency_preprod}"
+REQUESTED_ACCESS_PASSWORD="${ACCESS_PASSWORD:-}"
 CREDENTIAL_FILE="/root/agency-preprod-bootstrap-credentials.txt"
 
 [[ "$PREPROD_FQDN" =~ ^[A-Za-z0-9.-]+$ ]] || { echo "Invalid PREPROD_FQDN." >&2; exit 2; }
@@ -45,9 +46,10 @@ apt-get install -y \
   ca-certificates curl gnupg lsb-release software-properties-common \
   nginx ufw apache2-utils openssl rsync jq unzip certbot python3-certbot-nginx \
   postfix
+# Only smtp-sink is used. The Postfix MTA itself must never relay PREPROD mail.
+systemctl disable --now postfix 2>/dev/null || true
 
-# Ubuntu 24.04 ships PHP 8.3. Use the same widely-used maintained package
-# source as the current PHP 8.4 server line, then pin the runtime explicitly.
+# Ubuntu 24.04 ships PHP 8.3. Install the explicitly required PHP 8.4 runtime.
 if ! grep -Rqs '^deb .*ondrej/php' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
   add-apt-repository -y ppa:ondrej/php
 fi
@@ -64,7 +66,6 @@ if ! grep -Rqs 'mariadb.*11.8' /etc/apt/sources.list /etc/apt/sources.list.d 2>/
 fi
 apt-get update
 apt-get install -y mariadb-server mariadb-client mariadb-backup
-
 systemctl enable --now nginx php8.4-fpm mariadb
 
 if ! id "$DEPLOY_USER" >/dev/null 2>&1; then
@@ -106,7 +107,11 @@ if [[ -f "$CREDENTIAL_FILE" ]]; then
 fi
 DB_PASSWORD="${DB_PASSWORD:-$(openssl rand -hex 24)}"
 HASH_SALT="${HASH_SALT:-$(openssl rand -hex 32)}"
-ACCESS_PASSWORD="${ACCESS_PASSWORD:-$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)}"
+if [[ -n "$REQUESTED_ACCESS_PASSWORD" ]]; then
+  ACCESS_PASSWORD="$REQUESTED_ACCESS_PASSWORD"
+else
+  ACCESS_PASSWORD="${ACCESS_PASSWORD:-$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)}"
+fi
 
 umask 077
 cat > "$CREDENTIAL_FILE" <<EOF_CREDS
@@ -221,11 +226,11 @@ fi
 
 # No Drupal cron/queue systemd unit is installed here. External side effects
 # remain disabled until the real PREPROD validation explicitly enables them.
-
 php -v | head -n 1
 mariadb --version
 nginx -v
 systemctl is-active php8.4-fpm mariadb nginx agency-preprod-smtp-sink.service
+systemctl is-enabled postfix 2>/dev/null | grep -Eq 'disabled|masked' || true
 mariadb --protocol=socket -Nse 'SELECT @@max_allowed_packet' | grep -qx '67108864'
 
 cat <<EOF_DONE

--- a/scripts/preproduction/deploy-artifact.sh
+++ b/scripts/preproduction/deploy-artifact.sh
@@ -25,7 +25,7 @@ SWITCH_COMPLETED=0
 [[ -f "$PAYLOAD" && ! -L "$PAYLOAD" ]] || { echo "Candidate payload missing or unsafe." >&2; exit 2; }
 [[ -f "$METADATA" && ! -L "$METADATA" ]] || { echo "Candidate metadata missing or unsafe." >&2; exit 2; }
 
-for command in jq sha256sum tar flock; do
+for command in jq sha256sum tar flock openssl; do
   command -v "$command" >/dev/null 2>&1 || { echo "Missing command: $command" >&2; exit 2; }
 done
 
@@ -51,10 +51,7 @@ fail_trap() {
 trap 'fail_trap $LINENO' ERR
 
 actual_artifact_sha256="$(sha256sum "$PAYLOAD" | awk '{print $1}')"
-[[ "$actual_artifact_sha256" == "$EXPECTED_ARTIFACT_SHA256" ]] || {
-  echo "Artifact digest mismatch." >&2
-  exit 1
-}
+[[ "$actual_artifact_sha256" == "$EXPECTED_ARTIFACT_SHA256" ]] || { echo "Artifact digest mismatch." >&2; exit 1; }
 
 metadata_sha="$(jq -r '.candidate_sha // empty' "$METADATA")"
 metadata_artifact="$(jq -r '.artifact_sha256 // empty' "$METADATA")"
@@ -68,15 +65,11 @@ metadata_branch="$(jq -r '.source_branch // empty' "$METADATA")"
 mkdir -p "$RELEASES_DIR" "$BACKUPS_DIR"
 [[ ! -e "$RELEASE_DIR" ]] || { echo "Release already exists: $RELEASE_DIR" >&2; exit 1; }
 mkdir "$RELEASE_DIR"
-
 tar -xzf "$PAYLOAD" -C "$RELEASE_DIR"
 [[ -f "$RELEASE_DIR/composer.lock" ]] || { echo "composer.lock missing from candidate." >&2; exit 1; }
 [[ -f "$RELEASE_DIR/vendor/autoload.php" ]] || { echo "vendor/autoload.php missing; PREPROD must not rebuild dependencies." >&2; exit 1; }
 [[ -f "$RELEASE_DIR/web/index.php" ]] || { echo "Drupal entrypoint missing." >&2; exit 1; }
-[[ "$(sha256sum "$RELEASE_DIR/composer.lock" | awk '{print $1}')" == "$EXPECTED_COMPOSER_LOCK_SHA256" ]] || {
-  echo "Extracted composer.lock digest mismatch." >&2
-  exit 1
-}
+[[ "$(sha256sum "$RELEASE_DIR/composer.lock" | awk '{print $1}')" == "$EXPECTED_COMPOSER_LOCK_SHA256" ]] || { echo "Extracted composer.lock digest mismatch." >&2; exit 1; }
 cp "$METADATA" "$RELEASE_DIR/.agency-candidate.json"
 chmod 0644 "$RELEASE_DIR/.agency-candidate.json"
 
@@ -84,7 +77,6 @@ rm -rf "$RELEASE_DIR/web/sites/default/files"
 ln -s "$SHARED_DIR/files" "$RELEASE_DIR/web/sites/default/files"
 rm -f "$RELEASE_DIR/web/sites/default/settings.php"
 ln -s "$SHARED_DIR/settings/settings.php" "$RELEASE_DIR/web/sites/default/settings.php"
-
 find "$RELEASE_DIR" -xdev -type d -exec chmod a+rx {} +
 find "$RELEASE_DIR" -xdev -type f -exec chmod a+r {} +
 
@@ -101,13 +93,15 @@ if [[ -L "$CURRENT_LINK" ]]; then
   fi
 fi
 
-# First real PREPROD deployment starts from existing config when the dedicated
-# database is empty. No production data is required for this first path.
-if ! mariadb --defaults-extra-file=/dev/null 2>/dev/null; then
-  true
-fi
-
-if ! (cd "$RELEASE_DIR" && vendor/bin/drush status --fields=bootstrap --format=string 2>/dev/null | grep -qi successful); then
+# First real PREPROD deployment uses the dedicated empty database plus committed
+# configuration. Subsequent deployments require the existing Drupal key_value
+# table to remain queryable. The test is performed through Drupal's own database
+# settings so no DB credential is exposed to this script or its logs.
+if ! (cd "$RELEASE_DIR" && vendor/bin/drush sql:query 'SELECT 1 FROM key_value LIMIT 1' >/dev/null 2>&1); then
+  if [[ -n "$ACTIVE_RELEASE" ]]; then
+    echo "Existing PREPROD database is not Drupal-queryable; refusing destructive re-install." >&2
+    exit 1
+  fi
   log "First PREPROD install from existing config"
   ADMIN_PASSWORD="$(openssl rand -hex 18)"
   (cd "$RELEASE_DIR" && vendor/bin/drush site:install --existing-config -y \
@@ -137,11 +131,7 @@ vendor/bin/drush cr
 mail_scheme="$(vendor/bin/drush config:get system.mail mailer_dsn.scheme --format=string)"
 mail_host="$(vendor/bin/drush config:get system.mail mailer_dsn.host --format=string)"
 mail_port="$(vendor/bin/drush config:get system.mail mailer_dsn.port --format=string)"
-[[ "$mail_scheme" == "smtp" && "$mail_host" == "127.0.0.1" && "$mail_port" == "1025" ]] || {
-  echo "PREPROD mail is not isolated to the local sink." >&2
-  exit 1
-}
-
+[[ "$mail_scheme" == "smtp" && "$mail_host" == "127.0.0.1" && "$mail_port" == "1025" ]] || { echo "PREPROD mail is not isolated to the local sink." >&2; exit 1; }
 analytics_id="$(vendor/bin/drush config:get google_tag.settings default_google_tag_entity --format=string 2>/dev/null || true)"
 [[ -z "$analytics_id" ]] || { echo "Production analytics remains enabled in PREPROD." >&2; exit 1; }
 
@@ -150,7 +140,6 @@ if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
   MAINTENANCE_ENABLED=0
 fi
 
-# Keep three application releases and ten PREPROD database backups.
 mapfile -t releases < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
 if (( ${#releases[@]} > 3 )); then
   for old in "${releases[@]:3}"; do
@@ -164,8 +153,7 @@ if (( ${#backups[@]} > 10 )); then
 fi
 
 printf '[%s] SUCCESS | sha=%s | artifact_sha256=%s | composer_lock_sha256=%s | release=%s\n' \
-  "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$CANDIDATE_SHA" "$EXPECTED_ARTIFACT_SHA256" "$EXPECTED_COMPOSER_LOCK_SHA256" "$RELEASE_DIR" \
-  >> "$SHARED_DIR/deployments.log"
+  "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$CANDIDATE_SHA" "$EXPECTED_ARTIFACT_SHA256" "$EXPECTED_COMPOSER_LOCK_SHA256" "$RELEASE_DIR" >> "$SHARED_DIR/deployments.log"
 
 cat <<EOF_RESULT
 PREPROD_DEPLOY=PASS

--- a/scripts/preproduction/deploy-artifact.sh
+++ b/scripts/preproduction/deploy-artifact.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 027
+
+CANDIDATE_SHA="${1:-}"
+EXPECTED_ARTIFACT_SHA256="${2:-}"
+EXPECTED_COMPOSER_LOCK_SHA256="${3:-}"
+PAYLOAD="${4:-}"
+METADATA="${5:-}"
+
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/agency-preprod}"
+RELEASES_DIR="$PROJECT_ROOT/releases"
+SHARED_DIR="$PROJECT_ROOT/shared"
+BACKUPS_DIR="$SHARED_DIR/backups"
+CURRENT_LINK="$PROJECT_ROOT/current"
+TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+RELEASE_DIR="$RELEASES_DIR/${TIMESTAMP}-${CANDIDATE_SHA:0:12}"
+ACTIVE_RELEASE=""
+MAINTENANCE_ENABLED=0
+SWITCH_COMPLETED=0
+
+[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid candidate SHA." >&2; exit 2; }
+[[ "$EXPECTED_ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "Invalid artifact digest." >&2; exit 2; }
+[[ "$EXPECTED_COMPOSER_LOCK_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "Invalid composer.lock digest." >&2; exit 2; }
+[[ -f "$PAYLOAD" && ! -L "$PAYLOAD" ]] || { echo "Candidate payload missing or unsafe." >&2; exit 2; }
+[[ -f "$METADATA" && ! -L "$METADATA" ]] || { echo "Candidate metadata missing or unsafe." >&2; exit 2; }
+
+for command in jq sha256sum tar flock; do
+  command -v "$command" >/dev/null 2>&1 || { echo "Missing command: $command" >&2; exit 2; }
+done
+
+log() { printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$1"; }
+
+fail_trap() {
+  local rc="$?"
+  local line="${1:-unknown}"
+  trap - ERR
+  set +e
+  log "ERROR line=$line exit=$rc"
+  if [[ "$SWITCH_COMPLETED" -eq 0 ]]; then
+    rm -rf "$RELEASE_DIR"
+  elif [[ -n "$ACTIVE_RELEASE" && -d "$ACTIVE_RELEASE" ]]; then
+    ln -sfn "$ACTIVE_RELEASE" "$CURRENT_LINK"
+    log "Code symlink restored to previous release; database rollback is intentionally not automatic."
+  fi
+  if [[ "$MAINTENANCE_ENABLED" -eq 1 && -n "$ACTIVE_RELEASE" && -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
+    (cd "$ACTIVE_RELEASE" && vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer) || true
+  fi
+  exit "$rc"
+}
+trap 'fail_trap $LINENO' ERR
+
+actual_artifact_sha256="$(sha256sum "$PAYLOAD" | awk '{print $1}')"
+[[ "$actual_artifact_sha256" == "$EXPECTED_ARTIFACT_SHA256" ]] || {
+  echo "Artifact digest mismatch." >&2
+  exit 1
+}
+
+metadata_sha="$(jq -r '.candidate_sha // empty' "$METADATA")"
+metadata_artifact="$(jq -r '.artifact_sha256 // empty' "$METADATA")"
+metadata_lock="$(jq -r '.composer_lock_sha256 // empty' "$METADATA")"
+metadata_branch="$(jq -r '.source_branch // empty' "$METADATA")"
+[[ "$metadata_sha" == "$CANDIDATE_SHA" ]] || { echo "Metadata candidate SHA mismatch." >&2; exit 1; }
+[[ "$metadata_artifact" == "$EXPECTED_ARTIFACT_SHA256" ]] || { echo "Metadata artifact digest mismatch." >&2; exit 1; }
+[[ "$metadata_lock" == "$EXPECTED_COMPOSER_LOCK_SHA256" ]] || { echo "Metadata composer.lock digest mismatch." >&2; exit 1; }
+[[ "$metadata_branch" == release/* ]] || { echo "Candidate source branch is not release/*." >&2; exit 1; }
+
+mkdir -p "$RELEASES_DIR" "$BACKUPS_DIR"
+[[ ! -e "$RELEASE_DIR" ]] || { echo "Release already exists: $RELEASE_DIR" >&2; exit 1; }
+mkdir "$RELEASE_DIR"
+
+tar -xzf "$PAYLOAD" -C "$RELEASE_DIR"
+[[ -f "$RELEASE_DIR/composer.lock" ]] || { echo "composer.lock missing from candidate." >&2; exit 1; }
+[[ -f "$RELEASE_DIR/vendor/autoload.php" ]] || { echo "vendor/autoload.php missing; PREPROD must not rebuild dependencies." >&2; exit 1; }
+[[ -f "$RELEASE_DIR/web/index.php" ]] || { echo "Drupal entrypoint missing." >&2; exit 1; }
+[[ "$(sha256sum "$RELEASE_DIR/composer.lock" | awk '{print $1}')" == "$EXPECTED_COMPOSER_LOCK_SHA256" ]] || {
+  echo "Extracted composer.lock digest mismatch." >&2
+  exit 1
+}
+cp "$METADATA" "$RELEASE_DIR/.agency-candidate.json"
+chmod 0644 "$RELEASE_DIR/.agency-candidate.json"
+
+rm -rf "$RELEASE_DIR/web/sites/default/files"
+ln -s "$SHARED_DIR/files" "$RELEASE_DIR/web/sites/default/files"
+rm -f "$RELEASE_DIR/web/sites/default/settings.php"
+ln -s "$SHARED_DIR/settings/settings.php" "$RELEASE_DIR/web/sites/default/settings.php"
+
+find "$RELEASE_DIR" -xdev -type d -exec chmod a+rx {} +
+find "$RELEASE_DIR" -xdev -type f -exec chmod a+r {} +
+
+if [[ -L "$CURRENT_LINK" ]]; then
+  ACTIVE_RELEASE="$(readlink -f "$CURRENT_LINK")"
+  [[ -d "$ACTIVE_RELEASE" ]] || { echo "Current release link is invalid." >&2; exit 1; }
+  if [[ -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
+    backup="$BACKUPS_DIR/db-${TIMESTAMP}.sql.gz"
+    log "Backup current PREPROD database"
+    (cd "$ACTIVE_RELEASE" && vendor/bin/drush sql:dump --gzip --result-file="$backup")
+    log "Enable PREPROD maintenance mode"
+    (cd "$ACTIVE_RELEASE" && vendor/bin/drush state:set system.maintenance_mode 1 --input-format=integer)
+    MAINTENANCE_ENABLED=1
+  fi
+fi
+
+# First real PREPROD deployment starts from existing config when the dedicated
+# database is empty. No production data is required for this first path.
+if ! mariadb --defaults-extra-file=/dev/null 2>/dev/null; then
+  true
+fi
+
+if ! (cd "$RELEASE_DIR" && vendor/bin/drush status --fields=bootstrap --format=string 2>/dev/null | grep -qi successful); then
+  log "First PREPROD install from existing config"
+  ADMIN_PASSWORD="$(openssl rand -hex 18)"
+  (cd "$RELEASE_DIR" && vendor/bin/drush site:install --existing-config -y \
+    --account-name=preprod-admin --account-pass="$ADMIN_PASSWORD")
+  printf 'username=preprod-admin\npassword=%s\n' "$ADMIN_PASSWORD" > "$SHARED_DIR/settings/preprod-admin.env"
+  chmod 0600 "$SHARED_DIR/settings/preprod-admin.env"
+fi
+
+log "Switch candidate into PREPROD current"
+ln -sfn "$RELEASE_DIR" "$CURRENT_LINK"
+SWITCH_COMPLETED=1
+[[ "$(readlink -f "$CURRENT_LINK")" == "$(readlink -f "$RELEASE_DIR")" ]] || { echo "Release switch failed." >&2; exit 1; }
+
+cd "$CURRENT_LINK"
+log "Drupal updb"
+vendor/bin/drush updb -y
+log "Drupal cim"
+vendor/bin/drush cim -y
+PREPROD_SPLIT="$CURRENT_LINK/config/splits/preproduction"
+[[ -d "$PREPROD_SPLIT" ]] || { echo "PREPROD split directory missing." >&2; exit 1; }
+log "PREPROD config split import"
+vendor/bin/drush config:import --source="$PREPROD_SPLIT" --partial -y
+log "Drupal cache rebuild"
+vendor/bin/drush cr
+
+# Fail closed on the side-effect contract before declaring the candidate live.
+mail_scheme="$(vendor/bin/drush config:get system.mail mailer_dsn.scheme --format=string)"
+mail_host="$(vendor/bin/drush config:get system.mail mailer_dsn.host --format=string)"
+mail_port="$(vendor/bin/drush config:get system.mail mailer_dsn.port --format=string)"
+[[ "$mail_scheme" == "smtp" && "$mail_host" == "127.0.0.1" && "$mail_port" == "1025" ]] || {
+  echo "PREPROD mail is not isolated to the local sink." >&2
+  exit 1
+}
+
+analytics_id="$(vendor/bin/drush config:get google_tag.settings default_google_tag_entity --format=string 2>/dev/null || true)"
+[[ -z "$analytics_id" ]] || { echo "Production analytics remains enabled in PREPROD." >&2; exit 1; }
+
+if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
+  vendor/bin/drush state:set system.maintenance_mode 0 --input-format=integer
+  MAINTENANCE_ENABLED=0
+fi
+
+# Keep three application releases and ten PREPROD database backups.
+mapfile -t releases < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+if (( ${#releases[@]} > 3 )); then
+  for old in "${releases[@]:3}"; do
+    old_path="$RELEASES_DIR/$old"
+    [[ "$(readlink -f "$CURRENT_LINK")" == "$(readlink -f "$old_path")" ]] || rm -rf "$old_path"
+  done
+fi
+mapfile -t backups < <(find "$BACKUPS_DIR" -maxdepth 1 -type f -name 'db-*.sql.gz' -printf '%f\n' | sort -r)
+if (( ${#backups[@]} > 10 )); then
+  for old in "${backups[@]:10}"; do rm -f "$BACKUPS_DIR/$old"; done
+fi
+
+printf '[%s] SUCCESS | sha=%s | artifact_sha256=%s | composer_lock_sha256=%s | release=%s\n' \
+  "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$CANDIDATE_SHA" "$EXPECTED_ARTIFACT_SHA256" "$EXPECTED_COMPOSER_LOCK_SHA256" "$RELEASE_DIR" \
+  >> "$SHARED_DIR/deployments.log"
+
+cat <<EOF_RESULT
+PREPROD_DEPLOY=PASS
+candidate_sha=$CANDIDATE_SHA
+artifact_sha256=$EXPECTED_ARTIFACT_SHA256
+composer_lock_sha256=$EXPECTED_COMPOSER_LOCK_SHA256
+release_dir=$RELEASE_DIR
+EOF_RESULT

--- a/scripts/preproduction/inspect-deploy.sh
+++ b/scripts/preproduction/inspect-deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REQUEST_ID="${1:-}"
+CANDIDATE_SHA="${2:-}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/agency-preprod}"
+REQUEST_DIR="$PROJECT_ROOT/shared/deploy-jobs/$REQUEST_ID"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+WORKER_SCRIPT="$REQUEST_DIR/worker.sh"
+
+if [[ ! "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ || ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ || "$REQUEST_ID" != *"-$CANDIDATE_SHA" ]]; then
+  printf 'schema_version=1\ncandidate_sha=%s\noutcome=INVALID\nreason=invalid_request_identity\n' "$CANDIDATE_SHA"
+  exit 0
+fi
+if [[ ! -d "$REQUEST_DIR" || -L "$REQUEST_DIR" ]]; then
+  printf 'schema_version=1\nrequest_id=%s\ncandidate_sha=%s\noutcome=NOT_STARTED\n' "$REQUEST_ID" "$CANDIDATE_SHA"
+  exit 0
+fi
+
+field() { sed -n "s/^${1}=//p" "$2" | head -n 1; }
+if [[ -s "$RESULT_FILE" && ! -L "$RESULT_FILE" ]]; then
+  [[ "$(field request_id "$RESULT_FILE")" == "$REQUEST_ID" ]] || { echo 'outcome=INVALID'; echo 'reason=result_request_mismatch'; exit 0; }
+  [[ "$(field candidate_sha "$RESULT_FILE")" == "$CANDIDATE_SHA" ]] || { echo 'outcome=INVALID'; echo 'reason=result_sha_mismatch'; exit 0; }
+  outcome="$(field outcome "$RESULT_FILE")"
+  [[ "$outcome" =~ ^(SUCCESS|FAILURE|LOCKED)$ ]] || { echo 'outcome=INVALID'; echo 'reason=result_outcome_invalid'; exit 0; }
+  cat "$RESULT_FILE"
+  exit 0
+fi
+if [[ -s "$PID_FILE" && ! -L "$PID_FILE" ]]; then
+  pid="$(tr -d '\r\n' < "$PID_FILE")"
+  if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+    command_line="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    if [[ "$command_line" == *"$WORKER_SCRIPT"* ]]; then
+      printf 'schema_version=1\nrequest_id=%s\ncandidate_sha=%s\noutcome=RUNNING\nworker_pid=%s\n' "$REQUEST_ID" "$CANDIDATE_SHA" "$pid"
+      exit 0
+    fi
+  fi
+  printf 'schema_version=1\nrequest_id=%s\ncandidate_sha=%s\noutcome=LOST\n' "$REQUEST_ID" "$CANDIDATE_SHA"
+  exit 0
+fi
+printf 'schema_version=1\nrequest_id=%s\ncandidate_sha=%s\noutcome=STARTING\n' "$REQUEST_ID" "$CANDIDATE_SHA"

--- a/scripts/preproduction/launch-deploy.sh
+++ b/scripts/preproduction/launch-deploy.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REQUEST_ID="${1:-}"
+CANDIDATE_SHA="${2:-}"
+ARTIFACT_SHA256="${3:-}"
+COMPOSER_LOCK_SHA256="${4:-}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/agency-preprod}"
+JOBS_DIR="$PROJECT_ROOT/shared/deploy-jobs"
+LOCK_FILE="$PROJECT_ROOT/shared/deploy.lock"
+REQUEST_DIR="$JOBS_DIR/$REQUEST_ID"
+DEPLOY_SCRIPT="$REQUEST_DIR/deploy-artifact.sh"
+PAYLOAD="$REQUEST_DIR/agency-release-candidate.tar.gz"
+METADATA="$REQUEST_DIR/candidate.json"
+WORKER_SCRIPT="$REQUEST_DIR/worker.sh"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+OUTPUT_FILE="$REQUEST_DIR/output.log"
+
+[[ "$REQUEST_ID" =~ ^run-[0-9]+-[0-9]+-[0-9a-f]{40}$ ]] || { echo "Invalid request id." >&2; exit 2; }
+[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid candidate SHA." >&2; exit 2; }
+[[ "$REQUEST_ID" == *"-$CANDIDATE_SHA" ]] || { echo "Request SHA mismatch." >&2; exit 2; }
+[[ "$ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "Invalid artifact digest." >&2; exit 2; }
+[[ "$COMPOSER_LOCK_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "Invalid lock digest." >&2; exit 2; }
+[[ -d "$REQUEST_DIR" && ! -L "$REQUEST_DIR" ]] || { echo "Unsafe request directory." >&2; exit 2; }
+for file in "$DEPLOY_SCRIPT" "$PAYLOAD" "$METADATA"; do
+  [[ -f "$file" && ! -L "$file" ]] || { echo "Required request file is missing or unsafe: $file" >&2; exit 2; }
+done
+[[ ! -e "$RESULT_FILE" && ! -e "$PID_FILE" ]] || { echo "Request was already launched." >&2; exit 2; }
+
+umask 077
+chmod 700 "$DEPLOY_SCRIPT"
+: > "$OUTPUT_FILE"
+
+cat > "$WORKER_SCRIPT" <<'EOF_WORKER'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+REQUEST_DIR="${1:?}"
+REQUEST_ID="${2:?}"
+CANDIDATE_SHA="${3:?}"
+ARTIFACT_SHA256="${4:?}"
+COMPOSER_LOCK_SHA256="${5:?}"
+LOCK_FILE="${6:?}"
+RESULT_FILE="$REQUEST_DIR/result.env"
+PID_FILE="$REQUEST_DIR/pid"
+OUTPUT_FILE="$REQUEST_DIR/output.log"
+RESULT_WRITTEN=0
+
+write_result() {
+  local outcome="$1" exit_code="$2"
+  local tmp="${RESULT_FILE}.tmp.$$"
+  RESULT_WRITTEN=1
+  {
+    printf 'schema_version=1\n'
+    printf 'request_id=%s\n' "$REQUEST_ID"
+    printf 'candidate_sha=%s\n' "$CANDIDATE_SHA"
+    printf 'artifact_sha256=%s\n' "$ARTIFACT_SHA256"
+    printf 'composer_lock_sha256=%s\n' "$COMPOSER_LOCK_SHA256"
+    printf 'outcome=%s\n' "$outcome"
+    printf 'exit_code=%s\n' "$exit_code"
+    printf 'finished_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$tmp"
+  mv -f "$tmp" "$RESULT_FILE"
+}
+trap 'rc=$?; [[ "$RESULT_WRITTEN" -eq 1 ]] || write_result FAILURE "$rc" || true' EXIT
+printf '%s\n' "$$" > "$PID_FILE"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  write_result LOCKED 75
+  exit 75
+fi
+set +e
+"$REQUEST_DIR/deploy-artifact.sh" \
+  "$CANDIDATE_SHA" "$ARTIFACT_SHA256" "$COMPOSER_LOCK_SHA256" \
+  "$REQUEST_DIR/agency-release-candidate.tar.gz" "$REQUEST_DIR/candidate.json" \
+  >> "$OUTPUT_FILE" 2>&1
+rc="$?"
+set -e
+if [[ "$rc" -eq 0 ]]; then write_result SUCCESS 0; else write_result FAILURE "$rc"; fi
+exit "$rc"
+EOF_WORKER
+chmod 700 "$WORKER_SCRIPT"
+nohup setsid --wait "$WORKER_SCRIPT" \
+  "$REQUEST_DIR" "$REQUEST_ID" "$CANDIDATE_SHA" "$ARTIFACT_SHA256" "$COMPOSER_LOCK_SHA256" "$LOCK_FILE" \
+  </dev/null >> "$REQUEST_DIR/bootstrap.log" 2>&1 &
+
+printf 'request_id=%s\ncandidate_sha=%s\nlauncher_outcome=DETACHED\n' "$REQUEST_ID" "$CANDIDATE_SHA"

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ConfigurationLanguageSafeProvenanceCohort754Test.php
@@ -84,7 +84,7 @@ final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
     $root = dirname(DRUPAL_ROOT);
     $files = glob($root . '/config/sync/*.yml');
     self::assertIsArray($files);
-    self::assertCount(595, $files);
+    self::assertCount(596, $files);
 
     $counts = [];
     foreach ($files as $path) {
@@ -99,7 +99,7 @@ final class ConfigurationLanguageSafeProvenanceCohort754Test extends TestCase {
 
     self::assertSame([
       '__none__' => 59,
-      'en' => 496,
+      'en' => 497,
       'fr' => 39,
       'und' => 1,
     ], $counts);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionRealHostWorkflowTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionRealHostWorkflowTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the first real PREPROD host and immutable deploy path.
+ *
+ * @group agency_project_tests
+ */
+final class PreproductionRealHostWorkflowTest extends TestCase {
+
+  /**
+   * The host bootstrap keeps PREPROD isolated from production.
+   */
+  public function testHostBootstrapIsIsolatedAndIdempotent(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/preproduction/bootstrap-host.sh';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'VERSION_CODENAME:-}" != "noble"',
+      '/var/www/agency-preprod',
+      'agency-preprod',
+      'php8.4-fpm',
+      'mariadb-11.8',
+      'max_allowed_packet = 64M',
+      'bind-address = 127.0.0.1',
+      'agency-preprod-smtp-sink.service',
+      '127.0.0.1:1025',
+      'systemctl disable --now postfix',
+      'X-Robots-Tag "noindex, nofollow, noarchive"',
+      'auth_basic "Agency PREPROD"',
+      "config_split.config_split.production']['status'] = FALSE",
+      "config_split.config_split.preproduction']['status'] = TRUE",
+      "putenv('OPENAI_API_KEY')",
+      "ufw allow 'Nginx Full'",
+      'certbot --nginx',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+
+    foreach ([
+      '/var/www/agency/current',
+      'EMERGING_DIGITAL_SMTP_',
+      'BETTERUPTIME_API_TOKEN',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * The PREPROD split routes mail only to the local sink.
+   */
+  public function testPreproductionSplitIsFailSafe(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $definition = DrupalYaml::decode((string) file_get_contents(
+      $root . '/config/sync/config_split.config_split.preproduction.yml',
+    ));
+    $mail = DrupalYaml::decode((string) file_get_contents(
+      $root . '/config/splits/preproduction/system.mail.yml',
+    ));
+
+    self::assertIsArray($definition);
+    self::assertIsArray($mail);
+    self::assertFalse($definition['status']);
+    self::assertSame('preproduction', $definition['id']);
+    self::assertContains('system.mail', $definition['complete_list']);
+    self::assertSame('smtp', $mail['mailer_dsn']['scheme']);
+    self::assertSame('127.0.0.1', $mail['mailer_dsn']['host']);
+    self::assertSame(1025, $mail['mailer_dsn']['port']);
+    self::assertNull($mail['mailer_dsn']['user']);
+    self::assertNull($mail['mailer_dsn']['password']);
+  }
+
+  /**
+   * PREPROD consumes the immutable candidate without rebuilding it.
+   */
+  public function testArtifactDeployerVerifiesIdentityWithoutRebuild(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/preproduction/deploy-artifact.sh';
+    self::assertFileExists($path);
+    $script = (string) file_get_contents($path);
+
+    foreach ([
+      'EXPECTED_ARTIFACT_SHA256',
+      'EXPECTED_COMPOSER_LOCK_SHA256',
+      'artifact_sha256',
+      'composer_lock_sha256',
+      "metadata_branch\" == release/*",
+      'vendor/autoload.php',
+      'site:install --existing-config',
+      'drush updb -y',
+      'drush cim -y',
+      'config/splits/preproduction',
+      'drush cr',
+      '127.0.0.1',
+      '1025',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $script);
+    }
+
+    foreach ([
+      'composer install',
+      'git clone',
+      'config/splits/production',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * Governed workflows remain PREPROD-only and prove the real candidate.
+   */
+  public function testWorkflowsArePreproductionOnlyAndTerminallyValidated(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $bootstrap = (string) file_get_contents(
+      $root . '/.github/workflows/bootstrap-preproduction.yml',
+    );
+    $deploy = (string) file_get_contents(
+      $root . '/.github/workflows/deploy-preproduction.yml',
+    );
+    self::assertIsArray(DrupalYaml::decode($bootstrap));
+    self::assertIsArray(DrupalYaml::decode($deploy));
+
+    foreach ([
+      'workflow_dispatch:',
+      'environment: preproduction',
+      'PREPROD_BOOTSTRAP_SSH_PRIVATE_KEY',
+      'PREPROD_DEPLOY_PUBLIC_KEY',
+      'PREPROD_HTTP_PASSWORD',
+      'preprod.emergingdigital.be',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $bootstrap);
+    }
+
+    foreach ([
+      'candidate_sha',
+      'build-release-candidate.yml',
+      'agency-release-candidate-$CANDIDATE_SHA',
+      'artifact_sha256',
+      'composer_lock_sha256',
+      'PREPROD_DEPLOY_SSH_PRIVATE_KEY',
+      'PREPROD_SERVER_HOST',
+      'PREPROD_SERVER_USER',
+      "probe live '/health/live' 3",
+      "probe ready '/health/ready' 5",
+      "'{\"status\":\"ok\"}'",
+      "! grep -qi '^location:'",
+      'PLAYWRIGHT_HTTP_USERNAME: preprod',
+      'PLAYWRIGHT_HTTP_PASSWORD',
+      'visual_desktop == "PASS"',
+      'visual_mobile == "PASS"',
+      'READY_FOR_PROD',
+      'WAITING_FOR_HUMAN_GO',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $deploy);
+    }
+
+    foreach ([$bootstrap, $deploy] as $workflow) {
+      foreach ([
+        '${{ secrets.SSH_PRIVATE_KEY }}',
+        '${{ secrets.SERVER_HOST }}',
+        '${{ secrets.SERVER_USER }}',
+        'BETTERUPTIME_API_TOKEN',
+        'deploy-production.yml',
+      ] as $forbidden) {
+        self::assertStringNotContainsString($forbidden, $workflow);
+      }
+    }
+  }
+
+  /**
+   * Basic Auth can be tested without leaking request headers into traces.
+   */
+  public function testPlaywrightProtectedTargetDisablesTraceRetention(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $config = (string) file_get_contents($root . '/playwright.config.mjs');
+
+    self::assertStringContainsString('PLAYWRIGHT_HTTP_USERNAME', $config);
+    self::assertStringContainsString('PLAYWRIGHT_HTTP_PASSWORD', $config);
+    self::assertStringContainsString('httpCredentials: protectedTarget', $config);
+    self::assertStringContainsString(
+      "trace: protectedTarget ? 'off' : 'retain-on-failure'",
+      $config,
+    );
+  }
+
+}


### PR DESCRIPTION
## #797 — vraie PREPROD, tranche de provisionnement

Cette PR prépare l’exécution réelle avant création de l’hôte. Elle n’invente aucun environnement et ne modifie pas le chemin de promotion PROD.

### Hôte reproductible
- bootstrap idempotent Ubuntu 24.04 LTS ;
- Nginx + PHP-FPM 8.4 ;
- MariaDB 11.8, `max_allowed_packet=64M`, bind local ;
- user `agency-preprod`, racine `/var/www/agency-preprod`, `releases/current/shared`, deploy-jobs + lock ;
- DB/user/settings/files/backups PREPROD isolés ;
- UFW, TLS Certbot, Basic Auth, `X-Robots-Tag: noindex` ;
- cron/queues non activés par défaut.

### Side effects fail-safe
- split `preproduction` distinct de `production` ;
- mail Symfony Mailer vers `smtp-sink` local `127.0.0.1:1025` ;
- Postfix MTA désactivé ;
- production Config Split forcé OFF ;
- OpenAI retiré de l’environnement runtime ;
- GA4 doit rester absent, contrôle fail-closed au déploiement.

### Même artefact, aucun rebuild PREPROD
`deploy-preproduction.yml` :
- accepte uniquement un SHA exact déjà construit par `build-release-candidate.yml` sur `release/*` ;
- récupère l’artifact GitHub exact ;
- vérifie SHA candidate + SHA-256 artifact + SHA-256 composer.lock ;
- transfère le tarball déjà construit ;
- aucun `composer install` ni `git clone` sur PREPROD ;
- worker détaché + lock + backup + releases/current/shared ;
- `updb -> cim -> preproduction split -> cr` ;
- vérifie l’identité réellement active.

### Validation terminale réelle prévue dans le même run
- Basic Auth réellement protectrice ;
- `/health/live` 200 direct, JSON, no-store, <=3s ;
- `/health/ready` 200 direct, JSON, no-store, <=5s ;
- smoke `/fr/blog` ;
- Playwright desktop + mobile avec Basic Auth, traces désactivées afin de ne pas persister `Authorization` ;
- evidence non sensible ;
- résultat terminal `READY_FOR_PROD / WAITING_FOR_HUMAN_GO`.

### Important
Aucun serveur n’est encore déclaré réel. Après CI/merge de cette route, la prochaine étape est la création physique d’une VM PREPROD distincte de PROD, le DNS `preprod.emergingdigital.be` et les secrets **PREPROD-only**. Aucun secret PROD n’est réutilisé.

Le workflow `deploy-production.yml` et son déclenchement actuel restent inchangés dans #797.

Refs #797 #758.