### PR TITLE
Issue #802: bound PREPROD release and backup retention

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -50,3 +50,7 @@ jobs:
           grep -Fq 'sendmail_path' scripts/preproduction/validate-runtime.sh
           grep -Fq 'scripts/preproduction/validate-runtime.sh' .github/workflows/deploy-preproduction.yml
           grep -Fq 'curl --silent --show-error --location' .github/workflows/deploy-preproduction.yml
+          grep -Fq 'db-${TIMESTAMP}-${EXPECTED_SHA:0:12}.sql"' scripts/preproduction/deploy-candidate.sh
+          grep -Fq "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh
+          grep -Fq "release_retention='WARNING'" scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'active candidate remains valid' scripts/preproduction/deploy-candidate.sh

--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -51,6 +51,6 @@ jobs:
           grep -Fq 'scripts/preproduction/validate-runtime.sh' .github/workflows/deploy-preproduction.yml
           grep -Fq 'curl --silent --show-error --location' .github/workflows/deploy-preproduction.yml
           grep -Fq 'db-${TIMESTAMP}-${EXPECTED_SHA:0:12}.sql"' scripts/preproduction/deploy-candidate.sh
-          grep -Fq "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh
+          grep -Fq -- "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh
           grep -Fq "release_retention='WARNING'" scripts/preproduction/deploy-candidate.sh
           grep -Fq 'active candidate remains valid' scripts/preproduction/deploy-candidate.sh

--- a/scripts/preproduction/deploy-candidate.sh
+++ b/scripts/preproduction/deploy-candidate.sh
@@ -125,7 +125,7 @@ if [[ -L "$CURRENT_LINK" ]]; then
 fi
 
 if [[ -n "$ACTIVE_RELEASE" && -x "$ACTIVE_RELEASE/vendor/bin/drush" ]]; then
-  backup="$BACKUPS_DIR/db-${TIMESTAMP}-${EXPECTED_SHA:0:12}.sql.gz"
+  backup="$BACKUPS_DIR/db-${TIMESTAMP}-${EXPECTED_SHA:0:12}.sql"
   log "Create pre-deploy database backup."
   (
     cd "$ACTIVE_RELEASE"
@@ -192,21 +192,38 @@ fi
 } > "$EVIDENCE"
 chmod 640 "$EVIDENCE"
 
+release_retention='PASS'
 mapfile -t releases < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
 if (( ${#releases[@]} > 3 )); then
   for release in "${releases[@]:3}"; do
     release_path="$RELEASES_DIR/$release"
     if [[ "$(readlink -f "$CURRENT_LINK")" != "$(readlink -f "$release_path")" ]]; then
-      rm -rf "$release_path"
+      if ! rm -rf "$release_path"; then
+        release_retention='WARNING'
+        log "Warning: unable to prune stale release $release; active candidate remains valid."
+      fi
     fi
   done
 fi
 
-mapfile -t backups < <(find "$BACKUPS_DIR" -maxdepth 1 -type f -name 'db-*.sql.gz' -printf '%f\n' | sort -r)
+backup_retention='PASS'
+mapfile -t backups < <(
+  find "$BACKUPS_DIR" -maxdepth 1 -type f \
+    \( -name 'db-*.sql.gz' -o -name 'db-*.sql.gz.gz' \) \
+    -printf '%f\n' | sort -r
+)
 if (( ${#backups[@]} > 10 )); then
   for backup in "${backups[@]:10}"; do
-    rm -f "$BACKUPS_DIR/$backup"
+    if ! rm -f "$BACKUPS_DIR/$backup"; then
+      backup_retention='WARNING'
+      log "Warning: unable to prune stale database backup $backup."
+    fi
   done
 fi
+
+{
+  printf 'release_retention=%s\n' "$release_retention"
+  printf 'backup_retention=%s\n' "$backup_retention"
+} >> "$EVIDENCE"
 
 log "Candidate deployed without rebuild: $EXPECTED_SHA / $EXPECTED_ARTIFACT_SHA256."


### PR DESCRIPTION
Refs #802 #797

## Défaut récupéré
La candidate r2 a été activée avec `updb`, `cim`, split PREPROD et `cr` verts, puis le worker a échoué uniquement lors de la suppression d'une ancienne release contenant des fichiers non supprimables par `agency-preprod`.

Les mêmes logs ont prouvé que `sql:dump --gzip` recevait déjà un nom finissant en `.gz`, produisant des dumps `.sql.gz.gz` hors du motif de rétention.

## Correctif borné
- la purge d'une ancienne release non supprimable devient un warning de housekeeping après activation/evidence du candidat ;
- le warning est persisté dans `deployment-evidence.env` ;
- les nouveaux dumps utilisent une base `.sql` afin que Drush produise un seul `.gz` ;
- la rétention reconnaît temporairement les anciens `.sql.gz.gz` et les nouveaux `.sql.gz` ;
- validation PREPROD dédiée renforcée.

## Invariants
- aucune reconstruction sur l'hôte ;
- identité SHA + digest inchangée comme frontière de déploiement ;
- aucune mutation PROD ;
- aucune justification de resize issue de ce défaut.
