### PR TITLE
Issue #800: recover PREPROD runtime validation evidence

### DIFF
--- a/.github/workflows/deploy-preproduction.yml
+++ b/.github/workflows/deploy-preproduction.yml
@@ -119,13 +119,14 @@ jobs:
             scripts/preproduction/deploy-candidate.sh \
             scripts/preproduction/launch-deploy.sh \
             scripts/preproduction/inspect-deploy.sh \
+            scripts/preproduction/validate-runtime.sh \
             artifacts/preproduction-candidate/agency-release-candidate.tar.gz \
             artifacts/preproduction-candidate/agency-release-candidate.tar.gz.sha256 \
             artifacts/preproduction-candidate/candidate.json \
             "$SERVER_USER@$SERVER_HOST:$remote_dir/"
 
           ssh "$SERVER_USER@$SERVER_HOST" \
-            "chmod 700 '$remote_dir/deploy-candidate.sh' '$remote_dir/launch-deploy.sh' '$remote_dir/inspect-deploy.sh'; chmod 600 '$remote_dir/agency-release-candidate.tar.gz' '$remote_dir/agency-release-candidate.tar.gz.sha256' '$remote_dir/candidate.json'"
+            "chmod 700 '$remote_dir/deploy-candidate.sh' '$remote_dir/launch-deploy.sh' '$remote_dir/inspect-deploy.sh' '$remote_dir/validate-runtime.sh'; chmod 600 '$remote_dir/agency-release-candidate.tar.gz' '$remote_dir/agency-release-candidate.tar.gz.sha256' '$remote_dir/candidate.json'"
 
       - name: Launch detached PREPROD worker
         env:
@@ -243,6 +244,23 @@ jobs:
           collect_remote_evidence
           test "$terminal_outcome" = 'SUCCESS'
 
+      - name: Validate PREPROD runtime isolation and capacity
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/preproduction-validation
+          ssh \
+            -o ConnectTimeout=10 \
+            "$SERVER_USER@$SERVER_HOST" \
+            "'$REMOTE_DIR/validate-runtime.sh'" \
+            | tee artifacts/preproduction-validation/runtime.env
+          grep -Fxq 'side_effects=PASS' artifacts/preproduction-validation/runtime.env
+          grep -Fxq 'capacity_observed=PASS' artifacts/preproduction-validation/runtime.env
+
       - name: Validate direct health and protected HTTP smoke
         env:
           BASIC_USER: ${{ secrets.PREPROD_BASIC_AUTH_USER }}
@@ -258,15 +276,19 @@ jobs:
             body="artifacts/preproduction-validation/health-${endpoint}.json"
             status="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
               "$PREPROD_URL/health/$endpoint")"
+            printf 'health_%s_status=%s\n' "$endpoint" "$status" \
+              >> artifacts/preproduction-validation/http.env
             test "$status" = '200'
             test "$(jq -r '.status' "$body")" = 'ok'
           done
 
-          smoke_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+          smoke_status="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' \
             --user "$BASIC_USER:$BASIC_PASSWORD" \
             "$PREPROD_URL/fr/blog")"
+          printf 'http_smoke_status=%s\n' "$smoke_status" \
+            >> artifacts/preproduction-validation/http.env
           test "$smoke_status" = '200'
-          printf 'http_smoke=PASS\n' > artifacts/preproduction-validation/smoke.env
+          printf 'http_smoke=PASS\n' >> artifacts/preproduction-validation/http.env
 
       - name: Setup Node for Browser Validation
         uses: actions/setup-node@v4

--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -32,6 +32,7 @@ jobs:
           bash -n scripts/preproduction/deploy-candidate.sh
           bash -n scripts/preproduction/launch-deploy.sh
           bash -n scripts/preproduction/inspect-deploy.sh
+          bash -n scripts/preproduction/validate-runtime.sh
       - name: Validate PREPROD templates and immutable deploy boundaries
         shell: bash
         run: |
@@ -44,3 +45,8 @@ jobs:
           grep -Fq 'ARTIFACTS_DIR="$SHARED_DIR/artifacts"' scripts/preproduction/deploy-candidate.sh
           ! grep -Fq 'composer install' scripts/preproduction/deploy-candidate.sh
           ! grep -Fq 'git clone' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'side_effects=PASS' scripts/preproduction/validate-runtime.sh
+          grep -Fq 'oom_kill_count=' scripts/preproduction/validate-runtime.sh
+          grep -Fq 'sendmail_path' scripts/preproduction/validate-runtime.sh
+          grep -Fq 'scripts/preproduction/validate-runtime.sh' .github/workflows/deploy-preproduction.yml
+          grep -Fq 'curl --silent --show-error --location' .github/workflows/deploy-preproduction.yml

