### PR TITLE
#832 — Revalidate PROD read-only through pinned SSH trust

### DIFF
--- a/.github/workflows/prod-pinned-trust-readonly-rebaseline-validation.yml
+++ b/.github/workflows/prod-pinned-trust-readonly-rebaseline-validation.yml
@@ -1,0 +1,150 @@
+name: Validate PROD pinned-trust read-only rebaseline
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+      - '.github/workflows/prod-pinned-trust-readonly-rebaseline-validation.yml'
+      - 'scripts/production-ssh-trust/remote-readonly-rebaseline.sh'
+      - 'scripts/production-ssh-trust/manage-known-host.sh'
+      - 'scripts/production-ssh-trust/prod-ed25519.pub'
+      - 'scripts/production-ssh-trust/prod-ed25519.sha256'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPinnedTrustReadonlyRebaselineTest.php'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-readonly-rebaseline:
+    name: Prove #832 bounded read-only PROD rebaseline contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate shell syntax and pinned trust material
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n scripts/production-ssh-trust/manage-known-host.sh
+          bash -n scripts/production-ssh-trust/remote-readonly-rebaseline.sh
+          read -r key_type key_blob _ < scripts/production-ssh-trust/prod-ed25519.pub
+          test "$key_type" = 'ssh-ed25519'
+          test "$key_blob" = 'AAAAC3NzaC1lZDI1NTE5AAAAIHBzADlwNcSFBP6sYfGBH2SvD5NymTF6n2Ze996V4TqR'
+          fingerprint="$(ssh-keygen -lf scripts/production-ssh-trust/prod-ed25519.pub -E sha256 | awk '{print $2}')"
+          test "$fingerprint" = 'SHA256:Pflpbgh2vc9dUYe4fpXPxdwzhPqyy8vmbAOcS+BRLDQ'
+          grep -Fxq "$fingerprint" scripts/production-ssh-trust/prod-ed25519.sha256
+
+      - name: Prove owner authority and exact Agency runner boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          grep -Fq 'github.event.issue.number == 832' "$workflow"
+          grep -Fq '/agency-prod-readonly-rebaseline prove ' "$workflow"
+          grep -Fq "GITHUB_ACTOR\" == 'E-merging-digital'" "$workflow"
+          grep -Fq "GITHUB_RUN_ATTEMPT\" == '1'" "$workflow"
+          grep -Fq 'request_id must be fresh' "$workflow"
+          grep -Fq 'Read-only rebaseline must execute tooling from live main.' "$workflow"
+          grep -Fq "RUNNER_NAME\" == 'agency-browser-runner-01'" "$workflow"
+          ! grep -Fq 'workflow_dispatch:' "$workflow"
+
+      - name: Prove pinned trust precedes strict SSH
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          verify_line="$(grep -n -m1 'manage-known-host.sh VERIFY_ONLY' "$workflow" | cut -d: -f1)"
+          ssh_line="$(grep -n -m1 '^[[:space:]]*ssh ' "$workflow" | cut -d: -f1)"
+          test -n "$verify_line"
+          test -n "$ssh_line"
+          test "$verify_line" -lt "$ssh_line"
+          grep -Fq 'StrictHostKeyChecking=yes' "$workflow"
+          grep -Fq 'UserKnownHostsFile="$HOME/.ssh/known_hosts"' "$workflow"
+          grep -Fq 'IdentitiesOnly=yes' "$workflow"
+          ! grep -Fq 'ssh-keyscan' "$workflow"
+          ! grep -Fq 'StrictHostKeyChecking=no' "$workflow"
+          ! grep -Fq 'accept-new' "$workflow"
+
+      - name: Prove transient SSH credential cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          grep -Fq 'agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key' "$workflow"
+          grep -Fq 'AGENCY_PROD_READONLY_SSH_KEY' "$workflow"
+          grep -Fq 'chmod 600 "$key_path"' "$workflow"
+          grep -Fq '-i "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
+          grep -Fq 'Remove transient SSH credential after read-only session' "$workflow"
+          grep -Fq 'Finalize transient read-only session material' "$workflow"
+          grep -Fq 'rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
+          grep -Fq 'ssh_credential_cleanup=PASS' "$workflow"
+          test "$(grep -Fc 'always()' "$workflow")" -ge 2
+          ! grep -Fq '~/.ssh/id_ed25519' "$workflow"
+
+      - name: Prove release identity is fixed and receipt-bound
+        shell: bash
+        run: |
+          set -euo pipefail
+          remote='scripts/production-ssh-trust/remote-readonly-rebaseline.sh'
+          grep -Fq 'if [[ "$#" -ne 1 ]]' "$remote"
+          grep -Fq "PROJECT_ROOT='/var/www/agency'" "$remote"
+          grep -Fq 'CURRENT_RELEASE="$PROJECT_ROOT/current"' "$remote"
+          grep -Fq 'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"' "$remote"
+          grep -Fq 'current_release="$(readlink -f "$CURRENT_RELEASE")"' "$remote"
+          grep -Fq "'^release_path='" "$remote"
+          grep -Fq "'^candidate_sha='" "$remote"
+          grep -Fq '[[ "$matched_receipts" -eq 1 ]]' "$remote"
+          grep -Fq 'ACTIVE_RELEASE_PATH=RESOLVED' "$remote"
+          grep -Fq 'PROMOTION_RECEIPT_MATCH_COUNT=1' "$remote"
+          grep -Fq 'ACTIVE_PROD_RELEASE_MATCH=PASS' "$remote"
+          ! grep -Fq 'git -C' "$remote"
+          ! grep -Fq 'drush ' "$remote"
+          ! grep -Fq 'sql:' "$remote"
+          ! grep -Fq 'mysql ' "$remote"
+          ! grep -Fq 'mariadb ' "$remote"
+          ! grep -Fq 'scp ' "$remote"
+          ! grep -Fq 'rsync ' "$remote"
+
+      - name: Prove no PROD mutation, DB read or PREPROD route exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          remote='scripts/production-ssh-trust/remote-readonly-rebaseline.sh'
+          grep -Fq 'PROD_DB_READ=NONE' "$remote"
+          grep -Fq 'PROD_WRITE=NONE' "$remote"
+          grep -Fq 'PROD_SCHEDULER_MUTATION=NONE' "$remote"
+          grep -Fq 'PREPROD_MUTATION=NONE' "$remote"
+          ! grep -Fq 'drush ' "$workflow"
+          ! grep -Fq 'sql:' "$workflow"
+          ! grep -Fq 'deploy-production' "$workflow"
+          ! grep -Fq 'deploy-preproduction' "$workflow"
+          ! grep -Fq 'command_input' "$workflow"
+          ! grep -Fq 'sql_input' "$workflow"
+          ! grep -Fq 'path_input' "$workflow"
+          ! grep -Fq 'url_input' "$workflow"
+
+      - name: Prove fixed public probes and metadata-only evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          grep -Fq 'https://emergingdigital.be/health/live' "$workflow"
+          grep -Fq 'https://emergingdigital.be/health/ready' "$workflow"
+          grep -Fq 'https://emergingdigital.be/fr/blog' "$workflow"
+          grep -Fq 'pinned_ssh_trust=PASS' "$workflow"
+          grep -Fq 'strict_host_key_checking=YES' "$workflow"
+          grep -Fq 'active_release_path=RESOLVED' "$workflow"
+          grep -Fq 'promotion_receipt_match_count=1' "$workflow"
+          grep -Fq 'real_prod_snapshot=NOT_PERFORMED' "$workflow"
+          grep -Fq 'prod_db_read=NONE' "$workflow"
+          grep -Fq 'prod_write=NONE' "$workflow"
+          grep -Fq 'prod_deploy=NONE' "$workflow"
+          grep -Fq 'prod_scheduler_mutation=NONE' "$workflow"
+          grep -Fq 'preprod_mutation=NONE' "$workflow"
+          ! grep -Fq "printf 'server_host=" "$workflow"
+          ! grep -Fq "printf 'SERVER_HOST=" "$workflow"

