### PR TITLE
Issue #804: reconcile PREPROD Basic Auth safely

### DIFF
--- a/.github/workflows/deploy-preproduction.yml
+++ b/.github/workflows/deploy-preproduction.yml
@@ -120,13 +120,14 @@ jobs:
             scripts/preproduction/launch-deploy.sh \
             scripts/preproduction/inspect-deploy.sh \
             scripts/preproduction/validate-runtime.sh \
+            scripts/preproduction/reconcile-basic-auth.sh \
             artifacts/preproduction-candidate/agency-release-candidate.tar.gz \
             artifacts/preproduction-candidate/agency-release-candidate.tar.gz.sha256 \
             artifacts/preproduction-candidate/candidate.json \
             "$SERVER_USER@$SERVER_HOST:$remote_dir/"
 
           ssh "$SERVER_USER@$SERVER_HOST" \
-            "chmod 700 '$remote_dir/deploy-candidate.sh' '$remote_dir/launch-deploy.sh' '$remote_dir/inspect-deploy.sh' '$remote_dir/validate-runtime.sh'; chmod 600 '$remote_dir/agency-release-candidate.tar.gz' '$remote_dir/agency-release-candidate.tar.gz.sha256' '$remote_dir/candidate.json'"
+            "chmod 700 '$remote_dir/deploy-candidate.sh' '$remote_dir/launch-deploy.sh' '$remote_dir/inspect-deploy.sh' '$remote_dir/validate-runtime.sh' '$remote_dir/reconcile-basic-auth.sh'; chmod 600 '$remote_dir/agency-release-candidate.tar.gz' '$remote_dir/agency-release-candidate.tar.gz.sha256' '$remote_dir/candidate.json'"
 
       - name: Launch detached PREPROD worker
         env:
@@ -260,6 +261,33 @@ jobs:
             | tee artifacts/preproduction-validation/runtime.env
           grep -Fxq 'side_effects=PASS' artifacts/preproduction-validation/runtime.env
           grep -Fxq 'capacity_observed=PASS' artifacts/preproduction-validation/runtime.env