--- a/scripts/preproduction/validate-runtime.sh
+++ b/scripts/preproduction/validate-runtime.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 027
+
+PROJECT_ROOT="/var/www/agency-preprod"
+CURRENT="$PROJECT_ROOT/current"
+DRUSH="$CURRENT/vendor/bin/drush"
+
+fail() {
+  printf '[preprod-runtime] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ -L "$CURRENT" ]] || fail "Current PREPROD release symlink is missing."
+[[ -x "$DRUSH" ]] || fail "Drush is unavailable in the active PREPROD release."
+
+cd "$CURRENT"
+
+"$DRUSH" --quiet php:eval '
+$config = \Drupal::config("automated_cron.settings");
+if ((int) $config->get("interval") !== 0) {
+  throw new \RuntimeException("Automated cron is not disabled in PREPROD.");
+}
+$mail = \Drupal::config("system.mail");
+if ($mail->get("interface.default") !== "symfony_mailer") {
+  throw new \RuntimeException("PREPROD mail interface is not symfony_mailer.");
+}
+if ($mail->get("mailer_dsn.scheme") !== "native") {
+  throw new \RuntimeException("PREPROD mail transport is not native.");
+}
+if ($mail->get("mailer_dsn.user") !== NULL || $mail->get("mailer_dsn.password") !== NULL) {
+  throw new \RuntimeException("PREPROD mail transport unexpectedly contains credentials.");
+}
+if ((bool) \Drupal::config("config_split.config_split.production")->get("status") !== FALSE) {
+  throw new \RuntimeException("Production Config Split is active in PREPROD.");
+}
+if ((bool) \Drupal::config("config_split.config_split.preproduction")->get("status") !== TRUE) {
+  throw new \RuntimeException("PREPROD Config Split is not active.");
+}
+if (\Drupal::config("google_tag.settings")->get("default_google_tag_entity") !== NULL) {
+  throw new \RuntimeException("Google Tag is active in PREPROD.");
+}
+'
+
+sendmail_path="$(php8.4 -r 'echo (string) ini_get("sendmail_path");')"
+[[ "$sendmail_path" == "/bin/true" ]] || fail "PHP CLI sendmail_path is not /bin/true."
+
+mem_total_bytes="$(awk '/^MemTotal:/ {print $2 * 1024}' /proc/meminfo | cut -d. -f1)"
+mem_available_bytes="$(awk '/^MemAvailable:/ {print $2 * 1024}' /proc/meminfo | cut -d. -f1)"
+swap_total_bytes="$(awk '/^SwapTotal:/ {print $2 * 1024}' /proc/meminfo | cut -d. -f1)"
+swap_free_bytes="$(awk '/^SwapFree:/ {print $2 * 1024}' /proc/meminfo | cut -d. -f1)"
+cpu_count="$(nproc)"
+disk_total_bytes="$(df -B1 --output=size "$PROJECT_ROOT" | tail -n 1 | tr -d ' ')"
+disk_used_bytes="$(df -B1 --output=used "$PROJECT_ROOT" | tail -n 1 | tr -d ' ')"
+disk_available_bytes="$(df -B1 --output=avail "$PROJECT_ROOT" | tail -n 1 | tr -d ' ')"
+disk_used_percent="$(df -P "$PROJECT_ROOT" | awk 'NR == 2 {gsub(/%/, "", $5); print $5}')"
+oom_kill_count="$(awk '$1 == "oom_kill" {print $2}' /proc/vmstat 2>/dev/null || true)"
+oom_kill_count="${oom_kill_count:-0}"
+
+printf 'schema_version=1\n'
+printf 'side_effects=PASS\n'
+printf 'automated_cron=OFF\n'
+printf 'mail_transport=NATIVE_NULL_CREDENTIALS\n'
+printf 'php_sendmail_path=BIN_TRUE\n'
+printf 'production_config_split=OFF\n'
+printf 'preproduction_config_split=ON\n'
+printf 'google_tag=OFF\n'
+printf 'cpu_count=%s\n' "$cpu_count"
+printf 'mem_total_bytes=%s\n' "$mem_total_bytes"
+printf 'mem_available_bytes=%s\n' "$mem_available_bytes"
+printf 'swap_total_bytes=%s\n' "$swap_total_bytes"
+printf 'swap_free_bytes=%s\n' "$swap_free_bytes"
+printf 'disk_total_bytes=%s\n' "$disk_total_bytes"
+printf 'disk_used_bytes=%s\n' "$disk_used_bytes"
+printf 'disk_available_bytes=%s\n' "$disk_available_bytes"
+printf 'disk_used_percent=%s\n' "$disk_used_percent"
+printf 'oom_kill_count=%s\n' "$oom_kill_count"
+printf 'capacity_observed=PASS\n'


### PR DESCRIPTION
Refs #800 #797

## Défaut récupéré
Le premier déploiement immuable réel a réussi sur PREPROD, ainsi que `/health/live` et `/health/ready`. Le run échouait ensuite sur le smoke `/fr/blog`, dont le gate ne suivait pas les redirects et ne persistait pas le statut HTTP terminal.

## Correctif borné
- smoke protégé browser-equivalent avec suivi des redirects et statut HTTP non sensible persisté ;
- script runtime PREPROD pour prouver cron désactivé, mail natif sans credentials, `sendmail_path=/bin/true`, split production OFF, split preproduction ON, Google Tag OFF ;
- mesure CPU, mémoire disponible, swap, disque et compteur `oom_kill` ;
- validation shell/contract PR étendue au nouveau script.

## Invariants
- aucun rebuild sur PREPROD ;
- exact SHA + exact artifact digest inchangés comme frontière de déploiement ;
- aucun secret imprimé ;
- aucune mutation PROD ;
- aucun changement du trigger `main -> PROD`.

Après merge vert, #797 re-coupera une candidate depuis le nouveau `main` et rejouera la chaîne immuable réelle jusqu’à health/smoke/Playwright.