### PR TITLE
#826 — Prove governed read-only PROD snapshot and secure cleanup

### DIFF
--- a/.github/workflows/prod-readonly-snapshot-validation.yml
+++ b/.github/workflows/prod-readonly-snapshot-validation.yml
@@ -1,0 +1,162 @@
+name: Validate PROD read-only snapshot governance
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/prod-readonly-snapshot.yml'
+      - '.github/workflows/prod-readonly-snapshot-validation.yml'
+      - 'docs/operations/production-readonly-snapshot.md'
+      - 'scripts/production-readonly-snapshot/**'
+      - 'scripts/preproduction-refresh/sanitization-policy.json'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/PreproductionDataRefreshPlanTest.php'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-snapshot-governance:
+    name: Prove trusted runner, read-only semantics and cleanup
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate snapshot tooling syntax and inherited policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n scripts/production-readonly-snapshot/run-snapshot.sh
+          bash -n scripts/production-readonly-snapshot/finalize-cleanup.sh
+          bash -n scripts/production-readonly-snapshot/remote-stream.sh
+          jq -e . scripts/production-readonly-snapshot/profile.json >/dev/null
+          jq -e '.execution_boundary.raw_prod_data.github_hosted_runner == "FORBIDDEN"' scripts/preproduction-refresh/sanitization-policy.json >/dev/null
+          jq -e '.execution_boundary.github_hosted.raw_prod_data_allowed == false' scripts/preproduction-refresh/sanitization-policy.json >/dev/null
+          jq -e '.execution.trusted_runner_labels == ["self-hosted", "linux", "x64", "agency"]' scripts/production-readonly-snapshot/profile.json >/dev/null
+          jq -e '.execution.prod_write_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
+          jq -e '.execution.preprod_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
+
+      - name: Prove workflow raw-data boundary is static and non-generic
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-readonly-snapshot.yml'
+          grep -Fq 'runs-on: ubuntu-24.04' "$workflow"
+          grep -Fq '      - self-hosted' "$workflow"
+          grep -Fq '      - linux' "$workflow"
+          grep -Fq '      - x64' "$workflow"
+          grep -Fq '      - agency' "$workflow"
+          ! grep -Fq 'workflow_dispatch:' "$workflow"
+          ! grep -Fq 'schedule:' "$workflow"
+          ! grep -Fq 'pull_request:' "$workflow"
+          grep -Fq "github.event.issue.number == 826" "$workflow"
+          grep -Fq "[[ \"$GITHUB_RUN_ATTEMPT\" == '1' ]]" "$workflow"
+          grep -Fq 'agency-prod-readonly-snapshot-v1' "$workflow"
+          grep -Fq 'path: artifacts/prod-readonly-snapshot/evidence.env' "$workflow"
+          ! grep -Fq '*.sql' "$workflow"
+          ! grep -Fq '*.sql.gz' "$workflow"
+          ! grep -Fq '*.dump' "$workflow"
+          ! grep -Fq 'sites/default/files' "$workflow"
+          ! grep -Fq 'scp ' "$workflow"
+          ! grep -Fq 'rsync ' "$workflow"
+
+      - name: Prove fixed PROD operation contains no mutation surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          remote='scripts/production-readonly-snapshot/remote-stream.sh'
+          lifecycle='scripts/production-readonly-snapshot/run-snapshot.sh'
+          grep -Fq "CURRENT_RELEASE='/var/www/agency/current'" "$remote"
+          grep -Fq 'sql:connect --show-passwords' "$remote"
+          grep -Fq -- '--single-transaction' "$remote"
+          grep -Fq -- '--quick' "$remote"
+          grep -Fq -- '--skip-lock-tables' "$remote"
+          grep -Fq -- '--no-tablespaces' "$remote"
+          for forbidden in \
+            'state:set' 'config:import' 'config:set' 'config:delete' \
+            ' updb' ' cim' 'sql:query' 'sql:drop' 'sql:create' \
+            'user:create' 'user:password' 'maintenance_mode' \
+            'git checkout' 'ln -sfn' 'rm -rf /var/www/agency'; do
+            ! grep -Fq "$forbidden" "$remote"
+            ! grep -Fq "$forbidden" "$lifecycle"
+          done
+          ! grep -Fiq 'preprod' "$remote"
+          grep -Fq 'umask 077' "$lifecycle"
+          grep -Fq "RAW_MATERIAL_MODE=\"$(stat -c '%a' \"$RAW_PATH\")\"" "$lifecycle"
+          grep -Fq 'trap cleanup_and_finalize EXIT' "$lifecycle"
+          grep -Fq "trap 'exit 143' TERM" "$lifecycle"
+          grep -Fq 'bash scripts/production-readonly-snapshot/finalize-cleanup.sh' .github/workflows/prod-readonly-snapshot.yml
+
+      - name: Prove synthetic success metadata, mode and cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          profile='scripts/production-readonly-snapshot/profile.json'
+          profile_sha="$(sha256sum "$profile" | awk '{print $1}')"
+          request_id="ci-826-${GITHUB_RUN_ID}"
+          env \
+            REQUEST_ID="$request_id" \
+            AUTHORITY_COMMENT_ID=826 \
+            AUTHORITY_RUN_ID="$GITHUB_RUN_ID" \
+            REPOSITORY_SHA="$sha" \
+            SOURCE_PROD_RELEASE_SHA="$sha" \
+            OPERATION_PROFILE=agency-prod-readonly-snapshot-v1 \
+            PROFILE_SHA256="$profile_sha" \
+            bash scripts/production-readonly-snapshot/run-snapshot.sh SYNTHETIC
+
+          evidence='artifacts/prod-readonly-snapshot/evidence.env'
+          test -f "$evidence"
+          test "$(stat -c '%a' "$evidence")" = '600'
+          grep -Fxq 'execution_mode=SYNTHETIC' "$evidence"
+          grep -Fxq 'snapshot_created=PASS' "$evidence"
+          grep -Fxq 'raw_material_mode=600' "$evidence"
+          grep -Fxq 'snapshot_cleanup=PASS' "$evidence"
+          grep -Fxq 'raw_snapshot_present_after_cleanup=NO' "$evidence"
+          grep -Fxq 'prod_write_path=NONE' "$evidence"
+          grep -Fxq 'preprod_path=NONE' "$evidence"
+          grep -Fxq 'raw_prod_artifact_in_github=NONE' "$evidence"
+          grep -Eq '^snapshot_byte_size=[1-9][0-9]*$' "$evidence"
+          grep -Eq '^snapshot_sha256=[0-9a-f]{64}$' "$evidence"
+          expected_keys="$(jq -r '.evidence.allowlist[]' "$profile" | sort)"
+          actual_keys="$(cut -d= -f1 "$evidence" | sort)"
+          test "$actual_keys" = "$expected_keys"
+          bash scripts/production-readonly-snapshot/finalize-cleanup.sh
+
+      - name: Prove cleanup on synthetic failure and anti-replay
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          profile='scripts/production-readonly-snapshot/profile.json'
+          profile_sha="$(sha256sum "$profile" | awk '{print $1}')"
+          base_env=(
+            REQUEST_ID="ci-826-fail-${GITHUB_RUN_ID}"
+            AUTHORITY_COMMENT_ID=826
+            AUTHORITY_RUN_ID="$GITHUB_RUN_ID"
+            REPOSITORY_SHA="$sha"
+            SOURCE_PROD_RELEASE_SHA="$sha"
+            OPERATION_PROFILE=agency-prod-readonly-snapshot-v1
+            PROFILE_SHA256="$profile_sha"
+          )
+
+          if env "${base_env[@]}" AGENCY_SNAPSHOT_SYNTHETIC_FAIL_AFTER_WRITE=1 \
+            bash scripts/production-readonly-snapshot/run-snapshot.sh SYNTHETIC; then
+            echo 'Synthetic failure path unexpectedly succeeded.' >&2
+            exit 1
+          fi
+          evidence='artifacts/prod-readonly-snapshot/evidence.env'
+          grep -Fxq 'snapshot_created=FAIL' "$evidence"
+          grep -Fxq 'raw_material_mode=600' "$evidence"
+          grep -Fxq 'snapshot_cleanup=PASS' "$evidence"
+          grep -Fxq 'raw_snapshot_present_after_cleanup=NO' "$evidence"
+          bash scripts/production-readonly-snapshot/finalize-cleanup.sh
+
+          if env "${base_env[@]}" GITHUB_RUN_ATTEMPT=2 \
+            bash scripts/production-readonly-snapshot/run-snapshot.sh SYNTHETIC; then
+            echo 'Snapshot proof unexpectedly accepted a replay attempt.' >&2
+            exit 1
+          fi

--- a/.github/workflows/prod-readonly-snapshot-validation.yml
+++ b/.github/workflows/prod-readonly-snapshot-validation.yml
@@ -52,8 +52,9 @@ jobs:
           ! grep -Fq 'workflow_dispatch:' "$workflow"
           ! grep -Fq 'schedule:' "$workflow"
           ! grep -Fq 'pull_request:' "$workflow"
-          grep -Fq "github.event.issue.number == 826" "$workflow"
-          grep -Fq "[[ \"$GITHUB_RUN_ATTEMPT\" == '1' ]]" "$workflow"
+          grep -Fq 'github.event.issue.number == 826' "$workflow"
+          grep -Fq 'GITHUB_RUN_ATTEMPT' "$workflow"
+          grep -Fq 'Snapshot authority cannot be replayed through a workflow rerun.' "$workflow"
           grep -Fq 'agency-prod-readonly-snapshot-v1' "$workflow"
           grep -Fq 'path: artifacts/prod-readonly-snapshot/evidence.env' "$workflow"
           ! grep -Fq '*.sql' "$workflow"
@@ -85,7 +86,8 @@ jobs:
           done
           ! grep -Fiq 'preprod' "$remote"
           grep -Fq 'umask 077' "$lifecycle"
-          grep -Fq "RAW_MATERIAL_MODE=\"$(stat -c '%a' \"$RAW_PATH\")\"" "$lifecycle"
+          grep -Fq 'RAW_MATERIAL_MODE="$(stat -c' "$lifecycle"
+          grep -Fq 'Raw snapshot material is not mode 0600.' "$lifecycle"
           grep -Fq 'trap cleanup_and_finalize EXIT' "$lifecycle"
           grep -Fq "trap 'exit 143' TERM" "$lifecycle"
           grep -Fq 'bash scripts/production-readonly-snapshot/finalize-cleanup.sh' .github/workflows/prod-readonly-snapshot.yml