+
+      - name: Reconcile and validate PREPROD Basic Auth
+        env:
+          SERVER_HOST: ${{ secrets.PREPROD_SERVER_HOST }}
+          SERVER_USER: ${{ secrets.PREPROD_SERVER_USER }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+          BASIC_USER: ${{ secrets.PREPROD_BASIC_AUTH_USER }}
+          BASIC_PASSWORD: ${{ secrets.PREPROD_BASIC_AUTH_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$BASIC_USER"
+          test -n "$BASIC_PASSWORD"
+          mkdir -p artifacts/preproduction-validation
+          basic_user_b64="$(printf '%s' "$BASIC_USER" | base64 -w 0)"
+          basic_password_b64="$(printf '%s' "$BASIC_PASSWORD" | base64 -w 0)"
+          {
+            printf '%s\n' "$basic_user_b64"
+            printf '%s\n' "$basic_password_b64"
+          } | ssh \
+            -o ConnectTimeout=10 \
+            "$SERVER_USER@$SERVER_HOST" \
+            "'$REMOTE_DIR/reconcile-basic-auth.sh'" \
+            | tee artifacts/preproduction-validation/basic-auth.env
+          unset basic_user_b64 basic_password_b64
+          grep -Fxq 'basic_auth_credentials=PASS' \
+            artifacts/preproduction-validation/basic-auth.env
 
       - name: Validate direct health and protected HTTP smoke
         env:

--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -33,6 +33,7 @@ jobs:
           bash -n scripts/preproduction/launch-deploy.sh
           bash -n scripts/preproduction/inspect-deploy.sh
           bash -n scripts/preproduction/validate-runtime.sh
+          bash -n scripts/preproduction/reconcile-basic-auth.sh
       - name: Validate PREPROD templates and immutable deploy boundaries
         shell: bash
         run: |
@@ -49,6 +50,10 @@ jobs:
           grep -Fq 'oom_kill_count=' scripts/preproduction/validate-runtime.sh
           grep -Fq 'sendmail_path' scripts/preproduction/validate-runtime.sh
           grep -Fq 'scripts/preproduction/validate-runtime.sh' .github/workflows/deploy-preproduction.yml
+          grep -Fq 'scripts/preproduction/reconcile-basic-auth.sh' .github/workflows/deploy-preproduction.yml
+          grep -Fq 'basic_auth_credentials=PASS' scripts/preproduction/reconcile-basic-auth.sh
+          grep -Fq 'basic_auth_reconciliation_method=NO_PRIVILEGED_WRITE' scripts/preproduction/reconcile-basic-auth.sh
+          grep -Fq 'sudo -n install -o root -g www-data -m 640' scripts/preproduction/reconcile-basic-auth.sh
           grep -Fq 'curl --silent --show-error --location' .github/workflows/deploy-preproduction.yml
           grep -Fq 'db-${TIMESTAMP}-${EXPECTED_SHA:0:12}.sql"' scripts/preproduction/deploy-candidate.sh
           grep -Fq -- "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh

--- a/scripts/preproduction/reconcile-basic-auth.sh
+++ b/scripts/preproduction/reconcile-basic-auth.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+HTPASSWD_FILE="/etc/nginx/agency-preprod.htpasswd"
+TMP_FILE=""
+
+cleanup() {
+  if [[ -n "$TMP_FILE" && -f "$TMP_FILE" ]]; then
+    rm -f "$TMP_FILE"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'schema_version=1\n'
+  printf 'basic_auth_credentials=FAIL\n'
+  printf 'basic_auth_reconciled=NO\n'
+  printf 'basic_auth_failure=%s\n' "$1"
+  exit 1
+}
+
+read -r basic_user_b64 || fail 'MISSING_USERNAME_INPUT'
+read -r basic_password_b64 || fail 'MISSING_PASSWORD_INPUT'
+
+BASIC_USER="$(printf '%s' "$basic_user_b64" | base64 --decode)" || \
+  fail 'INVALID_USERNAME_INPUT'
+BASIC_PASSWORD="$(printf '%s' "$basic_password_b64" | base64 --decode)" || \
+  fail 'INVALID_PASSWORD_INPUT'
+unset basic_user_b64 basic_password_b64
+
+[[ -n "$BASIC_USER" ]] || fail 'EMPTY_USERNAME'
+[[ -n "$BASIC_PASSWORD" ]] || fail 'EMPTY_PASSWORD'
+[[ -f "$HTPASSWD_FILE" ]] || fail 'HTPASSWD_MISSING'
+[[ -r "$HTPASSWD_FILE" ]] || fail 'HTPASSWD_UNREADABLE'
+command -v htpasswd >/dev/null 2>&1 || fail 'HTPASSWD_TOOL_MISSING'
+
+verify_credentials() {
+  printf '%s\n' "$BASIC_PASSWORD" | \
+    htpasswd -vi "$HTPASSWD_FILE" "$BASIC_USER" >/dev/null 2>&1
+}
+
+if cut -d: -f1 "$HTPASSWD_FILE" | grep -Fxq "$BASIC_USER"; then
+  username_match='PASS'
+else
+  username_match='FAIL'
+fi
+
+if verify_credentials; then
+  printf 'schema_version=1\n'
+  printf 'basic_auth_username_match=%s\n' "$username_match"
+  printf 'basic_auth_credentials=PASS\n'
+  printf 'basic_auth_reconciled=NO\n'
+  printf 'basic_auth_reconciliation_method=NOT_REQUIRED\n'
+  exit 0
+fi
+
+TMP_FILE="$(mktemp /tmp/agency-preprod-htpasswd.XXXXXX)"
+printf '%s\n' "$BASIC_PASSWORD" | \
+  htpasswd -B -i -c "$TMP_FILE" "$BASIC_USER" >/dev/null 2>&1
+chmod 600 "$TMP_FILE"
+
+reconciliation_method=''
+if [[ -w "$HTPASSWD_FILE" ]] && cat "$TMP_FILE" > "$HTPASSWD_FILE"; then
+  reconciliation_method='DIRECT_WRITE'
+elif command -v sudo >/dev/null 2>&1 && \
+  sudo -n install -o root -g www-data -m 640 \
+    "$TMP_FILE" "$HTPASSWD_FILE" >/dev/null 2>&1; then
+  reconciliation_method='SUDO_INSTALL'
+else
+  printf 'schema_version=1\n'
+  printf 'basic_auth_username_match=%s\n' "$username_match"
+  printf 'basic_auth_credentials=FAIL\n'
+  printf 'basic_auth_reconciled=NO\n'
+  printf 'basic_auth_reconciliation_method=NO_PRIVILEGED_WRITE\n'
+  exit 42
+fi
+
+verify_credentials || fail 'RECONCILIATION_VERIFY_FAILED'
+
+printf 'schema_version=1\n'
+printf 'basic_auth_username_match=%s\n' "$username_match"
+printf 'basic_auth_credentials=PASS\n'
+printf 'basic_auth_reconciled=YES\n'
+printf 'basic_auth_reconciliation_method=%s\n' "$reconciliation_method"


### PR DESCRIPTION
Refs #804 #797

## Défaut récupéré
La candidate r3 est entièrement verte jusqu'au smoke protégé : worker SUCCESS, runtime isolation PASS, side-effects PASS, capacité PASS, `/health/live` et `/health/ready` 200/ok. Le couple Basic Auth des secrets GitHub reçoit encore HTTP 401.

## Correctif borné
- vérifie le couple GitHub contre le `htpasswd` sans imprimer les credentials ;
- si nécessaire, régénère un hash bcrypt dans un fichier temporaire et tente uniquement une écriture déjà autorisée : direct write ou `sudo -n install` borné ;
- ne désactive jamais Basic Auth et ne modifie pas Nginx ;
- persiste seulement des états non sensibles (`PASS`, `reconciled`, méthode ou `NO_PRIVILEGED_WRITE`) ;
- validation shell/contract étendue.

## Invariants
- aucun secret en logs/issues ;
- aucun rebuild PREPROD ;
- exact SHA + artifact digest restent la frontière de déploiement ;
- aucun changement PROD ni du mécanisme `main -> PROD` ;
- aucun resize sans preuve capacité.

Après CI verte + merge, #797 recoupera depuis le nouveau main et poursuivra jusqu'à smoke/Playwright terminaux.