### PR TITLE
#816 — Add fail-closed PREPROD data refresh PLAN

### DIFF
--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -100,7 +100,7 @@ jobs:
           sha="$(git rev-parse HEAD)"
 
           grep -Fq 'workflow_dispatch:' "$workflow"
-          ! grep -Fq '${{ secrets.' "$workflow"
+          ! grep -Fq 'secrets.' "$workflow"
           grep -Fq 'path: artifacts/preproduction-refresh-plan/plan.env' "$workflow"
           ! grep -Fq '*.sql' "$workflow"
           ! grep -Fq '*.sql.gz' "$workflow"

--- a/.github/workflows/preproduction-bootstrap-validation.yml
+++ b/.github/workflows/preproduction-bootstrap-validation.yml
@@ -6,12 +6,16 @@ on:
       - '.github/workflows/build-release-candidate.yml'
       - '.github/workflows/deploy-preproduction.yml'
       - '.github/workflows/preproduction-bootstrap-validation.yml'
+      - '.github/workflows/preproduction-data-refresh-plan.yml'
       - 'config/splits/preproduction/**'
       - 'config/sync/config_split.config_split.preproduction.yml'
+      - 'docs/operations/preproduction-data-refresh.md'
       - 'playwright.config.mjs'
       - 'scripts/preproduction/**'
+      - 'scripts/preproduction-refresh/**'
       - 'scripts/run-browser-validation.mjs'
       - 'tests/browser/**'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php'
       - 'web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionHostBootstrapTest.php'
 
 permissions:
@@ -35,6 +39,8 @@ jobs:
           bash -n scripts/preproduction/inspect-deploy.sh
           bash -n scripts/preproduction/validate-runtime.sh
           bash -n scripts/preproduction/reconcile-basic-auth.sh
+          bash -n scripts/preproduction-refresh/plan.sh
+          jq -e . scripts/preproduction-refresh/sanitization-policy.json >/dev/null
           node --check playwright.config.mjs
           node --check tests/browser/public-blog.spec.mjs
       - name: Validate PREPROD templates and immutable deploy boundaries
@@ -84,3 +90,62 @@ jobs:
           ! grep -Fq "if (await toggle.isVisible())" tests/browser/public-blog.spec.mjs
           grep -Fq "const drawerLink = drawer.getByRole('link'" tests/browser/public-blog.spec.mjs
           grep -Fq "await expect(drawerLink).toBeVisible()" tests/browser/public-blog.spec.mjs
+      - name: Validate PREPROD data-refresh PLAN safety boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/preproduction-data-refresh-plan.yml'
+          policy='scripts/preproduction-refresh/sanitization-policy.json'
+          script='scripts/preproduction-refresh/plan.sh'
+          sha="$(git rev-parse HEAD)"
+
+          grep -Fq 'workflow_dispatch:' "$workflow"
+          ! grep -Fq '${{ secrets.' "$workflow"
+          grep -Fq 'path: artifacts/preproduction-refresh-plan/plan.env' "$workflow"
+          ! grep -Fq '*.sql' "$workflow"
+          ! grep -Fq '*.sql.gz' "$workflow"
+          ! grep -Fq 'scp ' "$workflow"
+          ! grep -Fq 'ssh ' "$workflow"
+          ! grep -Fq 'rsync ' "$workflow"
+          ! grep -Fq 'sql:dump' "$workflow"
+
+          jq -e '.future_apply.implemented == false' "$policy" >/dev/null
+          jq -e '.future_apply.owner_authorization_required == true' "$policy" >/dev/null
+          jq -e '.github_evidence.raw_sql_allowed == false' "$policy" >/dev/null
+          jq -e '.github_evidence.pii_allowed == false' "$policy" >/dev/null
+          jq -e '.github_evidence.secrets_allowed == false' "$policy" >/dev/null
+
+          base_env=(
+            REQUEST_ID=ci-816-plan
+            REPOSITORY_SHA="$sha"
+            SOURCE_PROD_RELEASE_SHA="$sha"
+            PREPROD_RELEASE_SHA="$sha"
+            PREPROD_DISK_AVAILABLE_BYTES=3000
+            ESTIMATED_STAGING_BYTES=1000
+            REFRESH_LOCK_STATE=FREE
+          )
+
+          env "${base_env[@]}" bash "$script" PLAN
+          evidence='artifacts/preproduction-refresh-plan/plan.env'
+          test -f "$evidence"
+          grep -Fxq 'mode=PLAN' "$evidence"
+          grep -Fxq 'prod_write_path=NONE' "$evidence"
+          grep -Fxq 'real_prod_data_transfer=NONE' "$evidence"
+          grep -Fxq 'preprod_db_activation=NONE' "$evidence"
+          grep -Fxq 'raw_prod_data_in_github=NONE' "$evidence"
+          grep -Fxq 'apply_authority=NOT_AUTHORIZED' "$evidence"
+
+          if env "${base_env[@]}" bash "$script" APPLY; then
+            echo 'APPLY unexpectedly became executable.' >&2
+            exit 1
+          fi
+
+          if env "${base_env[@]}" REFRESH_LOCK_STATE=HELD bash "$script" PLAN; then
+            echo 'PLAN accepted an occupied refresh lock.' >&2
+            exit 1
+          fi
+
+          if env "${base_env[@]}" PREPROD_DISK_AVAILABLE_BYTES=2999 bash "$script" PLAN; then
+            echo 'PLAN accepted insufficient declared capacity.' >&2
+            exit 1
+          fi

--- a/.github/workflows/preproduction-data-refresh-plan.yml
+++ b/.github/workflows/preproduction-data-refresh-plan.yml
@@ -77,7 +77,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          scripts/preproduction-refresh/plan.sh PLAN
+          bash scripts/preproduction-refresh/plan.sh PLAN
 
       - name: Prove PLAN evidence boundary
         shell: bash

