### PR TITLE
Issue #814: exclude authenticated sessions from PROD GA4

### DIFF
--- a/.github/workflows/preproduction-analytics-network-proof.yml
+++ b/.github/workflows/preproduction-analytics-network-proof.yml
@@ -1,0 +1,74 @@
+name: Prove PREPRODUCTION analytics network isolation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'config/splits/production/google_tag.container.*.yml'
+      - 'tests/browser/**'
+      - 'scripts/run-browser-validation.mjs'
+      - 'web/modules/custom/agency_project_tests/tests/src/Functional/GoogleTagAuthenticatedExclusionTest.php'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php'
+      - '.github/workflows/preproduction-analytics-network-proof.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  prove-zero-ga4:
+    name: Real PREPROD zero-GA4 browser/network proof
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      BROWSER_VALIDATION_BASE_URL: https://preprod.emergingdigital.be
+      BROWSER_VALIDATION_HTTP_USERNAME: ${{ secrets.PREPROD_BASIC_AUTH_USER }}
+      BROWSER_VALIDATION_HTTP_PASSWORD: ${{ secrets.PREPROD_BASIC_AUTH_PASSWORD }}
+
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install browser validation dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Prove real PREPROD emits zero GA4 traffic
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$BROWSER_VALIDATION_HTTP_USERNAME"
+          test -n "$BROWSER_VALIDATION_HTTP_PASSWORD"
+          npm run browser:validate
+          result='artifacts/browser-validation/result.json'
+          test "$(jq -r '.result' "$result")" = 'PASS'
+          test "$(jq -r '[.projects[].checks.analytics] | all(. == "PASS")' "$result")" = 'true'
+          test "$(jq -r '[.projects[].google_analytics_requests] | add' "$result")" = '0'
+          test "$(jq -r '[.projects[].ga4_measurement_id_requests] | add' "$result")" = '0'
+          test "$(jq -r '.console_errors' "$result")" = '0'
+          test "$(jq -r '.page_errors' "$result")" = '0'
+          test "$(jq -r '.http_5xx' "$result")" = '0'
+          printf 'GA_PREPROD_NETWORK=ZERO\n'
+          printf 'GA_PREPROD_MEASUREMENT_ID_REQUESTS=ZERO\n'
+
+      - name: Upload non-sensitive browser proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: preproduction-analytics-network-${{ github.event.pull_request.head.sha }}-${{ github.run_id }}
+          path: artifacts/browser-validation
+          if-no-files-found: warn
+          retention-days: 30

--- a/config/splits/production/google_tag.container.G-K5TDNZCPTY.69f8b7287a84a3.47771255.yml
+++ b/config/splits/production/google_tag.container.G-K5TDNZCPTY.69f8b7287a84a3.47771255.yml
@@ -11,7 +11,14 @@ tag_container_ids:
 advanced_settings:
   consent_mode: false
 dimensions_metrics: {  }
-conditions: {  }
+conditions:
+  user_role:
+    id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    roles:
+      anonymous: anonymous
 events:
   webform_purchase: {  }
   sign_up:

--- a/tests/browser/public-blog.spec.mjs
+++ b/tests/browser/public-blog.spec.mjs
@@ -5,6 +5,8 @@ import { test, expect } from './support/browser-audit.mjs';
 const contract = JSON.parse(
   await readFile(new URL('./contracts/public-blog.json', import.meta.url), 'utf8'),
 );