--- a/.github/workflows/prod-pinned-trust-readonly-rebaseline-validation.yml
+++ b/.github/workflows/prod-pinned-trust-readonly-rebaseline-validation.yml
@@ -77,7 +77,7 @@ jobs:
           grep -Fq 'agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key' "$workflow"
           grep -Fq 'AGENCY_PROD_READONLY_SSH_KEY' "$workflow"
           grep -Fq 'chmod 600 "$key_path"' "$workflow"
-          grep -Fq '-i "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
+          grep -Fq -- '-i "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
           grep -Fq 'Remove transient SSH credential after read-only session' "$workflow"
           grep -Fq 'Finalize transient read-only session material' "$workflow"
           grep -Fq 'rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"

--- a/.github/workflows/prod-pinned-trust-readonly-rebaseline.yml
+++ b/.github/workflows/prod-pinned-trust-readonly-rebaseline.yml
@@ -134,10 +134,10 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_PRIVATE_KEY"
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+          key_path="$RUNNER_TEMP/agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          printf 'AGENCY_PROD_READONLY_SSH_KEY=%s\n' "$key_path" >> "$GITHUB_ENV"
 
       - name: Prove active PROD release through fixed receipt-bound read-only operation
         id: release
@@ -151,8 +151,12 @@ jobs:
           test -n "$SERVER_HOST"
           test -n "$SERVER_USER"
           [[ "$EXPECTED_PROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test -f "$AGENCY_PROD_READONLY_SSH_KEY"
+          test "$(stat -c '%a' "$AGENCY_PROD_READONLY_SSH_KEY")" = '600'
           output="$(
             ssh \
+              -i "$AGENCY_PROD_READONLY_SSH_KEY" \
+              -o IdentitiesOnly=yes \
               -o BatchMode=yes \
               -o ConnectTimeout=10 \
               -o StrictHostKeyChecking=yes \
@@ -164,12 +168,26 @@ jobs:
           printf '%s\n' "$output"
           active_sha="$(sed -n 's/^ACTIVE_PROD_RELEASE_SHA=//p' <<< "$output")"
           [[ "$active_sha" == "$EXPECTED_PROD_RELEASE_SHA" ]]
+          grep -Fxq 'ACTIVE_RELEASE_PATH=RESOLVED' <<< "$output"
+          grep -Fxq 'PROMOTION_RECEIPT_MATCH_COUNT=1' <<< "$output"
           grep -Fxq 'ACTIVE_PROD_RELEASE_MATCH=PASS' <<< "$output"
           grep -Fxq 'PROD_DB_READ=NONE' <<< "$output"
           grep -Fxq 'PROD_WRITE=NONE' <<< "$output"
           grep -Fxq 'PROD_SCHEDULER_MUTATION=NONE' <<< "$output"
           grep -Fxq 'PREPROD_MUTATION=NONE' <<< "$output"
           echo "active_prod_release_sha=$active_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Remove transient SSH credential after read-only session
+        id: ssh-cleanup
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${AGENCY_PROD_READONLY_SSH_KEY:-}" ]]; then
+            rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"
+            test ! -e "$AGENCY_PROD_READONLY_SSH_KEY"
+          fi
+          echo 'ssh_credential_cleanup=PASS' >> "$GITHUB_OUTPUT"
 
       - name: Prove current public live ready and smoke
         id: public
@@ -197,6 +215,7 @@ jobs:
           HEALTH_LIVE: ${{ steps.public.outputs.production_health_live }}
           HEALTH_READY: ${{ steps.public.outputs.production_health_ready }}
           SMOKE: ${{ steps.public.outputs.production_smoke }}
+          SSH_CREDENTIAL_CLEANUP: ${{ steps.ssh-cleanup.outputs.ssh_credential_cleanup }}
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         shell: bash
         run: |
@@ -210,10 +229,15 @@ jobs:
             printf 'authority_comment_id=%s\n' "$AUTHORITY_COMMENT_ID"
             printf 'repository_sha=%s\n' "$REPOSITORY_SHA"
             printf 'runner=%s\n' "$RUNNER_NAME"
+            printf 'pinned_ssh_trust=PASS\n'
+            printf 'strict_host_key_checking=YES\n'
+            printf 'active_release_path=RESOLVED\n'
+            printf 'promotion_receipt_match_count=1\n'
             printf 'active_prod_release_sha=%s\n' "$ACTIVE_PROD_RELEASE_SHA"
             printf 'production_health_live=%s\n' "$HEALTH_LIVE"
             printf 'production_health_ready=%s\n' "$HEALTH_READY"
             printf 'production_smoke=%s\n' "$SMOKE"
+            printf 'ssh_credential_cleanup=%s\n' "$SSH_CREDENTIAL_CLEANUP"
             printf '%s\n' "$trust"
             printf 'real_prod_snapshot=NOT_PERFORMED\n'
             printf 'prod_db_read=NONE\n'
@@ -224,6 +248,11 @@ jobs:
           } > "$evidence"
           chmod 600 "$evidence"
           grep -Fxq 'runner=agency-browser-runner-01' "$evidence"
+          grep -Fxq 'pinned_ssh_trust=PASS' "$evidence"
+          grep -Fxq 'strict_host_key_checking=YES' "$evidence"
+          grep -Fxq 'active_release_path=RESOLVED' "$evidence"
+          grep -Fxq 'promotion_receipt_match_count=1' "$evidence"
+          grep -Fxq 'ssh_credential_cleanup=PASS' "$evidence"
           grep -Fxq 'ENTRY_COUNT_FOR_SERVER_HOST=1' "$evidence"
           grep -Fxq 'KEY_TYPE=ssh-ed25519' "$evidence"
           grep -Fxq 'KEY_BLOB_MATCH=PASS' "$evidence"
@@ -241,10 +270,13 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Remove transient SSH credential and probe bodies
+      - name: Finalize transient read-only session material
         if: ${{ always() }}
         shell: bash
         run: |
           set -euo pipefail
-          rm -f ~/.ssh/id_ed25519 "$RUNNER_TEMP/agency-live.body" "$RUNNER_TEMP/agency-ready.body"
-          test ! -e ~/.ssh/id_ed25519
+          if [[ -n "${AGENCY_PROD_READONLY_SSH_KEY:-}" ]]; then
+            rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"
+            test ! -e "$AGENCY_PROD_READONLY_SSH_KEY"
+          fi
+          rm -f -- "$RUNNER_TEMP/agency-live.body" "$RUNNER_TEMP/agency-ready.body"

--- a/.github/workflows/prod-pinned-trust-readonly-rebaseline.yml
+++ b/.github/workflows/prod-pinned-trust-readonly-rebaseline.yml
@@ -1,0 +1,250 @@
+name: Governed PROD pinned-trust read-only rebaseline
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agency-prod-readonly-rebaseline
+  cancel-in-progress: false
+
+jobs:
+  validate-authority:
+    name: Validate fresh owner read-only rebaseline authority
+    if: >-
+      ${{
+        github.event.issue.pull_request == null &&
+        github.event.issue.number == 832 &&
+        startsWith(github.event.comment.body, '/agency-prod-readonly-rebaseline prove ')
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      request_id: ${{ steps.authority.outputs.request_id }}
+      authority_comment_id: ${{ steps.authority.outputs.authority_comment_id }}
+      main_sha: ${{ steps.authority.outputs.main_sha }}
+      expected_prod_release_sha: ${{ steps.authority.outputs.expected_prod_release_sha }}
+    steps:
+      - name: Validate actor, one-shot request and live main
+        id: authority
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_COMMENT: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          AUTHORITY_COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == 'E-merging-digital' ]]
+          [[ "$COMMENT_AUTHOR" == "$GITHUB_ACTOR" ]]
+          [[ "$ISSUE_NUMBER" == '832' ]]
+          [[ "$GITHUB_RUN_ATTEMPT" == '1' ]] || {
+            echo 'Read-only rebaseline authority cannot be replayed through a workflow rerun.' >&2
+            exit 1
+          }
+          [[ "$AUTHORITY_COMMENT_ID" =~ ^[0-9]+$ ]]
+
+          read -r command verb request_id requested_main expected_prod extra <<< "$TRIGGER_COMMENT"
+          [[ -z "${extra:-}" ]]
+          [[ "$command" == '/agency-prod-readonly-rebaseline' ]]
+          [[ "$verb" == 'prove' ]]
+          [[ "$request_id" =~ ^[A-Za-z0-9._-]{8,80}$ ]]
+          [[ "$requested_main" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$expected_prod" =~ ^[0-9a-f]{40}$ ]]
+          expected="/agency-prod-readonly-rebaseline prove $request_id $requested_main $expected_prod"
+          [[ "$TRIGGER_COMMENT" == "$expected" ]]
+
+          issue_json="$(gh api "repos/$GITHUB_REPOSITORY/issues/832")"
+          [[ "$(jq -r '.state' <<< "$issue_json")" == 'open' ]]
+          [[ "$(jq -r '.pull_request // empty' <<< "$issue_json")" == '' ]]
+          [[ "$(jq -r '.user.login' <<< "$issue_json")" == 'E-merging-digital' ]]
+
+          live_main="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')"
+          [[ "$requested_main" == "$live_main" ]] || {
+            echo 'Requested main SHA is stale.' >&2
+            exit 1
+          }
+          [[ "$EVENT_DEFAULT_SHA" == "$live_main" ]] || {
+            echo 'Read-only rebaseline must execute tooling from live main.' >&2
+            exit 1
+          }
+
+          comments="$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/832/comments?per_page=100" --jq '.[].body')"
+          request_prefix="/agency-prod-readonly-rebaseline prove $request_id "
+          match_count=0
+          while IFS= read -r body; do
+            if [[ "$body" == "$request_prefix"* ]]; then
+              match_count=$((match_count + 1))
+            fi
+          done <<< "$comments"
+          [[ "$match_count" -eq 1 ]] || {
+            echo 'request_id must be fresh and appear in exactly one owner authority comment.' >&2
+            exit 1
+          }
+
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+          echo "authority_comment_id=$AUTHORITY_COMMENT_ID" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$live_main" >> "$GITHUB_OUTPUT"
+          echo "expected_prod_release_sha=$expected_prod" >> "$GITHUB_OUTPUT"
+
+  rebaseline:
+    name: Prove PROD release and health through pinned trust
+    needs: validate-authority
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - agency
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact trusted main tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-authority.outputs.main_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Require exact Agency runner and pinned PROD trust
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RUNNER_NAME" == 'agency-browser-runner-01' ]]
+          test "$(git rev-parse HEAD)" = '${{ needs.validate-authority.outputs.main_sha }}'
+          test -n "$SERVER_HOST"
+          bash -n scripts/production-ssh-trust/manage-known-host.sh
+          bash -n scripts/production-ssh-trust/remote-readonly-rebaseline.sh
+          SERVER_HOST="$SERVER_HOST" bash scripts/production-ssh-trust/manage-known-host.sh VERIFY_ONLY >/dev/null
+
+      - name: Configure transient read-only PROD SSH credential
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Prove active PROD release through fixed receipt-bound read-only operation
+        id: release
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          EXPECTED_PROD_RELEASE_SHA: ${{ needs.validate-authority.outputs.expected_prod_release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SERVER_HOST"
+          test -n "$SERVER_USER"
+          [[ "$EXPECTED_PROD_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          output="$(
+            ssh \
+              -o BatchMode=yes \
+              -o ConnectTimeout=10 \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+              "$SERVER_USER@$SERVER_HOST" \
+              "bash -s -- '$EXPECTED_PROD_RELEASE_SHA'" \
+              < scripts/production-ssh-trust/remote-readonly-rebaseline.sh
+          )"
+          printf '%s\n' "$output"
+          active_sha="$(sed -n 's/^ACTIVE_PROD_RELEASE_SHA=//p' <<< "$output")"
+          [[ "$active_sha" == "$EXPECTED_PROD_RELEASE_SHA" ]]
+          grep -Fxq 'ACTIVE_PROD_RELEASE_MATCH=PASS' <<< "$output"
+          grep -Fxq 'PROD_DB_READ=NONE' <<< "$output"
+          grep -Fxq 'PROD_WRITE=NONE' <<< "$output"
+          grep -Fxq 'PROD_SCHEDULER_MUTATION=NONE' <<< "$output"
+          grep -Fxq 'PREPROD_MUTATION=NONE' <<< "$output"
+          echo "active_prod_release_sha=$active_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Prove current public live ready and smoke
+        id: public
+        shell: bash
+        run: |
+          set -euo pipefail
+          live_status="$(curl --silent --show-error --location --retry 3 --max-time 20 --output "$RUNNER_TEMP/agency-live.body" --write-out '%{http_code}' 'https://emergingdigital.be/health/live')"
+          ready_status="$(curl --silent --show-error --location --retry 3 --max-time 20 --output "$RUNNER_TEMP/agency-ready.body" --write-out '%{http_code}' 'https://emergingdigital.be/health/ready')"
+          smoke_status="$(curl --silent --show-error --location --retry 3 --max-time 20 --output /dev/null --write-out '%{http_code}' 'https://emergingdigital.be/fr/blog')"
+          [[ "$live_status" == '200' ]]
+          [[ "$ready_status" == '200' ]]
+          [[ "$smoke_status" == '200' ]]
+          test "$(tr -d '\r\n' < "$RUNNER_TEMP/agency-live.body")" = '{"status":"ok"}'
+          test "$(tr -d '\r\n' < "$RUNNER_TEMP/agency-ready.body")" = '{"status":"ok"}'
+          echo 'production_health_live=PASS' >> "$GITHUB_OUTPUT"
+          echo 'production_health_ready=PASS' >> "$GITHUB_OUTPUT"
+          echo 'production_smoke=PASS' >> "$GITHUB_OUTPUT"
+
+      - name: Write metadata-only rebaseline evidence
+        env:
+          REQUEST_ID: ${{ needs.validate-authority.outputs.request_id }}
+          AUTHORITY_COMMENT_ID: ${{ needs.validate-authority.outputs.authority_comment_id }}
+          REPOSITORY_SHA: ${{ needs.validate-authority.outputs.main_sha }}
+          ACTIVE_PROD_RELEASE_SHA: ${{ steps.release.outputs.active_prod_release_sha }}
+          HEALTH_LIVE: ${{ steps.public.outputs.production_health_live }}
+          HEALTH_READY: ${{ steps.public.outputs.production_health_ready }}
+          SMOKE: ${{ steps.public.outputs.production_smoke }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/production-readonly-rebaseline
+          evidence='artifacts/production-readonly-rebaseline/evidence.env'
+          trust="$(SERVER_HOST="$SERVER_HOST" bash scripts/production-ssh-trust/manage-known-host.sh VERIFY_ONLY)"
+          {
+            printf 'schema_version=1\n'
+            printf 'request_id=%s\n' "$REQUEST_ID"
+            printf 'authority_comment_id=%s\n' "$AUTHORITY_COMMENT_ID"
+            printf 'repository_sha=%s\n' "$REPOSITORY_SHA"
+            printf 'runner=%s\n' "$RUNNER_NAME"
+            printf 'active_prod_release_sha=%s\n' "$ACTIVE_PROD_RELEASE_SHA"
+            printf 'production_health_live=%s\n' "$HEALTH_LIVE"
+            printf 'production_health_ready=%s\n' "$HEALTH_READY"
+            printf 'production_smoke=%s\n' "$SMOKE"
+            printf '%s\n' "$trust"
+            printf 'real_prod_snapshot=NOT_PERFORMED\n'
+            printf 'prod_db_read=NONE\n'
+            printf 'prod_write=NONE\n'
+            printf 'prod_deploy=NONE\n'
+            printf 'prod_scheduler_mutation=NONE\n'
+            printf 'preprod_mutation=NONE\n'
+          } > "$evidence"
+          chmod 600 "$evidence"
+          grep -Fxq 'runner=agency-browser-runner-01' "$evidence"
+          grep -Fxq 'ENTRY_COUNT_FOR_SERVER_HOST=1' "$evidence"
+          grep -Fxq 'KEY_TYPE=ssh-ed25519' "$evidence"
+          grep -Fxq 'KEY_BLOB_MATCH=PASS' "$evidence"
+          grep -Fxq 'FINGERPRINT=SHA256:Pflpbgh2vc9dUYe4fpXPxdwzhPqyy8vmbAOcS+BRLDQ' "$evidence"
+          grep -Fxq 'KNOWN_HOSTS_MATCH=PASS' "$evidence"
+          grep -Fxq 'real_prod_snapshot=NOT_PERFORMED' "$evidence"
+          grep -Fxq 'prod_db_read=NONE' "$evidence"
+          grep -Fxq 'prod_write=NONE' "$evidence"
+
+      - name: Upload metadata-only read-only rebaseline evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-prod-readonly-rebaseline-${{ needs.validate-authority.outputs.request_id }}-${{ github.run_id }}
+          path: artifacts/production-readonly-rebaseline/evidence.env
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove transient SSH credential and probe bodies
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f ~/.ssh/id_ed25519 "$RUNNER_TEMP/agency-live.body" "$RUNNER_TEMP/agency-ready.body"
+          test ! -e ~/.ssh/id_ed25519

--- a/.github/workflows/prod-ssh-trust-validation.yml
+++ b/.github/workflows/prod-ssh-trust-validation.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - '.github/workflows/prod-readonly-snapshot.yml'
+      - '.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
       - '.github/workflows/prod-ssh-trust-provision.yml'
       - '.github/workflows/prod-ssh-trust-validation.yml'
       - 'scripts/production-ssh-trust/**'
       - 'docs/operations/production-ssh-trust.md'
       - 'docs/operations/production-readonly-snapshot.md'
+      - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPinnedTrustReadonlyRebaselineTest.php'
 
 permissions:
   contents: read
@@ -78,6 +80,51 @@ jobs:
           ! grep -Fq 'ssh ' "$workflow"
           ! grep -Fq 'scp ' "$workflow"
           ! grep -Fq 'rsync ' "$workflow"
+
+      - name: Prove read-only rebaseline is receipt-bound and fail-closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
+          remote='scripts/production-ssh-trust/remote-readonly-rebaseline.sh'
+          bash -n "$remote"
+          grep -Fq 'github.event.issue.number == 832' "$workflow"
+          grep -Fq '/agency-prod-readonly-rebaseline prove ' "$workflow"
+          grep -Fq "RUNNER_NAME\" == 'agency-browser-runner-01'" "$workflow"
+          grep -Fq 'scripts/production-ssh-trust/manage-known-host.sh VERIFY_ONLY' "$workflow"
+          grep -Fq 'StrictHostKeyChecking=yes' "$workflow"
+          grep -Fq 'UserKnownHostsFile="$HOME/.ssh/known_hosts"' "$workflow"
+          grep -Fq 'IdentitiesOnly=yes' "$workflow"
+          grep -Fq 'agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key' "$workflow"
+          grep -Fq 'rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
+          grep -Fq 'if: ${{ always() }}' "$workflow"
+          grep -Fq "PROJECT_ROOT='/var/www/agency'" "$remote"
+          grep -Fq 'CURRENT_RELEASE="$PROJECT_ROOT/current"' "$remote"
+          grep -Fq 'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"' "$remote"
+          grep -Fq "'^release_path='" "$remote"
+          grep -Fq "'^candidate_sha='" "$remote"
+          grep -Fq '[[ "$matched_receipts" -eq 1 ]]' "$remote"
+          grep -Fq 'ACTIVE_RELEASE_PATH=RESOLVED' "$remote"
+          grep -Fq 'PROMOTION_RECEIPT_MATCH_COUNT=1' "$remote"
+          grep -Fq 'PROD_DB_READ=NONE' "$remote"
+          grep -Fq 'PROD_WRITE=NONE' "$remote"
+          grep -Fq 'PREPROD_MUTATION=NONE' "$remote"
+          verify_line="$(grep -n -m1 'manage-known-host.sh VERIFY_ONLY' "$workflow" | cut -d: -f1)"
+          ssh_line="$(grep -n -m1 '^[[:space:]]*ssh ' "$workflow" | cut -d: -f1)"
+          test "$verify_line" -lt "$ssh_line"
+          ! grep -Fq 'ssh-keyscan' "$workflow"
+          ! grep -Fq 'StrictHostKeyChecking=no' "$workflow"
+          ! grep -Fq 'accept-new' "$workflow"
+          ! grep -Fq 'workflow_dispatch:' "$workflow"
+          ! grep -Fq 'drush ' "$workflow"
+          ! grep -Fq 'drush ' "$remote"
+          ! grep -Fq 'sql:' "$workflow"
+          ! grep -Fq 'sql:' "$remote"
+          ! grep -Fq 'git -C' "$remote"
+          ! grep -Fq 'deploy-production' "$workflow"
+          ! grep -Fq 'deploy-preproduction' "$workflow"
+          ! grep -Fq "printf 'server_host=" "$workflow"
+          ! grep -Fq "printf 'SERVER_HOST=" "$workflow"
 
       - name: Prove absent and wrong host identities fail closed
         shell: bash

--- a/.github/workflows/prod-ssh-trust-validation.yml
+++ b/.github/workflows/prod-ssh-trust-validation.yml
@@ -4,13 +4,11 @@ on:
   pull_request:
     paths:
       - '.github/workflows/prod-readonly-snapshot.yml'
-      - '.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
       - '.github/workflows/prod-ssh-trust-provision.yml'
       - '.github/workflows/prod-ssh-trust-validation.yml'
       - 'scripts/production-ssh-trust/**'
       - 'docs/operations/production-ssh-trust.md'
       - 'docs/operations/production-readonly-snapshot.md'
-      - 'web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPinnedTrustReadonlyRebaselineTest.php'
 
 permissions:
   contents: read
@@ -80,51 +78,6 @@ jobs:
           ! grep -Fq 'ssh ' "$workflow"
           ! grep -Fq 'scp ' "$workflow"
           ! grep -Fq 'rsync ' "$workflow"
-
-      - name: Prove read-only rebaseline is receipt-bound and fail-closed
-        shell: bash
-        run: |
-          set -euo pipefail
-          workflow='.github/workflows/prod-pinned-trust-readonly-rebaseline.yml'
-          remote='scripts/production-ssh-trust/remote-readonly-rebaseline.sh'
-          bash -n "$remote"
-          grep -Fq 'github.event.issue.number == 832' "$workflow"
-          grep -Fq '/agency-prod-readonly-rebaseline prove ' "$workflow"
-          grep -Fq "RUNNER_NAME\" == 'agency-browser-runner-01'" "$workflow"
-          grep -Fq 'scripts/production-ssh-trust/manage-known-host.sh VERIFY_ONLY' "$workflow"
-          grep -Fq 'StrictHostKeyChecking=yes' "$workflow"
-          grep -Fq 'UserKnownHostsFile="$HOME/.ssh/known_hosts"' "$workflow"
-          grep -Fq 'IdentitiesOnly=yes' "$workflow"
-          grep -Fq 'agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key' "$workflow"
-          grep -Fq 'rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"' "$workflow"
-          grep -Fq 'if: ${{ always() }}' "$workflow"
-          grep -Fq "PROJECT_ROOT='/var/www/agency'" "$remote"
-          grep -Fq 'CURRENT_RELEASE="$PROJECT_ROOT/current"' "$remote"
-          grep -Fq 'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"' "$remote"
-          grep -Fq "'^release_path='" "$remote"
-          grep -Fq "'^candidate_sha='" "$remote"
-          grep -Fq '[[ "$matched_receipts" -eq 1 ]]' "$remote"
-          grep -Fq 'ACTIVE_RELEASE_PATH=RESOLVED' "$remote"
-          grep -Fq 'PROMOTION_RECEIPT_MATCH_COUNT=1' "$remote"
-          grep -Fq 'PROD_DB_READ=NONE' "$remote"
-          grep -Fq 'PROD_WRITE=NONE' "$remote"
-          grep -Fq 'PREPROD_MUTATION=NONE' "$remote"
-          verify_line="$(grep -n -m1 'manage-known-host.sh VERIFY_ONLY' "$workflow" | cut -d: -f1)"
-          ssh_line="$(grep -n -m1 '^[[:space:]]*ssh ' "$workflow" | cut -d: -f1)"
-          test "$verify_line" -lt "$ssh_line"
-          ! grep -Fq 'ssh-keyscan' "$workflow"
-          ! grep -Fq 'StrictHostKeyChecking=no' "$workflow"
-          ! grep -Fq 'accept-new' "$workflow"
-          ! grep -Fq 'workflow_dispatch:' "$workflow"
-          ! grep -Fq 'drush ' "$workflow"
-          ! grep -Fq 'drush ' "$remote"
-          ! grep -Fq 'sql:' "$workflow"
-          ! grep -Fq 'sql:' "$remote"
-          ! grep -Fq 'git -C' "$remote"
-          ! grep -Fq 'deploy-production' "$workflow"
-          ! grep -Fq 'deploy-preproduction' "$workflow"
-          ! grep -Fq "printf 'server_host=" "$workflow"
-          ! grep -Fq "printf 'SERVER_HOST=" "$workflow"
 
       - name: Prove absent and wrong host identities fail closed
         shell: bash

--- a/scripts/production-ssh-trust/remote-readonly-rebaseline.sh
+++ b/scripts/production-ssh-trust/remote-readonly-rebaseline.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]] || [[ ! "$1" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'Expected exactly one immutable 40-character PROD release SHA.' >&2
+  exit 64
+fi
+
+EXPECTED_PROD_RELEASE_SHA="$1"
+PROJECT_ROOT='/var/www/agency'
+CURRENT_RELEASE="$PROJECT_ROOT/current"
+PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"
+
+current_release="$(readlink -f "$CURRENT_RELEASE")"
+[[ -n "$current_release" && -d "$current_release" ]] || {
+  echo 'Current PROD release cannot be resolved.' >&2
+  exit 65
+}
+[[ -d "$PROMOTIONS_DIR" ]] || {
+  echo 'Production promotion receipt directory is missing.' >&2
+  exit 66
+}
+
+matched_receipts=0
+actual_prod_release_sha=''
+shopt -s nullglob
+for receipt in "$PROMOTIONS_DIR"/*.env; do
+  receipt_release_path="$(grep -m1 '^release_path=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_release_path" == "$current_release" ]] || continue
+  matched_receipts=$((matched_receipts + 1))
+  receipt_candidate_sha="$(grep -m1 '^candidate_sha=' "$receipt" | cut -d= -f2- || true)"
+  [[ "$receipt_candidate_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'Matching production promotion receipt has an invalid candidate SHA.' >&2
+    exit 67
+  }
+  actual_prod_release_sha="$receipt_candidate_sha"
+done
+shopt -u nullglob
+
+[[ "$matched_receipts" -eq 1 ]] || {
+  echo 'Current PROD release must map to exactly one promotion receipt.' >&2
+  exit 68
+}
+[[ "$actual_prod_release_sha" == "$EXPECTED_PROD_RELEASE_SHA" ]] || {
+  echo 'Current PROD release identity does not match the expected rebaseline SHA.' >&2
+  exit 69
+}
+
+printf 'ACTIVE_PROD_RELEASE_SHA=%s\n' "$actual_prod_release_sha"
+printf 'ACTIVE_PROD_RELEASE_MATCH=PASS\n'
+printf 'PROD_DB_READ=NONE\n'
+printf 'PROD_WRITE=NONE\n'
+printf 'PROD_SCHEDULER_MUTATION=NONE\n'
+printf 'PREPROD_MUTATION=NONE\n'

--- a/scripts/production-ssh-trust/remote-readonly-rebaseline.sh
+++ b/scripts/production-ssh-trust/remote-readonly-rebaseline.sh
@@ -46,6 +46,8 @@ shopt -u nullglob
   exit 69
 }
 
+printf 'ACTIVE_RELEASE_PATH=RESOLVED\n'
+printf 'PROMOTION_RECEIPT_MATCH_COUNT=1\n'
 printf 'ACTIVE_PROD_RELEASE_SHA=%s\n' "$actual_prod_release_sha"
 printf 'ACTIVE_PROD_RELEASE_MATCH=PASS\n'
 printf 'PROD_DB_READ=NONE\n'

--- a/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPinnedTrustReadonlyRebaselineTest.php
+++ b/web/modules/custom/agency_project_tests/tests/src/Unit/ProductionPinnedTrustReadonlyRebaselineTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\agency_project_tests\Unit;
+
+use Drupal\Component\Serialization\Yaml as DrupalYaml;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the #832 pinned-trust PROD read-only rebaseline boundary.
+ *
+ * @group agency_project_tests
+ * @group production_pinned_trust_readonly_rebaseline
+ */
+final class ProductionPinnedTrustReadonlyRebaselineTest extends TestCase {
+
+  /**
+   * The route is owner-bound, one-shot, exact-main and runner constrained.
+   */
+  public function testAuthorityAndRunnerAreBounded(): void {
+    $workflow = $this->workflow();
+    $parsed = DrupalYaml::decode($workflow);
+    self::assertIsArray($parsed);
+
+    self::assertSame(
+      'ubuntu-24.04',
+      $parsed['jobs']['validate-authority']['runs-on'],
+    );
+    self::assertSame(
+      ['self-hosted', 'linux', 'x64', 'agency'],
+      $parsed['jobs']['rebaseline']['runs-on'],
+    );
+
+    foreach ([
+      'github.event.issue.number == 832',
+      '/agency-prod-readonly-rebaseline prove ',
+      "GITHUB_ACTOR\" == 'E-merging-digital'",
+      "GITHUB_RUN_ATTEMPT\" == '1'",
+      'request_id must be fresh',
+      'Read-only rebaseline must execute tooling from live main.',
+      "RUNNER_NAME\" == 'agency-browser-runner-01'",
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertStringNotContainsString('workflow_dispatch:', $workflow);
+    self::assertStringNotContainsString("\n  schedule:\n", $workflow);
+  }
+
+  /**
+   * Pinned host verification must happen before the first SSH connection.
+   */
+  public function testPinnedTrustPrecedesStrictSsh(): void {
+    $workflow = $this->workflow();
+    $verify = strpos(
+      $workflow,
+      'manage-known-host.sh VERIFY_ONLY',
+    );
+    $ssh = strpos($workflow, "\n            ssh \\");
+
+    self::assertNotFalse($verify);
+    self::assertNotFalse($ssh);
+    self::assertLessThan($ssh, $verify);
+
+    foreach ([
+      'StrictHostKeyChecking=yes',
+      'UserKnownHostsFile="$HOME/.ssh/known_hosts"',
+      'IdentitiesOnly=yes',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'ssh-keyscan',
+      'StrictHostKeyChecking=no',
+      'StrictHostKeyChecking=accept-new',
+      'accept-new',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * The credential is session-specific and removed on always cleanups.
+   */
+  public function testTransientSshCredentialIsAlwaysCleaned(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'agency-prod-readonly-rebaseline-${GITHUB_RUN_ID}.key',
+      'AGENCY_PROD_READONLY_SSH_KEY',
+      'chmod 600 "$key_path"',
+      '-i "$AGENCY_PROD_READONLY_SSH_KEY"',
+      'Remove transient SSH credential after read-only session',
+      'Finalize transient read-only session material',
+      'rm -f -- "$AGENCY_PROD_READONLY_SSH_KEY"',
+      'ssh_credential_cleanup=PASS',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    self::assertGreaterThanOrEqual(
+      2,
+      substr_count($workflow, 'if: ${{ always() }}'),
+    );
+    self::assertStringNotContainsString('~/.ssh/id_ed25519', $workflow);
+  }
+
+  /**
+   * Release identity comes only from the active release promotion receipt.
+   */
+  public function testReleaseIdentityIsReceiptBoundAndReadOnly(): void {
+    $remote = $this->remoteScript();
+
+    foreach ([
+      'if [[ "$#" -ne 1 ]]',
+      "PROJECT_ROOT='/var/www/agency'",
+      'CURRENT_RELEASE="$PROJECT_ROOT/current"',
+      'PROMOTIONS_DIR="$PROJECT_ROOT/shared/promotions"',
+      'current_release="$(readlink -f "$CURRENT_RELEASE")"',
+      "'^release_path='",
+      "'^candidate_sha='",
+      '[[ "$matched_receipts" -eq 1 ]]',
+      'PROMOTION_RECEIPT_MATCH_COUNT=1',
+      'ACTIVE_RELEASE_PATH=RESOLVED',
+      'ACTIVE_PROD_RELEASE_MATCH=PASS',
+    ] as $required) {
+      self::assertStringContainsString($required, $remote);
+    }
+
+    foreach ([
+      'git ',
+      'drush ',
+      'sql:',
+      'mysql ',
+      'mariadb ',
+      'scp ',
+      'rsync ',
+      'PREPROD_',
+    ] as $forbidden) {
+      if ($forbidden === 'PREPROD_') {
+        continue;
+      }
+      self::assertStringNotContainsString($forbidden, $remote);
+    }
+
+    self::assertStringContainsString('PROD_DB_READ=NONE', $remote);
+    self::assertStringContainsString('PROD_WRITE=NONE', $remote);
+    self::assertStringContainsString('PREPROD_MUTATION=NONE', $remote);
+  }
+
+  /**
+   * Public probes and evidence expose fixed, metadata-only outcomes.
+   */
+  public function testFixedPublicProbesAndMetadataOnlyEvidence(): void {
+    $workflow = $this->workflow();
+
+    foreach ([
+      'https://emergingdigital.be/health/live',
+      'https://emergingdigital.be/health/ready',
+      'https://emergingdigital.be/fr/blog',
+      'pinned_ssh_trust=PASS',
+      'strict_host_key_checking=YES',
+      'active_release_path=RESOLVED',
+      'promotion_receipt_match_count=1',
+      'real_prod_snapshot=NOT_PERFORMED',
+      'prod_db_read=NONE',
+      'prod_write=NONE',
+      'prod_deploy=NONE',
+      'prod_scheduler_mutation=NONE',
+      'preprod_mutation=NONE',
+    ] as $required) {
+      self::assertStringContainsString($required, $workflow);
+    }
+
+    foreach ([
+      'command_input',
+      'sql_input',
+      'path_input',
+      'url_input',
+      "printf 'server_host=",
+      "printf 'SERVER_HOST=",
+      'deploy-preproduction',
+      'deploy-production',
+      'drush ',
+      'sql:',
+    ] as $forbidden) {
+      self::assertStringNotContainsString($forbidden, $workflow);
+    }
+  }
+
+  /**
+   * Returns the governed #832 workflow.
+   */
+  private function workflow(): string {
+    return $this->file(
+      '.github/workflows/prod-pinned-trust-readonly-rebaseline.yml',
+      TRUE,
+    );
+  }
+
+  /**
+   * Returns the fixed remote receipt inspection operation.
+   */
+  private function remoteScript(): string {
+    return $this->file(
+      'scripts/production-ssh-trust/remote-readonly-rebaseline.sh',
+    );
+  }
+
+  /**
+   * Reads a repository file and optionally validates YAML syntax.
+   */
+  private function file(string $relative, bool $yaml = FALSE): string {
+    $root = dirname(DRUPAL_ROOT);
+    $path = $root . '/' . $relative;
+    self::assertFileExists($path);
+    if ($yaml) {
+      self::assertIsArray(Yaml::parseFile($path));
+    }
+    return (string) file_get_contents($path);
+  }
+
+}


### PR DESCRIPTION
Refs #832 #830 #826 #816.

Implements the bounded post-trust PROD read-only rebaseline on the exact Agency runner.

Key properties:
- exact `agency-browser-runner-01` plus `self-hosted/linux/x64/agency`;
- repository-pinned ED25519 host identity verified with `manage-known-host.sh VERIFY_ONLY` before SSH;
- `StrictHostKeyChecking=yes`, explicit `UserKnownHostsFile`, transient session-specific SSH key under `RUNNER_TEMP`, `IdentitiesOnly=yes`, mandatory `always()` cleanup;
- fixed remote operation only: resolve `/var/www/agency/current`, require exactly one matching promotion receipt by `release_path`, read only `candidate_sha`, compare to owner-authorized expected PROD release SHA;
- no `.git` runtime identity, no generic remote command/path/URL/SQL surface;
- fixed public `/health/live`, `/health/ready`, `/fr/blog` probes;
- metadata-only evidence, no SERVER_HOST output.

Safety boundary:

```text
PROD_DB_READ = NONE
PROD_WRITE = NONE
REAL_PROD_SNAPSHOT = NO
PREPROD_MUTATION = NONE
PROD_DEPLOY = NONE
PROD_SCHEDULER_MUTATION = NONE
```

No #826 snapshot execution is authorized or performed by this PR.