### PR TITLE
Issue #810: make PREPROD browser navigation mode deterministic

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -74,6 +74,7 @@ jobs:
           grep -Fq 'testMatch: contractTestMatch' playwright.config.mjs
           grep -Fq 'Unsupported BROWSER_VALIDATION_CONTRACT' playwright.config.mjs
           grep -Fq 'assert.deepEqual(Object.keys(contract).sort(), requiredTopLevelKeys.sort())' tests/browser/production-editorial-article.spec.mjs
-          grep -Fq "if (await toggle.isVisible())" tests/browser/public-blog.spec.mjs
+          grep -Fq "window.matchMedia('(max-width: 48rem)').matches" tests/browser/public-blog.spec.mjs
+          ! grep -Fq "if (await toggle.isVisible())" tests/browser/public-blog.spec.mjs
           grep -Fq "const drawerLink = drawer.getByRole('link'" tests/browser/public-blog.spec.mjs
           grep -Fq "await expect(drawerLink).toBeVisible()" tests/browser/public-blog.spec.mjs

--- a/tests/browser/public-blog.spec.mjs
+++ b/tests/browser/public-blog.spec.mjs
@@ -7,10 +7,15 @@ const contract = JSON.parse(
 );
 
 async function getVisiblePrimaryNavigationLink(page, name) {
-  const toggle = page.locator('[data-mobile-nav-toggle]');
-  const drawer = page.locator('[data-mobile-nav-drawer]');
+  const isMobile = await page.evaluate(() =>
+    window.matchMedia('(max-width: 48rem)').matches,
+  );
 
-  if (await toggle.isVisible()) {
+  if (isMobile) {
+    const toggle = page.locator('[data-mobile-nav-toggle]');
+    const drawer = page.locator('[data-mobile-nav-drawer]');
+
+    await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-label', 'Ouvrir le menu principal');
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
     await expect(drawer).toHaveAttribute('role', 'dialog');

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
@@ -149,15 +149,19 @@ final class PreproductionHostBootstrapTest extends TestCase {
   }
 
   /**
-   * Mobile browser proof uses the authoritative drawer after navigation.
+   * Browser proof uses the same responsive boundary as the theme.
    */
-  public function testBrowserValidationUsesMobileDrawerWhenToggleIsVisible(): void {
+  public function testBrowserValidationUsesDeterministicNavigationMode(): void {
     $root = dirname(DRUPAL_ROOT);
     $spec = (string) file_get_contents(
       $root . '/tests/browser/public-blog.spec.mjs',
     );
 
-    self::assertStringContainsString('if (await toggle.isVisible())', $spec);
+    self::assertStringContainsString(
+      "window.matchMedia('(max-width: 48rem)').matches",
+      $spec,
+    );
+    self::assertStringNotContainsString('if (await toggle.isVisible())', $spec);
     self::assertStringContainsString(
       "const drawerLink = drawer.getByRole('link'",
       $spec,


### PR DESCRIPTION
Refs #810 #797 #808

## Diagnostic r6
La candidate r6 a prouvé : exact artifact/worker/governed content/isolation/Basic Auth/health/smoke = PASS. Le Governed Content a créé `politique-cookies`; le projet mobile est intégralement PASS avec 0 console/page/4xx/5xx/failed request.

Le seul rouge est desktop avant ses checks. `getVisiblePrimaryNavigationLink()` sélectionne actuellement le mode mobile via `await toggle.isVisible()`. Juste après `domcontentloaded`, le bouton peut être fugitivement visible avant stabilisation CSS ; il devient ensuite caché avant `toggle.click()`, provoquant le timeout.

## Correctif borné
- le helper utilise désormais `window.matchMedia('(max-width: 48rem)').matches`, le même contrat responsive que le thème ;
- mobile exige toujours toggle visible + drawer et navigue dans le drawer ;
- desktop n'essaie jamais le toggle mobile et exige le lien desktop visible ;
- aucun gate functional/DOM/visual/console/network n'est modifié ;
- la validation PREPROD verrouille ce media query et interdit le retour au sélecteur `toggle.isVisible()`.

## Diff
2 fichiers seulement :
- `tests/browser/public-blog.spec.mjs` ;
- `.github/workflows/preproduction-bootstrap-validation.yml`.

Aucun changement applicatif Drupal, aucun allowlist réseau, aucun resize, aucun PROD. Après merge, nouvelle candidate requise car les bytes versionnés changent.