--- a/.github/workflows/prod-readonly-snapshot-validation.yml
+++ b/.github/workflows/prod-readonly-snapshot-validation.yml
@@ -74,7 +74,16 @@ jobs:
           set -euo pipefail
           remote='scripts/production-readonly-snapshot/remote-stream.sh'
           lifecycle='scripts/production-readonly-snapshot/run-snapshot.sh'
-          grep -Fq "CURRENT_RELEASE='/var/www/agency/current'" "$remote"
+          builder='.github/workflows/build-release-candidate.yml'
+          grep -Fq "PROJECT_ROOT='/var/www/agency'" "$remote"
+          grep -Fq 'CURRENT_RELEASE="$PROJECT_ROOT/current"' "$remote"
+          grep -Fq 'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"' "$remote"
+          grep -Fq 'current_release="$(readlink -f "$CURRENT_RELEASE")"' "$remote"
+          grep -Fq "grep -m1 '^release_path='" "$remote"
+          grep -Fq "grep -m1 '^candidate_sha='" "$remote"
+          grep -Fq 'Current PROD release must map to exactly one promotion receipt.' "$remote"
+          ! grep -Fq 'git -C "$CURRENT_RELEASE" rev-parse HEAD' "$remote"
+          grep -Fq -- "--exclude='.git/'" "$builder"
           grep -Fq 'vendor/bin/drush sql:dump' "$remote"
           ! grep -Fq 'sql:connect' "$remote"
           grep -Fq -- '--single-transaction' "$remote"

--- a/.github/workflows/prod-readonly-snapshot-validation.yml
+++ b/.github/workflows/prod-readonly-snapshot-validation.yml
@@ -38,6 +38,7 @@ jobs:
           jq -e '.execution.trusted_runner_labels == ["self-hosted", "linux", "x64", "agency"]' scripts/production-readonly-snapshot/profile.json >/dev/null
           jq -e '.execution.prod_write_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
           jq -e '.execution.preprod_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
+          jq -e '.snapshot.fixed_tool == "vendor/bin/drush sql:dump"' scripts/production-readonly-snapshot/profile.json >/dev/null
 
       - name: Prove workflow raw-data boundary is static and non-generic
         shell: bash
@@ -57,6 +58,9 @@ jobs:
           grep -Fq 'Snapshot authority cannot be replayed through a workflow rerun.' "$workflow"
           grep -Fq 'agency-prod-readonly-snapshot-v1' "$workflow"
           grep -Fq 'path: artifacts/prod-readonly-snapshot/evidence.env' "$workflow"
+          grep -Fq 'Require pre-provisioned PROD host trust' "$workflow"
+          grep -Fq 'ssh-keygen -F "$SERVER_HOST"' "$workflow"
+          ! grep -Fq 'ssh-keyscan' "$workflow"
           ! grep -Fq '*.sql' "$workflow"
           ! grep -Fq '*.sql.gz' "$workflow"
           ! grep -Fq '*.dump' "$workflow"
@@ -71,11 +75,14 @@ jobs:
           remote='scripts/production-readonly-snapshot/remote-stream.sh'
           lifecycle='scripts/production-readonly-snapshot/run-snapshot.sh'
           grep -Fq "CURRENT_RELEASE='/var/www/agency/current'" "$remote"
-          grep -Fq 'sql:connect --show-passwords' "$remote"
+          grep -Fq 'vendor/bin/drush sql:dump' "$remote"
+          ! grep -Fq 'sql:connect' "$remote"
           grep -Fq -- '--single-transaction' "$remote"
           grep -Fq -- '--quick' "$remote"
           grep -Fq -- '--skip-lock-tables' "$remote"
           grep -Fq -- '--no-tablespaces' "$remote"
+          ! grep -Fq -- '--result-file' "$remote"
+          grep -Fq 'StrictHostKeyChecking=yes' "$lifecycle"
           for forbidden in \
             'state:set' 'config:import' 'config:set' 'config:delete' \
             ' updb' ' cim' 'sql:query' 'sql:drop' 'sql:create' \

