### PR TITLE
Issue #823: separate PROD scheduler authority from functional promotion

### DIFF
--- a/.github/workflows/production-promotion-validation.yml
+++ b/.github/workflows/production-promotion-validation.yml
@@ -8,11 +8,15 @@ on:
       - '.github/workflows/deploy-production.yml'
       - '.github/workflows/promote-production.yml'
       - '.github/workflows/production-promotion-validation.yml'
+      - '.github/workflows/production-scheduler-readonly-audit.yml'
+      - '.github/workflows/production-scheduler-change.yml'
       - 'scripts/launch-production-deploy.sh'
       - 'scripts/production-promotion/**'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPromotionSafetyTest.php'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php'
       - 'docs/operations/preproduction.md'
+      - 'docs/operations/environment-side-effects.md'
   push:
     branches:
       - main
@@ -20,11 +24,15 @@ on:
       - '.github/workflows/deploy-production.yml'
       - '.github/workflows/promote-production.yml'
       - '.github/workflows/production-promotion-validation.yml'
+      - '.github/workflows/production-scheduler-readonly-audit.yml'
+      - '.github/workflows/production-scheduler-change.yml'
       - 'scripts/launch-production-deploy.sh'
       - 'scripts/production-promotion/**'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPromotionSafetyTest.php'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php'
       - 'docs/operations/preproduction.md'
+      - 'docs/operations/environment-side-effects.md'
 
 permissions:
   contents: read
@@ -51,6 +59,8 @@ jobs:
           bash -n scripts/production-promotion/promote-candidate.sh
           bash -n scripts/production-promotion/launch-promotion.sh
           bash -n scripts/production-promotion/inspect-promotion.sh
+          bash -n scripts/production-promotion/reconcile-cron.sh
+          bash -n scripts/production-promotion/mutate-cron.sh
           bash -n scripts/launch-production-deploy.sh
 
       - name: Prove legacy push-main production deploy is retired
@@ -84,6 +94,37 @@ jobs:
           ! grep -R -Fq 'composer install' scripts/production-promotion
           ! grep -R -Fq 'git pull' scripts/production-promotion
 
+      - name: Prove functional promotion scheduler handling is verify-only
+        shell: bash
+        run: |
+          set -euo pipefail
+          promotion='scripts/production-promotion/promote-candidate.sh'
+          verifier='scripts/production-promotion/reconcile-cron.sh'
+          mutation_workflow='.github/workflows/production-scheduler-change.yml'
+          mutator='scripts/production-promotion/mutate-cron.sh'
+
+          grep -Fq 'reconcile-cron.sh' "$promotion"
+          ! grep -Fq 'mutate-cron.sh' "$promotion"
+          grep -Fq 'VERIFY_ONLY' "$verifier"
+          grep -Fq 'Functional promotion may only VERIFY_ONLY the PROD scheduler.' "$verifier"
+          grep -Fq 'production_scheduler_runtime_state=CONTROLLED' "$verifier"
+          ! grep -Fq 'crontab "$tmp"' "$verifier"
+
+          grep -Fq 'issue_comment:' "$mutation_workflow"
+          grep -Fq "github.event.comment.author_association == 'OWNER'" "$mutation_workflow"
+          grep -Fq '/agency-production-scheduler\ action=' "$mutation_workflow"
+          grep -Fq 'release=([0-9a-f]{40})' "$mutation_workflow"
+          grep -Fq 'expected=(ABSENT|CONTROLLED|MANAGED_DRIFT)' "$mutation_workflow"
+          ! grep -Eq '^  workflow_dispatch:' "$mutation_workflow"
+          ! grep -Eq '^  push:' "$mutation_workflow"
+
+          grep -Fq 'OWNER_ISSUE_COMMENT' "$mutator"
+          grep -Fq 'Current production release identity differs from authorized identity.' "$mutator"
+          grep -Fq 'crontab "$tmp"' "$mutator"
+          grep -Fq 'CREATE requires expected state ABSENT.' "$mutator"
+          grep -Fq 'UPDATE requires expected state MANAGED_DRIFT.' "$mutator"
+          grep -Fq 'REMOVE requires expected state CONTROLLED.' "$mutator"
+
       - name: Prove anti-replay and rollback boundary
         shell: bash
         run: |
@@ -101,3 +142,4 @@ jobs:
           set -euo pipefail
           php -l web/modules/custom/agency_project_tests/tests/src/Unit/ProductionDeploymentSafetyTest.php
           php -l web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPromotionSafetyTest.php
+          php -l web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php