--- a/.github/workflows/preproduction-data-refresh-plan.yml
+++ b/.github/workflows/preproduction-data-refresh-plan.yml
@@ -1,0 +1,103 @@
+name: PLAN PREPROD data refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      request_id:
+        description: Non-sensitive refresh request identifier
+        required: true
+        type: string
+      source_prod_release_sha:
+        description: Read-only observed PROD application release SHA
+        required: true
+        type: string
+      preprod_release_sha:
+        description: Read-only observed PREPROD application release SHA
+        required: true
+        type: string
+      preprod_disk_available_bytes:
+        description: Read-only observed PREPROD free bytes
+        required: true
+        type: string
+      estimated_staging_bytes:
+        description: Non-sensitive estimated bytes for future isolated staging
+        required: true
+        type: string
+      refresh_lock_state:
+        description: Read-only observed future refresh lock state
+        required: true
+        type: choice
+        options:
+          - FREE
+          - HELD
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agency-preprod-data-refresh-plan
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Validate metadata-only PREPROD refresh plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Require reviewed main tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+
+      - name: Checkout exact PLAN tooling
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate PLAN shell and policy syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n scripts/preproduction-refresh/plan.sh
+          jq -e . scripts/preproduction-refresh/sanitization-policy.json >/dev/null
+
+      - name: Run fail-closed PLAN
+        env:
+          REQUEST_ID: ${{ inputs.request_id }}
+          REPOSITORY_SHA: ${{ github.sha }}
+          SOURCE_PROD_RELEASE_SHA: ${{ inputs.source_prod_release_sha }}
+          PREPROD_RELEASE_SHA: ${{ inputs.preprod_release_sha }}
+          PREPROD_DISK_AVAILABLE_BYTES: ${{ inputs.preprod_disk_available_bytes }}
+          ESTIMATED_STAGING_BYTES: ${{ inputs.estimated_staging_bytes }}
+          REFRESH_LOCK_STATE: ${{ inputs.refresh_lock_state }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/preproduction-refresh/plan.sh PLAN
+
+      - name: Prove PLAN evidence boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence='artifacts/preproduction-refresh-plan/plan.env'
+          test -f "$evidence"
+          test "$(stat -c '%a' "$evidence")" = '600'
+          grep -Fxq 'mode=PLAN' "$evidence"
+          grep -Fxq 'prod_write_path=NONE' "$evidence"
+          grep -Fxq 'real_prod_data_transfer=NONE' "$evidence"
+          grep -Fxq 'preprod_db_activation=NONE' "$evidence"
+          grep -Fxq 'raw_prod_data_in_github=NONE' "$evidence"
+          grep -Fxq 'apply_authority=NOT_AUTHORIZED' "$evidence"
+          test "$(find artifacts/preproduction-refresh-plan -type f | wc -l)" -eq 1
+
+      - name: Upload metadata-only PLAN evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-preprod-refresh-plan-${{ inputs.request_id }}
+          path: artifacts/preproduction-refresh-plan/plan.env
+          if-no-files-found: error
+          retention-days: 7

--- a/docs/operations/preproduction-data-refresh.md
+++ b/docs/operations/preproduction-data-refresh.md
@@ -1,0 +1,165 @@
+# PREPROD data refresh from anonymized PROD snapshot
+
+Issue: #816.
+
+This document is the durable safety contract for refreshing Agency PREPROD data from a production snapshot. It is a data-refresh mechanism, not an application deployment. It must preserve the immutable application release already active in PREPROD and must never trigger production promotion.
+
+## Authority and phases
+
+The mechanism has two distinct phases:
+
+- `PLAN`: repository/preflight only. It may validate non-sensitive metadata, prerequisites, capacity declarations, refresh-lock state and expected release identities. It performs no PROD write, no PROD snapshot, no PROD data transfer, no PREPROD database import/replacement/activation and no runtime side-effect mutation.
+- `APPLY`: future owner-authorized operation. It is not implemented or authorized by the first #816 tranche. The first real APPLY is a human boundary after Project Lead review.
+
+Issue creation, branch creation, PR merge, PLAN success, old comments and previous production GO are not APPLY authority.
+
+The first implementation intentionally has no executable APPLY path. A future APPLY must require a newly created OWNER authorization bound to all of: refresh request ID, current PROD release identity, current PREPROD release identity, sanitization policy digest, expected source snapshot identity and the exact requested transition. Authorization must be anti-replay and auditable.
+
+## Production boundary
+
+PROD is strictly read-only for this mechanism. A future snapshot operation may read the production database, but the refresh implementation must have no route that can:
+
+- enable PROD maintenance mode;
+- alter Drupal configuration/content/users/tables;
+- change PROD cron or scheduler state;
+- change the active PROD release;
+- write credentials/settings into PROD;
+- trigger a production deployment.
+
+The phase-1 PLAN route does not connect to PROD and does not create a snapshot.
+
+## Data classification
+
+### Preserve for fidelity
+
+Where present in the source schema and required by the current application release, preserve public/editorial state such as:
+
+- nodes and revisions;
+- taxonomy, translations and aliases;
+- paragraphs/entity-reference revisions;
+- menu/link content and redirects;
+- media metadata required by public editorial content;
+- other public editorial entity state required to reproduce production behavior.
+
+Private files are never copied by default. Public-file synchronization is out of scope for this first tranche.
+
+### Mandatory sanitization/removal before any future activation
+
+The repository-owned policy in `scripts/preproduction-refresh/sanitization-policy.json` is authoritative for the first contract version. A future sanitizer must discover the actual imported schema and fail closed when a mandatory sensitive surface cannot be mapped safely.
+
+At minimum it must deterministically handle:
+
+- Drupal users: imported identifying values are anonymized; imported password/session/reset material is invalidated; imported accounts do not become the PREPROD administrative access route. A PREPROD-only administrator is recreated/preserved from server-owned PREPROD bootstrap state after sanitization. Imported user email/name transformations must be deterministic by UID and use non-routable `example.invalid` values.
+- Webform submissions and submission data: delete by default.
+- Sessions: delete all.
+- Flood/rate-limit state: delete all imported state.
+- `dblog`/watchdog: delete imported rows because request/user/IP data may be present.
+- caches, render/dynamic cache and discovery caches: clear imported cache state.
+- batch/temp state: clear.
+- queues: clear imported queue items by default, including Link Checker, mail and AI/provider work. Unknown externally acting queue state fails closed.
+- cron/update/announcements/link-checker execution state: reset imported runtime state before activation.
+- one-time login/password-reset/session material: invalidate/remove.
+- persisted credentials or secret-like state: remove or replace from PREPROD server-owned state; unknown credential-bearing state fails closed.
+- production-only environment state: never survives activation.
+
+`drush sql:sanitize` may be used as one layer in a future APPLY, but it is not sufficient proof by itself and does not replace Agency-specific sanitization.
+
+## PREPROD side-effect hardening
+
+Before a future imported database may become active, fail closed unless all of the following are proven against the isolated staged database/current PREPROD runtime contract:
+
+- production Config Split = OFF;
+- preproduction Config Split = ON;
+- Google Tag/GA4 outbound behavior = OFF;
+- mail uses the PREPROD sink/null behavior and contains no production credential;
+- Drupal automated cron = OFF;
+- external AI/provider egress = OFF and no production provider credential is available;
+- no production webhook/API credential is present;
+- copied Link Checker/other externally acting queues are empty or explicitly bounded by a future approved fixture policy;
+- Webform submissions = 0;
+- active sessions = 0;
+- staged Drupal bootstrap health = PASS;
+- Basic Auth remains preserved by the host boundary;
+- PREPROD noindex remains preserved by the host boundary.
+
+The existing `scripts/preproduction/settings.php.template` and `scripts/preproduction/validate-runtime.sh` remain the application-side source of truth for the normal PREPROD side-effect contract. #816 must not weaken them.
+
+## Isolated staging and activation design
+
+A future APPLY must use an isolated staging database. The public PREPROD web runtime must never point to the imported database before sanitization and all side-effect assertions are terminal PASS.
+
+Required future sequence:
+
+1. acquire a dedicated PREPROD data-refresh lock;
+2. prove current PROD/PREPROD release identities and capacity;
+3. create a read-only PROD snapshot into transient material with restrictive permissions (`0600`);
+4. transfer transient raw material only over an encrypted transport and never through GitHub artifacts;
+5. import into an isolated PREPROD staging DB that is not referenced by the public runtime;
+6. sanitize deterministically and run fail-closed assertions;
+7. bootstrap/validate the staged DB with the currently deployed PREPROD application release;
+8. create and verify a backup of the current PREPROD DB and record the previous data-refresh identity;
+9. activate only the sanitized staging data boundary while preserving the application release identity;
+10. run applicable `updb`/canonical config convergence, PREPROD split and runtime validation;
+11. publish metadata-only evidence and clean transient raw material on success or failure.
+
+PROD is never part of rollback.
+
+## Rollback boundary
+
+Before activation a future APPLY must record:
+
+- verified current PREPROD DB backup identity;
+- previous PREPROD data-refresh identity;
+- active PREPROD application release identity.
+
+If activation or post-activation validation fails, restore the previous PREPROD data boundary without changing the application release. No automatic or manual rollback action is ever performed against PROD.
+
+## Governed Content rule
+
+A sanitized production snapshot is the fidelity baseline. The refresh path must **not** automatically execute `emerging:governed-content --all`, because that could silently overwrite production editorial fidelity.
+
+After a refresh, the current release may run Governed Content validation and dry-run for evidence. Applying governed content is allowed only when the currently deployed release explicitly requires that convergence and the change is authorized as part of the release/content governance path. Data refresh itself is not authority to overwrite refreshed editorial content.
+
+## Evidence contract
+
+GitHub evidence is metadata only. Raw SQL, copied files, PII and secrets are forbidden.
+
+Allowed evidence for this mechanism is limited to stable identifiers and aggregate metadata such as:
+
+- refresh request ID;
+- repository/release SHA identities;
+- sanitization policy version and SHA-256;
+- aggregate byte counts/capacity values;
+- aggregate removed-row counts without values;
+- source snapshot digest/size after a future APPLY (digest/size only, never bytes);
+- PREPROD backup/data-refresh identities;
+- PASS/FAIL side-effect assertions;
+- health/smoke outcomes.
+
+No email address, IP address, password/hash, session/reset token, form submission value, API token, credential, SQL content or private file content may be logged, committed, attached to an issue/PR or uploaded as an Actions artifact.
+
+The phase-1 PLAN workflow uploads only `artifacts/preproduction-refresh-plan/plan.env`, whose keys are generated from a fixed allowlist by `scripts/preproduction-refresh/plan.sh`.
+
+## Public files
+
+Public-file synchronization is not implemented in this tranche. If later required:
+
+- capacity must be checked first;
+- private files remain `NEVER` by default;
+- only already-public PROD files may be considered;
+- generated/cache/temp files should be excluded where reproducible;
+- a staged/rollback boundary must be preserved.
+
+## Phase-1 stop boundary
+
+For #816 phase 1:
+
+```text
+PROD_WRITE_PATH=NONE
+REAL_PROD_DATA_TRANSFER=NONE
+PREPROD_DB_ACTIVATION=NONE
+RAW_PROD_DATA_IN_GITHUB=NONE
+FIRST_REAL_APPLY=NOT_AUTHORIZED
+```
+
+Once the repository PLAN implementation and exact-head CI are terminal green, Delivery stops for Project Lead review before any real PROD snapshot, data transfer, staging import or PREPROD mutation.

--- a/docs/operations/preproduction-data-refresh.md
+++ b/docs/operations/preproduction-data-refresh.md
@@ -15,6 +15,21 @@ Issue creation, branch creation, PR merge, PLAN success, old comments and previo
 
 The first implementation intentionally has no executable APPLY path. A future APPLY must require a newly created OWNER authorization bound to all of: refresh request ID, current PROD release identity, current PREPROD release identity, sanitization policy digest, expected source snapshot identity and the exact requested transition. Authorization must be anti-replay and auditable.
 
+## Execution boundary for raw PROD data
+
+GitHub-hosted infrastructure is allowed only as an authority, metadata and validation gateway for this mechanism. A GitHub-hosted job may validate repository state, exact identities, policy, non-sensitive aggregate metadata and authorization prerequisites.
+
+`RAW PROD DATA ON GITHUB-HOSTED RUNNER = FORBIDDEN`.
+
+Any future step that materializes or manipulates raw production snapshot data must use exactly one of these execution paths:
+
+- the trusted Agency runner with all required labels `self-hosted`, `linux`, `x64`, `agency`; or
+- a strictly controlled server-to-server path between controlled hosts where the raw production data never transits through and never materializes on GitHub-hosted infrastructure.
+
+A future implementation must fail closed if a raw-data step is assigned to any other runner class or if a server-to-server path would route raw bytes through GitHub-hosted infrastructure. Metadata-only PLAN jobs may remain on `ubuntu-24.04` because they do not materialize or manipulate raw production data.
+
+This boundary is independent from artifact policy: raw production SQL/files are forbidden as GitHub artifacts even when the raw-data step itself runs on trusted infrastructure.
+
 ## Production boundary
 
 PROD is strictly read-only for this mechanism. A future snapshot operation may read the production database, but the refresh implementation must have no route that can:
@@ -92,8 +107,8 @@ Required future sequence:
 
 1. acquire a dedicated PREPROD data-refresh lock;
 2. prove current PROD/PREPROD release identities and capacity;
-3. create a read-only PROD snapshot into transient material with restrictive permissions (`0600`);
-4. transfer transient raw material only over an encrypted transport and never through GitHub artifacts;
+3. create a read-only PROD snapshot into transient material with restrictive permissions (`0600`) only on an execution path allowed by the raw-data boundary above;
+4. transfer transient raw material only over an encrypted transport, only through an allowed raw-data execution path, and never through GitHub-hosted infrastructure or GitHub artifacts;
 5. import into an isolated PREPROD staging DB that is not referenced by the public runtime;
 6. sanitize deterministically and run fail-closed assertions;
 7. bootstrap/validate the staged DB with the currently deployed PREPROD application release;
@@ -148,7 +163,8 @@ Public-file synchronization is not implemented in this tranche. If later require
 - private files remain `NEVER` by default;
 - only already-public PROD files may be considered;
 - generated/cache/temp files should be excluded where reproducible;
-- a staged/rollback boundary must be preserved.
+- a staged/rollback boundary must be preserved;
+- any raw PROD file synchronization must obey the same trusted Agency runner or controlled server-to-server execution boundary and may never materialize raw PROD files on GitHub-hosted infrastructure.
 
 ## Phase-1 stop boundary
 

--- a/scripts/preproduction-refresh/plan.sh
+++ b/scripts/preproduction-refresh/plan.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+MODE="${1:-PLAN}"
+REQUEST_ID="${REQUEST_ID:-}"
+REPOSITORY_SHA="${REPOSITORY_SHA:-}"
+SOURCE_PROD_RELEASE_SHA="${SOURCE_PROD_RELEASE_SHA:-}"
+PREPROD_RELEASE_SHA="${PREPROD_RELEASE_SHA:-}"
+PREPROD_DISK_AVAILABLE_BYTES="${PREPROD_DISK_AVAILABLE_BYTES:-}"
+ESTIMATED_STAGING_BYTES="${ESTIMATED_STAGING_BYTES:-}"
+REFRESH_LOCK_STATE="${REFRESH_LOCK_STATE:-}"
+POLICY="scripts/preproduction-refresh/sanitization-policy.json"
+OUTPUT_DIR="artifacts/preproduction-refresh-plan"
+EVIDENCE="$OUTPUT_DIR/plan.env"
+CAPACITY_MULTIPLIER=3
+
+fail() {
+  printf '[preprod-refresh-plan] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+case "$MODE" in
+  PLAN)
+    ;;
+  *)
+    fail "Only PLAN is implemented. APPLY is not authorized or executable in this tranche."
+    ;;
+esac
+
+for command_name in bash git jq sha256sum flock; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "Required PLAN capability is unavailable: $command_name."
+done
+
+[[ "$REQUEST_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$ ]] || fail "REQUEST_ID is missing or invalid."
+[[ "$REPOSITORY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "REPOSITORY_SHA is invalid."
+[[ "$SOURCE_PROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "SOURCE_PROD_RELEASE_SHA is invalid."
+[[ "$PREPROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "PREPROD_RELEASE_SHA is invalid."
+[[ "$PREPROD_DISK_AVAILABLE_BYTES" =~ ^[0-9]+$ ]] || fail "PREPROD_DISK_AVAILABLE_BYTES is invalid."
+[[ "$ESTIMATED_STAGING_BYTES" =~ ^[0-9]+$ ]] || fail "ESTIMATED_STAGING_BYTES is invalid."
+[[ "$REFRESH_LOCK_STATE" == "FREE" ]] || fail "Refresh lock state is not FREE."
+
+(( PREPROD_DISK_AVAILABLE_BYTES > 0 )) || fail "PREPROD available capacity must be positive."
+(( ESTIMATED_STAGING_BYTES > 0 )) || fail "Estimated staging size must be positive."
+(( ESTIMATED_STAGING_BYTES <= 1000000000000000 )) || fail "Estimated staging size is outside the supported PLAN range."
+
+actual_repository_sha="$(git rev-parse HEAD)"
+[[ "$actual_repository_sha" == "$REPOSITORY_SHA" ]] || fail "Repository SHA does not match the checked-out PLAN source."
+
+[[ -f "$POLICY" ]] || fail "Sanitization policy is missing."
+[[ -f scripts/preproduction/settings.php.template ]] || fail "PREPROD settings template is missing."
+[[ -f scripts/preproduction/validate-runtime.sh ]] || fail "PREPROD runtime validator is missing."
+[[ -f docs/operations/environment-side-effects.md ]] || fail "Environment side-effect contract is missing."
+[[ -f docs/operations/preproduction-data-refresh.md ]] || fail "PREPROD data-refresh contract is missing."
+
+jq -e '
+  .schema_version == 1
+  and .policy_version == "agency-preprod-refresh-v1"
+  and .scope.source == "PROD_READ_ONLY"
+  and .scope.target == "PREPROD_ISOLATED_STAGING_DB"
+  and .scope.private_files == "NEVER"
+  and .future_apply.implemented == false
+  and .future_apply.owner_authorization_required == true
+  and .future_apply.isolated_staging_db_required == true
+  and .future_apply.prod_rollback_path == "NONE"
+  and .github_evidence.raw_sql_allowed == false
+  and .github_evidence.pii_allowed == false
+  and .github_evidence.secrets_allowed == false
+  and .github_evidence.phase_1_artifact_path == "artifacts/preproduction-refresh-plan/plan.env"
+' "$POLICY" >/dev/null || fail "Sanitization policy contract is invalid."
+
+for mandatory_id in \
+  users \
+  preprod_admin \
+  webform_submissions \
+  sessions \
+  flood_rate_limit \
+  dblog_watchdog \
+  caches \
+  batch_temp_state \
+  queues \
+  cron_update_announcements_linkchecker_state \
+  one_time_auth_material \
+  persisted_credentials \
+  production_environment_state; do
+  jq -e --arg id "$mandatory_id" \
+    '.mandatory_sanitization[] | select(.id == $id and .required == true)' \
+    "$POLICY" >/dev/null || fail "Mandatory sanitization rule is missing: $mandatory_id."
+done
+
+for assertion in \
+  webform_submissions_zero \
+  active_sessions_zero \
+  production_mail_transport_inactive \
+  production_config_split_off \
+  preproduction_config_split_on \
+  google_tag_off \
+  provider_egress_off \
+  production_credentials_absent \
+  externally_acting_queues_cleared_or_explicitly_bounded \
+  staged_db_bootstrap_health_pass \
+  basic_auth_preserved \
+  noindex_preserved; do
+  jq -e --arg assertion "$assertion" \
+    '.activation_assertions | index($assertion) != null' \
+    "$POLICY" >/dev/null || fail "Activation assertion is missing: $assertion."
+done
+
+grep -Fq "config_split.config_split.production']['status'] = FALSE" scripts/preproduction/settings.php.template \
+  || fail "PREPROD production split override is missing."
+grep -Fq "config_split.config_split.preproduction']['status'] = TRUE" scripts/preproduction/settings.php.template \
+  || fail "PREPROD split override is missing."
+grep -Fq "automated_cron.settings']['interval'] = 0" scripts/preproduction/settings.php.template \
+  || fail "PREPROD automated cron override is missing."
+grep -Fq "google_tag.settings']['default_google_tag_entity'] = NULL" scripts/preproduction/settings.php.template \
+  || fail "PREPROD Google Tag override is missing."
+grep -Fq "agency_external_ai_egress_enabled'] = FALSE" scripts/preproduction/settings.php.template \
+  || fail "PREPROD external AI gate is missing."
+grep -Fq 'side_effects=PASS' scripts/preproduction/validate-runtime.sh \
+  || fail "PREPROD side-effect runtime assertion is missing."
+
+required_capacity_bytes=$(( ESTIMATED_STAGING_BYTES * CAPACITY_MULTIPLIER ))
+(( PREPROD_DISK_AVAILABLE_BYTES >= required_capacity_bytes )) \
+  || fail "Declared PREPROD capacity is below the phase-1 safety multiplier."
+
+policy_version="$(jq -r '.policy_version' "$POLICY")"
+policy_sha256="$(sha256sum "$POLICY" | awk '{print $1}')"
+[[ "$policy_sha256" =~ ^[0-9a-f]{64}$ ]] || fail "Sanitization policy digest is invalid."
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+cat > "$EVIDENCE" <<EOF
+schema_version=1
+mode=PLAN
+request_id=$REQUEST_ID
+repository_sha=$REPOSITORY_SHA
+source_prod_release_sha=$SOURCE_PROD_RELEASE_SHA
+preprod_release_sha=$PREPROD_RELEASE_SHA
+sanitization_policy_version=$policy_version
+sanitization_policy_sha256=$policy_sha256
+preprod_disk_available_bytes=$PREPROD_DISK_AVAILABLE_BYTES
+estimated_staging_bytes=$ESTIMATED_STAGING_BYTES
+required_capacity_bytes=$required_capacity_bytes
+refresh_lock_state=FREE
+capacity=PASS
+repository_contract=PASS
+prod_write_path=NONE
+real_prod_data_transfer=NONE
+preprod_db_activation=NONE
+raw_prod_data_in_github=NONE
+apply_authority=NOT_AUTHORIZED
+EOF
+chmod 600 "$EVIDENCE"
+
+if find "$OUTPUT_DIR" -type f \( -name '*.sql' -o -name '*.sql.gz' -o -name '*.dump' -o -name '*.tar' -o -name '*.tar.gz' \) -print -quit | grep -q .; then
+  fail "Raw or archive material appeared in the PLAN evidence directory."
+fi
+
+expected_keys='schema_version mode request_id repository_sha source_prod_release_sha preprod_release_sha sanitization_policy_version sanitization_policy_sha256 preprod_disk_available_bytes estimated_staging_bytes required_capacity_bytes refresh_lock_state capacity repository_contract prod_write_path real_prod_data_transfer preprod_db_activation raw_prod_data_in_github apply_authority'
+actual_keys="$(cut -d= -f1 "$EVIDENCE" | tr '\n' ' ' | sed 's/ $//')"
+[[ "$actual_keys" == "$expected_keys" ]] || fail "PLAN evidence key allowlist drifted."
+
+printf '[preprod-refresh-plan] PLAN PASS: metadata-only evidence generated at %s.\n' "$EVIDENCE"

--- a/scripts/preproduction-refresh/sanitization-policy.json
+++ b/scripts/preproduction-refresh/sanitization-policy.json
@@ -7,6 +7,34 @@
     "private_files": "NEVER",
     "public_files": "OUT_OF_SCOPE_PHASE_1"
   },
+  "execution_boundary": {
+    "github_hosted": {
+      "allowed_roles": [
+        "AUTHORITY_GATEWAY",
+        "NON_SENSITIVE_METADATA_VALIDATION",
+        "POLICY_VALIDATION"
+      ],
+      "raw_prod_data_allowed": false
+    },
+    "raw_prod_data": {
+      "github_hosted_runner": "FORBIDDEN",
+      "allowed_paths": [
+        {
+          "type": "TRUSTED_AGENCY_RUNNER",
+          "required_labels": [
+            "self-hosted",
+            "linux",
+            "x64",
+            "agency"
+          ]
+        },
+        {
+          "type": "CONTROLLED_SERVER_TO_SERVER",
+          "requirement": "RAW_DATA_NEVER_TRANSITS_OR_MATERIALIZES_ON_GITHUB_HOSTED_INFRASTRUCTURE"
+        }
+      ]
+    }
+  },
   "preserve_for_fidelity": [
     "nodes_and_revisions",
     "taxonomy_and_translations",

--- a/scripts/preproduction-refresh/sanitization-policy.json
+++ b/scripts/preproduction-refresh/sanitization-policy.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "policy_version": "agency-preprod-refresh-v1",
+  "scope": {
+    "source": "PROD_READ_ONLY",
+    "target": "PREPROD_ISOLATED_STAGING_DB",
+    "private_files": "NEVER",
+    "public_files": "OUT_OF_SCOPE_PHASE_1"
+  },
+  "preserve_for_fidelity": [
+    "nodes_and_revisions",
+    "taxonomy_and_translations",
+    "paragraphs_and_entity_reference_revisions",
+    "menu_link_content",
+    "path_aliases_and_redirects",
+    "public_media_metadata",
+    "other_public_editorial_state_required_by_current_release"
+  ],
+  "mandatory_sanitization": [
+    {
+      "id": "users",
+      "action": "ANONYMIZE_IDENTIFIERS_AND_INVALIDATE_AUTH",
+      "deterministic_rule": "Imported account identifiers are transformed by uid to preprod-user-<uid> and preprod-user+<uid>@example.invalid; imported passwords, init/reset/session material are invalidated; no imported account supplies PREPROD administrative access.",
+      "required": true
+    },
+    {
+      "id": "preprod_admin",
+      "action": "RESTORE_SERVER_OWNED_PREPROD_ADMIN_ROUTE",
+      "deterministic_rule": "PREPROD administrative access is recreated or preserved from PREPROD server-owned bootstrap state only after imported account authentication material is invalidated.",
+      "required": true
+    },
+    {
+      "id": "webform_submissions",
+      "action": "DELETE_ALL",
+      "deterministic_rule": "All imported Webform submissions and submission data are removed before activation.",
+      "required": true
+    },
+    {
+      "id": "sessions",
+      "action": "DELETE_ALL",
+      "deterministic_rule": "All imported active session state is removed before activation.",
+      "required": true
+    },
+    {
+      "id": "flood_rate_limit",
+      "action": "DELETE_ALL",
+      "deterministic_rule": "All imported flood/rate-limit state is removed before activation.",
+      "required": true
+    },
+    {
+      "id": "dblog_watchdog",
+      "action": "DELETE_ALL",
+      "deterministic_rule": "Imported watchdog/dblog rows are removed because request, user or IP data may be present.",
+      "required": true
+    },
+    {
+      "id": "caches",
+      "action": "CLEAR_ALL_IMPORTED_CACHE_STATE",
+      "deterministic_rule": "Imported cache, render, dynamic-page-cache and discovery cache state is cleared.",
+      "required": true
+    },
+    {
+      "id": "batch_temp_state",
+      "action": "DELETE_ALL",
+      "deterministic_rule": "Imported batch and temporary execution state is cleared.",
+      "required": true
+    },
+    {
+      "id": "queues",
+      "action": "DELETE_ALL_BY_DEFAULT",
+      "deterministic_rule": "Imported queue items are cleared by default, including Link Checker, mail and AI/provider work; unknown externally acting queue state fails closed.",
+      "required": true
+    },
+    {
+      "id": "cron_update_announcements_linkchecker_state",
+      "action": "RESET_IMPORTED_RUNTIME_STATE",
+      "deterministic_rule": "Imported cron/update/announcements/link-checker execution state is reset before activation.",
+      "required": true
+    },
+    {
+      "id": "one_time_auth_material",
+      "action": "INVALIDATE_OR_DELETE",
+      "deterministic_rule": "One-time login, password-reset, session and equivalent authentication material is invalidated or removed.",
+      "required": true
+    },
+    {
+      "id": "persisted_credentials",
+      "action": "REMOVE_OR_REPLACE_FROM_PREPROD_SERVER_STATE",
+      "deterministic_rule": "Persisted credential or secret-like state is removed or replaced only from PREPROD server-owned state; unknown credential-bearing state fails closed.",
+      "required": true
+    },
+    {
+      "id": "production_environment_state",
+      "action": "REMOVE",
+      "deterministic_rule": "Production-only environment state never survives PREPROD activation.",
+      "required": true
+    }
+  ],
+  "activation_assertions": [
+    "webform_submissions_zero",
+    "active_sessions_zero",
+    "production_mail_transport_inactive",
+    "production_config_split_off",
+    "preproduction_config_split_on",
+    "google_tag_off",
+    "provider_egress_off",
+    "production_credentials_absent",
+    "externally_acting_queues_cleared_or_explicitly_bounded",
+    "staged_db_bootstrap_health_pass",
+    "basic_auth_preserved",
+    "noindex_preserved"
+  ],
+  "governed_content": {
+    "refresh_default": "VALIDATE_AND_DRY_RUN_ONLY",
+    "automatic_apply": false,
+    "apply_rule": "Only the current release/content governance path may authorize an apply; data refresh itself is never authority to overwrite refreshed editorial content."
+  },
+  "future_apply": {
+    "implemented": false,
+    "owner_authorization_required": true,
+    "anti_replay_required": true,
+    "isolated_staging_db_required": true,
+    "preprod_backup_verified_before_activation": true,
+    "preserve_application_release_identity": true,
+    "prod_rollback_path": "NONE"
+  },
+  "github_evidence": {
+    "raw_sql_allowed": false,
+    "pii_allowed": false,
+    "secrets_allowed": false,
+    "private_files_allowed": false,
+    "phase_1_artifact_path": "artifacts/preproduction-refresh-plan/plan.env"
+  }
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the phase-1 PREPROD data-refresh PLAN boundary.
+ *
+ * @group agency_project_tests
+ * @group preproduction_data_refresh
+ */
+final class PreproductionDataRefreshPlanTest extends TestCase {
+
+  /**
+   * The route is manual PLAN only and has no remote mutation credentials.
+   */
+  public function testWorkflowIsManualMetadataOnlyPlan(): void {
+    $workflow = $this->workflow();
+
+    self::assertStringContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString("\n  push:\n", $workflow);
+    self::assertStringNotContainsString("\n  pull_request:\n", $workflow);
+    self::assertStringNotContainsString("\n  schedule:\n", $workflow);
+    self::assertStringContainsString(
+      "test \"$GITHUB_REF\" = 'refs/heads/main'",
+      $workflow,
+    );
+    self::assertStringNotContainsString('${{ secrets.', $workflow);
+
+    foreach ([
+      'ssh ',
+      'scp ',
+      'rsync ',
+      'mariadb ',
+      'mysql ',
+      'drush ',
+      'curl ',
+      'wget ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * GitHub may receive only the fixed metadata PLAN evidence file.
+   */
+  public function testWorkflowCannotUploadRawProductionData(): void {
+    $workflow = $this->workflow();
+
+    self::assertStringContainsString(
+      'path: artifacts/preproduction-refresh-plan/plan.env',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'raw_prod_data_in_github=NONE',
+      $workflow,
+    );
+    foreach ([
+      '*.sql',
+      '*.sql.gz',
+      '*.dump',
+      'shared/backups',
+      'sites/default/files',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The script has no executable APPLY or data movement path.
+   */
+  public function testPlanScriptRejectsApplyAndContainsNoDataPath(): void {
+    $script = $this->script();
+
+    self::assertStringContainsString(
+      'Only PLAN is implemented. APPLY is not authorized or executable',
+      $script,
+    );
+    self::assertStringContainsString(
+      'prod_write_path=NONE',
+      $script,
+    );
+    self::assertStringContainsString(
+      'real_prod_data_transfer=NONE',
+      $script,
+    );
+    self::assertStringContainsString(
+      'preprod_db_activation=NONE',
+      $script,
+    );
+    self::assertStringContainsString(
+      'apply_authority=NOT_AUTHORIZED',
+      $script,
+    );
+
+    foreach ([
+      'ssh ',
+      'scp ',
+      'rsync ',
+      'mariadb-dump',
+      'mysqldump',
+      'sql:dump',
+      'drush ',
+      'curl ',
+      'wget ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+  }
+
+  /**
+   * Invalid identity, lock and capacity states fail closed.
+   */
+  public function testPlanScriptHasFailClosedPreconditions(): void {
+    $script = $this->script();
+
+    foreach ([
+      'REPOSITORY_SHA is invalid.',
+      'SOURCE_PROD_RELEASE_SHA is invalid.',
+      'PREPROD_RELEASE_SHA is invalid.',
+      'Refresh lock state is not FREE.',
+      'PREPROD available capacity must be positive.',
+      'Estimated staging size must be positive.',
+      'Repository SHA does not match the checked-out PLAN source.',
+      'CAPACITY_MULTIPLIER=3',
+      'Declared PREPROD capacity is below the phase-1 safety multiplier.',
+    ] as $required) {
+      self::assertStringContainsString($required, $script);
+    }
+  }
+
+  /**
+   * The policy covers all sensitive state required by #816.
+   */
+  public function testSanitizationPolicyIsCompleteAndApplyIsDisabled(): void {
+    $policy = $this->policy();
+
+    self::assertSame(1, $policy['schema_version']);
+    self::assertSame(
+      'agency-preprod-refresh-v1',
+      $policy['policy_version'],
+    );
+    self::assertSame('PROD_READ_ONLY', $policy['scope']['source']);
+    self::assertSame('NEVER', $policy['scope']['private_files']);
+    self::assertFalse($policy['future_apply']['implemented']);
+    self::assertTrue(
+      $policy['future_apply']['owner_authorization_required'],
+    );
+    self::assertSame('NONE', $policy['future_apply']['prod_rollback_path']);
+    self::assertFalse($policy['github_evidence']['raw_sql_allowed']);
+    self::assertFalse($policy['github_evidence']['pii_allowed']);
+    self::assertFalse($policy['github_evidence']['secrets_allowed']);
+
+    $rules = [];
+    foreach ($policy['mandatory_sanitization'] as $rule) {
+      self::assertTrue($rule['required']);
+      $rules[] = $rule['id'];
+    }
+
+    foreach ([
+      'users',
+      'preprod_admin',
+      'webform_submissions',
+      'sessions',
+      'flood_rate_limit',
+      'dblog_watchdog',
+      'caches',
+      'batch_temp_state',
+      'queues',
+      'cron_update_announcements_linkchecker_state',
+      'one_time_auth_material',
+      'persisted_credentials',
+      'production_environment_state',
+    ] as $required) {
+      self::assertContains($required, $rules);
+    }
+  }
+
+  /**
+   * All mandatory pre-activation assertions are versioned.
+   */
+  public function testPolicyContainsFailClosedActivationAssertions(): void {
+    $assertions = $this->policy()['activation_assertions'];
+
+    foreach ([
+      'webform_submissions_zero',
+      'active_sessions_zero',
+      'production_mail_transport_inactive',
+      'production_config_split_off',
+      'preproduction_config_split_on',
+      'google_tag_off',
+      'provider_egress_off',
+      'production_credentials_absent',
+      'externally_acting_queues_cleared_or_explicitly_bounded',
+      'staged_db_bootstrap_health_pass',
+      'basic_auth_preserved',
+      'noindex_preserved',
+    ] as $required) {
+      self::assertContains($required, $assertions);
+    }
+  }
+
+  /**
+   * Governed Content and rollback remain outside implicit refresh mutation.
+   */
+  public function testDocumentationDefinesFidelityAndRollbackBoundary(): void {
+    $document = $this->document();
+
+    foreach ([
+      'must **not** automatically execute `emerging:governed-content --all`',
+      'isolated staging database',
+      'PROD is never part of rollback',
+      'FIRST_REAL_APPLY=NOT_AUTHORIZED',
+      'Private files are never copied by default',
+    ] as $required) {
+      self::assertStringContainsString($required, $document);
+    }
+  }
+
+  /**
+   * Returns and validates the manual PLAN workflow.
+   */
+  private function workflow(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/.github/workflows/preproduction-data-refresh-plan.yml';
+
+    self::assertFileExists($path);
+    self::assertIsArray(Yaml::parseFile($path));
+
+    return (string) file_get_contents($path);
+  }
+
+  /**
+   * Returns the phase-1 PLAN script.
+   */
+  private function script(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/scripts/preproduction-refresh/plan.sh';
+    self::assertFileExists($path);
+
+    return (string) file_get_contents($path);
+  }
+
+  /**
+   * Returns the decoded sanitization policy.
+   *
+   * @return array<string, mixed>
+   *   The sanitization policy.
+   */
+  private function policy(): array {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root
+      . '/scripts/preproduction-refresh/sanitization-policy.json';
+    self::assertFileExists($path);
+
+    $policy = json_decode(
+      (string) file_get_contents($path),
+      TRUE,
+      512,
+      JSON_THROW_ON_ERROR,
+    );
+    self::assertIsArray($policy);
+
+    return $policy;
+  }
+
+  /**
+   * Returns the durable data-refresh contract.
+   */
+  private function document(): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/docs/operations/preproduction-data-refresh.md';
+    self::assertFileExists($path);
+
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
@@ -26,7 +26,7 @@ final class PreproductionDataRefreshPlanTest extends TestCase {
     self::assertStringNotContainsString("\n  pull_request:\n", $workflow);
     self::assertStringNotContainsString("\n  schedule:\n", $workflow);
     self::assertStringContainsString(
-      "test \"$GITHUB_REF\" = 'refs/heads/main'",
+      'test "$GITHUB_REF" = \'refs/heads/main\'',
       $workflow,
     );
     self::assertStringNotContainsString('${{ secrets.', $workflow);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php
@@ -22,6 +22,7 @@ final class PreproductionDataRefreshPlanTest extends TestCase {
     $workflow = $this->workflow();
 
     self::assertStringContainsString('workflow_dispatch:', $workflow);
+    self::assertStringContainsString('runs-on: ubuntu-24.04', $workflow);
     self::assertStringNotContainsString("\n  push:\n", $workflow);
     self::assertStringNotContainsString("\n  pull_request:\n", $workflow);
     self::assertStringNotContainsString("\n  schedule:\n", $workflow);
@@ -177,6 +178,49 @@ final class PreproductionDataRefreshPlanTest extends TestCase {
       'production_environment_state',
     ] as $required) {
       self::assertContains($required, $rules);
+    }
+  }
+
+  /**
+   * Raw PROD data may never execute on GitHub-hosted infrastructure.
+   */
+  public function testRawProdDataExecutionBoundaryIsFailClosed(): void {
+    $policy = $this->policy();
+    $boundary = $policy['execution_boundary'];
+
+    self::assertFalse($boundary['github_hosted']['raw_prod_data_allowed']);
+    self::assertContains(
+      'NON_SENSITIVE_METADATA_VALIDATION',
+      $boundary['github_hosted']['allowed_roles'],
+    );
+    self::assertSame(
+      'FORBIDDEN',
+      $boundary['raw_prod_data']['github_hosted_runner'],
+    );
+
+    $paths = [];
+    foreach ($boundary['raw_prod_data']['allowed_paths'] as $path) {
+      $paths[$path['type']] = $path;
+    }
+
+    self::assertSame(
+      ['self-hosted', 'linux', 'x64', 'agency'],
+      $paths['TRUSTED_AGENCY_RUNNER']['required_labels'],
+    );
+    self::assertSame(
+      'RAW_DATA_NEVER_TRANSITS_OR_MATERIALIZES_ON_GITHUB_HOSTED_INFRASTRUCTURE',
+      $paths['CONTROLLED_SERVER_TO_SERVER']['requirement'],
+    );
+
+    $document = $this->document();
+    foreach ([
+      'RAW PROD DATA ON GITHUB-HOSTED RUNNER = FORBIDDEN',
+      '`self-hosted`, `linux`, `x64`, `agency`',
+      'strictly controlled server-to-server path',
+      'never materializes on GitHub-hosted infrastructure',
+      'Metadata-only PLAN jobs may remain on `ubuntu-24.04`',
+    ] as $required) {
+      self::assertStringContainsString($required, $document);
     }
   }
 


### PR DESCRIPTION
Refs #816.

## Scope

Phase 1 only: PLAN / repository preflight. No real PROD snapshot, no PROD data transfer, no PREPROD DB import/activation and no runtime side-effect mutation.

Implemented:
- durable data classification, sanitization, side-effect, staging, rollback and Governed Content contract;
- versioned sanitization policy covering users/auth material, Webform, sessions, flood, dblog, caches, batch/temp, queues, Link Checker/runtime state and persisted credentials;
- manual metadata-only `workflow_dispatch` PLAN route, restricted to reviewed `main` tooling;
- fixed metadata-only evidence artifact (`plan.env`) with no raw SQL/file payload path;
- fail-closed identity, capacity and refresh-lock checks;
- APPLY explicitly non-executable and not authorized;
- PHPUnit regression coverage plus PREPROD validation workflow checks.

## Safety boundary

```text
PROD_WRITE_PATH=NONE
REAL_PROD_DATA_TRANSFER=NONE
PREPROD_DB_ACTIVATION=NONE
RAW_PROD_DATA_IN_GITHUB=NONE
FIRST_REAL_APPLY=NOT_AUTHORIZED
```

The PR must stop for Project Lead review after exact-head CI is terminal green. It must not be merged as authorization for a first real APPLY.