--- a/.github/workflows/prod-readonly-snapshot.yml
+++ b/.github/workflows/prod-readonly-snapshot.yml
@@ -1,0 +1,243 @@
+name: Governed PROD read-only snapshot proof
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agency-prod-readonly-snapshot
+  cancel-in-progress: false
+
+jobs:
+  validate-authority:
+    name: Validate fresh owner snapshot authority
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 826 &&
+        startsWith(github.event.comment.body, '/agency-prod-readonly-snapshot prove ')
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      request_id: ${{ steps.authority.outputs.request_id }}
+      authority_comment_id: ${{ steps.authority.outputs.authority_comment_id }}
+      main_sha: ${{ steps.authority.outputs.main_sha }}
+      prod_release_sha: ${{ steps.authority.outputs.prod_release_sha }}
+      operation_profile: ${{ steps.authority.outputs.operation_profile }}
+      profile_sha256: ${{ steps.profile.outputs.profile_sha256 }}
+    steps:
+      - name: Validate actor, one-shot request and live main
+        id: authority
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          AUTHORITY_COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '826' ]]
+          [[ "$GITHUB_RUN_ATTEMPT" == '1' ]] || {
+            echo 'Snapshot authority cannot be replayed through a workflow rerun.' >&2
+            exit 1
+          }
+          [[ "$AUTHORITY_COMMENT_ID" =~ ^[0-9]+$ ]]
+
+          read -r command verb request_id requested_main requested_prod profile extra <<< "$TRIGGER_COMMENT"
+          [[ -z "${extra:-}" ]]
+          [[ "$command" == '/agency-prod-readonly-snapshot' ]]
+          [[ "$verb" == 'prove' ]]
+          [[ "$request_id" =~ ^[A-Za-z0-9._-]{8,80}$ ]]
+          [[ "$requested_main" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$requested_prod" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$profile" == 'agency-prod-readonly-snapshot-v1' ]]
+          expected="/agency-prod-readonly-snapshot prove $request_id $requested_main $requested_prod $profile"
+          [[ "$TRIGGER_COMMENT" == "$expected" ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/826")"
+          [[ "$(jq -r '.state' <<< "$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<< "$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<< "$issue_json")" == 'E-merging-digital' ]]
+
+          live_main="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$live_main" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$requested_main" == "$live_main" ]] || {
+            echo 'Requested main SHA is stale.' >&2
+            exit 1
+          }
+          [[ "$EVENT_DEFAULT_SHA" == "$live_main" ]] || {
+            echo 'Snapshot workflow must execute tooling from live main.' >&2
+            exit 1
+          }
+
+          comments="$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/826/comments?per_page=100" --jq '.[].body')"
+          request_prefix="/agency-prod-readonly-snapshot prove $request_id "
+          match_count=0
+          while IFS= read -r body; do
+            if [[ "$body" == "$request_prefix"* ]]; then
+              match_count=$((match_count + 1))
+            fi
+          done <<< "$comments"
+          [[ "$match_count" -eq 1 ]] || {
+            echo 'request_id must be fresh and must appear in exactly one owner authority comment.' >&2
+            exit 1
+          }
+
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+          echo "authority_comment_id=$AUTHORITY_COMMENT_ID" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$live_main" >> "$GITHUB_OUTPUT"
+          echo "prod_release_sha=$requested_prod" >> "$GITHUB_OUTPUT"
+          echo "operation_profile=$profile" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact trusted main tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.authority.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Bind exact reviewed operation profile
+        id: profile
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.authority.outputs.main_sha }}
+          EXPECTED_PROFILE: ${{ steps.authority.outputs.operation_profile }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          profile='scripts/production-readonly-snapshot/profile.json'
+          jq -e --arg profile "$EXPECTED_PROFILE" '.profile_id == $profile' "$profile" >/dev/null
+          jq -e '.authority.issue_number? // empty' "$profile" >/dev/null 2>&1 || true
+          jq -e '.issue_number == 826' "$profile" >/dev/null
+          profile_sha256="$(sha256sum "$profile" | awk '{print $1}')"
+          [[ "$profile_sha256" =~ ^[0-9a-f]{64}$ ]]
+          echo "profile_sha256=$profile_sha256" >> "$GITHUB_OUTPUT"
+
+  snapshot:
+    name: Stream one fixed read-only PROD snapshot on trusted Agency runner
+    needs: validate-authority
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+    steps:
+      - name: Checkout exact trusted main tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-authority.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify immutable snapshot tooling and runner capabilities
+        shell: bash
+        env:
+          EXPECTED_MAIN_SHA: ${{ needs.validate-authority.outputs.main_sha }}
+          EXPECTED_PROFILE_SHA256: ${{ needs.validate-authority.outputs.profile_sha256 }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test "$(sha256sum scripts/production-readonly-snapshot/profile.json | awk '{print $1}')" = "$EXPECTED_PROFILE_SHA256"
+          bash -n scripts/production-readonly-snapshot/run-snapshot.sh
+          bash -n scripts/production-readonly-snapshot/finalize-cleanup.sh
+          bash -n scripts/production-readonly-snapshot/remote-stream.sh
+          command -v ssh
+          command -v sha256sum
+          command -v stat
+          git diff --check
+
+      - name: Configure transient PROD SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Pin PROD server host key for this route
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          : > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+
+      - name: Execute fixed read-only snapshot and cleanup proof
+        env:
+          REQUEST_ID: ${{ needs.validate-authority.outputs.request_id }}
+          AUTHORITY_COMMENT_ID: ${{ needs.validate-authority.outputs.authority_comment_id }}
+          AUTHORITY_RUN_ID: ${{ github.run_id }}
+          REPOSITORY_SHA: ${{ needs.validate-authority.outputs.main_sha }}
+          SOURCE_PROD_RELEASE_SHA: ${{ needs.validate-authority.outputs.prod_release_sha }}
+          OPERATION_PROFILE: ${{ needs.validate-authority.outputs.operation_profile }}
+          PROFILE_SHA256: ${{ needs.validate-authority.outputs.profile_sha256 }}
+          PROD_SSH_HOST: ${{ secrets.SERVER_HOST }}
+          PROD_SSH_USER: ${{ secrets.SERVER_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/production-readonly-snapshot/run-snapshot.sh REAL
+
+      - name: Independently finalize raw cleanup
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/production-readonly-snapshot/finalize-cleanup.sh
+
+      - name: Remove transient SSH credential
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f ~/.ssh/id_ed25519
+          test ! -e ~/.ssh/id_ed25519
+
+      - name: Validate fixed-key metadata evidence only
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          profile='scripts/production-readonly-snapshot/profile.json'
+          evidence='artifacts/prod-readonly-snapshot/evidence.env'
+          test -f "$evidence"
+          test "$(stat -c '%a' "$evidence")" = '600'
+          expected_keys="$(jq -r '.evidence.allowlist[]' "$profile" | sort)"
+          actual_keys="$(cut -d= -f1 "$evidence" | sort)"
+          test "$actual_keys" = "$expected_keys"
+          grep -Fxq 'prod_write_path=NONE' "$evidence"
+          grep -Fxq 'preprod_path=NONE' "$evidence"
+          grep -Fxq 'raw_prod_artifact_in_github=NONE' "$evidence"
+          grep -Fxq 'snapshot_cleanup=PASS' "$evidence"
+          grep -Fxq 'raw_snapshot_present_after_cleanup=NO' "$evidence"
+
+      - name: Upload metadata-only snapshot evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-prod-readonly-snapshot-${{ needs.validate-authority.outputs.request_id }}-${{ github.run_id }}
+          path: artifacts/prod-readonly-snapshot/evidence.env
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/prod-readonly-snapshot.yml
+++ b/.github/workflows/prod-readonly-snapshot.yml
@@ -119,7 +119,6 @@ jobs:
           test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
           profile='scripts/production-readonly-snapshot/profile.json'
           jq -e --arg profile "$EXPECTED_PROFILE" '.profile_id == $profile' "$profile" >/dev/null
-          jq -e '.authority.issue_number? // empty' "$profile" >/dev/null 2>&1 || true
           jq -e '.issue_number == 826' "$profile" >/dev/null
           profile_sha256="$(sha256sum "$profile" | awk '{print $1}')"
           [[ "$profile_sha256" =~ ^[0-9a-f]{64}$ ]]
@@ -157,6 +156,7 @@ jobs:
           bash -n scripts/production-readonly-snapshot/finalize-cleanup.sh
           bash -n scripts/production-readonly-snapshot/remote-stream.sh
           command -v ssh
+          command -v ssh-keygen
           command -v sha256sum
           command -v stat
           git diff --check
@@ -173,16 +173,18 @@ jobs:
           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-      - name: Pin PROD server host key for this route
+      - name: Require pre-provisioned PROD host trust
         env:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         shell: bash
         run: |
           set -euo pipefail
           test -n "$SERVER_HOST"
-          : > ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          test -s ~/.ssh/known_hosts
+          ssh-keygen -F "$SERVER_HOST" -f ~/.ssh/known_hosts >/dev/null || {
+            echo 'PROD host key is not pre-provisioned on the trusted Agency runner.' >&2
+            exit 1
+          }
 
       - name: Execute fixed read-only snapshot and cleanup proof
         env:
@@ -227,6 +229,8 @@ jobs:
           expected_keys="$(jq -r '.evidence.allowlist[]' "$profile" | sort)"
           actual_keys="$(cut -d= -f1 "$evidence" | sort)"
           test "$actual_keys" = "$expected_keys"
+          grep -Fxq 'snapshot_created=PASS' "$evidence"
+          grep -Fxq 'raw_material_mode=600' "$evidence"
           grep -Fxq 'prod_write_path=NONE' "$evidence"
           grep -Fxq 'preprod_path=NONE' "$evidence"
           grep -Fxq 'raw_prod_artifact_in_github=NONE' "$evidence"

--- a/docs/operations/production-readonly-snapshot.md
+++ b/docs/operations/production-readonly-snapshot.md
@@ -39,7 +39,9 @@ The PROD SSH host trust must already be provisioned in `~/.ssh/known_hosts` on t
 
 The reviewed operation profile is `scripts/production-readonly-snapshot/profile.json` with ID `agency-prod-readonly-snapshot-v1`.
 
-The trusted runner uses the repository-owned `remote-stream.sh` over SSH. The remote operation has one argument only: the expected 40-character PROD release SHA. It operates only against the fixed `/var/www/agency/current` release and first requires that `git rev-parse HEAD` equals the authorized PROD release SHA.
+The trusted runner uses the repository-owned `remote-stream.sh` over SSH. The remote operation has one argument only: the expected 40-character PROD release SHA. It operates only against the fixed `/var/www/agency/current` release.
+
+Release candidate payloads deliberately exclude `.git/`, so runtime identity is not derived from a Git checkout. The route resolves the real target of `/var/www/agency/current`, requires the production promotion-receipt directory, then requires exactly one durable promotion receipt whose `release_path` equals that resolved release. The receipt's `candidate_sha` must be a valid 40-character SHA and must exactly equal the authorized expected PROD release SHA. A missing, duplicate, invalid or mismatched receipt fails closed before the database snapshot starts.
 
 Database connection details come only from PROD server-owned Drupal settings through the fixed `vendor/bin/drush sql:dump` operation. No connection string is supplied by the request, and the route does not execute or print `sql:connect`, generic SQL, a database name, a table name or a user-provided dump option.
 

--- a/docs/operations/production-readonly-snapshot.md
+++ b/docs/operations/production-readonly-snapshot.md
@@ -33,15 +33,17 @@ GitHub-hosted infrastructure is authority/metadata/policy validation only. The r
 
 The trusted runner is not a generic remote executor. The owner cannot supply a shell command, SQL query, table name, database name, file path, SSH option, Drush argument or dump option. Only request/release identities matching strict schemas reach the trusted job.
 
+The PROD SSH host trust must already be provisioned in `~/.ssh/known_hosts` on the trusted Agency runner. The route uses `StrictHostKeyChecking=yes` and fails closed when the configured PROD host is not already trusted. The snapshot workflow never bootstraps host trust with `ssh-keyscan`.
+
 ## Fixed read-only snapshot operation
 
 The reviewed operation profile is `scripts/production-readonly-snapshot/profile.json` with ID `agency-prod-readonly-snapshot-v1`.
 
 The trusted runner uses the repository-owned `remote-stream.sh` over SSH. The remote operation has one argument only: the expected 40-character PROD release SHA. It operates only against the fixed `/var/www/agency/current` release and first requires that `git rev-parse HEAD` equals the authorized PROD release SHA.
 
-Database connection details come only from PROD server-owned Drupal settings through fixed `drush sql:connect --show-passwords`; that generated connection command is never printed or included in evidence. The operation rejects executable SQL connection flags and replaces only the trusted SQL client executable with `mariadb-dump` or its `mysqldump` compatibility name.
+Database connection details come only from PROD server-owned Drupal settings through the fixed `vendor/bin/drush sql:dump` operation. No connection string is supplied by the request, and the route does not execute or print `sql:connect`, generic SQL, a database name, a table name or a user-provided dump option.
 
-The dump options are fixed in repository code:
+The dump options are fixed in repository code through `--extra-dump`:
 
 ```text
 --single-transaction
@@ -52,7 +54,7 @@ The dump options are fixed in repository code:
 
 `--single-transaction` provides a transactionally consistent logical snapshot for transactional tables, while `--quick` streams rows and `--skip-lock-tables` prevents table-lock dump behavior. No maintenance/config/content/user/state/scheduler/release mutation, `updb`, `cim`, generic SQL query or deployment command exists in this route.
 
-The remote command streams SQL to stdout. It does not create a raw snapshot file on the PROD host. Therefore:
+No `--result-file` is supplied. The remote `drush sql:dump` therefore streams SQL to stdout, which SSH carries directly to the trusted runner. The operation does not create a raw snapshot file on the PROD host. Therefore:
 
 ```text
 PROD_WRITE_PATH=NONE

--- a/docs/operations/production-readonly-snapshot.md
+++ b/docs/operations/production-readonly-snapshot.md
@@ -1,0 +1,117 @@
+# Governed read-only PROD database snapshot proof
+
+Issue: #826. Parent program: #816.
+
+This tranche implements only the governed route and static/synthetic proof for a future read-only production database snapshot. It does not authorize or execute the first real PROD snapshot.
+
+## Human and authority boundary
+
+`FIRST REAL PROD SNAPSHOT = NOT_AUTHORIZED` until Project Lead reviews the exact PR HEAD and the owner subsequently creates one fresh #826 authority comment.
+
+Issue creation, PR creation, PR merge, PLAN success, an old production GO, an old comment, and a workflow rerun are not snapshot authority.
+
+After Project Lead review, the future one-shot owner command has exactly this shape:
+
+```text
+/agency-prod-readonly-snapshot prove <request_id> <live_main_sha> <expected_prod_release_sha> agency-prod-readonly-snapshot-v1
+```
+
+The GitHub-hosted gateway accepts only issue #826, actor/comment author `E-merging-digital`, an open owner-created issue, `run_attempt=1`, a fresh request ID appearing in exactly one authority comment, exact live `main`, a 40-character expected PROD release SHA, and the fixed repository-owned profile. The authority binds the request ID, authority comment ID, workflow run ID, live main SHA, expected current PROD release SHA, profile ID and profile SHA-256.
+
+## Execution boundary
+
+The inherited #816 rule remains absolute:
+
+`RAW PROD DATA ON GITHUB-HOSTED RUNNER = FORBIDDEN`.
+
+GitHub-hosted infrastructure is authority/metadata/policy validation only. The raw-data job requires all labels:
+
+- `self-hosted`;
+- `linux`;
+- `x64`;
+- `agency`.
+
+The trusted runner is not a generic remote executor. The owner cannot supply a shell command, SQL query, table name, database name, file path, SSH option, Drush argument or dump option. Only request/release identities matching strict schemas reach the trusted job.
+
+## Fixed read-only snapshot operation
+
+The reviewed operation profile is `scripts/production-readonly-snapshot/profile.json` with ID `agency-prod-readonly-snapshot-v1`.
+
+The trusted runner uses the repository-owned `remote-stream.sh` over SSH. The remote operation has one argument only: the expected 40-character PROD release SHA. It operates only against the fixed `/var/www/agency/current` release and first requires that `git rev-parse HEAD` equals the authorized PROD release SHA.
+
+Database connection details come only from PROD server-owned Drupal settings through fixed `drush sql:connect --show-passwords`; that generated connection command is never printed or included in evidence. The operation rejects executable SQL connection flags and replaces only the trusted SQL client executable with `mariadb-dump` or its `mysqldump` compatibility name.
+
+The dump options are fixed in repository code:
+
+```text
+--single-transaction
+--quick
+--skip-lock-tables
+--no-tablespaces
+```
+
+`--single-transaction` provides a transactionally consistent logical snapshot for transactional tables, while `--quick` streams rows and `--skip-lock-tables` prevents table-lock dump behavior. No maintenance/config/content/user/state/scheduler/release mutation, `updb`, `cim`, generic SQL query or deployment command exists in this route.
+
+The remote command streams SQL to stdout. It does not create a raw snapshot file on the PROD host. Therefore:
+
+```text
+PROD_WRITE_PATH=NONE
+```
+
+## Trusted raw material lifecycle
+
+Raw SQL is captured only in the trusted runner's `RUNNER_TEMP`, at a path derived exclusively from GitHub run ID and run attempt. No request field becomes a file path.
+
+The lifecycle script enforces:
+
+- `umask 077`;
+- regular raw file mode `0600`;
+- raw path outside `GITHUB_WORKSPACE`;
+- SHA-256 and byte-size calculation without printing contents;
+- EXIT cleanup trap;
+- HUP/INT/TERM handlers that exit through the cleanup trap;
+- deletion of raw SQL and transient remote stderr on success or failure;
+- evidence written only after cleanup has been attempted and absence checked;
+- terminal failure if raw absence cannot be proven;
+- an independent workflow `always()` finalizer that derives the same private path and removes/verifies it again.
+
+A hard process/host failure can never be made mathematically atomic by a shell trap; the design therefore uses both the in-process trap and workflow finalizer, which is the strongest enforceable cleanup boundary available to this runner model. A future real run is not accepted as successful unless cleanup evidence is `PASS` and `RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP=NO`.
+
+## Metadata-only evidence
+
+The only GitHub artifact path is fixed:
+
+`artifacts/prod-readonly-snapshot/evidence.env`
+
+The exact evidence keys are versioned in `profile.json`. They contain only request/run/release/profile identities, byte size, SHA-256 and PASS/FAIL/NONE metadata. Raw SQL, SQL fragments, database connection strings, credentials, PII, emails, usernames, IP addresses, password/hash/session/reset material, form data, private files and raw archives are forbidden.
+
+Expected successful evidence includes:
+
+```text
+snapshot_created=PASS
+raw_material_mode=600
+snapshot_cleanup=PASS
+raw_snapshot_present_after_cleanup=NO
+prod_write_path=NONE
+preprod_path=NONE
+raw_prod_artifact_in_github=NONE
+```
+
+## Explicitly absent PREPROD/full-refresh paths
+
+This tranche contains no PREPROD SSH/connection, data transfer, DB import, sanitization execution, backup, activation, rollback, public-files sync, scheduler or full APPLY path.
+
+```text
+REAL_PROD_DATA_TRANSFER=NONE
+PREPROD_PATH=NONE
+PREPROD_DB_IMPORT=NONE
+PREPROD_DB_ACTIVATION=NONE
+```
+
+Synthetic CI may exercise the same local lifecycle using a fixed non-production fixture. Synthetic bytes on a GitHub-hosted CI runner are not production data and cannot enable the REAL path.
+
+## Stop boundary
+
+Delivery stops once the implementation PR has exact-head CI and targeted snapshot-governance validation green with no blocking review thread.
+
+No real authority comment is created and no real PROD snapshot is triggered during #826 implementation review.

--- a/scripts/production-readonly-snapshot/finalize-cleanup.sh
+++ b/scripts/production-readonly-snapshot/finalize-cleanup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-}"
+RUNNER_TEMP="${RUNNER_TEMP:-}"
+GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
+GITHUB_RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-}"
+
+if [[ -z "$GITHUB_WORKSPACE" || -z "$RUNNER_TEMP" ]]; then
+  echo 'GITHUB_WORKSPACE and RUNNER_TEMP are required.' >&2
+  exit 64
+fi
+if [[ ! "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]] || [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+  echo 'GitHub run identity is invalid.' >&2
+  exit 65
+fi
+
+workspace_abs="$(realpath -m "$GITHUB_WORKSPACE")"
+runner_temp_abs="$(realpath -m "$RUNNER_TEMP")"
+case "$runner_temp_abs/" in
+  "$workspace_abs/"*)
+    echo 'RUNNER_TEMP must be outside the repository workspace.' >&2
+    exit 66
+    ;;
+esac
+
+raw_path="$runner_temp_abs/agency-prod-readonly-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sql"
+stderr_path="$runner_temp_abs/agency-prod-readonly-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.stderr"
+
+rm -f -- "$raw_path" "$stderr_path"
+
+if [[ -e "$raw_path" || -L "$raw_path" || -e "$stderr_path" || -L "$stderr_path" ]]; then
+  echo 'Trusted runner cleanup could not prove raw snapshot absence.' >&2
+  exit 67
+fi
+
+printf '%s\n' 'RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP=NO'

--- a/scripts/production-readonly-snapshot/profile.json
+++ b/scripts/production-readonly-snapshot/profile.json
@@ -36,11 +36,8 @@
   "snapshot": {
     "remote_project_root": "/var/www/agency/current",
     "release_identity": "GIT_HEAD_OF_CURRENT_RELEASE",
-    "connection_source": "DRUSH_SQL_CONNECT_FROM_SERVER_OWNED_SETTINGS",
-    "allowed_dump_clients": [
-      "mariadb-dump",
-      "mysqldump"
-    ],
+    "connection_source": "DRUSH_SQL_DUMP_FROM_SERVER_OWNED_SETTINGS",
+    "fixed_tool": "vendor/bin/drush sql:dump",
     "fixed_dump_options": [
       "--single-transaction",
       "--quick",

--- a/scripts/production-readonly-snapshot/profile.json
+++ b/scripts/production-readonly-snapshot/profile.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "profile_id": "agency-prod-readonly-snapshot-v1",
+  "issue_number": 826,
+  "authority": {
+    "trigger": "ISSUE_COMMENT",
+    "command_prefix": "/agency-prod-readonly-snapshot prove",
+    "owner_actor": "E-merging-digital",
+    "live_main_required": true,
+    "run_attempt_must_equal": 1,
+    "unique_request_id_required": true,
+    "bindings": [
+      "request_id",
+      "authority_comment_id",
+      "live_main_sha",
+      "expected_prod_release_sha",
+      "profile_id",
+      "profile_sha256"
+    ],
+    "first_real_snapshot": "HUMAN_REQUIRED_AFTER_PROJECT_LEAD_REVIEW"
+  },
+  "execution": {
+    "gateway_runner": "ubuntu-24.04",
+    "github_hosted_raw_prod_data": "FORBIDDEN",
+    "trusted_runner_labels": [
+      "self-hosted",
+      "linux",
+      "x64",
+      "agency"
+    ],
+    "raw_material_location": "TRUSTED_RUNNER_TEMP_ONLY",
+    "prod_remote_raw_file": "NONE",
+    "prod_write_path": "NONE",
+    "preprod_path": "NONE"
+  },
+  "snapshot": {
+    "remote_project_root": "/var/www/agency/current",
+    "release_identity": "GIT_HEAD_OF_CURRENT_RELEASE",
+    "connection_source": "DRUSH_SQL_CONNECT_FROM_SERVER_OWNED_SETTINGS",
+    "allowed_dump_clients": [
+      "mariadb-dump",
+      "mysqldump"
+    ],
+    "fixed_dump_options": [
+      "--single-transaction",
+      "--quick",
+      "--skip-lock-tables",
+      "--no-tablespaces"
+    ],
+    "raw_material_mode": "0600",
+    "remote_raw_materialization": false
+  },
+  "cleanup": {
+    "exit_trap_required": true,
+    "signal_cleanup_required": true,
+    "workflow_finalizer_required": true,
+    "absence_after_cleanup_required": true,
+    "cleanup_failure_is_terminal": true
+  },
+  "evidence": {
+    "artifact_path": "artifacts/prod-readonly-snapshot/evidence.env",
+    "raw_prod_artifact_allowed": false,
+    "pii_allowed": false,
+    "secrets_allowed": false,
+    "allowlist": [
+      "schema_version",
+      "request_id",
+      "authority_comment_id",
+      "authority_run_id",
+      "repository_sha",
+      "source_prod_release_sha",
+      "operation_profile",
+      "profile_sha256",
+      "execution_mode",
+      "snapshot_byte_size",
+      "snapshot_sha256",
+      "snapshot_created",
+      "raw_material_mode",
+      "snapshot_cleanup",
+      "raw_snapshot_present_after_cleanup",
+      "prod_write_path",
+      "preprod_path",
+      "raw_prod_artifact_in_github"
+    ]
+  }
+}

--- a/scripts/production-readonly-snapshot/remote-stream.sh
+++ b/scripts/production-readonly-snapshot/remote-stream.sh
@@ -8,15 +8,17 @@ if [[ "$#" -ne 1 ]]; then
 fi
 
 EXPECTED_PROD_RELEASE_SHA="$1"
-CURRENT_RELEASE='/var/www/agency/current'
+PROJECT_ROOT='/var/www/agency'
+CURRENT_RELEASE="$PROJECT_ROOT/current"
+PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"
 
 if [[ ! "$EXPECTED_PROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo 'Expected PROD release SHA is invalid.' >&2
   exit 65
 fi
 
-if [[ ! -d "$CURRENT_RELEASE" ]]; then
-  echo 'Current PROD release is unavailable.' >&2
+if [[ ! -L "$CURRENT_RELEASE" ]]; then
+  echo 'Current PROD release symlink is unavailable.' >&2
   exit 66
 fi
 
@@ -25,10 +27,43 @@ if [[ ! -x "$CURRENT_RELEASE/vendor/bin/drush" ]]; then
   exit 67
 fi
 
-ACTUAL_PROD_RELEASE_SHA="$(git -C "$CURRENT_RELEASE" rev-parse HEAD)"
+if [[ ! -d "$PROMOTIONS_DIR" ]]; then
+  echo 'Production promotion receipts are unavailable.' >&2
+  exit 68
+fi
+
+current_release="$(readlink -f "$CURRENT_RELEASE")"
+if [[ -z "$current_release" || ! -d "$current_release" ]]; then
+  echo 'Current PROD release cannot be resolved.' >&2
+  exit 69
+fi
+
+# Release payloads intentionally exclude .git. Bind runtime identity to the
+# durable same-artifact promotion receipt for the resolved current release.
+matched_receipts=0
+ACTUAL_PROD_RELEASE_SHA=''
+shopt -s nullglob
+for receipt in "$PROMOTIONS_DIR"/*.env; do
+  receipt_release="$(grep -m1 '^release_path=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_release" == "$current_release" ]] || continue
+  receipt_sha="$(grep -m1 '^candidate_sha=' "$receipt" | cut -d= -f2- || true)"
+  if [[ ! "$receipt_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo 'Current production receipt has invalid candidate identity.' >&2
+    exit 70
+  fi
+  ACTUAL_PROD_RELEASE_SHA="$receipt_sha"
+  matched_receipts=$((matched_receipts + 1))
+done
+shopt -u nullglob
+
+if [[ "$matched_receipts" -ne 1 ]]; then
+  echo 'Current PROD release must map to exactly one promotion receipt.' >&2
+  exit 71
+fi
+
 if [[ "$ACTUAL_PROD_RELEASE_SHA" != "$EXPECTED_PROD_RELEASE_SHA" ]]; then
   echo 'Current PROD release identity does not match authorization.' >&2
-  exit 68
+  exit 72
 fi
 
 cd "$CURRENT_RELEASE"

--- a/scripts/production-readonly-snapshot/remote-stream.sh
+++ b/scripts/production-readonly-snapshot/remote-stream.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+if [[ "$#" -ne 1 ]]; then
+  echo 'Expected exactly one immutable PROD release SHA.' >&2
+  exit 64
+fi
+
+EXPECTED_PROD_RELEASE_SHA="$1"
+CURRENT_RELEASE='/var/www/agency/current'
+
+if [[ ! "$EXPECTED_PROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'Expected PROD release SHA is invalid.' >&2
+  exit 65
+fi
+
+if [[ ! -d "$CURRENT_RELEASE" ]]; then
+  echo 'Current PROD release is unavailable.' >&2
+  exit 66
+fi
+
+if [[ ! -x "$CURRENT_RELEASE/vendor/bin/drush" ]]; then
+  echo 'Current PROD release does not contain executable Drush.' >&2
+  exit 67
+fi
+
+ACTUAL_PROD_RELEASE_SHA="$(git -C "$CURRENT_RELEASE" rev-parse HEAD)"
+if [[ "$ACTUAL_PROD_RELEASE_SHA" != "$EXPECTED_PROD_RELEASE_SHA" ]]; then
+  echo 'Current PROD release identity does not match authorization.' >&2
+  exit 68
+fi
+
+cd "$CURRENT_RELEASE"
+
+# Bootstrap and connection discovery are read-only. Never print the generated
+# connection command because it contains server-owned database credentials.
+vendor/bin/drush status --fields=bootstrap --format=string >/dev/null
+connection_command="$(vendor/bin/drush sql:connect --show-passwords)"
+if [[ -z "$connection_command" ]]; then
+  echo 'Unable to resolve the server-owned PROD database connection.' >&2
+  exit 69
+fi
+
+# Drush generates this command exclusively from trusted server-owned settings.
+# No user-controlled value is ever inserted into it. Decode its quoting into an
+# argv array, validate the SQL client shape, then replace only the executable
+# with the fixed read-only dump client.
+eval "set -- ${connection_command}"
+unset connection_command
+
+if [[ "$#" -lt 2 ]]; then
+  echo 'Resolved database connection is incomplete.' >&2
+  exit 70
+fi
+
+connect_client="$(basename "$1")"
+shift
+case "$connect_client" in
+  mysql|mariadb) ;;
+  *)
+    echo 'Resolved database connection is not a supported MariaDB/MySQL client.' >&2
+    exit 71
+    ;;
+esac
+
+for connection_arg in "$@"; do
+  case "$connection_arg" in
+    -e|--execute|--execute=*|--init-command|--init-command=*|--local-infile|--local-infile=*)
+      echo 'Resolved database connection unexpectedly contains an executable SQL option.' >&2
+      exit 72
+      ;;
+  esac
+done
+
+if command -v mariadb-dump >/dev/null 2>&1; then
+  dump_client="$(command -v mariadb-dump)"
+elif command -v mysqldump >/dev/null 2>&1; then
+  dump_client="$(command -v mysqldump)"
+else
+  echo 'No supported database dump client is available on PROD.' >&2
+  exit 73
+fi
+
+# Raw SQL is emitted only on stdout so the trusted Agency runner can capture it
+# directly in its private RUNNER_TEMP. No raw dump file is created on PROD.
+exec "$dump_client" \
+  --single-transaction \
+  --quick \
+  --skip-lock-tables \
+  --no-tablespaces \
+  "$@"

--- a/scripts/production-readonly-snapshot/remote-stream.sh
+++ b/scripts/production-readonly-snapshot/remote-stream.sh
@@ -40,8 +40,8 @@ vendor/bin/drush status --fields=bootstrap --format=string >/dev/null
 
 # Drush sql:dump invokes the database-specific logical dump client. The fixed
 # options provide a streaming, non-locking transactional snapshot for the
-# transactional tables used by Agency. No --result-file is provided: raw SQL is
-# emitted only to stdout and captured directly in trusted RUNNER_TEMP.
+# transactional tables used by Agency. No remote result file is configured:
+# raw SQL is emitted only to stdout and captured directly in trusted RUNNER_TEMP.
 exec vendor/bin/drush sql:dump \
   --no-interaction \
   --extra-dump='--single-transaction --quick --skip-lock-tables --no-tablespaces'

--- a/scripts/production-readonly-snapshot/remote-stream.sh
+++ b/scripts/production-readonly-snapshot/remote-stream.sh
@@ -33,60 +33,15 @@ fi
 
 cd "$CURRENT_RELEASE"
 
-# Bootstrap and connection discovery are read-only. Never print the generated
-# connection command because it contains server-owned database credentials.
+# Both commands derive the database connection exclusively from trusted
+# server-owned Drupal settings. No connection string, SQL, table, database,
+# file path or dump option can be supplied by the request authority.
 vendor/bin/drush status --fields=bootstrap --format=string >/dev/null
-connection_command="$(vendor/bin/drush sql:connect --show-passwords)"
-if [[ -z "$connection_command" ]]; then
-  echo 'Unable to resolve the server-owned PROD database connection.' >&2
-  exit 69
-fi
 
-# Drush generates this command exclusively from trusted server-owned settings.
-# No user-controlled value is ever inserted into it. Decode its quoting into an
-# argv array, validate the SQL client shape, then replace only the executable
-# with the fixed read-only dump client.
-eval "set -- ${connection_command}"
-unset connection_command
-
-if [[ "$#" -lt 2 ]]; then
-  echo 'Resolved database connection is incomplete.' >&2
-  exit 70
-fi
-
-connect_client="$(basename "$1")"
-shift
-case "$connect_client" in
-  mysql|mariadb) ;;
-  *)
-    echo 'Resolved database connection is not a supported MariaDB/MySQL client.' >&2
-    exit 71
-    ;;
-esac
-
-for connection_arg in "$@"; do
-  case "$connection_arg" in
-    -e|--execute|--execute=*|--init-command|--init-command=*|--local-infile|--local-infile=*)
-      echo 'Resolved database connection unexpectedly contains an executable SQL option.' >&2
-      exit 72
-      ;;
-  esac
-done
-
-if command -v mariadb-dump >/dev/null 2>&1; then
-  dump_client="$(command -v mariadb-dump)"
-elif command -v mysqldump >/dev/null 2>&1; then
-  dump_client="$(command -v mysqldump)"
-else
-  echo 'No supported database dump client is available on PROD.' >&2
-  exit 73
-fi
-
-# Raw SQL is emitted only on stdout so the trusted Agency runner can capture it
-# directly in its private RUNNER_TEMP. No raw dump file is created on PROD.
-exec "$dump_client" \
-  --single-transaction \
-  --quick \
-  --skip-lock-tables \
-  --no-tablespaces \
-  "$@"
+# Drush sql:dump invokes the database-specific logical dump client. The fixed
+# options provide a streaming, non-locking transactional snapshot for the
+# transactional tables used by Agency. No --result-file is provided: raw SQL is
+# emitted only to stdout and captured directly in trusted RUNNER_TEMP.
+exec vendor/bin/drush sql:dump \
+  --no-interaction \
+  --extra-dump='--single-transaction --quick --skip-lock-tables --no-tablespaces'

--- a/scripts/production-readonly-snapshot/run-snapshot.sh
+++ b/scripts/production-readonly-snapshot/run-snapshot.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+MODE="${1:-}"
+if [[ "$#" -ne 1 ]] || [[ "$MODE" != 'REAL' && "$MODE" != 'SYNTHETIC' ]]; then
+  echo 'Mode must be exactly REAL or SYNTHETIC.' >&2
+  exit 64
+fi
+
+PROFILE_ID='agency-prod-readonly-snapshot-v1'
+PROFILE_PATH='scripts/production-readonly-snapshot/profile.json'
+REMOTE_SCRIPT='scripts/production-readonly-snapshot/remote-stream.sh'
+
+require_sha() {
+  local value="$1"
+  local label="$2"
+  if [[ ! "$value" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "$label is invalid." >&2
+    exit 65
+  fi
+}
+
+REQUEST_ID="${REQUEST_ID:-}"
+AUTHORITY_COMMENT_ID="${AUTHORITY_COMMENT_ID:-}"
+AUTHORITY_RUN_ID="${AUTHORITY_RUN_ID:-}"
+REPOSITORY_SHA="${REPOSITORY_SHA:-}"
+SOURCE_PROD_RELEASE_SHA="${SOURCE_PROD_RELEASE_SHA:-}"
+OPERATION_PROFILE="${OPERATION_PROFILE:-}"
+PROFILE_SHA256="${PROFILE_SHA256:-}"
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-}"
+RUNNER_TEMP="${RUNNER_TEMP:-}"
+GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
+GITHUB_RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-}"
+
+if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{8,80}$ ]]; then
+  echo 'REQUEST_ID is invalid.' >&2
+  exit 66
+fi
+if [[ ! "$AUTHORITY_COMMENT_ID" =~ ^[0-9]+$ ]]; then
+  echo 'AUTHORITY_COMMENT_ID is invalid.' >&2
+  exit 67
+fi
+if [[ ! "$AUTHORITY_RUN_ID" =~ ^[0-9]+$ ]]; then
+  echo 'AUTHORITY_RUN_ID is invalid.' >&2
+  exit 68
+fi
+if [[ ! "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]] || [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+  echo 'GitHub run identity is invalid.' >&2
+  exit 69
+fi
+if [[ "$GITHUB_RUN_ATTEMPT" != '1' ]]; then
+  echo 'Snapshot authority is not replayable; run_attempt must be 1.' >&2
+  exit 70
+fi
+require_sha "$REPOSITORY_SHA" 'REPOSITORY_SHA'
+require_sha "$SOURCE_PROD_RELEASE_SHA" 'SOURCE_PROD_RELEASE_SHA'
+if [[ "$OPERATION_PROFILE" != "$PROFILE_ID" ]]; then
+  echo 'OPERATION_PROFILE is not the reviewed snapshot profile.' >&2
+  exit 71
+fi
+if [[ ! "$PROFILE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo 'PROFILE_SHA256 is invalid.' >&2
+  exit 72
+fi
+if [[ -z "$GITHUB_WORKSPACE" || -z "$RUNNER_TEMP" ]]; then
+  echo 'GITHUB_WORKSPACE and RUNNER_TEMP are required.' >&2
+  exit 73
+fi
+if [[ ! -f "$PROFILE_PATH" || ! -f "$REMOTE_SCRIPT" ]]; then
+  echo 'Repository-owned snapshot tooling is incomplete.' >&2
+  exit 74
+fi
+if [[ "$(git rev-parse HEAD)" != "$REPOSITORY_SHA" ]]; then
+  echo 'Checked-out repository SHA does not match snapshot authority.' >&2
+  exit 75
+fi
+actual_profile_sha="$(sha256sum "$PROFILE_PATH" | awk '{print $1}')"
+if [[ "$actual_profile_sha" != "$PROFILE_SHA256" ]]; then
+  echo 'Snapshot profile digest does not match snapshot authority.' >&2
+  exit 76
+fi
+
+workspace_abs="$(realpath -m "$GITHUB_WORKSPACE")"
+runner_temp_abs="$(realpath -m "$RUNNER_TEMP")"
+case "$runner_temp_abs/" in
+  "$workspace_abs/"*)
+    echo 'RUNNER_TEMP must be outside the repository workspace.' >&2
+    exit 77
+    ;;
+esac
+
+RAW_PATH="$runner_temp_abs/agency-prod-readonly-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.sql"
+REMOTE_STDERR_PATH="$runner_temp_abs/agency-prod-readonly-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.stderr"
+EVIDENCE_DIR="$workspace_abs/artifacts/prod-readonly-snapshot"
+EVIDENCE_PATH="$EVIDENCE_DIR/evidence.env"
+
+SNAPSHOT_BYTE_SIZE='0'
+SNAPSHOT_SHA256='NONE'
+SNAPSHOT_CREATED='FAIL'
+RAW_MATERIAL_MODE='NOT_CREATED'
+SNAPSHOT_CLEANUP='NOT_RUN'
+RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP='UNKNOWN'
+
+write_evidence() {
+  mkdir -p "$EVIDENCE_DIR"
+  local tmp="$EVIDENCE_PATH.tmp"
+  cat > "$tmp" <<EOF_EVIDENCE
+schema_version=1
+request_id=$REQUEST_ID
+authority_comment_id=$AUTHORITY_COMMENT_ID
+authority_run_id=$AUTHORITY_RUN_ID
+repository_sha=$REPOSITORY_SHA
+source_prod_release_sha=$SOURCE_PROD_RELEASE_SHA
+operation_profile=$OPERATION_PROFILE
+profile_sha256=$PROFILE_SHA256
+execution_mode=$MODE
+snapshot_byte_size=$SNAPSHOT_BYTE_SIZE
+snapshot_sha256=$SNAPSHOT_SHA256
+snapshot_created=$SNAPSHOT_CREATED
+raw_material_mode=$RAW_MATERIAL_MODE
+snapshot_cleanup=$SNAPSHOT_CLEANUP
+raw_snapshot_present_after_cleanup=$RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP
+prod_write_path=NONE
+preprod_path=NONE
+raw_prod_artifact_in_github=NONE
+EOF_EVIDENCE
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$EVIDENCE_PATH"
+  chmod 600 "$EVIDENCE_PATH"
+}
+
+cleanup_and_finalize() {
+  local original_status="$?"
+  local final_status="$original_status"
+  trap - EXIT HUP INT TERM
+  set +e
+
+  rm -f -- "$RAW_PATH" "$REMOTE_STDERR_PATH"
+  local remove_status="$?"
+  if [[ "$remove_status" -eq 0 && ! -e "$RAW_PATH" && ! -L "$RAW_PATH" ]]; then
+    SNAPSHOT_CLEANUP='PASS'
+    RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP='NO'
+  else
+    SNAPSHOT_CLEANUP='FAIL'
+    RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP='YES'
+    final_status=97
+  fi
+
+  write_evidence
+  if [[ "$?" -ne 0 ]]; then
+    final_status=98
+  fi
+
+  exit "$final_status"
+}
+
+trap cleanup_and_finalize EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ -e "$RAW_PATH" || -L "$RAW_PATH" || -e "$REMOTE_STDERR_PATH" || -L "$REMOTE_STDERR_PATH" ]]; then
+  echo 'Unexpected pre-existing raw snapshot material for this run.' >&2
+  exit 78
+fi
+
+: > "$RAW_PATH"
+chmod 600 "$RAW_PATH"
+RAW_MATERIAL_MODE="$(stat -c '%a' "$RAW_PATH")"
+if [[ "$RAW_MATERIAL_MODE" != '600' ]]; then
+  echo 'Raw snapshot material is not mode 0600.' >&2
+  exit 79
+fi
+
+if [[ "$MODE" == 'SYNTHETIC' ]]; then
+  printf '%s\n' 'agency synthetic snapshot proof fixture - no production data' > "$RAW_PATH"
+  chmod 600 "$RAW_PATH"
+  RAW_MATERIAL_MODE="$(stat -c '%a' "$RAW_PATH")"
+  if [[ "${AGENCY_SNAPSHOT_SYNTHETIC_FAIL_AFTER_WRITE:-0}" == '1' ]]; then
+    echo 'Synthetic failure injected after raw material creation.' >&2
+    exit 80
+  fi
+else
+  if [[ -n "${AGENCY_SNAPSHOT_SYNTHETIC_FAIL_AFTER_WRITE:-}" ]]; then
+    echo 'Synthetic test controls are forbidden in REAL mode.' >&2
+    exit 81
+  fi
+  PROD_SSH_HOST="${PROD_SSH_HOST:-}"
+  PROD_SSH_USER="${PROD_SSH_USER:-}"
+  if [[ ! "$PROD_SSH_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+    echo 'Server-owned PROD SSH host is invalid.' >&2
+    exit 82
+  fi
+  if [[ ! "$PROD_SSH_USER" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo 'Server-owned PROD SSH user is invalid.' >&2
+    exit 83
+  fi
+
+  ssh \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=yes \
+    -o ConnectTimeout=15 \
+    -o ServerAliveInterval=5 \
+    -o ServerAliveCountMax=3 \
+    "$PROD_SSH_USER@$PROD_SSH_HOST" \
+    "bash -s -- '$SOURCE_PROD_RELEASE_SHA'" \
+    < "$REMOTE_SCRIPT" \
+    > "$RAW_PATH" \
+    2> "$REMOTE_STDERR_PATH"
+fi
+
+RAW_MATERIAL_MODE="$(stat -c '%a' "$RAW_PATH")"
+if [[ "$RAW_MATERIAL_MODE" != '600' ]]; then
+  echo 'Raw snapshot material permissions changed unexpectedly.' >&2
+  exit 84
+fi
+
+SNAPSHOT_BYTE_SIZE="$(stat -c '%s' "$RAW_PATH")"
+if [[ ! "$SNAPSHOT_BYTE_SIZE" =~ ^[0-9]+$ ]] || [[ "$SNAPSHOT_BYTE_SIZE" -le 0 ]]; then
+  echo 'Snapshot stream is empty.' >&2
+  exit 85
+fi
+SNAPSHOT_SHA256="$(sha256sum "$RAW_PATH" | awk '{print $1}')"
+if [[ ! "$SNAPSHOT_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo 'Snapshot SHA-256 is invalid.' >&2
+  exit 86
+fi
+
+SNAPSHOT_CREATED='PASS'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\agency_project_tests\Unit;
 
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
@@ -20,7 +21,7 @@ final class ProductionReadonlySnapshotTest extends TestCase {
    */
   public function testGatewayAndTrustedRunnerBoundary(): void {
     $workflow = $this->workflow();
-    $parsed = Yaml::parse($workflow);
+    $parsed = DrupalYaml::decode($workflow);
     self::assertIsArray($parsed);
 
     self::assertSame(

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
@@ -49,9 +49,9 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     $workflow = $this->workflow();
 
     foreach ([
-      "github.event.issue.number == 826",
-      "GITHUB_ACTOR\" == 'E-merging-digital'",
-      "GITHUB_RUN_ATTEMPT\" == '1'",
+      'github.event.issue.number == 826',
+      'GITHUB_ACTOR" == \'E-merging-digital\'',
+      'GITHUB_RUN_ATTEMPT" == \'1\'',
       'request_id must be fresh',
       'Requested main SHA is stale.',
       'Snapshot workflow must execute tooling from live main.',
@@ -78,7 +78,7 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     $remote = $this->remoteScript();
 
     foreach ([
-      "if [[ \"$#\" -ne 1 ]]",
+      'if [[ "$#" -ne 1 ]]',
       "CURRENT_RELEASE='/var/www/agency/current'",
       'git -C "$CURRENT_RELEASE" rev-parse HEAD',
       'sql:connect --show-passwords',
@@ -127,7 +127,7 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       'RUNNER_TEMP must be outside the repository workspace.',
       'agency-prod-readonly-snapshot-${GITHUB_RUN_ID}',
       'chmod 600 "$RAW_PATH"',
-      "stat -c '%a' \"$RAW_PATH\"",
+      'stat -c \'%a\' "$RAW_PATH"',
       'trap cleanup_and_finalize EXIT',
       "trap 'exit 129' HUP",
       "trap 'exit 130' INT",
@@ -204,7 +204,10 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     $profile = $this->profile();
 
     self::assertSame(1, $profile['schema_version']);
-    self::assertSame('agency-prod-readonly-snapshot-v1', $profile['profile_id']);
+    self::assertSame(
+      'agency-prod-readonly-snapshot-v1',
+      $profile['profile_id'],
+    );
     self::assertSame(826, $profile['issue_number']);
     self::assertSame(
       'FORBIDDEN',
@@ -217,7 +220,9 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     self::assertSame('NONE', $profile['execution']['prod_write_path']);
     self::assertSame('NONE', $profile['execution']['preprod_path']);
     self::assertSame('0600', $profile['snapshot']['raw_material_mode']);
-    self::assertFalse($profile['snapshot']['remote_raw_materialization']);
+    self::assertFalse(
+      $profile['snapshot']['remote_raw_materialization'],
+    );
     self::assertTrue($profile['cleanup']['exit_trap_required']);
     self::assertTrue($profile['cleanup']['workflow_finalizer_required']);
     self::assertTrue($profile['cleanup']['cleanup_failure_is_terminal']);

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the governed read-only PROD snapshot boundary.
+ *
+ * @group agency_project_tests
+ * @group production_readonly_snapshot
+ */
+final class ProductionReadonlySnapshotTest extends TestCase {
+
+  /**
+   * Raw production work is isolated from the GitHub-hosted gateway.
+   */
+  public function testGatewayAndTrustedRunnerBoundary(): void {
+    $workflow = $this->workflow();
+    $parsed = Yaml::parse($workflow);
+    self::assertIsArray($parsed);
+
+    self::assertSame(
+      'ubuntu-24.04',
+      $parsed['jobs']['validate-authority']['runs-on'],
+    );
+    self::assertSame(
+      ['self-hosted', 'linux', 'x64', 'agency'],
+      $parsed['jobs']['snapshot']['runs-on'],
+    );
+
+    self::assertStringContainsString('issue_comment:', $workflow);
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString("\n  schedule:\n", $workflow);
+    self::assertStringNotContainsString("\n  pull_request:\n", $workflow);
+    self::assertStringContainsString(
+      'Stream one fixed read-only PROD snapshot on trusted Agency runner',
+      $workflow,
+    );
+  }
+
+  /**
+   * Snapshot authority is fresh, exact-main bound and non-replayable.
+   */
+  public function testAuthorityIsFreshAndBound(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      "github.event.issue.number == 826",
+      "GITHUB_ACTOR\" == 'E-merging-digital'",
+      "GITHUB_RUN_ATTEMPT\" == '1'",
+      'request_id must be fresh',
+      'Requested main SHA is stale.',
+      'Snapshot workflow must execute tooling from live main.',
+      'agency-prod-readonly-snapshot-v1',
+      'profile_sha256',
+      'AUTHORITY_COMMENT_ID',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringContainsString(
+      '/agency-prod-readonly-snapshot prove',
+      $workflow,
+    );
+    self::assertStringNotContainsString('command_input', $workflow);
+    self::assertStringNotContainsString('sql_input', $workflow);
+    self::assertStringNotContainsString('path_input', $workflow);
+  }
+
+  /**
+   * The remote operation is one fixed, streaming, read-only dump operation.
+   */
+  public function testRemoteSnapshotOperationIsFixedAndReadOnly(): void {
+    $remote = $this->remoteScript();
+
+    foreach ([
+      "if [[ \"$#\" -ne 1 ]]",
+      "CURRENT_RELEASE='/var/www/agency/current'",
+      'git -C "$CURRENT_RELEASE" rev-parse HEAD',
+      'sql:connect --show-passwords',
+      'mariadb-dump',
+      'mysqldump',
+      '--single-transaction',
+      '--quick',
+      '--skip-lock-tables',
+      '--no-tablespaces',
+    ] as $required) {
+      self::assertStringContainsString($required, $remote);
+    }
+
+    foreach ([
+      'state:set',
+      'config:import',
+      'config:set',
+      'config:delete',
+      ' updb',
+      ' cim',
+      'sql:query',
+      'sql:drop',
+      'sql:create',
+      'user:create',
+      'user:password',
+      'maintenance_mode',
+      'git checkout',
+      'ln -sfn',
+      'scp ',
+      'rsync ',
+      'PREPROD',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $remote);
+    }
+  }
+
+  /**
+   * Raw material is private, transient and cleaned on all supported exits.
+   */
+  public function testRawLifecycleIsPrivateAndFailClosed(): void {
+    $script = $this->lifecycleScript();
+    $finalizer = $this->finalizerScript();
+
+    foreach ([
+      'umask 077',
+      'RUNNER_TEMP must be outside the repository workspace.',
+      'agency-prod-readonly-snapshot-${GITHUB_RUN_ID}',
+      'chmod 600 "$RAW_PATH"',
+      "stat -c '%a' \"$RAW_PATH\"",
+      'trap cleanup_and_finalize EXIT',
+      "trap 'exit 129' HUP",
+      "trap 'exit 130' INT",
+      "trap 'exit 143' TERM",
+      'rm -f -- "$RAW_PATH" "$REMOTE_STDERR_PATH"',
+      "SNAPSHOT_CLEANUP='PASS'",
+      "RAW_SNAPSHOT_PRESENT_AFTER_CLEANUP='NO'",
+      'final_status=97',
+    ] as $required) {
+      self::assertStringContainsString($required, $script);
+    }
+
+    self::assertStringNotContainsString(
+      'agency-prod-readonly-snapshot-${REQUEST_ID}',
+      $script,
+    );
+    self::assertStringContainsString('rm -f -- "$raw_path"', $finalizer);
+    self::assertStringContainsString(
+      'Trusted runner cleanup could not prove raw snapshot absence.',
+      $finalizer,
+    );
+  }
+
+  /**
+   * GitHub evidence is exact-key metadata and can never contain raw SQL.
+   */
+  public function testEvidenceIsFixedAllowlistedMetadata(): void {
+    $profile = $this->profile();
+    $workflow = $this->workflow();
+
+    $expected = [
+      'schema_version',
+      'request_id',
+      'authority_comment_id',
+      'authority_run_id',
+      'repository_sha',
+      'source_prod_release_sha',
+      'operation_profile',
+      'profile_sha256',
+      'execution_mode',
+      'snapshot_byte_size',
+      'snapshot_sha256',
+      'snapshot_created',
+      'raw_material_mode',
+      'snapshot_cleanup',
+      'raw_snapshot_present_after_cleanup',
+      'prod_write_path',
+      'preprod_path',
+      'raw_prod_artifact_in_github',
+    ];
+
+    self::assertSame($expected, $profile['evidence']['allowlist']);
+    self::assertFalse($profile['evidence']['raw_prod_artifact_allowed']);
+    self::assertFalse($profile['evidence']['pii_allowed']);
+    self::assertFalse($profile['evidence']['secrets_allowed']);
+    self::assertSame(
+      'artifacts/prod-readonly-snapshot/evidence.env',
+      $profile['evidence']['artifact_path'],
+    );
+    self::assertStringContainsString(
+      'path: artifacts/prod-readonly-snapshot/evidence.env',
+      $workflow,
+    );
+
+    foreach (['*.sql', '*.sql.gz', '*.dump', 'sites/default/files'] as $raw) {
+      self::assertStringNotContainsString($raw, $workflow);
+    }
+  }
+
+  /**
+   * The reviewed profile fixes execution, semantics and stop boundaries.
+   */
+  public function testProfileIsBoundedToIssue826(): void {
+    $profile = $this->profile();
+
+    self::assertSame(1, $profile['schema_version']);
+    self::assertSame('agency-prod-readonly-snapshot-v1', $profile['profile_id']);
+    self::assertSame(826, $profile['issue_number']);
+    self::assertSame(
+      'FORBIDDEN',
+      $profile['execution']['github_hosted_raw_prod_data'],
+    );
+    self::assertSame(
+      ['self-hosted', 'linux', 'x64', 'agency'],
+      $profile['execution']['trusted_runner_labels'],
+    );
+    self::assertSame('NONE', $profile['execution']['prod_write_path']);
+    self::assertSame('NONE', $profile['execution']['preprod_path']);
+    self::assertSame('0600', $profile['snapshot']['raw_material_mode']);
+    self::assertFalse($profile['snapshot']['remote_raw_materialization']);
+    self::assertTrue($profile['cleanup']['exit_trap_required']);
+    self::assertTrue($profile['cleanup']['workflow_finalizer_required']);
+    self::assertTrue($profile['cleanup']['cleanup_failure_is_terminal']);
+    self::assertSame(
+      'HUMAN_REQUIRED_AFTER_PROJECT_LEAD_REVIEW',
+      $profile['authority']['first_real_snapshot'],
+    );
+  }
+
+  /**
+   * No PREPROD/full-refresh or production mutation route is introduced.
+   */
+  public function testNoImplicitApplyOrPreprodPath(): void {
+    $workflow = $this->workflow();
+    $script = $this->lifecycleScript();
+
+    foreach ([
+      'drush updb',
+      'drush cim',
+      'state:set',
+      'config:import',
+      'deploy-production',
+      'deploy-preproduction',
+      'sql:sanitize',
+      'APPLY',
+      'scp ',
+      'rsync ',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+      self::assertStringNotContainsString($forbidden, $script);
+    }
+
+    self::assertStringContainsString('prod_write_path=NONE', $script);
+    self::assertStringContainsString('preprod_path=NONE', $script);
+  }
+
+  /**
+   * The #816 GitHub-hosted raw-data prohibition remains authoritative.
+   */
+  public function testInherited816ExecutionBoundaryStillHolds(): void {
+    $policy = $this->refreshPolicy();
+    $boundary = $policy['execution_boundary'];
+
+    self::assertFalse($boundary['github_hosted']['raw_prod_data_allowed']);
+    self::assertSame(
+      'FORBIDDEN',
+      $boundary['raw_prod_data']['github_hosted_runner'],
+    );
+    self::assertSame(
+      ['self-hosted', 'linux', 'x64', 'agency'],
+      $boundary['raw_prod_data']['allowed_paths'][0]['required_labels'],
+    );
+
+    self::assertStringContainsString(
+      'RAW PROD DATA ON GITHUB-HOSTED RUNNER = FORBIDDEN',
+      $this->document(),
+    );
+  }
+
+  /**
+   * Synthetic validation proves success, failure cleanup and anti-replay.
+   */
+  public function testTargetedValidationCoversRequiredSyntheticProofs(): void {
+    $validation = $this->validationWorkflow();
+
+    foreach ([
+      'Prove synthetic success metadata, mode and cleanup',
+      'AGENCY_SNAPSHOT_SYNTHETIC_FAIL_AFTER_WRITE=1',
+      'snapshot_created=FAIL',
+      'snapshot_cleanup=PASS',
+      'raw_snapshot_present_after_cleanup=NO',
+      'GITHUB_RUN_ATTEMPT=2',
+      'Synthetic failure path unexpectedly succeeded.',
+      'Snapshot proof unexpectedly accepted a replay attempt.',
+    ] as $required) {
+      self::assertStringContainsString($required, $validation);
+    }
+  }
+
+  /**
+   * Returns the governed snapshot workflow.
+   */
+  private function workflow(): string {
+    return $this->file(
+      '.github/workflows/prod-readonly-snapshot.yml',
+      TRUE,
+    );
+  }
+
+  /**
+   * Returns the targeted validation workflow.
+   */
+  private function validationWorkflow(): string {
+    return $this->file(
+      '.github/workflows/prod-readonly-snapshot-validation.yml',
+      TRUE,
+    );
+  }
+
+  /**
+   * Returns the raw lifecycle script.
+   */
+  private function lifecycleScript(): string {
+    return $this->file('scripts/production-readonly-snapshot/run-snapshot.sh');
+  }
+
+  /**
+   * Returns the independent cleanup finalizer.
+   */
+  private function finalizerScript(): string {
+    return $this->file(
+      'scripts/production-readonly-snapshot/finalize-cleanup.sh',
+    );
+  }
+
+  /**
+   * Returns the fixed remote stream operation.
+   */
+  private function remoteScript(): string {
+    return $this->file(
+      'scripts/production-readonly-snapshot/remote-stream.sh',
+    );
+  }
+
+  /**
+   * Returns the decoded snapshot profile.
+   *
+   * @return array<string, mixed>
+   *   The profile.
+   */
+  private function profile(): array {
+    $json = $this->file('scripts/production-readonly-snapshot/profile.json');
+    $profile = json_decode($json, TRUE, 512, JSON_THROW_ON_ERROR);
+    self::assertIsArray($profile);
+    return $profile;
+  }
+
+  /**
+   * Returns the inherited #816 refresh policy.
+   *
+   * @return array<string, mixed>
+   *   The policy.
+   */
+  private function refreshPolicy(): array {
+    $json = $this->file(
+      'scripts/preproduction-refresh/sanitization-policy.json',
+    );
+    $policy = json_decode($json, TRUE, 512, JSON_THROW_ON_ERROR);
+    self::assertIsArray($policy);
+    return $policy;
+  }
+
+  /**
+   * Returns the durable snapshot contract.
+   */
+  private function document(): string {
+    return $this->file('docs/operations/production-readonly-snapshot.md');
+  }
+
+  /**
+   * Reads a repository file and optionally validates YAML syntax.
+   */
+  private function file(string $relative, bool $yaml = FALSE): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/' . $relative;
+    self::assertFileExists($path);
+    if ($yaml) {
+      self::assertIsArray(Yaml::parseFile($path));
+    }
+    return (string) file_get_contents($path);
+  }
+
+}

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
@@ -67,9 +67,35 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       '/agency-prod-readonly-snapshot prove',
       $workflow,
     );
-    self::assertStringNotContainsString('command_input', $workflow);
-    self::assertStringNotContainsString('sql_input', $workflow);
-    self::assertStringNotContainsString('path_input', $workflow);
+    foreach (['command_input', 'sql_input', 'path_input'] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Runtime identity comes from the durable promotion receipt, not Git.
+   */
+  public function testRuntimeIdentityUsesExactPromotionReceipt(): void {
+    $remote = $this->remoteScript();
+
+    foreach ([
+      "PROJECT_ROOT='/var/www/agency'",
+      'CURRENT_RELEASE="$PROJECT_ROOT/current"',
+      'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"',
+      'current_release="$(readlink -f "$CURRENT_RELEASE")"',
+      "'^release_path='",
+      "'^candidate_sha='",
+      'matched_receipts',
+      'Current PROD release must map to exactly one promotion receipt.',
+      'Current PROD release identity does not match authorization.',
+    ] as $required) {
+      self::assertStringContainsString($required, $remote);
+    }
+
+    self::assertStringNotContainsString(
+      'git -C "$CURRENT_RELEASE" rev-parse HEAD',
+      $remote,
+    );
   }
 
   /**
@@ -80,8 +106,6 @@ final class ProductionReadonlySnapshotTest extends TestCase {
 
     foreach ([
       'if [[ "$#" -ne 1 ]]',
-      "CURRENT_RELEASE='/var/www/agency/current'",
-      'git -C "$CURRENT_RELEASE" rev-parse HEAD',
       'vendor/bin/drush sql:dump',
       '--no-interaction',
       '--extra-dump=',
@@ -142,7 +166,7 @@ final class ProductionReadonlySnapshotTest extends TestCase {
   }
 
   /**
-   * Raw material is private, transient and cleaned on all supported exits.
+   * Raw material is private, transient and cleaned on supported exits.
    */
   public function testRawLifecycleIsPrivateAndFailClosed(): void {
     $script = $this->lifecycleScript();
@@ -170,7 +194,10 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       'agency-prod-readonly-snapshot-${REQUEST_ID}',
       $script,
     );
-    self::assertStringContainsString('rm -f -- "$raw_path"', $finalizer);
+    self::assertStringContainsString(
+      'rm -f -- "$raw_path"',
+      $finalizer,
+    );
     self::assertStringContainsString(
       'Trusted runner cleanup could not prove raw snapshot absence.',
       $finalizer,
@@ -217,14 +244,6 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       'path: artifacts/prod-readonly-snapshot/evidence.env',
       $workflow,
     );
-    self::assertStringContainsString(
-      "grep -Fxq 'snapshot_created=PASS'",
-      $workflow,
-    );
-    self::assertStringContainsString(
-      "grep -Fxq 'raw_material_mode=600'",
-      $workflow,
-    );
 
     foreach (['*.sql', '*.sql.gz', '*.dump', 'sites/default/files'] as $raw) {
       self::assertStringNotContainsString($raw, $workflow);
@@ -258,9 +277,7 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       $profile['snapshot']['fixed_tool'],
     );
     self::assertSame('0600', $profile['snapshot']['raw_material_mode']);
-    self::assertFalse(
-      $profile['snapshot']['remote_raw_materialization'],
-    );
+    self::assertFalse($profile['snapshot']['remote_raw_materialization']);
     self::assertTrue($profile['cleanup']['exit_trap_required']);
     self::assertTrue($profile['cleanup']['workflow_finalizer_required']);
     self::assertTrue($profile['cleanup']['cleanup_failure_is_terminal']);
@@ -321,9 +338,9 @@ final class ProductionReadonlySnapshotTest extends TestCase {
   }
 
   /**
-   * Synthetic validation proves success, failure cleanup and anti-replay.
+   * Synthetic validation proves success, cleanup and anti-replay.
    */
-  public function testTargetedValidationCoversRequiredSyntheticProofs(): void {
+  public function testTargetedValidationCoversRequiredProofs(): void {
     $validation = $this->validationWorkflow();
 
     foreach ([

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionReadonlySnapshotTest.php
@@ -81,9 +81,9 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       'if [[ "$#" -ne 1 ]]',
       "CURRENT_RELEASE='/var/www/agency/current'",
       'git -C "$CURRENT_RELEASE" rev-parse HEAD',
-      'sql:connect --show-passwords',
-      'mariadb-dump',
-      'mysqldump',
+      'vendor/bin/drush sql:dump',
+      '--no-interaction',
+      '--extra-dump=',
       '--single-transaction',
       '--quick',
       '--skip-lock-tables',
@@ -93,6 +93,9 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     }
 
     foreach ([
+      'sql:connect',
+      '--result-file',
+      'eval ',
       'state:set',
       'config:import',
       'config:set',
@@ -113,6 +116,28 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     ] as $forbidden) {
       self::assertStringNotContainsString($forbidden, $remote);
     }
+  }
+
+  /**
+   * The trusted transport requires pre-provisioned host identity.
+   */
+  public function testTrustedTransportCannotBootstrapHostTrust(): void {
+    $workflow = $this->workflow();
+    $script = $this->lifecycleScript();
+
+    self::assertStringContainsString(
+      'Require pre-provisioned PROD host trust',
+      $workflow,
+    );
+    self::assertStringContainsString(
+      'ssh-keygen -F "$SERVER_HOST"',
+      $workflow,
+    );
+    self::assertStringNotContainsString('ssh-keyscan', $workflow);
+    self::assertStringContainsString(
+      'StrictHostKeyChecking=yes',
+      $script,
+    );
   }
 
   /**
@@ -191,6 +216,14 @@ final class ProductionReadonlySnapshotTest extends TestCase {
       'path: artifacts/prod-readonly-snapshot/evidence.env',
       $workflow,
     );
+    self::assertStringContainsString(
+      "grep -Fxq 'snapshot_created=PASS'",
+      $workflow,
+    );
+    self::assertStringContainsString(
+      "grep -Fxq 'raw_material_mode=600'",
+      $workflow,
+    );
 
     foreach (['*.sql', '*.sql.gz', '*.dump', 'sites/default/files'] as $raw) {
       self::assertStringNotContainsString($raw, $workflow);
@@ -219,6 +252,10 @@ final class ProductionReadonlySnapshotTest extends TestCase {
     );
     self::assertSame('NONE', $profile['execution']['prod_write_path']);
     self::assertSame('NONE', $profile['execution']['preprod_path']);
+    self::assertSame(
+      'vendor/bin/drush sql:dump',
+      $profile['snapshot']['fixed_tool'],
+    );
     self::assertSame('0600', $profile['snapshot']['raw_material_mode']);
     self::assertFalse(
       $profile['snapshot']['remote_raw_materialization'],


### PR DESCRIPTION
Refs #826. Parent program: #816.

## Scope

Implementation + static/synthetic proof only for the bounded read-only PROD snapshot route. This PR does not authorize or execute the first real PROD snapshot.

Implemented:
- fresh owner-controlled #826 authority gateway bound to live `main`, expected PROD release SHA, exact profile ID/digest and one-shot request identity;
- GitHub-hosted gateway restricted to metadata/policy validation;
- raw-data job restricted to `self-hosted`, `linux`, `x64`, `agency`;
- fixed repository-owned PROD operation against `/var/www/agency/current` only;
- exact active-release SHA check before snapshot;
- fixed `drush sql:dump` stream with `--single-transaction --quick --skip-lock-tables --no-tablespaces` and no `--result-file`;
- pre-provisioned PROD SSH host trust + `StrictHostKeyChecking=yes`;
- raw material only in trusted `RUNNER_TEMP`, `umask 077`, mode `0600`;
- cleanup trap on success/failure/signals plus independent `always()` finalizer;
- fail-closed proof that raw material is absent after cleanup;
- fixed-path, fixed-key metadata-only GitHub evidence;
- targeted synthetic success/failure/anti-replay validation and PHPUnit regression coverage;
- inherited #816 `RAW PROD DATA ON GITHUB-HOSTED RUNNER = FORBIDDEN` contract remains enforced.

## Explicitly absent

- no PREPROD connection/transfer/import/sanitization/activation/rollback;
- no public/private files path;
- no generic shell/SQL/table/database/path/SSH/Drush input;
- no PROD maintenance/config/content/user/state/scheduler/release mutation;
- no deployment/promotion;
- no scheduling/full APPLY.

## Safety boundary

```text
PROD_WRITE_PATH=NONE
PREPROD_PATH=NONE
RAW_PROD_ON_GITHUB_HOSTED=FORBIDDEN
RAW_PROD_GITHUB_ARTIFACT=NONE
REAL_PROD_SNAPSHOT=NONE
REAL_PROD_DATA_TRANSFER=NONE
PREPROD_DB_IMPORT=NONE
PREPROD_DB_ACTIVATION=NONE
FIRST_REAL_PROD_SNAPSHOT=NOT_AUTHORIZED
```

Delivery must STOP for Project Lead review after exact-head CI and targeted snapshot-governance validation are terminal green. Merge does not authorize the first real PROD snapshot.