--- a/.github/workflows/production-scheduler-change.yml
+++ b/.github/workflows/production-scheduler-change.yml
@@ -1,0 +1,147 @@
+name: Change production scheduler with explicit owner authority
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: agency-production-scheduler
+  cancel-in-progress: false
+
+jobs:
+  change:
+    name: Explicitly authorized production scheduler mutation
+    if: >-
+      ${{ github.event.issue.state == 'open'
+          && github.event.issue.pull_request == null
+          && github.event.issue.user.login == 'E-merging-digital'
+          && github.event.comment.user.login == 'E-merging-digital'
+          && github.event.comment.author_association == 'OWNER'
+          && startsWith(github.event.comment.body, '/agency-production-scheduler ') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout live scheduler tooling
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Authorize exact scheduler transition
+        id: auth
+        env:
+          GO_BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GO_BODY" != *$'\n'* ]]
+          if [[ ! "$GO_BODY" =~ ^/agency-production-scheduler\ action=(CREATE|UPDATE|REMOVE)\ release=([0-9a-f]{40})\ expected=(ABSENT|CONTROLLED|MANAGED_DRIFT)$ ]]; then
+            echo 'Scheduler command does not match the explicit authority contract.' >&2
+            exit 1
+          fi
+
+          action="${BASH_REMATCH[1]}"
+          release_sha="${BASH_REMATCH[2]}"
+          expected_state="${BASH_REMATCH[3]}"
+          auth_body_sha="$(printf '%s' "$GO_BODY" | sha256sum | awk '{print $1}')"
+
+          case "$action:$expected_state" in
+            CREATE:ABSENT|UPDATE:MANAGED_DRIFT|REMOVE:CONTROLLED) ;;
+            *)
+              echo 'Requested scheduler transition is not valid for the authorized expected state.' >&2
+              exit 1
+              ;;
+          esac
+
+          [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]
+          [[ "$auth_body_sha" =~ ^[0-9a-f]{64}$ ]]
+
+          echo "action=$action" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "expected_state=$expected_state" >> "$GITHUB_OUTPUT"
+          echo "auth_body_sha=$auth_body_sha" >> "$GITHUB_OUTPUT"
+          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Configure production SSH identity
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Stage bounded scheduler request
+        id: request
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          RELEASE_SHA: ${{ steps.auth.outputs.release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          request_id="scheduler-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA:0:12}"
+          remote_dir="/var/www/agency/shared/scheduler-jobs/${request_id}"
+          [[ "$request_id" =~ ^scheduler-[0-9]+-[0-9]+-[0-9a-f]{12}$ ]]
+          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
+
+          ssh "$SERVER_USER@$SERVER_HOST" \
+            "umask 077; mkdir -p '$remote_dir'; test ! -L '$remote_dir'; test ! -e '$remote_dir/scheduler-change-evidence.env'"
+          scp \
+            scripts/production-promotion/mutate-cron.sh \
+            "$SERVER_USER@$SERVER_HOST:$remote_dir/"
+          ssh "$SERVER_USER@$SERVER_HOST" "chmod 700 '$remote_dir/mutate-cron.sh'"
+
+      - name: Apply explicitly authorized scheduler transition
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          ACTION: ${{ steps.auth.outputs.action }}
+          RELEASE_SHA: ${{ steps.auth.outputs.release_sha }}
+          EXPECTED_STATE: ${{ steps.auth.outputs.expected_state }}
+          COMMENT_ID: ${{ steps.auth.outputs.comment_id }}
+          AUTH_BODY_SHA: ${{ steps.auth.outputs.auth_body_sha }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" \
+            "SCHEDULER_AUTHORITY_KIND=OWNER_ISSUE_COMMENT '$REMOTE_DIR/mutate-cron.sh' '$ACTION' '$RELEASE_SHA' '$EXPECTED_STATE' '$COMMENT_ID' '$AUTH_BODY_SHA' '$REMOTE_DIR'"
+
+      - name: Recover non-sensitive scheduler mutation evidence
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          REMOTE_DIR: ${{ steps.request.outputs.remote_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/production-scheduler
+          scp "$SERVER_USER@$SERVER_HOST:$REMOTE_DIR/scheduler-change-evidence.env" \
+            artifacts/production-scheduler/scheduler-change-evidence.env
+          chmod 600 artifacts/production-scheduler/scheduler-change-evidence.env
+
+      - name: Upload scheduler mutation evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-production-scheduler-${{ steps.auth.outputs.release_sha }}-${{ github.run_id }}
+          path: artifacts/production-scheduler
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/production-scheduler-readonly-audit.yml
+++ b/.github/workflows/production-scheduler-readonly-audit.yml
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - '.github/workflows/production-scheduler-readonly-audit.yml'
+      - '.github/workflows/production-scheduler-change.yml'
       - 'config/sync/automated_cron.settings.yml'
       - 'config/splits/production/automated_cron.settings.yml'
       - 'config/splits/preproduction/automated_cron.settings.yml'
       - 'scripts/production-promotion/reconcile-cron.sh'
+      - 'scripts/production-promotion/mutate-cron.sh'
       - 'docs/operations/environment-side-effects.md'
 
 permissions:
@@ -17,12 +19,19 @@ permissions:
 
 jobs:
   audit:
-    name: Detect real PROD cron owner without mutation
+    name: Verify exact PROD scheduler contract without mutation
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
+      - name: Checkout exact scheduler verifier
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Configure production read-only SSH access
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -39,7 +48,7 @@ jobs:
           ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Audit scheduler ownership without exposing commands
+      - name: Verify exact scheduler contract without mutation
         env:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
           SERVER_USER: ${{ secrets.SERVER_USER }}
@@ -48,67 +57,8 @@ jobs:
           set -euo pipefail
           test -n "$SERVER_HOST"
           test -n "$SERVER_USER"
-
-          ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" 'bash -s' <<'REMOTE'
-          set -euo pipefail
-
-          current='/var/www/agency/current'
-          drush="$current/vendor/bin/drush"
-
-          [[ -L "$current" ]]
-          printf 'prod_current_release=PASS\n'
-          [[ -x "$drush" ]]
-          printf 'prod_drush=PASS\n'
-          command -v crontab >/dev/null 2>&1
-          printf 'prod_crontab_available=PASS\n'
-          command -v flock >/dev/null 2>&1
-          printf 'prod_flock_available=PASS\n'
-
-          interval="$(
-            cd "$current"
-            "$drush" --quiet php:eval \
-              'echo (int) \Drupal::config("automated_cron.settings")->get("interval");'
-          )"
-          interval="$(printf '%s' "$interval" | tr -cd '0-9')"
-          [[ "$interval" =~ ^[0-9]+$ ]]
-          printf 'prod_automated_cron_interval=%s\n' "$interval"
-
-          user_cron_count="$(
-            (crontab -l 2>/dev/null || true) \
-              | grep -Eic '(^|[[:space:]])([^#]*)(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
-              || true
-          )"
-          user_cron_count="${user_cron_count:-0}"
-          printf 'deploy_user_drush_cron_entries=%s\n' "$user_cron_count"
-
-          system_cron_count="$(
-            {
-              grep -ERils --exclude='*.dpkg-*' --exclude='*.bak' \
-                '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
-                /etc/crontab /etc/cron.d /etc/cron.hourly /etc/cron.daily \
-                /etc/cron.weekly /etc/cron.monthly 2>/dev/null \
-                || true
-            } | wc -l | tr -d ' '
-          )"
-          printf 'system_cron_drush_cron_files=%s\n' "$system_cron_count"
-
-          systemd_cron_count="$(
-            {
-              grep -ERils --exclude='*.wants' \
-                '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
-                /etc/systemd/system 2>/dev/null \
-                || true
-            } | wc -l | tr -d ' '
-          )"
-          printf 'systemd_drush_cron_units=%s\n' "$systemd_cron_count"
-
-          [[ "$user_cron_count" =~ ^[0-9]+$ ]]
-          [[ "$system_cron_count" =~ ^[0-9]+$ ]]
-          [[ "$systemd_cron_count" =~ ^[0-9]+$ ]]
-
-          external_count=$((user_cron_count + system_cron_count + systemd_cron_count))
-
-          printf 'schema_version=1\n'
-          printf 'external_drush_cron_scheduler_count=%s\n' "$external_count"
-          printf 'prod_scheduler_audit=PASS\n'
-          REMOTE
+          verifier='scripts/production-promotion/reconcile-cron.sh'
+          test -f "$verifier"
+          ! grep -Fq 'crontab "$tmp"' "$verifier"
+          ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" \
+            'SCHEDULER_ACTION=VERIFY_ONLY bash -s' < "$verifier"

--- a/.github/workflows/production-scheduler-readonly-audit.yml
+++ b/.github/workflows/production-scheduler-readonly-audit.yml
@@ -62,3 +62,24 @@ jobs:
           ! grep -Fq 'crontab "$tmp"' "$verifier"
           ssh -o ConnectTimeout=10 "$SERVER_USER@$SERVER_HOST" \
             'SCHEDULER_ACTION=VERIFY_ONLY bash -s' < "$verifier"
+
+      - name: Verify current production health and public smoke without mutation
+        env:
+          PROD_URL: https://emergingdigital.be
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for endpoint in live ready; do
+            status="$(curl --silent --show-error --location --retry 3 --max-time 20 \
+              --output /dev/null --write-out '%{http_code}' \
+              "$PROD_URL/health/$endpoint")"
+            [[ "$status" == '200' ]]
+            printf 'production_health_%s=%s\n' "$endpoint" "$status"
+          done
+
+          smoke_status="$(curl --silent --show-error --location --retry 3 --max-time 20 \
+            --output /dev/null --write-out '%{http_code}' "$PROD_URL/fr/blog")"
+          [[ "$smoke_status" == '200' ]]
+          printf 'production_smoke_status=%s\n' "$smoke_status"
+          printf 'production_smoke=PASS\n'

--- a/docs/operations/environment-side-effects.md
+++ b/docs/operations/environment-side-effects.md
@@ -9,7 +9,7 @@ This document is the durable contract for external side effects in Agency. Confi
 | GA4 / Google Tag | PROD_OVERRIDE | OFF | OFF | Anonymous users eligible only; authenticated users excluded by native Google Tag `user_role` condition; consent still applies |
 | Email | PROD_OVERRIDE + runtime secret | Mailpit | `symfony_mailer` native transport, null credentials, PHP `sendmail_path=/bin/true` | SMTP transport; credential injected from server environment only |
 | Drupal automated cron | SAME | OFF (`interval: 0`), manual | OFF (`interval: 0`), manual/bounded | OFF (`interval: 0`); operating-system scheduler owns execution |
-| Drupal cron scheduler | PROD runtime | None | None | Exactly one deploy-user crontab installed by governed PROD promotion, every 15 minutes, protected by `flock` |
+| Drupal cron scheduler | PROD runtime + separate authority | None | None | Exactly one deploy-user crontab, every 15 minutes, protected by `flock`; functional promotion is VERIFY_ONLY and cannot create/update/remove it |
 | OpenAI / external AI provider | runtime gate | OFF by default; explicit `AGENCY_AI_EGRESS_ENABLED` opt-in required | Forced OFF; Key disabled; no provider credential; chatbot guard blocks external calls | OFF by default; activation requires an explicit product/config change plus runtime credential |
 | Link Checker | DEV_OVERRIDE / PREPROD_OVERRIDE / PROD_OVERRIDE | DDEV canonical host, manual | PREPROD canonical host, manual/bounded | Production canonical host, scheduler-driven |
 | Drupal Update notifications | SAME | No Drupal email recipient | No Drupal email recipient | No Drupal email recipient; dependency/security monitoring is owned outside Drupal mail |
@@ -19,11 +19,68 @@ This document is the durable contract for external side effects in Agency. Confi
 | Simple Sitemap / SEO output | SAME + web runtime | Local only | noindex + Basic Auth | Public canonical output |
 | Custom external API / webhook writes | runtime gate | OFF/fake unless explicitly opted in | OFF/sandbox unless an explicit trusted proof authorizes it | Explicit PROD feature only |
 
-## Evidence and current live baseline
+## Current production scheduler baseline
 
-The read-only production scheduler audit on 25 August 2026 established `automated_cron interval = 0` and found zero deploy-user, system-cron or systemd `drush cron` schedulers. This is a live gap, not permission to mutate PROD. The repository therefore keeps automated cron disabled everywhere and prepares one controlled scheduler that is installed only by the already governed same-artifact production promotion after an explicit owner GO.
+The first read-only scheduler audit under #815 established `automated_cron interval = 0` and found no external Drupal scheduler before the first governed same-artifact production promotion.
 
-The scheduler reconciliation is fail-closed: it requires `crontab` and `flock`, refuses an unmanaged Drupal cron scheduler, preserves unrelated crontab entries, converges the tagged Agency entry to exactly one instance, and does not run during PREPROD deployment.
+The successful r10 promotion of candidate `a2e28b5c9206e0c5f2b97c81d871f30cbae1a4e9` then created one deploy-user scheduler as an implicit side effect. The application promotion itself remained healthy, but scheduler creation was outside the exact release GO and is classified under #812/#823 as `POST_MUTATION_POLICY_DEVIATION`.
+
+A fresh read-only rerun of scheduler audit `32892375791` after r10 proved the current technical state:
+
+- Drupal automated cron = `0`;
+- deploy-user `drush cron` entries = `1`;
+- system cron duplicates = `0`;
+- systemd duplicates = `0`;
+- external Drupal scheduler count = `1`;
+- `crontab` and `flock` available;
+- audit = PASS.
+
+The controlled contract is:
+
+```text
+marker   = # agency-drupal-cron
+schedule = */15 * * * *
+lock     = /var/www/agency/shared/cron.lock
+command  = cd /var/www/agency/current && flock -n <lock> vendor/bin/drush cron -q
+```
+
+The current scheduler is therefore technically aligned with the desired architecture. Its governance disposition remains a Project Lead decision: KEEP/RATIFY or REMOVE. Repository convergence does not retroactively authorize the r10 scheduler write and does not itself mutate the current scheduler.
+
+## Scheduler authority boundary
+
+`scripts/production-promotion/reconcile-cron.sh` keeps its historical filename for compatibility with the established promotion route, but its contract is now strictly `VERIFY_ONLY`:
+
+- default action = `VERIFY_ONLY`;
+- any other action is rejected;
+- it never writes `crontab`;
+- it requires automated cron to remain disabled;
+- it requires exactly one marker and exactly one exact controlled deploy-user scheduler;
+- it rejects unmanaged deploy-user, system cron and systemd schedulers;
+- drift or duplicates fail closed.
+
+Functional release promotion invokes this verifier and therefore cannot CREATE, UPDATE or REMOVE the PROD scheduler.
+
+Scheduler mutation is a separate owner-authorized operation through `.github/workflows/production-scheduler-change.yml`. The exact authorization command binds:
+
+- requested transition: `CREATE`, `UPDATE` or `REMOVE`;
+- current production release SHA;
+- expected scheduler state;
+- owner-authored GitHub comment ID;
+- SHA-256 digest of the authorization body.
+
+Allowed transitions are deliberately bounded:
+
+```text
+ABSENT        --CREATE--> CONTROLLED
+MANAGED_DRIFT --UPDATE--> CONTROLLED
+CONTROLLED    --REMOVE--> ABSENT
+```
+
+`UNMANAGED` and `INVALID` are never writable preconditions. The mutator also resolves the current production symlink back to exactly one successful production promotion receipt and refuses a release identity mismatch before any crontab write.
+
+A scheduler mutation is never inferred from a functional release GO, from secret availability, from the desired architecture or from an existing scheduler. It requires its own exact owner authority.
+
+## External provider and environment notes
 
 OpenAI secret presence is never authority. The common Key entity is disabled by default. DDEV/trusted proof must explicitly opt in; PREPROD forces provider egress OFF. `agency_ai_translation` checks the environment gate before making an HTTP request, while the chatbot Future AI path retains its own environment guard. Normal PREPROD validation must prove: external AI gate blocked, OpenAI Key disabled, `OPENAI_API_KEY` absent, and chatbot external calls disallowed.
 
@@ -33,6 +90,8 @@ Link Checker uses real Drupal configuration differences: common DEV configuratio
 
 Repository search for `webhook` found no active custom webhook implementation in application code during #815. The identified custom external-provider surfaces are the AI translation client and chatbot Future AI path; both are governed by explicit runtime authorization rather than secret presence.
 
-## Promotion boundary
+## Repository-change boundary
 
-No change in this issue mutates PROD. The scheduler installer is only invoked inside `scripts/production-promotion/promote-candidate.sh`, whose caller already requires the exact candidate SHA, artifact digest, Composer lock digest, successful PREPROD evidence and an explicit owner-authored GO. Until such GO exists, current PROD remains unchanged.
+The #823 recovery PR performs `PROD_MUTATION = NONE`. Its PR-time scheduler audit is read-only and executes the same verify-only contract against PROD. An ordinary merge to `main` must not deploy the application and must not mutate the scheduler.
+
+After repository convergence, #812 remains open until the Project Lead explicitly dispositions the already-present scheduler. If the decision is KEEP/RATIFY, no runtime write is required merely to preserve the existing entry. If the decision is REMOVE, that is a real production mutation and must use the separate explicit scheduler authority.

--- a/scripts/production-promotion/mutate-cron.sh
+++ b/scripts/production-promotion/mutate-cron.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+ACTION="${1:-}"
+EXPECTED_RELEASE_SHA="${2:-}"
+EXPECTED_STATE="${3:-}"
+AUTH_COMMENT_ID="${4:-}"
+AUTH_BODY_SHA256="${5:-}"
+REQUEST_DIR="${6:-}"
+AUTHORITY_KIND="${SCHEDULER_AUTHORITY_KIND:-}"
+
+PROJECT_ROOT='/var/www/agency'
+CURRENT="$PROJECT_ROOT/current"
+DRUSH="$CURRENT/vendor/bin/drush"
+PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"
+LOCK_FILE="$PROJECT_ROOT/shared/cron.lock"
+MARKER='# agency-drupal-cron'
+SCHEDULE='*/15 * * * *'
+EXPECTED_LINE="$SCHEDULE cd $CURRENT && flock -n $LOCK_FILE vendor/bin/drush cron -q $MARKER"
+EVIDENCE="$REQUEST_DIR/scheduler-change-evidence.env"
+
+fail() {
+  printf '[prod-cron-mutate] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+case "$ACTION" in
+  CREATE)
+    [[ "$EXPECTED_STATE" == 'ABSENT' ]] || fail 'CREATE requires expected state ABSENT.'
+    ;;
+  UPDATE)
+    [[ "$EXPECTED_STATE" == 'MANAGED_DRIFT' ]] || fail 'UPDATE requires expected state MANAGED_DRIFT.'
+    ;;
+  REMOVE)
+    [[ "$EXPECTED_STATE" == 'CONTROLLED' ]] || fail 'REMOVE requires expected state CONTROLLED.'
+    ;;
+  *)
+    fail 'Scheduler action must be CREATE, UPDATE or REMOVE.'
+    ;;
+esac
+
+[[ "$AUTHORITY_KIND" == 'OWNER_ISSUE_COMMENT' ]] \
+  || fail 'Separate owner issue-comment authority is required.'
+[[ "$EXPECTED_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail 'Expected production release SHA is invalid.'
+[[ "$AUTH_COMMENT_ID" =~ ^[0-9]+$ ]] || fail 'Authorization comment id is invalid.'
+[[ "$AUTH_BODY_SHA256" =~ ^[0-9a-f]{64}$ ]] || fail 'Authorization body digest is invalid.'
+[[ -d "$REQUEST_DIR" && ! -L "$REQUEST_DIR" ]] || fail 'Scheduler request directory is invalid.'
+[[ -L "$CURRENT" ]] || fail 'Production current symlink is missing.'
+[[ -x "$DRUSH" ]] || fail 'Drush is unavailable on the current release.'
+[[ -d "$PROMOTIONS_DIR" ]] || fail 'Production promotion receipts are unavailable.'
+command -v crontab >/dev/null 2>&1 || fail 'crontab is unavailable.'
+command -v flock >/dev/null 2>&1 || fail 'flock is unavailable.'
+
+current_release="$(readlink -f "$CURRENT")"
+[[ -n "$current_release" ]] || fail 'Current production release cannot be resolved.'
+
+matched_receipts=0
+current_release_sha=''
+shopt -s nullglob
+for receipt in "$PROMOTIONS_DIR"/*.env; do
+  receipt_release="$(grep -m1 '^release_path=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_release" == "$current_release" ]] || continue
+  receipt_sha="$(grep -m1 '^candidate_sha=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_sha" =~ ^[0-9a-f]{40}$ ]] || fail 'Current production receipt has invalid candidate identity.'
+  current_release_sha="$receipt_sha"
+  matched_receipts=$((matched_receipts + 1))
+done
+shopt -u nullglob
+[[ "$matched_receipts" == '1' ]] || fail 'Current production release must map to exactly one promotion receipt.'
+[[ "$current_release_sha" == "$EXPECTED_RELEASE_SHA" ]] || fail 'Current production release identity differs from authorized identity.'
+
+RUNTIME_STATE='INVALID'
+SYSTEM_CRON_COUNT='0'
+SYSTEMD_CRON_COUNT='0'
+MARKER_COUNT='0'
+EXACT_COUNT='0'
+USER_CRON_COUNT='0'
+UNTAGGED_COUNT='0'
+CRONTAB_TEXT=''
+
+inspect_state() {
+  local interval
+
+  interval="$(
+    cd "$CURRENT"
+    "$DRUSH" --quiet php:eval \
+      'echo (int) \Drupal::config("automated_cron.settings")->get("interval");'
+  )"
+  interval="$(printf '%s' "$interval" | tr -cd '0-9')"
+  [[ "$interval" == '0' ]] || {
+    RUNTIME_STATE='INVALID'
+    return
+  }
+
+  SYSTEM_CRON_COUNT="$(
+    {
+      grep -ERils --exclude='*.dpkg-*' --exclude='*.bak' \
+        '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
+        /etc/crontab /etc/cron.d /etc/cron.hourly /etc/cron.daily \
+        /etc/cron.weekly /etc/cron.monthly 2>/dev/null || true
+    } | wc -l | tr -d ' '
+  )"
+  SYSTEMD_CRON_COUNT="$(
+    {
+      grep -ERils --exclude='*.wants' \
+        '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
+        /etc/systemd/system 2>/dev/null || true
+    } | wc -l | tr -d ' '
+  )"
+
+  CRONTAB_TEXT="$(crontab -l 2>/dev/null || true)"
+  MARKER_COUNT="$(printf '%s\n' "$CRONTAB_TEXT" | grep -Fc "$MARKER" || true)"
+  EXACT_COUNT="$(printf '%s\n' "$CRONTAB_TEXT" | grep -Fxc "$EXPECTED_LINE" || true)"
+  USER_CRON_COUNT="$(
+    printf '%s\n' "$CRONTAB_TEXT" \
+      | grep -Eic '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
+      || true
+  )"
+  UNTAGGED_COUNT="$(
+    printf '%s\n' "$CRONTAB_TEXT" \
+      | grep -Fv "$MARKER" \
+      | grep -Eic '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
+      || true
+  )"
+
+  if [[ "$SYSTEM_CRON_COUNT" != '0' || "$SYSTEMD_CRON_COUNT" != '0' || "$UNTAGGED_COUNT" != '0' ]]; then
+    RUNTIME_STATE='UNMANAGED'
+  elif [[ "$MARKER_COUNT" == '0' && "$USER_CRON_COUNT" == '0' ]]; then
+    RUNTIME_STATE='ABSENT'
+  elif [[ "$MARKER_COUNT" == '1' && "$USER_CRON_COUNT" == '1' && "$EXACT_COUNT" == '1' ]]; then
+    RUNTIME_STATE='CONTROLLED'
+  elif [[ "$MARKER_COUNT" == '1' && "$USER_CRON_COUNT" == '1' && "$EXACT_COUNT" == '0' ]]; then
+    RUNTIME_STATE='MANAGED_DRIFT'
+  else
+    RUNTIME_STATE='UNMANAGED'
+  fi
+}
+
+inspect_state
+[[ "$RUNTIME_STATE" == "$EXPECTED_STATE" ]] \
+  || fail "Scheduler state is $RUNTIME_STATE, expected authorized state $EXPECTED_STATE."
+
+before_state="$RUNTIME_STATE"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+case "$ACTION" in
+  CREATE)
+    printf '%s\n' "$CRONTAB_TEXT" > "$tmp"
+    printf '%s\n' "$EXPECTED_LINE" >> "$tmp"
+    ;;
+  UPDATE)
+    printf '%s\n' "$CRONTAB_TEXT" | grep -Fv "$MARKER" > "$tmp" || true
+    printf '%s\n' "$EXPECTED_LINE" >> "$tmp"
+    ;;
+  REMOVE)
+    printf '%s\n' "$CRONTAB_TEXT" | grep -Fv "$MARKER" > "$tmp" || true
+    ;;
+esac
+
+crontab "$tmp"
+inspect_state
+
+case "$ACTION" in
+  CREATE|UPDATE)
+    [[ "$RUNTIME_STATE" == 'CONTROLLED' ]] || fail 'Authorized scheduler mutation did not converge to CONTROLLED.'
+    ;;
+  REMOVE)
+    [[ "$RUNTIME_STATE" == 'ABSENT' ]] || fail 'Authorized scheduler removal did not converge to ABSENT.'
+    ;;
+esac
+
+after_state="$RUNTIME_STATE"
+{
+  printf 'schema_version=1\n'
+  printf 'scheduler_action=%s\n' "$ACTION"
+  printf 'production_release_sha=%s\n' "$EXPECTED_RELEASE_SHA"
+  printf 'expected_scheduler_state=%s\n' "$EXPECTED_STATE"
+  printf 'scheduler_state_before=%s\n' "$before_state"
+  printf 'scheduler_state_after=%s\n' "$after_state"
+  printf 'authorization_kind=OWNER_ISSUE_COMMENT\n'
+  printf 'authorization_comment_id=%s\n' "$AUTH_COMMENT_ID"
+  printf 'authorization_body_sha256=%s\n' "$AUTH_BODY_SHA256"
+  printf 'production_scheduler_marker=%s\n' "$MARKER"
+  printf 'production_scheduler_interval_minutes=15\n'
+  printf 'production_scheduler_flock=%s\n' "$LOCK_FILE"
+  printf 'changed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+} > "$EVIDENCE"
+chmod 600 "$EVIDENCE"
+
+printf 'scheduler_action=%s\n' "$ACTION"
+printf 'scheduler_state_before=%s\n' "$before_state"
+printf 'scheduler_state_after=%s\n' "$after_state"

--- a/scripts/production-promotion/reconcile-cron.sh
+++ b/scripts/production-promotion/reconcile-cron.sh
@@ -5,6 +5,7 @@ umask 077
 PROJECT_ROOT='/var/www/agency'
 CURRENT="$PROJECT_ROOT/current"
 DRUSH="$CURRENT/vendor/bin/drush"
+PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"
 LOCK_FILE="$PROJECT_ROOT/shared/cron.lock"
 MARKER='# agency-drupal-cron'
 SCHEDULE='*/15 * * * *'
@@ -23,6 +24,25 @@ command -v crontab >/dev/null 2>&1 || fail 'crontab is unavailable.'
 command -v flock >/dev/null 2>&1 || fail 'flock is unavailable.'
 [[ -L "$CURRENT" ]] || fail 'Production current symlink is missing.'
 [[ -x "$DRUSH" ]] || fail 'Drush is unavailable on the current release.'
+[[ -d "$PROMOTIONS_DIR" ]] || fail 'Production promotion receipts are unavailable.'
+
+current_release="$(readlink -f "$CURRENT")"
+[[ -n "$current_release" ]] || fail 'Current production release cannot be resolved.'
+matched_receipts=0
+current_release_sha=''
+shopt -s nullglob
+for receipt in "$PROMOTIONS_DIR"/*.env; do
+  receipt_release="$(grep -m1 '^release_path=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_release" == "$current_release" ]] || continue
+  receipt_sha="$(grep -m1 '^candidate_sha=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || fail 'Current production receipt has invalid candidate identity.'
+  current_release_sha="$receipt_sha"
+  matched_receipts=$((matched_receipts + 1))
+done
+shopt -u nullglob
+[[ "$matched_receipts" == '1' ]] \
+  || fail 'Current production release must map to exactly one promotion receipt.'
 
 interval="$(
   cd "$CURRENT"
@@ -70,6 +90,8 @@ untagged_count="$(
 [[ "$controlled_count" == '1' ]] || fail 'Deploy-user Drupal scheduler count is not exactly one.'
 [[ "$untagged_count" == '0' ]] || fail 'An unmanaged deploy-user Drupal cron scheduler exists.'
 
+printf 'production_current_release=%s\n' "$current_release"
+printf 'production_current_release_sha=%s\n' "$current_release_sha"
 printf 'production_scheduler_action=VERIFY_ONLY\n'
 printf 'production_scheduler=DEPLOY_USER_CRONTAB\n'
 printf 'production_scheduler_entries=1\n'

--- a/scripts/production-promotion/reconcile-cron.sh
+++ b/scripts/production-promotion/reconcile-cron.sh
@@ -8,16 +8,29 @@ DRUSH="$CURRENT/vendor/bin/drush"
 LOCK_FILE="$PROJECT_ROOT/shared/cron.lock"
 MARKER='# agency-drupal-cron'
 SCHEDULE='*/15 * * * *'
+EXPECTED_LINE="$SCHEDULE cd $CURRENT && flock -n $LOCK_FILE vendor/bin/drush cron -q $MARKER"
+SCHEDULER_ACTION="${SCHEDULER_ACTION:-${1:-VERIFY_ONLY}}"
 
 fail() {
   printf '[prod-cron] ERROR: %s\n' "$1" >&2
   exit 1
 }
 
+[[ "$SCHEDULER_ACTION" == 'VERIFY_ONLY' ]] \
+  || fail 'Functional promotion may only VERIFY_ONLY the PROD scheduler.'
+
 command -v crontab >/dev/null 2>&1 || fail 'crontab is unavailable.'
 command -v flock >/dev/null 2>&1 || fail 'flock is unavailable.'
 [[ -L "$CURRENT" ]] || fail 'Production current symlink is missing.'
 [[ -x "$DRUSH" ]] || fail 'Drush is unavailable on the current release.'
+
+interval="$(
+  cd "$CURRENT"
+  "$DRUSH" --quiet php:eval \
+    'echo (int) \Drupal::config("automated_cron.settings")->get("interval");'
+)"
+interval="$(printf '%s' "$interval" | tr -cd '0-9')"
+[[ "$interval" == '0' ]] || fail 'Drupal automated cron must remain disabled in PROD.'
 
 system_cron_count="$(
   {
@@ -34,32 +47,36 @@ systemd_cron_count="$(
       /etc/systemd/system 2>/dev/null || true
   } | wc -l | tr -d ' '
 )"
