### PR TITLE
Issue #806: bind PREPROD browser contracts to their specs

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Validate PREPROD shell syntax
+      - name: Validate PREPROD shell and browser syntax
         shell: bash
         run: |
           set -euo pipefail
@@ -34,6 +34,7 @@ jobs:
           bash -n scripts/preproduction/inspect-deploy.sh
           bash -n scripts/preproduction/validate-runtime.sh
           bash -n scripts/preproduction/reconcile-basic-auth.sh
+          node --check playwright.config.mjs
       - name: Validate PREPROD templates and immutable deploy boundaries
         shell: bash
         run: |
@@ -59,3 +60,10 @@ jobs:
           grep -Fq -- "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh
           grep -Fq "release_retention='WARNING'" scripts/preproduction/deploy-candidate.sh
           grep -Fq 'active candidate remains valid' scripts/preproduction/deploy-candidate.sh
+          test -f tests/browser/contracts/public-blog.json
+          test -f tests/browser/contracts/production-editorial-401.json
+          grep -Fq "'public-blog.json': '**/public-blog.spec.mjs'" playwright.config.mjs
+          grep -Fq "'production-editorial-401.json': '**/production-editorial-article.spec.mjs'" playwright.config.mjs
+          grep -Fq 'testMatch: contractTestMatch' playwright.config.mjs
+          grep -Fq 'Unsupported BROWSER_VALIDATION_CONTRACT' playwright.config.mjs
+          grep -Fq 'assert.deepEqual(Object.keys(contract).sort(), requiredTopLevelKeys.sort())' tests/browser/production-editorial-article.spec.mjs

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,12 +1,28 @@
+import path from 'node:path';
 import { defineConfig } from '@playwright/test';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL;
 const httpUsername = process.env.BROWSER_VALIDATION_HTTP_USERNAME ?? '';
 const httpPassword = process.env.BROWSER_VALIDATION_HTTP_PASSWORD ?? '';
+const contractFile = path.basename(
+  process.env.BROWSER_VALIDATION_CONTRACT
+    ?? 'tests/browser/contracts/public-blog.json',
+);
+const contractTestMatches = {
+  'public-blog.json': '**/public-blog.spec.mjs',
+  'production-editorial-401.json': '**/production-editorial-article.spec.mjs',
+};
+const contractTestMatch = contractTestMatches[contractFile];
 
 if (!baseURL) {
   throw new Error(
     'PLAYWRIGHT_BASE_URL is required. Use `npm run browser:validate` to detect DDEV automatically.',
+  );
+}
+
+if (!contractTestMatch) {
+  throw new Error(
+    `Unsupported BROWSER_VALIDATION_CONTRACT: ${contractFile}`,
   );
 }
 
@@ -25,6 +41,7 @@ const httpCredentials = httpUsername && httpPassword
 
 export default defineConfig({
   testDir: './tests/browser',
+  testMatch: contractTestMatch,
   timeout: 30_000,
   expect: {
     timeout: 5_000,


### PR DESCRIPTION
Refs #806 #797

## Diagnostic
La candidate r4 a passé l’intégralité du chemin PREPROD jusqu’au browser gate. Le run a échoué avant toute exécution desktop/mobile parce que le config Playwright chargeait tous les specs de `tests/browser` sous un seul `BROWSER_VALIDATION_CONTRACT`.

Le test `production-editorial-article.spec.mjs` et son contrat #401 restent cohérents et dédiés au proof éditorial. Le workflow browser canonique #398 sélectionne déjà explicitement `public-blog.spec.mjs` pour le contrat `public-blog.json`.

## Correctif
- `playwright.config.mjs` route désormais `public-blog.json` uniquement vers `public-blog.spec.mjs` ;
- `production-editorial-401.json` uniquement vers `production-editorial-article.spec.mjs` ;
- tout contrat inconnu échoue fermé ;
- la validation PREPROD vérifie la syntaxe Node, les deux bindings et la présence intacte du contrôle de schéma strict #401.

## Validation locale
- `node --check playwright.config.mjs` = PASS ;
- mapping public-blog -> public-blog.spec = PASS ;
- mapping production-editorial-401 -> production-editorial-article.spec = PASS ;
- contrat inconnu non routé = PASS.

## Invariants
- aucun contrôle de schéma supprimé ou assoupli ;
- aucun changement applicatif Drupal ;
- aucune mutation PROD ;
- aucun resize ;
- après merge, recut r5 requis car ces fichiers versionnés sont inclus dans les bytes de release.
