### PR TITLE
Issue #808: recover PREPROD mobile proof and governed content

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -11,6 +11,7 @@ on:
       - 'playwright.config.mjs'
       - 'scripts/preproduction/**'
       - 'scripts/run-browser-validation.mjs'
+      - 'tests/browser/**'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php'
 
 permissions:
@@ -35,6 +36,7 @@ jobs:
           bash -n scripts/preproduction/validate-runtime.sh
           bash -n scripts/preproduction/reconcile-basic-auth.sh
           node --check playwright.config.mjs
+          node --check tests/browser/public-blog.spec.mjs
       - name: Validate PREPROD templates and immutable deploy boundaries
         shell: bash
         run: |
@@ -60,6 +62,11 @@ jobs:
           grep -Fq -- "-name 'db-*.sql.gz.gz'" scripts/preproduction/deploy-candidate.sh
           grep -Fq "release_retention='WARNING'" scripts/preproduction/deploy-candidate.sh
           grep -Fq 'active candidate remains valid' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'emerging:governed-content:validate' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'emerging:governed-content --all --dry-run' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'emerging:governed-content --all' scripts/preproduction/deploy-candidate.sh
+          grep -Fq "governed_content='PASS'" scripts/preproduction/deploy-candidate.sh
+          ! grep -Fq 'drush" list --format=list' scripts/preproduction/deploy-candidate.sh
           test -f tests/browser/contracts/public-blog.json
           test -f tests/browser/contracts/production-editorial-401.json
           grep -Fq "'public-blog.json': '**/public-blog.spec.mjs'" playwright.config.mjs
@@ -67,3 +74,6 @@ jobs:
           grep -Fq 'testMatch: contractTestMatch' playwright.config.mjs
           grep -Fq 'Unsupported BROWSER_VALIDATION_CONTRACT' playwright.config.mjs
           grep -Fq 'assert.deepEqual(Object.keys(contract).sort(), requiredTopLevelKeys.sort())' tests/browser/production-editorial-article.spec.mjs
+          grep -Fq "if (await toggle.isVisible())" tests/browser/public-blog.spec.mjs
+          grep -Fq "const drawerLink = drawer.getByRole('link'" tests/browser/public-blog.spec.mjs
+          grep -Fq "await expect(drawerLink).toBeVisible()" tests/browser/public-blog.spec.mjs

--- a/scripts/preproduction/deploy-candidate.sh
+++ b/scripts/preproduction/deploy-candidate.sh
@@ -168,11 +168,13 @@ preprod_split="$CURRENT_LINK/config/splits/preproduction"
 [[ -d "$preprod_split" ]] || fail "PREPROD config split directory is missing."
 "$CURRENT_LINK/vendor/bin/drush" config:import --source="$preprod_split" --partial -y
 
-if "$CURRENT_LINK/vendor/bin/drush" list --format=list | grep -Fxq 'emerging:governed-content'; then
-  "$CURRENT_LINK/vendor/bin/drush" emerging:governed-content:validate
-  "$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all --dry-run
-  "$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all
-fi
+log "Validate governed content catalog."
+"$CURRENT_LINK/vendor/bin/drush" emerging:governed-content:validate
+log "Preview governed content synchronization."
+"$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all --dry-run
+log "Apply governed content synchronization."
+"$CURRENT_LINK/vendor/bin/drush" emerging:governed-content --all
+governed_content='PASS'
 
 "$CURRENT_LINK/vendor/bin/drush" cr
 if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
@@ -188,6 +190,7 @@ fi
   printf 'source_branch=%s\n' "$source_branch"
   printf 'release_path=%s\n' "$NEW_RELEASE"
   printf 'artifact_archive=%s\n' "$archive_dir"
+  printf 'governed_content=%s\n' "$governed_content"
   printf 'deployed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 } > "$EVIDENCE"
 chmod 640 "$EVIDENCE"