-[[ "$system_cron_count" == '0' ]] || fail 'An unmanaged system cron Drupal scheduler already exists.'
-[[ "$systemd_cron_count" == '0' ]] || fail 'An unmanaged systemd Drupal scheduler already exists.'
+[[ "$system_cron_count" == '0' ]] || fail 'An unmanaged system cron Drupal scheduler exists.'
+[[ "$systemd_cron_count" == '0' ]] || fail 'An unmanaged systemd Drupal scheduler exists.'
 
-tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
-(crontab -l 2>/dev/null || true) | grep -Fv "$MARKER" > "$tmp" || true
-
-untagged_count="$(
-  grep -Eic '(^|[[:space:]])([^#]*)(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' "$tmp" || true
-)"
-[[ "$untagged_count" == '0' ]] || fail 'An unmanaged deploy-user Drupal cron scheduler already exists.'
-
-printf '%s cd %s && flock -n %s vendor/bin/drush cron -q %s\n' \
-  "$SCHEDULE" "$CURRENT" "$LOCK_FILE" "$MARKER" >> "$tmp"
-crontab "$tmp"
-
-marker_count="$(crontab -l | grep -Fc "$MARKER" || true)"
-[[ "$marker_count" == '1' ]] || fail 'Controlled Drupal cron entry did not converge to exactly one entry.'
-
+crontab_text="$(crontab -l 2>/dev/null || true)"
+marker_count="$(printf '%s\n' "$crontab_text" | grep -Fc "$MARKER" || true)"
+exact_count="$(printf '%s\n' "$crontab_text" | grep -Fxc "$EXPECTED_LINE" || true)"
 controlled_count="$(