+const expectZeroGa4 = process.env.BROWSER_VALIDATION_EXPECT_ZERO_GA4 === '1';
+const ga4MeasurementId = 'G-K5TDNZCPTY';
 
 async function getVisiblePrimaryNavigationLink(page, name) {
   const isMobile = await page.evaluate(() =>
@@ -90,6 +92,7 @@ test.describe('Browser validation capability proof', () => {
       viewportWidth: window.innerWidth,
       hasHorizontalOverflow:
         document.documentElement.scrollWidth > window.innerWidth + 1,
+      html: document.documentElement.outerHTML,
     }));
 
     expect(dom.h1Count, 'The page must expose exactly one H1.').toBe(1);
@@ -100,6 +103,22 @@ test.describe('Browser validation capability proof', () => {
     ).toBeFalsy();
 
     audit.checks.dom = 'PASS';
+
+    if (expectZeroGa4) {
+      expect(
+        audit.analyticsRequests,
+        'PREPROD must not emit Google Tag / Google Analytics / collect requests.',
+      ).toEqual([]);
+      expect(
+        audit.analyticsMeasurementRequests,
+        `PREPROD must not emit requests containing ${ga4MeasurementId}.`,
+      ).toEqual([]);
+      expect(
+        dom.html,
+        `PREPROD must not inject ${ga4MeasurementId} into the rendered page.`,
+      ).not.toContain(ga4MeasurementId);
+      audit.checks.analytics = 'PASS';
+    }
 
     const screenshotDirectory = path.resolve(
       'artifacts/browser-validation/screenshots',

--- a/tests/browser/public-blog.spec.mjs
+++ b/tests/browser/public-blog.spec.mjs
@@ -5,7 +5,10 @@ import { test, expect } from './support/browser-audit.mjs';
 const contract = JSON.parse(
   await readFile(new URL('./contracts/public-blog.json', import.meta.url), 'utf8'),
 );
-const expectZeroGa4 = process.env.BROWSER_VALIDATION_EXPECT_ZERO_GA4 === '1';
+const browserBaseUrl = process.env.BROWSER_VALIDATION_BASE_URL ?? 'http://127.0.0.1';
+const expectZeroGa4 =
+  new URL(browserBaseUrl).hostname === 'preprod.emergingdigital.be'
+  || process.env.BROWSER_VALIDATION_EXPECT_ZERO_GA4 === '1';
 const ga4MeasurementId = 'G-K5TDNZCPTY';
 
 async function getVisiblePrimaryNavigationLink(page, name) {

--- a/tests/browser/support/browser-audit.mjs
+++ b/tests/browser/support/browser-audit.mjs
@@ -3,10 +3,26 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const artifactRoot = path.resolve('artifacts/browser-validation');
+const ga4MeasurementId = 'G-K5TDNZCPTY';
 
 function isSameOrigin(url, baseURL) {
   try {
     return new URL(url).origin === new URL(baseURL).origin;
+  }
+  catch {
+    return false;
+  }
+}
+
+function isGoogleAnalyticsRequest(url) {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname === 'www.googletagmanager.com'
+      || hostname.endsWith('.googletagmanager.com')
+      || hostname === 'www.google-analytics.com'
+      || hostname.endsWith('.google-analytics.com')
+      || parsed.pathname.includes('/collect');
   }
   catch {
     return false;
@@ -26,6 +42,7 @@ export const test = base.extend({
         visual: 'NOT_RUN',
         console: 'NOT_RUN',
         network: 'NOT_RUN',
+        analytics: 'NOT_RUN',
       },
       consoleErrors: [],
       consoleWarnings: [],
@@ -33,6 +50,8 @@ export const test = base.extend({
       unexpectedHttp4xx: [],
       http5xx: [],
       failedRequests: [],
+      analyticsRequests: [],
+      analyticsMeasurementRequests: [],
       screenshot: null,
     };
 
@@ -55,6 +74,22 @@ export const test = base.extend({
         name: error.name,
         message: error.message,
       });
+    };
+
+    const onRequest = (request) => {
+      const url = request.url();
+      const entry = {
+        method: request.method(),
+        resourceType: request.resourceType(),
+        url,
+      };
+
+      if (isGoogleAnalyticsRequest(url)) {
+        audit.analyticsRequests.push(entry);
+      }
+      if (url.includes(ga4MeasurementId)) {
+        audit.analyticsMeasurementRequests.push(entry);
+      }
     };
 
     const onResponse = (response) => {
@@ -92,6 +127,7 @@ export const test = base.extend({
 
     page.on('console', onConsole);
     page.on('pageerror', onPageError);
+    page.on('request', onRequest);
     page.on('response', onResponse);
     page.on('requestfailed', onRequestFailed);
 
@@ -99,6 +135,7 @@ export const test = base.extend({
 
     page.off('console', onConsole);
     page.off('pageerror', onPageError);
+    page.off('request', onRequest);
     page.off('response', onResponse);
     page.off('requestfailed', onRequestFailed);
 
@@ -108,7 +145,7 @@ export const test = base.extend({
     await mkdir(evidenceDirectory, { recursive: true });
 
     const evidence = {
-      schema_version: 1,
+      schema_version: 2,
       project,
       result,
       status: testInfo.status,
@@ -120,6 +157,8 @@ export const test = base.extend({
       unexpected_http_4xx: audit.unexpectedHttp4xx.length,
       http_5xx: audit.http5xx.length,
       failed_requests: audit.failedRequests.length,
+      google_analytics_requests: audit.analyticsRequests.length,
+      ga4_measurement_id_requests: audit.analyticsMeasurementRequests.length,
       details: {
         console_errors: audit.consoleErrors,
         console_warnings: audit.consoleWarnings,
@@ -127,6 +166,8 @@ export const test = base.extend({
         unexpected_http_4xx: audit.unexpectedHttp4xx,
         http_5xx: audit.http5xx,
         failed_requests: audit.failedRequests,
+        google_analytics_requests: audit.analyticsRequests,
+        ga4_measurement_id_requests: audit.analyticsMeasurementRequests,
       },
       screenshot: audit.screenshot,
       trace: result === 'FAIL' ? 'See test-results trace.zip for this project.' : null,

--- a/web/modules/custom/agency_project_tests/tests/src/Functional/GoogleTagAuthenticatedExclusionTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Functional/GoogleTagAuthenticatedExclusionTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Functional;
+
+use Drupal\google_tag\Entity\TagContainer;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Proves the PROD-like GA4 audience boundary with native Google Tag conditions.
+ *
+ * @group agency_project_tests
+ * @group google_tag_environment_policy
+ */
+#[RunTestsInSeparateProcesses]
+final class GoogleTagAuthenticatedExclusionTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'google_tag',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A representative public page.
+   */
+  private Node $page;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    NodeType::create([
+      'type' => 'page',
+      'name' => 'Basic page',
+    ])->save();
+
+    TagContainer::create([
+      'id' => 'G-K5TDNZCPTY.69f8b7287a84a3.47771255',
+      'label' => 'G-K5TDNZCPTY',
+      'status' => TRUE,
+      'weight' => 0,
+      'tag_container_ids' => [
+        'G-K5TDNZCPTY',
+        '',
+      ],
+      'advanced_settings' => [
+        'consent_mode' => FALSE,
+      ],
+      'dimensions_metrics' => [],
+      'conditions' => [
+        'user_role' => [
+          'id' => 'user_role',
+          'negate' => FALSE,
+          'context_mapping' => [
+            'user' => '@user.current_user_context:current_user',
+          ],
+          'roles' => [
+            'anonymous' => 'anonymous',
+          ],
+        ],
+      ],
+      'events' => [],
+    ])->save();
+
+    $this->config('google_tag.settings')
+      ->set('default_google_tag_entity', 'G-K5TDNZCPTY.69f8b7287a84a3.47771255')
+      ->save();
+
+    $this->page = Node::create([
+      'type' => 'page',
+      'title' => 'Analytics audience proof',
+      'status' => Node::PUBLISHED,
+    ]);
+    $this->page->save();
+
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * Anonymous PROD-like traffic remains eligible for the configured GA4 tag.
+   */
+  public function testAnonymousPageContainsGa4Injection(): void {
+    $this->drupalGet($this->page->toUrl());
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('G-K5TDNZCPTY');
+  }
+
+  /**
+   * Every authenticated account is excluded regardless of its eventual role.
+   */
+  public function testAuthenticatedPageContainsNoGa4Injection(): void {
+    $account = $this->drupalCreateUser();
+    self::assertNotFalse($account);
+    $this->drupalLogin($account);
+
+    $this->drupalGet($this->page->toUrl());
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseNotContains('G-K5TDNZCPTY');
+    $this->assertSession()->responseNotContains('googletagmanager.com');
+    $this->assertSession()->responseNotContains('google-analytics.com');
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the repository-owned GA4 environment and audience policy.
+ *
+ * @group agency_project_tests
+ * @group google_tag_environment_policy
+ */
+final class GoogleTagEnvironmentPolicyTest extends TestCase {
+
+  /**
+   * PROD GA4 remains enabled only for anonymous users via a native condition.
+   */
+  public function testProductionContainerWhitelistsAnonymousRole(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/config/splits/production/'
+      . 'google_tag.container.G-K5TDNZCPTY.69f8b7287a84a3.47771255.yml';
+
+    self::assertFileExists($path);
+    $config = Yaml::decode((string) file_get_contents($path));
+    self::assertIsArray($config);
+    self::assertTrue($config['status']);
+    self::assertContains('G-K5TDNZCPTY', $config['tag_container_ids']);
+    self::assertArrayHasKey('conditions', $config);
+    self::assertNotSame([], $config['conditions']);
+    self::assertSame([
+      'id' => 'user_role',
+      'negate' => FALSE,
+      'context_mapping' => [
+        'user' => '@user.current_user_context:current_user',
+      ],
+      'roles' => [
+        'anonymous' => 'anonymous',
+      ],
+    ], $config['conditions']['user_role'] ?? NULL);
+  }
+
+  /**
+   * The real PREPROD browser workflow must enforce zero GA4 traffic.
+   */
+  public function testPreproductionBrowserProofRequiresZeroGa4Traffic(): void {
+    $root = dirname(DRUP_ROOT);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
@@ -43,10 +43,31 @@ final class GoogleTagEnvironmentPolicyTest extends TestCase {
   }
 
   /**
-   * The real PREPROD browser workflow must enforce zero GA4 traffic.
+   * Real PREPROD validation must fail if browser/network GA4 silence is lost.
    */
   public function testPreproductionBrowserProofRequiresZeroGa4Traffic(): void {
-    $root = dirname(DRUP_ROOT);
+    $root = dirname(DRUPAL_ROOT);
+    $workflow = (string) file_get_contents(
+      $root . '/.github/workflows/deploy-preproduction.yml',
+    );
+    $spec = (string) file_get_contents(
+      $root . '/tests/browser/public-blog.spec.mjs',
+    );
+    $audit = (string) file_get_contents(
+      $root . '/tests/browser/support/browser-audit.mjs',
+    );
+
+    self::assertStringContainsString(
+      "BROWSER_VALIDATION_EXPECT_ZERO_GA4: '1'",
+      $workflow,
+    );
+    self::assertStringContainsString('audit.analyticsRequests', $spec);
+    self::assertStringContainsString('audit.analyticsMeasurementRequests', $spec);
+    self::assertStringContainsString("dom.html", $spec);
+    self::assertStringContainsString('googletagmanager.com', $audit);
+    self::assertStringContainsString('google-analytics.com', $audit);
+    self::assertStringContainsString("parsed.pathname.includes('/collect')", $audit);
+    self::assertStringContainsString('G-K5TDNZCPTY', $audit);
   }
 
 }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/GoogleTagEnvironmentPolicyTest.php
@@ -43,13 +43,10 @@ final class GoogleTagEnvironmentPolicyTest extends TestCase {
   }
 
   /**
-   * Real PREPROD validation must fail if browser/network GA4 silence is lost.
+   * Real PREPROD browser validation must fail if GA4 silence is lost.
    */
   public function testPreproductionBrowserProofRequiresZeroGa4Traffic(): void {
     $root = dirname(DRUPAL_ROOT);
-    $workflow = (string) file_get_contents(
-      $root . '/.github/workflows/deploy-preproduction.yml',
-    );
     $spec = (string) file_get_contents(
       $root . '/tests/browser/public-blog.spec.mjs',
     );
@@ -58,12 +55,12 @@ final class GoogleTagEnvironmentPolicyTest extends TestCase {
     );
 
     self::assertStringContainsString(
-      "BROWSER_VALIDATION_EXPECT_ZERO_GA4: '1'",
-      $workflow,
+      "hostname === 'preprod.emergingdigital.be'",
+      $spec,
     );
     self::assertStringContainsString('audit.analyticsRequests', $spec);
     self::assertStringContainsString('audit.analyticsMeasurementRequests', $spec);
-    self::assertStringContainsString("dom.html", $spec);
+    self::assertStringContainsString('dom.html', $spec);
     self::assertStringContainsString('googletagmanager.com', $audit);
     self::assertStringContainsString('google-analytics.com', $audit);
     self::assertStringContainsString("parsed.pathname.includes('/collect')", $audit);


### PR DESCRIPTION
## #814

Implements the native Google Tag user-role condition for the production-only GA4 container. The container keeps measurement ID `G-K5TDNZCPTY` and is eligible only for the Drupal `anonymous` role; all authenticated users are excluded without Twig or custom tracking JS.

Adds two proof layers:
- repository regression that fails if the production container returns to `conditions: {}`;
- PROD-like BrowserTestBase coverage for anonymous eligibility vs authenticated absence;
- Playwright network auditing records Google Tag / Google Analytics / collect requests and automatically requires zero GA4 traffic and zero Measurement ID injection on `preprod.emergingdigital.be`.

No production mutation. No PROD GO. r7 remains withdrawn.

Refs #814 #815 #812.