### PR TITLE
Issue #819: reconcile shared PREPROD settings during deploy

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -47,6 +47,12 @@ jobs:
           grep -Fq 'auth_basic off' scripts/preproduction/nginx-agency-preprod.conf.template
           grep -Fq 'sha256sum -c' scripts/preproduction/deploy-candidate.sh
           grep -Fq 'ARTIFACTS_DIR="$SHARED_DIR/artifacts"' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'scripts/preproduction/settings.php.template' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'source "$RUNTIME_ENV"' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'reconcile_settings' scripts/preproduction/deploy-candidate.sh
+          grep -Fq 'mv -f "$SETTINGS_TMP" "$SETTINGS_FILE"' scripts/preproduction/deploy-candidate.sh
+          grep -Fq "agency_external_ai_egress_enabled'] = FALSE" scripts/preproduction/settings.php.template
+          ! grep -Fq 'openssl rand' scripts/preproduction/deploy-candidate.sh
           ! grep -Fq 'composer install' scripts/preproduction/deploy-candidate.sh
           ! grep -Fq 'git clone' scripts/preproduction/deploy-candidate.sh
           grep -Fq 'side_effects=PASS' scripts/preproduction/validate-runtime.sh

--- a/scripts/preproduction/deploy-candidate.sh
+++ b/scripts/preproduction/deploy-candidate.sh
@@ -11,6 +11,10 @@ SHARED_DIR="$PROJECT_ROOT/shared"
 CURRENT_LINK="$PROJECT_ROOT/current"
 RUNTIME_ENV="$SHARED_DIR/settings/runtime.env"
 SETTINGS_FILE="$SHARED_DIR/settings/settings.php"
+SETTINGS_TMP="${SETTINGS_FILE}.tmp.$$"
+DB_NAME="agency_preprod"
+DB_USER="agency_preprod"
+PREPROD_HOSTNAME="preprod.emergingdigital.be"
 BACKUPS_DIR="$SHARED_DIR/backups"
 ARTIFACTS_DIR="$SHARED_DIR/artifacts"
 TIMESTAMP="$(date -u '+%Y%m%d%H%M%S')"
@@ -44,6 +48,7 @@ fail_trap() {
   trap - ERR
   set +e
   log "Deployment failed at line ${line_no} (exit ${exit_code})."
+  rm -f "$SETTINGS_TMP" || true
 
   if [[ "$MAINTENANCE_ENABLED" -eq 1 ]]; then
     recovery_release="$ACTIVE_RELEASE"
@@ -63,6 +68,29 @@ fail_trap() {
   fi
 
   exit "$exit_code"
+}
+
+reconcile_settings() {
+  local settings_template="$NEW_RELEASE/scripts/preproduction/settings.php.template"
+  local trusted_host_regex="${PREPROD_HOSTNAME//./\\.}"
+
+  [[ -f "$settings_template" ]] || fail "Candidate PREPROD settings template is missing."
+  [[ -n "${DB_PASSWORD:-}" ]] || fail "DB_PASSWORD is missing from runtime.env."
+  [[ -n "${HASH_SALT:-}" ]] || fail "HASH_SALT is missing from runtime.env."
+
+  rm -f "$SETTINGS_TMP"
+  sed \
+    -e "s|@@DB_NAME@@|$DB_NAME|g" \
+    -e "s|@@DB_USER@@|$DB_USER|g" \
+    -e "s|@@DB_PASSWORD@@|$DB_PASSWORD|g" \
+    -e "s|@@HASH_SALT@@|$HASH_SALT|g" \
+    -e "s|@@PROJECT_ROOT@@|$PROJECT_ROOT|g" \
+    -e "s|@@TRUSTED_HOST_REGEX@@|$trusted_host_regex|g" \
+    "$settings_template" > "$SETTINGS_TMP"
+  chgrp www-data "$SETTINGS_TMP"
+  chmod 640 "$SETTINGS_TMP"
+  mv -f "$SETTINGS_TMP" "$SETTINGS_FILE"
+  log "Shared PREPROD settings converged from the exact candidate template."
 }
 
 trap 'fail_trap $LINENO' ERR
@@ -142,6 +170,8 @@ fi
 
 # shellcheck disable=SC1090
 source "$RUNTIME_ENV"
+reconcile_settings
+
 if ! (
   cd "$NEW_RELEASE"
   vendor/bin/drush status --field=bootstrap 2>/dev/null | grep -q 'Successful'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php
@@ -63,6 +63,10 @@ final class PreproductionHostBootstrapTest extends TestCase {
       "automated_cron.settings']['interval'] = 0",
       $settingsContent,
     );
+    self::assertStringContainsString(
+      "agency_external_ai_egress_enabled'] = FALSE",
+      $settingsContent,
+    );
   }
 
   /**
@@ -94,6 +98,27 @@ final class PreproductionHostBootstrapTest extends TestCase {
     self::assertStringNotContainsString('composer install', $content);
     self::assertStringNotContainsString('git clone', $content);
     self::assertStringNotContainsString('/var/www/agency/shared', $content);
+  }
+
+  /**
+   * Candidate deployment converges server-owned settings without new secrets.
+   */
+  public function testCandidateDeployReconcilesSharedSettings(): void {
+    $root = dirname(DRUPAL_ROOT);
+    $deploy = (string) file_get_contents(
+      $root . '/scripts/preproduction/deploy-candidate.sh',
+    );
+
+    foreach ([
+      'scripts/preproduction/settings.php.template',
+      'source "$RUNTIME_ENV"',
+      'reconcile_settings',
+      'mv -f "$SETTINGS_TMP" "$SETTINGS_FILE"',
+    ] as $expected) {
+      self::assertStringContainsString($expected, $deploy);
+    }
+
+    self::assertStringNotContainsString('openssl rand', $deploy);
   }
 
   /**


### PR DESCRIPTION
## #819 — recover r8 PREPROD runtime isolation failure

r8 proved that the immutable candidate deploy itself succeeds, but runtime validation correctly failed because the server-owned shared `settings.php` predated the #815 environment contract.

### Fix

- render `scripts/preproduction/settings.php.template` from the exact candidate into a temporary shared settings file;
- reuse the existing `runtime.env` DB/hash values without regeneration or logging;
- replace shared `settings.php` atomically with preserved `www-data` group and `0640` mode;
- converge settings only after the active PREPROD DB backup/maintenance boundary and before the new release bootstrap/switch;
- retain fail-closed `agency_external_ai_egress_enabled = FALSE` and disabled OpenAI Key entity;
- add PHPUnit and workflow regressions proving deploy-time convergence and forbidding secret regeneration in the deploy script.

No PROD mutation. No provider key copied. No weakening of PREPROD isolation.

r8 remains immutable/stale. After this PR merges, the next release proof must use a fresh r9 candidate.

Closes #819
Refs #812 #814 #815 #816.