-  crontab -l \
+  printf '%s\n' "$crontab_text" \
     | grep -Eic '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
     || true
 )"
-[[ "$controlled_count" == '1' ]] || fail 'Drupal cron did not converge to exactly one deploy-user scheduler.'
+untagged_count="$(
+  printf '%s\n' "$crontab_text" \
+    | grep -Fv "$MARKER" \
+    | grep -Eic '(drush|vendor/bin/drush)[[:space:]]+cron([[:space:]]|$)' \
+    || true
+)"
 
+[[ "$marker_count" == '1' ]] || fail 'Controlled Agency scheduler marker count is not exactly one.'
+[[ "$exact_count" == '1' ]] || fail 'Controlled Agency scheduler does not match the exact expected contract.'
+[[ "$controlled_count" == '1' ]] || fail 'Deploy-user Drupal scheduler count is not exactly one.'
+[[ "$untagged_count" == '0' ]] || fail 'An unmanaged deploy-user Drupal cron scheduler exists.'
+
+printf 'production_scheduler_action=VERIFY_ONLY\n'
 printf 'production_scheduler=DEPLOY_USER_CRONTAB\n'
 printf 'production_scheduler_entries=1\n'
+printf 'production_scheduler_marker=%s\n' "$MARKER"
 printf 'production_scheduler_interval_minutes=15\n'