--- a/tests/browser/public-blog.spec.mjs
+++ b/tests/browser/public-blog.spec.mjs
@@ -7,39 +7,42 @@ const contract = JSON.parse(
 );
 
 async function getVisiblePrimaryNavigationLink(page, name) {
-  const link = page.getByRole('link', {
-    name,
-    exact: true,
-  }).first();
-
-  if (await link.isVisible()) {
-    return link;
-  }
-
   const toggle = page.locator('[data-mobile-nav-toggle]');
   const drawer = page.locator('[data-mobile-nav-drawer]');
 
-  await expect(toggle).toBeVisible();
-  await expect(toggle).toHaveAttribute('aria-label', 'Ouvrir le menu principal');
-  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-  await expect(drawer).toHaveAttribute('role', 'dialog');
-  await expect(drawer).toHaveAttribute('aria-label', 'Menu principal');
-  await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+  if (await toggle.isVisible()) {
+    await expect(toggle).toHaveAttribute('aria-label', 'Ouvrir le menu principal');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(drawer).toHaveAttribute('role', 'dialog');
+    await expect(drawer).toHaveAttribute('aria-label', 'Menu principal');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true');
 
-  await toggle.click();
+    await toggle.click();
 
-  await expect(toggle).toHaveAttribute('aria-label', 'Fermer le menu principal');
-  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
-  await expect(drawer).toHaveAttribute('aria-hidden', 'false');
-  await expect(
-    page.getByRole('dialog', {
-      name: 'Menu principal',
+    await expect(toggle).toHaveAttribute('aria-label', 'Fermer le menu principal');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false');
+    await expect(
+      page.getByRole('dialog', {
+        name: 'Menu principal',
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    const drawerLink = drawer.getByRole('link', {
+      name,
       exact: true,
-    }),
-  ).toBeVisible();
-  await expect(link).toBeVisible();
+    }).first();
+    await expect(drawerLink).toBeVisible();
+    return drawerLink;
+  }
 
-  return link;
+  const desktopLink = page.getByRole('link', {
+    name,
+    exact: true,
+  }).first();
+  await expect(desktopLink).toBeVisible();
+  return desktopLink;
 }
 
 test.describe('Browser validation capability proof', () => {

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
@@ -81,12 +81,16 @@ final class PreproductionHostBootstrapTest extends TestCase {
       'config/splits/preproduction',
       'updb -y',
       'cim -y',
-      '--dry-run',
+      'emerging:governed-content:validate',
+      'emerging:governed-content --all --dry-run',
+      'emerging:governed-content --all',
+      "governed_content='PASS'",
       'OPENAI_API_KEY',
     ] as $expected) {
       self::assertStringContainsString($expected, $content);
     }
 
+    self::assertStringNotContainsString('list --format=list', $content);
     self::assertStringNotContainsString('composer install', $content);
     self::assertStringNotContainsString('git clone', $content);
     self::assertStringNotContainsString('/var/www/agency/shared', $content);
@@ -142,6 +146,26 @@ final class PreproductionHostBootstrapTest extends TestCase {
       );
     }
     self::assertStringContainsString('httpCredentials', $config);
+  }
+
+  /**
+   * Mobile browser proof uses the authoritative drawer after navigation.
+   */
+  public function testBrowserValidationUsesMobileDrawerWhenToggleIsVisible(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $spec = (string) file_get_contents(
+      $root . '/tests/browser/public-blog.spec.mjs',
+    );
+
+    self::assertStringContainsString('if (await toggle.isVisible())', $spec);
+    self::assertStringContainsString(
+      "const drawerLink = drawer.getByRole('link'",
+      $spec,
+    );
+    self::assertStringContainsString(
+      'await expect(drawerLink).toBeVisible()',
+      $spec,
+    );
   }
 
 }


### PR DESCRIPTION
Refs #808 #797

## Défauts récupérés sur r5
Le contract-routing #806 est prouvé corrigé : Playwright exécute réellement `public-blog.spec.mjs` sur desktop et mobile.

La r5 révèle ensuite deux défauts bornés :
1. desktop = PASS intégral, mais le helper mobile peut observer fugitivement le lien de navigation avant que le JS responsive ne déplace le menu dans le drawer après navigation ; le locator devient ensuite invisible au clic ;
2. le bandeau cookies mobile déclenche un vrai 404 same-origin sur `/fr/politique-de-cookies`.

## Cause du 404
`politique-cookies` appartient au catalogue Governed Content mais n’est pas fourni par le `default_content` initial. PREPROD devait appliquer le catalogue, mais `deploy-candidate.sh` utilisait `drush list --format=list | grep ...` comme détection. Le Drush embarqué ne produit pas de liste de noms avec ce format, donc le bloc était silencieusement sauté. PROD exécute déjà `emerging:governed-content --all` directement.

## Correctif
- PREPROD exécute désormais obligatoirement et fail-closed : `emerging:governed-content:validate` -> `--all --dry-run` -> `--all` ;
- `deployment-evidence.env` porte `governed_content=PASS` ;
- le skip `list --format=list` est interdit par validation et PHPUnit ;
- sur mobile, le helper prend le toggle visible comme autorité, ouvre explicitement le drawer et cible le lien dans ce drawer ; desktop conserve la navigation visible normale ;
- le 404 cookie reste couvert par le gate réseau : aucune allowlist/ignorance ajoutée.

## Validation locale ciblée
- `bash -n` du bloc Governed Content modifié = PASS ;
- `node --check` du helper mobile modifié = PASS.

## Invariants
- exact artifact/no rebuild inchangé ;
- side-effects PREPROD inchangés ;
- aucune mutation PROD manuelle ;
- aucun resize : r5 observe OOM=0, disque 22%, ~1.02 GB RAM disponible ;
- après merge, nouvelle candidate requise car les bytes versionnés changent.
