### PR TITLE
Issue #821: prove zero GA after explicit consent acceptance

### DIFF
--- a/.github/workflows/preproduction-analytics-network-proof.yml
+++ b/.github/workflows/preproduction-analytics-network-proof.yml
@@ -46,7 +46,7 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      - name: Prove real PREPROD emits zero GA4 traffic
+      - name: Prove real PREPROD emits zero GA4 traffic after consent
         shell: bash
         run: |
           set -euo pipefail
@@ -55,13 +55,15 @@ jobs:
           npm run browser:validate
           result='artifacts/browser-validation/result.json'
           test "$(jq -r '.result' "$result")" = 'PASS'
+          test "$(jq -r '[.projects[].checks.consent] | all(. == "PASS")' "$result")" = 'true'
           test "$(jq -r '[.projects[].checks.analytics] | all(. == "PASS")' "$result")" = 'true'
           test "$(jq -r '[.projects[].google_analytics_requests] | add' "$result")" = '0'
           test "$(jq -r '[.projects[].ga4_measurement_id_requests] | add' "$result")" = '0'
           test "$(jq -r '.console_errors' "$result")" = '0'
           test "$(jq -r '.page_errors' "$result")" = '0'
           test "$(jq -r '.http_5xx' "$result")" = '0'
-          printf 'GA_PREPROD_NETWORK=ZERO\n'
+          printf 'COOKIE_CONSENT_ACCEPTED=PASS\n'
+          printf 'GA_PREPROD_NETWORK_AFTER_CONSENT=ZERO\n'
           printf 'GA_PREPROD_MEASUREMENT_ID_REQUESTS=ZERO\n'
 
       - name: Upload non-sensitive browser proof

--- a/tests/browser/public-blog.spec.mjs
+++ b/tests/browser/public-blog.spec.mjs
@@ -10,6 +10,7 @@ const expectZeroGa4 =
   new URL(browserBaseUrl).hostname === 'preprod.emergingdigital.be'
   || process.env.BROWSER_VALIDATION_EXPECT_ZERO_GA4 === '1';
 const ga4MeasurementId = 'G-K5TDNZCPTY';
+const consentStorageKey = 'ed_cookie_consent_v1';
 
 async function getVisiblePrimaryNavigationLink(page, name) {
   const isMobile = await page.evaluate(() =>
@@ -55,6 +56,25 @@ async function getVisiblePrimaryNavigationLink(page, name) {
   return desktopLink;
 }
 
+async function acceptExternalConsent(page, audit) {
+  const banner = page.locator('#ed-cookie-banner');
+  const acceptButton = page.locator('[data-ed-cookie-action="accept"]');
+
+  await expect(banner).toBeVisible();
+  await expect(acceptButton).toBeVisible();
+  await acceptButton.click();
+  await expect(banner).toHaveCount(0);
+
+  const consent = await page.evaluate((storageKey) => {
+    const raw = window.localStorage.getItem(storageKey);
+    return raw ? JSON.parse(raw) : null;
+  }, consentStorageKey);
+
+  expect(consent?.necessary).toBe(true);
+  expect(consent?.external).toBe(true);
+  audit.checks.consent = 'PASS';
+}
+
 test.describe('Browser validation capability proof', () => {
   test(`${contract.id}: public Blog is usable and rendered cleanly`, async ({
     page,
@@ -74,6 +94,10 @@ test.describe('Browser validation capability proof', () => {
       page.getByRole('heading', { name: 'Blog', level: 1 }),
     ).toBeVisible();
     await expect(page.locator('main')).toBeVisible();
+
+    if (expectZeroGa4) {
+      await acceptExternalConsent(page, audit);
+    }
 
     const servicesLink = await getVisiblePrimaryNavigationLink(page, 'Services');
     await servicesLink.click();
@@ -108,6 +132,7 @@ test.describe('Browser validation capability proof', () => {
     audit.checks.dom = 'PASS';
 
     if (expectZeroGa4) {
+      expect(audit.checks.consent).toBe('PASS');
       expect(
         audit.analyticsRequests,
         'PREPROD must not emit Google Tag / Google Analytics / collect requests.',


### PR DESCRIPTION
## #821 — close the consent-specific PREPROD proof gap

r9 is otherwise green, but its browser proof did not actively accept cookie consent. This PR makes that invariant explicit and executable.

### Exact proof added

On real PREPROD, in each fresh desktop/mobile Playwright context:
- require the real cookie banner and `[data-ed-cookie-action="accept"]` control;
- click `Accepter`;
- prove `ed_cookie_consent_v1.external === true` in localStorage;
- continue normal Services → Blog navigation after consent;
- keep the same network audit active for the full flow;
- assert zero Google Tag / Google Analytics / `/collect` requests;
- assert zero requests containing `G-K5TDNZCPTY` and no ID injection in rendered HTML;
- record `checks.consent = PASS` in per-project evidence.

The dedicated real-PREPROD analytics workflow now refuses green unless consent is PASS on both desktop and mobile.

No application behavior change. No PROD mutation. No secrets changed.

After merge, r9 is stale release evidence and the next candidate must be fresh.

Closes #821
Refs #814 #815 #819 #812.