### PR TITLE
#828 — Align snapshot profile with promotion receipt runtime identity

### DIFF
--- a/.github/workflows/prod-readonly-snapshot-validation.yml
+++ b/.github/workflows/prod-readonly-snapshot-validation.yml
@@ -39,6 +39,7 @@ jobs:
           jq -e '.execution.prod_write_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
           jq -e '.execution.preprod_path == "NONE"' scripts/production-readonly-snapshot/profile.json >/dev/null
           jq -e '.snapshot.fixed_tool == "vendor/bin/drush sql:dump"' scripts/production-readonly-snapshot/profile.json >/dev/null
+          jq -e '.snapshot.release_identity == "PROMOTION_RECEIPT_CURRENT_RELEASE_EXACT_CANDIDATE_SHA"' scripts/production-readonly-snapshot/profile.json >/dev/null
 
       - name: Prove workflow raw-data boundary is static and non-generic
         shell: bash
@@ -81,8 +82,14 @@ jobs:
           grep -Fq 'current_release="$(readlink -f "$CURRENT_RELEASE")"' "$remote"
           grep -Fq "grep -m1 '^release_path='" "$remote"
           grep -Fq "grep -m1 '^candidate_sha='" "$remote"
+          grep -Fq 'matched_receipts=$((matched_receipts + 1))' "$remote"
           grep -Fq 'Current PROD release must map to exactly one promotion receipt.' "$remote"
-          ! grep -Fq 'git -C "$CURRENT_RELEASE" rev-parse HEAD' "$remote"
+          grep -Fq 'if [[ "$ACTUAL_PROD_RELEASE_SHA" != "$EXPECTED_PROD_RELEASE_SHA" ]]' "$remote"
+          grep -Fq 'Current PROD release identity does not match authorization.' "$remote"
+          ! grep -Fq 'git rev-parse' "$remote"
+          ! grep -Fq 'git -C' "$remote"
+          ! grep -Fq '.git/' "$remote"
+          ! grep -Fq 'GIT_HEAD_OF_CURRENT_RELEASE' "$remote"
           grep -Fq -- "--exclude='.git/'" "$builder"
           grep -Fq 'vendor/bin/drush sql:dump' "$remote"
           ! grep -Fq 'sql:connect' "$remote"

--- a/scripts/production-readonly-snapshot/profile.json
+++ b/scripts/production-readonly-snapshot/profile.json
@@ -35,7 +35,7 @@
   },
   "snapshot": {
     "remote_project_root": "/var/www/agency/current",
-    "release_identity": "GIT_HEAD_OF_CURRENT_RELEASE",
+    "release_identity": "PROMOTION_RECEIPT_CURRENT_RELEASE_EXACT_CANDIDATE_SHA",
     "connection_source": "DRUSH_SQL_DUMP_FROM_SERVER_OWNED_SETTINGS",
     "fixed_tool": "vendor/bin/drush sql:dump",
     "fixed_dump_options": [


### PR DESCRIPTION
Refs #828 #826 #816 PR #827.

## Scope

Minimal pre-first-real-snapshot contract convergence only.

Changes:
- replace stale `snapshot.release_identity = GIT_HEAD_OF_CURRENT_RELEASE` with `PROMOTION_RECEIPT_CURRENT_RELEASE_EXACT_CANDIDATE_SHA`;
- extend targeted governance validation to bind that exact profile semantic;
- continue proving the runtime requires the resolved current release, `PROMOTIONS_DIR`, `release_path`, `candidate_sha`, exactly one matching promotion receipt, and exact equality with the authorized expected PROD release SHA;
- explicitly reject Git runtime identity markers (`git rev-parse`, `git -C`, `.git/`, stale `GIT_HEAD_OF_CURRENT_RELEASE`) in `remote-stream.sh`.

No runtime snapshot implementation, authority gateway, SSH trust, dump command/options, RUNNER_TEMP lifecycle, cleanup, evidence allowlist, PROD/PREPROD path or scheduler behavior is changed.

## Safety boundary

```text
REAL_PROD_SNAPSHOT=NO
PROD_WRITE=NONE
PROD_DEPLOY=NONE
PROD_SCHEDULER_MUTATION=NONE
PREPROD_CONNECTION=NONE
PREPROD_MUTATION=NONE
```

No `/agency-prod-readonly-snapshot prove ...` authorization is created by this PR. Merge does not authorize a real snapshot.

Expected profile identity:

```text
PROMOTION_RECEIPT_CURRENT_RELEASE_EXACT_CANDIDATE_SHA
```

Profile ID remains `agency-prod-readonly-snapshot-v1` because no real v1 snapshot authority/run has ever consumed the profile.