+printf 'production_scheduler_flock=%s\n' "$LOCK_FILE"
+printf 'production_scheduler_runtime_state=CONTROLLED\n'
+printf 'prod_automated_cron_interval=0\n'
+printf 'system_cron_drush_cron_files=0\n'
+printf 'systemd_drush_cron_units=0\n'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/EnvironmentSideEffectPolicyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/EnvironmentSideEffectPolicyTest.php
@@ -119,7 +119,7 @@ final class EnvironmentSideEffectPolicyTest extends TestCase {
       'Simple Sitemap / SEO output',
       'Custom external API / webhook writes',
       'VERIFY_ONLY',
-      'OWNER_ISSUE_COMMENT',
+      'production-scheduler-change.yml',
     ] as $expected) {
       self::assertStringContainsString($expected, $matrix);
     }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/EnvironmentSideEffectPolicyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/EnvironmentSideEffectPolicyTest.php
@@ -49,7 +49,7 @@ final class EnvironmentSideEffectPolicyTest extends TestCase {
   }
 
   /**
-   * Provider egress and PROD scheduling require explicit authority.
+   * Provider egress and PROD scheduler writes require explicit authority.
    */
   public function testRuntimeGatesAreFailClosed(): void {
     $root = dirname(DRUPAL_ROOT);
@@ -66,8 +66,14 @@ final class EnvironmentSideEffectPolicyTest extends TestCase {
     $promotion = (string) file_get_contents(
       $root . '/scripts/production-promotion/promote-candidate.sh',
     );
-    $scheduler = (string) file_get_contents(
+    $schedulerVerifier = (string) file_get_contents(
       $root . '/scripts/production-promotion/reconcile-cron.sh',
+    );
+    $schedulerMutator = (string) file_get_contents(
+      $root . '/scripts/production-promotion/mutate-cron.sh',
+    );
+    $schedulerWorkflow = (string) file_get_contents(
+      $root . '/.github/workflows/production-scheduler-change.yml',
     );
 
     self::assertStringContainsString('AGENCY_AI_EGRESS_ENABLED', $settings);
@@ -77,9 +83,20 @@ final class EnvironmentSideEffectPolicyTest extends TestCase {
     self::assertStringContainsString('OPENAI_API_KEY', $runtime);
 
     self::assertStringContainsString('reconcile-cron.sh', $promotion);
-    self::assertStringContainsString('# agency-drupal-cron', $scheduler);
-    self::assertStringContainsString('flock -n', $scheduler);
-    self::assertStringContainsString('*/15 * * * *', $scheduler);
+    self::assertStringNotContainsString('mutate-cron.sh', $promotion);
+    self::assertStringContainsString('VERIFY_ONLY', $schedulerVerifier);
+    self::assertStringContainsString('# agency-drupal-cron', $schedulerVerifier);
+    self::assertStringContainsString('flock -n', $schedulerVerifier);
+    self::assertStringContainsString('*/15 * * * *', $schedulerVerifier);
+    self::assertStringNotContainsString('crontab "$tmp"', $schedulerVerifier);
+
+    self::assertStringContainsString('OWNER_ISSUE_COMMENT', $schedulerMutator);
+    self::assertStringContainsString('crontab "$tmp"', $schedulerMutator);
+    self::assertStringContainsString('/agency-production-scheduler', $schedulerWorkflow);
+    self::assertStringContainsString(
+      "github.event.comment.author_association == 'OWNER'",
+      $schedulerWorkflow,
+    );
   }
 
   /**
@@ -101,6 +118,8 @@ final class EnvironmentSideEffectPolicyTest extends TestCase {
       'Cookie consent',
       'Simple Sitemap / SEO output',
       'Custom external API / webhook writes',
+      'VERIFY_ONLY',
+      'OWNER_ISSUE_COMMENT',
     ] as $expected) {
       self::assertStringContainsString($expected, $matrix);
     }

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
@@ -29,7 +29,7 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
       $verifier,
     );
     self::assertStringContainsString(
-      "[[ \"$SCHEDULER_ACTION\" == 'VERIFY_ONLY' ]]",
+      '[[ "$SCHEDULER_ACTION" == \'VERIFY_ONLY\' ]]',
       $verifier,
     );
     self::assertStringContainsString(
@@ -96,10 +96,10 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
     }
 
     foreach ([
-      "CREATE)",
-      "UPDATE)",
-      "REMOVE)",
-      "[[ \"$AUTHORITY_KIND\" == 'OWNER_ISSUE_COMMENT' ]]",
+      'CREATE)',
+      'UPDATE)',
+      'REMOVE)',
+      '[[ "$AUTHORITY_KIND" == \'OWNER_ISSUE_COMMENT\' ]]',
       'AUTH_COMMENT_ID="${4:-}"',
       'AUTH_BODY_SHA256="${5:-}"',
       'Current production release identity differs from authorized identity.',
@@ -119,9 +119,9 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
     $mutator = $this->script('scripts/production-promotion/mutate-cron.sh');
 
     self::assertStringContainsString("RUNTIME_STATE='UNMANAGED'", $mutator);
-    self::assertStringContainsString("CREATE requires expected state ABSENT.", $mutator);
-    self::assertStringContainsString("UPDATE requires expected state MANAGED_DRIFT.", $mutator);
-    self::assertStringContainsString("REMOVE requires expected state CONTROLLED.", $mutator);
+    self::assertStringContainsString('CREATE requires expected state ABSENT.', $mutator);
+    self::assertStringContainsString('UPDATE requires expected state MANAGED_DRIFT.', $mutator);
+    self::assertStringContainsString('REMOVE requires expected state CONTROLLED.', $mutator);
     self::assertStringNotContainsString('CREATE:UNMANAGED', $mutator);
     self::assertStringNotContainsString('UPDATE:UNMANAGED', $mutator);
     self::assertStringNotContainsString('REMOVE:UNMANAGED', $mutator);
@@ -139,10 +139,13 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
       $workflow,
     );
     self::assertStringContainsString(
-      "! grep -Fq 'crontab \"$tmp\"' \"$verifier\"",
+      '! grep -Fq \'crontab "$tmp"\' "$verifier"',
       $workflow,
     );
-    self::assertStringNotContainsString('mutate-cron.sh\' <', $workflow);
+    self::assertStringNotContainsString(
+      'SCHEDULER_AUTHORITY_KIND=OWNER_ISSUE_COMMENT',
+      $workflow,
+    );
   }
 
   /**

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects PROD scheduler authority from functional promotion side effects.
+ *
+ * @group agency_project_tests
+ * @group production_scheduler
+ */
+final class SchedulerGovernanceSafetyTest extends TestCase {
+
+  /**
+   * Functional promotion can only verify the scheduler and never write it.
+   */
+  public function testFunctionalPromotionSchedulerPathIsVerifyOnly(): void {
+    $promotion = $this->script('scripts/production-promotion/promote-candidate.sh');
+    $verifier = $this->script('scripts/production-promotion/reconcile-cron.sh');
+
+    self::assertStringContainsString('reconcile-cron.sh', $promotion);
+    self::assertStringNotContainsString('mutate-cron.sh', $promotion);
+    self::assertStringContainsString(
+      'SCHEDULER_ACTION="${SCHEDULER_ACTION:-${1:-VERIFY_ONLY}}"',
+      $verifier,
+    );
+    self::assertStringContainsString(
+      "[[ \"$SCHEDULER_ACTION\" == 'VERIFY_ONLY' ]]",
+      $verifier,
+    );
+    self::assertStringContainsString(
+      'Functional promotion may only VERIFY_ONLY the PROD scheduler.',
+      $verifier,
+    );
+    self::assertStringNotContainsString('crontab "$tmp"', $verifier);
+    self::assertStringNotContainsString('mktemp', $verifier);
+  }
+
+  /**
+   * Verify-only accepts only the exact controlled scheduler contract.
+   */
+  public function testVerifyOnlyContractFailsClosedOnDriftOrDuplicates(): void {
+    $verifier = $this->script('scripts/production-promotion/reconcile-cron.sh');
+
+    foreach ([
+      "MARKER='# agency-drupal-cron'",
+      "SCHEDULE='*/15 * * * *'",
+      'LOCK_FILE="$PROJECT_ROOT/shared/cron.lock"',
+      'Drupal automated cron must remain disabled in PROD.',
+      'An unmanaged system cron Drupal scheduler exists.',
+      'An unmanaged systemd Drupal scheduler exists.',
+      'Controlled Agency scheduler marker count is not exactly one.',
+      'Controlled Agency scheduler does not match the exact expected contract.',
+      'Deploy-user Drupal scheduler count is not exactly one.',
+      'An unmanaged deploy-user Drupal cron scheduler exists.',
+      'production_scheduler_action=VERIFY_ONLY',
+      'production_scheduler_runtime_state=CONTROLLED',
+    ] as $required) {
+      self::assertStringContainsString($required, $verifier);
+    }
+  }
+
+  /**
+   * Scheduler writes exist only behind the dedicated explicit authority path.
+   */
+  public function testSchedulerMutationRequiresSeparateExactOwnerAuthority(): void {
+    $workflow = $this->workflow('.github/workflows/production-scheduler-change.yml');
+    $mutator = $this->script('scripts/production-promotion/mutate-cron.sh');
+
+    self::assertStringContainsString('issue_comment:', $workflow);
+    self::assertStringContainsString('- created', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString("\n  push:\n", $workflow);
+    self::assertStringContainsString(
+      "github.event.comment.user.login == 'E-merging-digital'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "github.event.comment.author_association == 'OWNER'",
+      $workflow,
+    );
+    foreach ([
+      '/agency-production-scheduler\\ action=',
+      'release=([0-9a-f]{40})',
+      'expected=(ABSENT|CONTROLLED|MANAGED_DRIFT)',
+      'CREATE:ABSENT|UPDATE:MANAGED_DRIFT|REMOVE:CONTROLLED',
+      'auth_body_sha',
+      'comment_id',
+      'SCHEDULER_AUTHORITY_KIND=OWNER_ISSUE_COMMENT',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      "CREATE)",
+      "UPDATE)",
+      "REMOVE)",
+      "[[ \"$AUTHORITY_KIND\" == 'OWNER_ISSUE_COMMENT' ]]",
+      'AUTH_COMMENT_ID="${4:-}"',
+      'AUTH_BODY_SHA256="${5:-}"',
+      'Current production release identity differs from authorized identity.',
+      'Scheduler state is $RUNTIME_STATE, expected authorized state $EXPECTED_STATE.',
+      'crontab "$tmp"',
+      'authorization_comment_id=',
+      'authorization_body_sha256=',
+    ] as $required) {
+      self::assertStringContainsString($required, $mutator);
+    }
+  }
+
+  /**
+   * Unmanaged state is never an authorized mutation precondition.
+   */
+  public function testSchedulerMutationStateTransitionsAreBounded(): void {
+    $mutator = $this->script('scripts/production-promotion/mutate-cron.sh');
+
+    self::assertStringContainsString("RUNTIME_STATE='UNMANAGED'", $mutator);
+    self::assertStringContainsString("CREATE requires expected state ABSENT.", $mutator);
+    self::assertStringContainsString("UPDATE requires expected state MANAGED_DRIFT.", $mutator);
+    self::assertStringContainsString("REMOVE requires expected state CONTROLLED.", $mutator);
+    self::assertStringNotContainsString('CREATE:UNMANAGED', $mutator);
+    self::assertStringNotContainsString('UPDATE:UNMANAGED', $mutator);
+    self::assertStringNotContainsString('REMOVE:UNMANAGED', $mutator);
+  }
+
+  /**
+   * The PR-time PROD audit executes only the verify-only contract.
+   */
+  public function testProductionSchedulerAuditIsReadOnly(): void {
+    $workflow = $this->workflow('.github/workflows/production-scheduler-readonly-audit.yml');
+
+    self::assertStringContainsString('pull_request:', $workflow);
+    self::assertStringContainsString(
+      "'SCHEDULER_ACTION=VERIFY_ONLY bash -s'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "! grep -Fq 'crontab \"$tmp\"' \"$verifier\"",
+      $workflow,
+    );
+    self::assertStringNotContainsString('mutate-cron.sh\' <', $workflow);
+  }
+
+  /**
+   * Returns a parsed workflow and its source text.
+   */
+  private function workflow(string $relativePath): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/' . $relativePath;
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+  /**
+   * Returns a repository-owned script.
+   */
+  private function script(string $relativePath): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/' . $relativePath;
+    self::assertFileExists($path);
+
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/SchedulerGovernanceSafetyTest.php
@@ -41,6 +41,25 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
   }
 
   /**
+   * Verify-only binds scheduler proof to the exact current production release.
+   */
+  public function testVerifyOnlyBindsCurrentReleaseReceipt(): void {
+    $verifier = $this->script('scripts/production-promotion/reconcile-cron.sh');
+
+    foreach ([
+      'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"',
+      'current_release="$(readlink -f "$CURRENT")"',
+      "'^release_path='",
+      "'^candidate_sha='",
+      'Current production release must map to exactly one promotion receipt.',
+      'production_current_release=%s',
+      'production_current_release_sha=%s',
+    ] as $required) {
+      self::assertStringContainsString($required, $verifier);
+    }
+  }
+
+  /**
    * Verify-only accepts only the exact controlled scheduler contract.
    */
   public function testVerifyOnlyContractFailsClosedOnDriftOrDuplicates(): void {
@@ -128,7 +147,7 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
   }
 
   /**
-   * The PR-time PROD audit executes only the verify-only contract.
+   * The PR-time PROD audit executes only read-only verification and probes.
    */
   public function testProductionSchedulerAuditIsReadOnly(): void {
     $workflow = $this->workflow('.github/workflows/production-scheduler-readonly-audit.yml');
@@ -146,6 +165,15 @@ final class SchedulerGovernanceSafetyTest extends TestCase {
       'SCHEDULER_AUTHORITY_KIND=OWNER_ISSUE_COMMENT',
       $workflow,
     );
+    foreach ([
+      'Verify current production health and public smoke without mutation',
+      'https://emergingdigital.be',
+      '"$PROD_URL/health/$endpoint"',
+      '"$PROD_URL/fr/blog"',
+      'production_smoke=PASS',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #823 only after terminal review/merge evidence.

## Problem

r10 application promotion succeeded, but the functional promotion implicitly created the PROD Drupal scheduler. That scheduler is technically healthy and directionally matches #815, yet its creation was not part of the exact release GO.

## Change

- keep the historical `reconcile-cron.sh` call used by functional promotion, but make that script strictly `VERIFY_ONLY` and remove every crontab write path from it;
- require exactly one controlled deploy-user scheduler, `automated_cron=0`, exact `*/15` schedule, Agency marker, `flock` lock, and zero unmanaged system/systemd/deploy-user duplicates;
- add a distinct `production-scheduler-change.yml` owner-authorized path for CREATE/UPDATE/REMOVE;
- bind scheduler mutation authority to current PROD release SHA, expected scheduler state, owner comment id and authorization body digest;
- refuse UNMANAGED/INVALID scheduler states and bound transitions to ABSENT->CREATE, MANAGED_DRIFT->UPDATE, CONTROLLED->REMOVE;
- make the PR-time PROD scheduler audit execute the exact verify-only script;
- add scheduler governance regression tests and cutover validation;
- update the durable environment side-effect contract with the r10 policy deviation and current scheduler disposition boundary.

## Safety

`RECOVERY_PR_PROD_MUTATION = NONE`.

This PR does not rerun r10 promotion, deploy an application release, edit the current PROD crontab, remove the current scheduler, create another scheduler or restore any database.

The existing scheduler remains unchanged pending Project Lead KEEP/RATIFY vs REMOVE disposition under #812.

Refs #812 #815 #758. #816 remains out of scope.